### PR TITLE
Update the dependency version of node-pre-gyp

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -31,7 +31,7 @@
     "arguejs": "^0.2.3",
     "lodash": "^4.15.0",
     "nan": "^2.0.0",
-    "node-pre-gyp": "^0.6.35",
+    "node-pre-gyp": "^0.6.38",
     "protobufjs": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -33,7 +33,7 @@
       "arguejs": "^0.2.3",
       "lodash": "^4.15.0",
       "nan": "^2.0.0",
-      "node-pre-gyp": "^0.6.35",
+      "node-pre-gyp": "^0.6.38",
       "protobufjs": "^5.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
As requested in grpc/grpc#12798, update the dependency on node-pre-gyp to a version that has fixed the reported vulnerability, to ensure that any future grpc package has at least that version.