### PR TITLE
Upgrade npm versions for every version of node in test scripts

### DIFF
--- a/run-tests.bat
+++ b/run-tests.bat
@@ -31,6 +31,7 @@ call npm install || goto :error
 for %%v in (4.8.4 6.11.3 7.9.0 8.5.0) do (
   nvm install %%v
   nvm use %%v
+  npm install -g npm
   node -e "console.log(process.versions)"
 
   call .\node_modules\.bin\gulp clean.all || goto :error

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -48,6 +48,7 @@ do
   echo "Switching to node version $version"
   nvm install $version
   nvm use $version
+  npm install -g npm
   set -ex
 
   mkdir -p "reports/node$version"


### PR DESCRIPTION
This will hopefully fix the Windows test failures we've been seeing on some PRs.