### PR TITLE
Fix run-tests.sh script

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -22,7 +22,7 @@ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.4/install.sh | b
 set -e
 cd $(dirname $0)
 
-if [ "x$node_versions" == "x" ] ; then
+if [ "x$node_versions" = "x" ] ; then
   node_versions="6 7 8"
 fi
 


### PR DESCRIPTION
Fixes  ```grpc-node/run-tests.sh: 25: [: x: unexpected operator```