### PR TITLE
Move dependencies around, add gulp target for document generation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ gulp.task('install.all', 'Install dependencies for all subdirectory packages',
           ['js.core.install', 'native.core.install', 'health-check.install', 'internal.test.install']);
 
 gulp.task('install.all.windows', 'Install dependencies for all subdirectory packages for MS Windows',
-          ['js.core.install', 'native.core.install.windows', 'health-check.install']);
+          ['js.core.install', 'native.core.install.windows', 'health-check.install', 'internal.test.install']);
 
 gulp.task('lint', 'Emit linting errors in source and test files',
           ['js.core.lint', 'native.core.lint']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ require('./test/gulpfile');
 const root = __dirname;
 
 gulp.task('install.all', 'Install dependencies for all subdirectory packages',
-          ['js.core.install', 'native.core.install', 'health-check.install']);
+          ['js.core.install', 'native.core.install', 'health-check.install', 'internal.test.install']);
 
 gulp.task('lint', 'Emit linting errors in source and test files',
           ['js.core.lint', 'native.core.lint']);
@@ -51,5 +51,7 @@ gulp.task('test.only', 'Run tests without rebuilding anything',
 gulp.task('test', 'Run all tests', ['build'], () => {
   gulp.start('test.only');
 });
+
+gulp.task('doc.gen', 'Generate documentation', ['native.core.doc.gen']);
 
 gulp.task('default', ['help']);

--- a/package.json
+++ b/package.json
@@ -8,29 +8,23 @@
     "name": "Google Inc."
   },
   "license": "Apache-2.0",
-  "dependencies": {
-    "async": "^2.5.0",
-    "body-parser": "^1.18.0",
-    "execa": "^0.8.0",
-    "express": "^4.15.4",
-    "google-auth-library": "^0.11.0",
-    "lodash": "^4.17.4",
-    "mocha-jenkins-reporter": "^0.3.9",
-    "poisson-process": "^0.2.2"
-  },
   "devDependencies": {
     "del": "^3.0.0",
+    "execa": "^0.8.0",
     "gulp": "^3.9.1",
     "gulp-help": "^1.6.1",
+    "gulp-jsdoc3": "^1.0.1",
     "gulp-jshint": "^2.0.4",
     "gulp-mocha": "^4.3.1",
     "gulp-sourcemaps": "^2.6.1",
     "gulp-tslint": "^8.1.1",
     "gulp-typescript": "^3.2.2",
     "gulp-util": "^3.0.8",
+    "jsdoc": "^3.3.2",
     "jshint": "^2.9.5",
     "merge2": "^1.1.0",
     "mocha": "^3.5.3",
+    "mocha-jenkins-reporter": "^0.3.9",
     "through2": "^2.0.3",
     "tslint": "^5.5.0",
     "typescript": "^2.5.1"

--- a/packages/grpc-native-core/gulpfile.js
+++ b/packages/grpc-native-core/gulpfile.js
@@ -4,6 +4,7 @@ const help = require('gulp-help');
 // gulp-help monkeypatches tasks to have an additional description parameter
 const gulp = help(_gulp);
 
+const jsdoc = require('gulp-jsdoc3');
 const jshint = require('gulp-jshint');
 const mocha = require('gulp-mocha');
 const execa = require('execa');
@@ -46,4 +47,10 @@ gulp.task('native.core.build', 'Build native package', () => {
 
 gulp.task('native.core.test', 'Run all tests', ['native.core.build'], () => {
   return gulp.src(`${testDir}/*.js`).pipe(mocha({reporter: 'mocha-jenkins-reporter'}));
+});
+
+gulp.task('native.core.doc.gen', 'Generate docs', (cb) => {
+  var config = require('./jsdoc_conf.json');
+  gulp.src([`${nativeCoreDir}/README.md`, `${nativeCoreDir}/index.js`, `${srcDir}/*.js`], {read: false})
+      .pipe(jsdoc(config, cb));
 });

--- a/packages/grpc-native-core/jsdoc_conf.json
+++ b/packages/grpc-native-core/jsdoc_conf.json
@@ -2,14 +2,8 @@
   "tags": {
     "allowUnknownTags": true
   },
-  "source": {
-    "include": [ "src/node/index.js", "src/node/src" ],
-    "includePattern": "src/node/.+\\.js(doc)?$",
-    "excludePattern": "(^|\\/|\\\\)_"
-  },
   "opts": {
-    "package": "package.json",
-    "readme": "src/node/README.md"
+    "destination": "docs/gen/native/core"
   },
   "plugins": ["plugins/markdown"],
   "templates": {

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -19,10 +19,7 @@
     "lib": "src/node/src"
   },
   "scripts": {
-    "lint": "node ./node_modules/jshint/bin/jshint src test index.js --exclude-path=.jshintignore",
-    "test": "./node_modules/.bin/mocha test && npm run-script lint",
     "electron-build": "./node_modules/.bin/node-pre-gyp configure build --runtime=electron --disturl=https://atom.io/download/atom-shell",
-    "gen_docs": "./node_modules/.bin/jsdoc -c jsdoc_conf.json",
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha test",
     "install": "./node_modules/.bin/node-pre-gyp install --fallback-to-build --library=static_library"
   },
@@ -37,16 +34,9 @@
     "protobufjs": "^5.0.0"
   },
   "devDependencies": {
-    "async": "^2.0.1",
-    "body-parser": "^1.15.2",
     "electron-mocha": "^3.1.1",
-    "express": "^4.14.0",
-    "google-auth-library": "^0.9.2",
     "google-protobuf": "^3.0.0",
-    "istanbul": "^0.4.4",
-    "jsdoc": "^3.3.2",
-    "minimist": "^1.1.0",
-    "poisson-process": "^0.2.1"
+    "istanbul": "^0.4.4"
   },
   "engines": {
     "node": ">=4"

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -19,6 +19,7 @@
     "lib": "src/node/src"
   },
   "scripts": {
+    "build": "./node_modules/.bin/node-pre-gyp build",
     "electron-build": "./node_modules/.bin/node-pre-gyp configure build --runtime=electron --disturl=https://atom.io/download/atom-shell",
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha test",
     "install": "./node_modules/.bin/node-pre-gyp install --fallback-to-build --library=static_library"

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -21,6 +21,7 @@
       "lib": "src/node/src"
     },
     "scripts": {
+      "build": "./node_modules/.bin/node-pre-gyp build",
       "electron-build": "./node_modules/.bin/node-pre-gyp configure build --runtime=electron --disturl=https://atom.io/download/atom-shell",
       "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha test",
       "install": "./node_modules/.bin/node-pre-gyp install --fallback-to-build --library=static_library"

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -21,10 +21,7 @@
       "lib": "src/node/src"
     },
     "scripts": {
-      "lint": "node ./node_modules/jshint/bin/jshint src test index.js --exclude-path=.jshintignore",
-      "test": "./node_modules/.bin/mocha test && npm run-script lint",
       "electron-build": "./node_modules/.bin/node-pre-gyp configure build --runtime=electron --disturl=https://atom.io/download/atom-shell",
-      "gen_docs": "./node_modules/.bin/jsdoc -c jsdoc_conf.json",
       "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha test",
       "install": "./node_modules/.bin/node-pre-gyp install --fallback-to-build --library=static_library"
     },
@@ -39,19 +36,9 @@
       "protobufjs": "^5.0.0"
     },
     "devDependencies": {
-      "async": "^2.0.1",
-      "body-parser": "^1.15.2",
       "electron-mocha": "^3.1.1",
-      "express": "^4.14.0",
-      "google-auth-library": "^0.9.2",
       "google-protobuf": "^3.0.0",
-      "istanbul": "^0.4.4",
-      "jsdoc": "^3.3.2",
-      "jshint": "^2.5.0",
-      "minimist": "^1.1.0",
-      "mocha": "^3.0.2",
-      "mocha-jenkins-reporter": "^0.2.3",
-      "poisson-process": "^0.2.1"
+      "istanbul": "^0.4.4"
     },
     "engines": {
       "node": ">=4"

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -33,8 +33,7 @@ gulp.task('internal.test.clean.links', 'Delete npm links', () => {
 });
 
 gulp.task('internal.test.install', 'Install test dependencies', () => {
-  return execa('npm', ['install', '--build-from-source', '--unsafe-perm'],
-               {cwd: testDir, stdio: 'inherit'});
+  return execa('npm', ['install'], {cwd: testDir, stdio: 'inherit'});
 });
 
 gulp.task('internal.test.clean.all', 'Delete all files created by tasks',

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -15,6 +15,11 @@ gulp.task('internal.test.clean.links', 'Delete npm links', () => {
   return del(path.resolve(testDir, 'node_modules/grpc'));
 });
 
+gulp.task('internal.test.install', 'Install test dependencies', () => {
+  return execa('npm', ['install', '--build-from-source', '--unsafe-perm'],
+               {cwd: testDir, stdio: 'inherit'});
+});
+
 gulp.task('internal.test.clean.all', 'Delete all files created by tasks',
 	  ['internal.test.clean.links']);
 

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "grpc-node-test",
+  "version": "0.1.0",
+  "description": "Dummy package for the grpc-node repository tests",
+  "private": true,
+  "keywords": [],
+  "author": {
+    "name": "Google Inc."
+  },
+  "license": "Apache-2.0",
+  "contributors": [
+    {
+      "name": "Google Inc."
+    }
+  ],
+  "dependencies": {
+    "async": "^2.0.1",
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
+    "google-auth-library": "^0.9.2",
+    "lodash": "^4.17.4",
+    "minimist": "^1.1.0",
+    "poisson-process": "^0.2.1"
+  }
+}


### PR DESCRIPTION
This is the convention I'm following for dependencies:

 - For the packages, "dependencies" have runtime dependencies, and "devDependencies" have test dependencies.
 - For the root package, "devDependencies" have scripting dependencies (i.e. stuff that is used in gulpfiles).
 - For the test package, "dependencies" contain runtime test dependencies.

This PR doesn't entirely complete that. The istambul dependency is still in the native package because of SBoudrias/gulp-istanbul#118.