### PR TITLE
Update grpc/grpc submodule and package versions to 1.7.0-pre1

### DIFF
--- a/packages/grpc-health-check/package.json
+++ b/packages/grpc-health-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-health-check",
-  "version": "1.7.0-dev",
+  "version": "1.7.0-pre1",
   "author": "Google Inc.",
   "description": "Health check service for use with gRPC",
   "repository": {

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc",
-  "version": "1.7.0-dev",
+  "version": "1.7.0-pre1",
   "author": "Google Inc.",
   "description": "gRPC Library for Node",
   "homepage": "https://grpc.io/",

--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-tools",
-  "version": "1.7.0-dev",
+  "version": "1.7.0-pre1",
   "author": "Google Inc.",
   "description": "Tools for developing with gRPC on Node.js",
   "homepage": "https://grpc.io/",


### PR DESCRIPTION
This is a prerequisite for publishing prerelease packages.