### PR TITLE
Add an index file that exposes the public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "author": {
     "name": "Google Inc."
   },
+  "main": "build/src/index.js",
+  "types": "src/index.ts",
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/mocha": "^2.2.42",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,5 @@
+export * from './call-credentials';
+export * from './channel-credentials';
+export * from './client';
+export * from './constants';
+export * from './metadata';


### PR DESCRIPTION
This adds an index file, and points to it and the corresponding generated file in `package.json`.