### PR TITLE
Added script to merge jenkins logs per node version

### DIFF
--- a/merge_kokoro_logs.js
+++ b/merge_kokoro_logs.js
@@ -1,0 +1,38 @@
+const xml2js = require('xml2js');
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
+const readDir = util.promisify(fs.readdir);
+
+const rootDir = __dirname;
+
+readDir(rootDir + '/reports')
+    .then((dirNames) =>
+          Promise.all(dirNames.map((dirName) =>
+                                   readDir(path.resolve(rootDir, 'reports', dirName))
+                                   .then((fileNames) =>
+                                         Promise.all(fileNames.map((name) =>
+                                                                   readFile(path.resolve(rootDir, 'reports', dirName, name))
+                                                                   .then((content) => {
+                                                                     let parser = new xml2js.Parser();
+                                                                     const parseString = util.promisify(parser.parseString.bind(parser));
+                                                                     return parseString(content);
+                                                                   })
+                                                                  ))
+                                        )
+                                   .then((objects) => {
+                                     let merged = objects[0];
+                                     merged.testsuites.testsuite = Array.prototype.concat.apply([], objects.map((obj) => obj.testsuites.testsuite));
+                                     let builder = new xml2js.Builder();
+                                     let xml = builder.buildObject(merged);
+                                     let resultName = path.resolve(rootDir, 'reports', dirName, 'sponge_log.xml');
+                                     console.log(`Writing ${resultName}`);
+                                     return writeFile(resultName, xml);
+                                   })
+                                  ))
+         )
+    .catch((error) => {
+      console.error(error);
+    });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "mocha": "^3.5.3",
     "through2": "^2.0.3",
     "tslint": "^5.5.0",
-    "typescript": "^2.5.1"
+    "typescript": "^2.5.1",
+    "xml2js": "^0.4.19"
   },
   "contributors": [
     {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -30,6 +30,7 @@ if [ ! -n "$node_versions" ] ; then
 fi
 
 set +ex
+nvm install 8
 nvm install lts/*
 nvm use lts/*
 set -ex
@@ -43,7 +44,6 @@ mkdir -p reports
 
 for version in ${node_versions}
 do
-  cd $ROOT
   # Install and setup node for the version we want.
   set +ex
   echo "Switching to node version $version"
@@ -59,11 +59,13 @@ do
 
   # Rebuild libraries and run tests.
   JUNIT_REPORT_PATH="reports/node$version/" JUNIT_REPORT_STACK=1 ./node_modules/.bin/gulp native.test || FAILED="true"
-  cd "reports/node$version"
-  for file in * ; do
-    mv $file $(echo $file | sed 's/\(.*\)\.xml/\1_sponge_log.xml/')
-  done
 done
+
+set +ex
+nvm use 8
+set -ex
+
+node merge_kokoro_logs.js
 
 if [ "$FAILED" != "" ]
 then

--- a/test/kokoro/linux.cfg
+++ b/test/kokoro/linux.cfg
@@ -19,6 +19,6 @@ build_file: "grpc-node/kokoro.sh"
 timeout_mins: 60
 action {
   define_artifacts {
-    regex: "github/grpc-node/reports/**"
+    regex: "github/grpc-node/reports/**/sponge_log.xml"
   }
 }

--- a/test/kokoro/macos.cfg
+++ b/test/kokoro/macos.cfg
@@ -19,6 +19,6 @@ build_file: "grpc-node/kokoro.sh"
 timeout_mins: 60
 action {
   define_artifacts {
-    regex: "github/grpc-node/reports/**"
+    regex: "github/grpc-node/reports/**/sponge_log.xml"
   }
 }


### PR DESCRIPTION
Now Kokoro should get just one log per version to fix the issue mentioned in [this comment](https://github.com/grpc/grpc-node/pull/33#issuecomment-331239556)