### PR TITLE
Fix some typos and type links in the jsDocs

### DIFF
--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -67,7 +67,7 @@ grpc.setDefaultRootsPem(fs.readFileSync(SSL_ROOTS_PATH, 'ascii'));
  * @param {(number|string)=} [options.protobufjsVersion='detect'] 5 and 6
  *     respectively indicate that an object from the corresponding version of
  *     Protobuf.js is provided in the value argument. If the option is 'detect',
- *     gRPC wll guess what the version is based on the structure of the value.
+ *     gRPC will guess what the version is based on the structure of the value.
  * @return {Object<string, *>} The resulting gRPC object.
  */
 exports.loadObject = function loadObject(value, options) {

--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -213,7 +213,7 @@ exports.ServerCredentials = grpc.ServerCredentials;
  * Create insecure server credentials
  * @name grpc.ServerCredentials.createInsecure
  * @kind function
- * @return grpc.ServerCredentials
+ * @return {grpc.ServerCredentials}
  */
 
 /**
@@ -234,7 +234,7 @@ exports.ServerCredentials = grpc.ServerCredentials;
  *     the server
  * @param {boolean} [checkClientCertificate=false] Indicates that the server
  *     should request and verify the client's certificates
- * @return grpc.ServerCredentials
+ * @return {grpc.ServerCredentials}
  */
 
 exports.makeGenericClientConstructor = client.makeClientConstructor;

--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -393,8 +393,8 @@ ClientDuplexStream.prototype.getPeer = getPeer;
 
 /**
  * Any client call type
- * @typedef {(ClientUnaryCall|ClientReadableStream|
- *            ClientWritableStream|ClientDuplexStream)}
+ * @typedef {(grpc~ClientUnaryCall|grpc~ClientReadableStream|
+ *            grpc~ClientWritableStream|grpc~ClientDuplexStream)}
  *     grpc.Client~Call
  */
 
@@ -450,7 +450,7 @@ function getCall(channel, method, options) {
  * @memberof grpc
  * @constructor
  * @param {string} address Server address to connect to
- * @param {grpc~ChannelCredentials} credentials Credentials to use to connect to
+ * @param {grpc.credentials~ChannelCredentials} credentials Credentials to use to connect to
  *     the server
  * @param {Object} options Options to apply to channel creation
  */
@@ -929,7 +929,7 @@ exports.makeClientConstructor = function(methods, serviceName,
  * Return the underlying channel object for the specified client
  * @memberof grpc
  * @alias grpc~getClientChannel
- * @param {Client} client The client
+ * @param {grpc.Client} client The client
  * @return {Channel} The channel
  * @see grpc.Client#getChannel
  */
@@ -945,7 +945,7 @@ exports.getClientChannel = function(client) {
  * start connecting if it has not already done so.
  * @memberof grpc
  * @alias grpc~waitForClientReady
- * @param {Client} client The client to wait on
+ * @param {grpc.Client} client The client to wait on
  * @param {grpc~Deadline} deadline When to stop waiting for a connection. Pass
  *     Infinity to wait forever.
  * @param {function(Error)} callback The callback to call when done attempting

--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -929,7 +929,7 @@ exports.makeClientConstructor = function(methods, serviceName,
  * Return the underlying channel object for the specified client
  * @memberof grpc
  * @alias grpc~getClientChannel
- * @param {Client} client
+ * @param {Client} client The client
  * @return {Channel} The channel
  * @see grpc.Client#getChannel
  */

--- a/packages/grpc-native-core/src/common.js
+++ b/packages/grpc-native-core/src/common.js
@@ -145,7 +145,7 @@ exports.defaultGrpcOptions = {
  * a number of milliseconds since the Unix Epoch. If it is Infinity, the
  * deadline will never be reached. If it is -Infinity, the deadline has already
  * passed.
- * @typedef {(number|date)} grpc~Deadline
+ * @typedef {(number|Date)} grpc~Deadline
  */
 
 /**

--- a/packages/grpc-native-core/src/constants.js
+++ b/packages/grpc-native-core/src/constants.js
@@ -139,7 +139,8 @@ exports.status = {
    * a backoff.
    *
    * See litmus test above for deciding between FAILED_PRECONDITION,
-   * ABORTED, and UNAVAILABLE. */
+   * ABORTED, and UNAVAILABLE.
+   */
   UNAVAILABLE: 14,
   /** Unrecoverable data loss or corruption. */
   DATA_LOSS: 15,
@@ -150,7 +151,7 @@ exports.status = {
   UNAUTHENTICATED: 16
 };
 
-/* The comments about propagation bit flags are copied rom
+/* The comments about propagation bit flags are copied from
  * include/grpc/impl/codegen/propagation_bits.h for the purpose of including
  * them in generated documentation.
  */

--- a/packages/grpc-native-core/src/credentials.js
+++ b/packages/grpc-native-core/src/credentials.js
@@ -86,7 +86,7 @@ var _ = require('lodash');
  * @param {Buffer=} private_key The client certificate private key, if
  *     applicable
  * @param {Buffer=} cert_chain The client certificate cert chain, if applicable
- * @return {grpc.credentials.ChannelCredentials} The SSL Credentials object
+ * @return {grpc.credentials~ChannelCredentials} The SSL Credentials object
  */
 exports.createSsl = ChannelCredentials.createSsl;
 
@@ -113,7 +113,7 @@ exports.createSsl = ChannelCredentials.createSsl;
  * @alias grpc.credentials.createFromMetadataGenerator
  * @param {grpc.credentials~generateMetadata} metadata_generator The function
  *     that generates metadata
- * @return {grpc.credentials.CallCredentials} The credentials object
+ * @return {grpc.credentials~CallCredentials} The credentials object
  */
 exports.createFromMetadataGenerator = function(metadata_generator) {
   return CallCredentials.createFromPlugin(function(service_url, cb_data,
@@ -143,7 +143,7 @@ exports.createFromMetadataGenerator = function(metadata_generator) {
  * @alias grpc.credentials.createFromGoogleCredential
  * @param {external:GoogleCredential} google_credential The Google credential
  *     object to use
- * @return {grpc.credentials.CallCredentials} The resulting credentials object
+ * @return {grpc.credentials~CallCredentials} The resulting credentials object
  */
 exports.createFromGoogleCredential = function(google_credential) {
   return exports.createFromMetadataGenerator(function(auth_context, callback) {
@@ -166,10 +166,10 @@ exports.createFromGoogleCredential = function(google_credential) {
  * ChannelCredentials object.
  * @memberof grpc.credentials
  * @alias grpc.credentials.combineChannelCredentials
- * @param {ChannelCredentials} channel_credential The ChannelCredentials to
+ * @param {grpc.credentials~ChannelCredentials} channel_credential The ChannelCredentials to
  *     start with
- * @param {...CallCredentials} credentials The CallCredentials to compose
- * @return ChannelCredentials A credentials object that combines all of the
+ * @param {...grpc.credentials~CallCredentials} credentials The CallCredentials to compose
+ * @return {grpc.credentials~ChannelCredentials} A credentials object that combines all of the
  *     input credentials
  */
 exports.combineChannelCredentials = function(channel_credential) {
@@ -184,8 +184,8 @@ exports.combineChannelCredentials = function(channel_credential) {
  * Combine any number of CallCredentials into a single CallCredentials object
  * @memberof grpc.credentials
  * @alias grpc.credentials.combineCallCredentials
- * @param {...CallCredentials} credentials the CallCredentials to compose
- * @return CallCredentials A credentials object that combines all of the input
+ * @param {...grpc.credentials~CallCredentials} credentials The CallCredentials to compose
+ * @return {grpc.credentials~CallCredentials} A credentials object that combines all of the input
  *     credentials
  */
 exports.combineCallCredentials = function() {
@@ -202,6 +202,6 @@ exports.combineCallCredentials = function() {
  * @memberof grpc.credentials
  * @alias grpc.credentials.createInsecure
  * @kind function
- * @return {ChannelCredentials} The insecure credentials object
+ * @return {grpc.credentials~ChannelCredentials} The insecure credentials object
  */
 exports.createInsecure = ChannelCredentials.createInsecure;

--- a/packages/grpc-native-core/src/metadata.js
+++ b/packages/grpc-native-core/src/metadata.js
@@ -132,7 +132,7 @@ Metadata.prototype.getMap = function() {
 
 /**
  * Clone the metadata object.
- * @return {Metadata} The new cloned object
+ * @return {grpc.Metadata} The new cloned object
  */
 Metadata.prototype.clone = function() {
   var copy = new Metadata();

--- a/packages/grpc-native-core/src/server.js
+++ b/packages/grpc-native-core/src/server.js
@@ -470,7 +470,7 @@ ServerDuplexStream.prototype._write = _write;
 /**
  * Send the initial metadata for a writable stream.
  * @alias grpc~ServerUnaryCall#sendMetadata
- * @param {Metadata} responseMetadata Metadata to send
+ * @param {grpc.Metadata} responseMetadata Metadata to send
  */
 function sendMetadata(responseMetadata) {
   /* jshint validthis: true */


### PR DESCRIPTION
I've come across some typos and missing links in the documentation. They are fixed in this PR.