### PR TITLE
Add original name aliases for generated client methods

### DIFF
--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -912,6 +912,9 @@ exports.makeClientConstructor = function(methods, serviceName,
     }
     // Associate all provided attributes with the method
     _.assign(ServiceClient.prototype[name], attrs);
+    if (attrs.originalName) {
+      ServiceClient.prototype[attrs.originalName] = ServiceClient.prototype[name];
+    }
   });
 
   ServiceClient.service = methods;

--- a/test/api/surface_test.js
+++ b/test/api/surface_test.js
@@ -215,6 +215,10 @@ describe('Client constructor building', function() {
       grpc.makeGenericClientConstructor(illegal_service_attrs);
     }, /\$/);
   });
+  it('Should add aliases for original names', function() {
+    var Client = grpc.makeGenericClientConstructor(mathServiceAttrs);
+    assert.strictEqual(Client.prototype.add, Client.prototype.Add);
+  });
 });
 describe('waitForClientReady', function() {
   var server;


### PR DESCRIPTION
This fixes grpc/grpc#12135