### PR TITLE
Disable warning in recent GCC versions that hits BoringSSL

### DIFF
--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -207,6 +207,9 @@
           'target_name': 'boringssl',
           'product_prefix': 'lib',
           'type': 'static_library',
+          'cflags': [
+            '-Wimplicit-fallthrough=0'
+          ],
           'dependencies': [
           ],
           'sources': [

--- a/packages/grpc-native-core/templates/binding.gyp.template
+++ b/packages/grpc-native-core/templates/binding.gyp.template
@@ -194,6 +194,9 @@
             'target_name': '${lib.name}',
             'product_prefix': 'lib',
             'type': 'static_library',
+            'cflags': [
+              '-Wimplicit-fallthrough=0'
+            ],
             'dependencies': [
               % for dep in getattr(lib, 'deps', []):
               '${dep}',


### PR DESCRIPTION
This fixes grpc/grpc#12536