### PR TITLE
Add artifact build scripts for native core

### DIFF
--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -208,7 +208,7 @@
           'product_prefix': 'lib',
           'type': 'static_library',
           'cflags': [
-            '-Wimplicit-fallthrough=0'
+            '-Wno-implicit-fallthrough'
           ],
           'dependencies': [
           ],

--- a/packages/grpc-native-core/templates/binding.gyp.template
+++ b/packages/grpc-native-core/templates/binding.gyp.template
@@ -195,7 +195,7 @@
             'product_prefix': 'lib',
             'type': 'static_library',
             'cflags': [
-              '-Wimplicit-fallthrough=0'
+              '-Wno-implicit-fallthrough'
             ],
             'dependencies': [
               % for dep in getattr(lib, 'deps', []):

--- a/packages/grpc-native-core/tools/run_tests/artifacts/build_artifact_node.bat
+++ b/packages/grpc-native-core/tools/run_tests/artifacts/build_artifact_node.bat
@@ -1,0 +1,48 @@
+@rem Copyright 2016 gRPC authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+
+set node_versions=4.0.0 5.0.0 6.0.0 7.0.0 8.0.0
+
+set electron_versions=1.0.0 1.1.0 1.2.0 1.3.0 1.4.0 1.5.0 1.6.0 1.7.0
+
+set PATH=%PATH%;C:\Program Files\nodejs\;%APPDATA%\npm
+
+del /f /q BUILD || rmdir build /s /q
+
+call npm update || goto :error
+
+mkdir -p %ARTIFACTS_OUT%
+
+for %%v in (%node_versions%) do (
+  call .\node_modules\.bin\node-pre-gyp.cmd configure build --target=%%v --target_arch=%1
+
+@rem Try again after removing openssl headers
+  rmdir "%USERPROFILE%\.node-gyp\%%v\include\node\openssl" /S /Q
+  rmdir "%USERPROFILE%\.node-gyp\iojs-%%v\include\node\openssl" /S /Q
+  call .\node_modules\.bin\node-pre-gyp.cmd build package --target=%%v --target_arch=%1 || goto :error
+
+  xcopy /Y /I /S build\stage\* %ARTIFACTS_OUT%\ || goto :error
+)
+
+for %%v in (%electron_versions%) do (
+  cmd /V /C "set "HOME=%USERPROFILE%\electron-gyp" && call .\node_modules\.bin\node-pre-gyp.cmd configure rebuild package --runtime=electron --target=%%v --target_arch=%1 --disturl=https://atom.io/download/electron" || goto :error
+
+  xcopy /Y /I /S build\stage\* %ARTIFACTS_OUT%\ || goto :error
+)
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+goto :EOF
+
+:error
+exit /b 1

--- a/packages/grpc-native-core/tools/run_tests/artifacts/build_artifact_node.sh
+++ b/packages/grpc-native-core/tools/run_tests/artifacts/build_artifact_node.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NODE_TARGET_ARCH=$1
+NODE_TARGET_OS=$2
+source ~/.nvm/nvm.sh
+
+nvm use 8
+set -ex
+
+cd $(dirname $0)/../../..
+
+rm -rf build || true
+
+mkdir -p "${ARTIFACTS_OUT}"
+
+npm update
+
+node_versions=( 4.0.0 5.0.0 6.0.0 7.0.0 8.0.0 )
+
+electron_versions=( 1.0.0 1.1.0 1.2.0 1.3.0 1.4.0 1.5.0 1.6.0 1.7.0 )
+
+for version in ${node_versions[@]}
+do
+  ./node_modules/.bin/node-pre-gyp configure rebuild package --target=$version --target_arch=$NODE_TARGET_ARCH --grpc_alpine=true
+  cp -r build/stage/* "${ARTIFACTS_OUT}"/
+  if [ "$NODE_TARGET_ARCH" == 'x64' ] && [ "$NODE_TARGET_OS" == 'linux' ]
+  then
+    # Cross compile for ARM on x64
+    CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ LD=arm-linux-gnueabihf-g++ ./node_modules/.bin/node-pre-gyp configure rebuild package testpackage --target=$version --target_arch=arm
+    cp -r build/stage/* "${ARTIFACTS_OUT}"/
+  fi
+done
+
+for version in ${electron_versions[@]}
+do
+  HOME=~/.electron-gyp ./node_modules/.bin/node-pre-gyp configure rebuild package --runtime=electron --target=$version --target_arch=$NODE_TARGET_ARCH --disturl=https://atom.io/download/electron
+  cp -r build/stage/* "${ARTIFACTS_OUT}"/
+done

--- a/packages/grpc-native-core/tools/run_tests/artifacts/build_package_node.sh
+++ b/packages/grpc-native-core/tools/run_tests/artifacts/build_package_node.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source ~/.nvm/nvm.sh
+
+nvm use 8
+set -ex
+
+cd $(dirname $0)/../../..
+
+base=$(pwd)
+
+artifacts=$base/artifacts
+
+mkdir -p $artifacts
+cp -r $EXTERNAL_GIT_ROOT/platform={windows,linux,macos}/artifacts/node_ext_*/* $artifacts/ || true
+
+npm update
+npm pack
+
+cp grpc-*.tgz $artifacts/grpc.tgz
+
+mkdir -p bin
+
+cd $base/src/node/health_check
+npm pack
+cp grpc-health-check-*.tgz $artifacts/
+
+cd $base/src/node/tools
+npm update
+npm pack
+cp grpc-tools-*.tgz $artifacts/
+tools_version=$(npm list | grep -oP '(?<=grpc-tools@)\S+')
+
+output_dir=$artifacts/grpc-precompiled-binaries/node/grpc-tools/v$tools_version
+mkdir -p $output_dir
+
+well_known_protos=( any api compiler/plugin descriptor duration empty field_mask source_context struct timestamp type wrappers )
+
+for arch in {x86,x64}; do
+  case $arch in
+    x86)
+      node_arch=ia32
+      ;;
+    *)
+      node_arch=$arch
+      ;;
+  esac
+  for plat in {windows,linux,macos}; do
+    case $plat in
+      windows)
+        node_plat=win32
+        ;;
+      macos)
+        node_plat=darwin
+        ;;
+      *)
+        node_plat=$plat
+        ;;
+    esac
+    rm -r bin/*
+    input_dir="$EXTERNAL_GIT_ROOT/platform=${plat}/artifacts/protoc_${plat}_${arch}"
+    cp $input_dir/protoc* bin/
+    cp $input_dir/grpc_node_plugin* bin/
+    mkdir -p bin/google/protobuf
+    mkdir -p bin/google/protobuf/compiler  # needed for plugin.proto
+    for proto in "${well_known_protos[@]}"; do
+      cp $base/third_party/protobuf/src/google/protobuf/$proto.proto bin/google/protobuf/$proto.proto
+    done
+    tar -czf $output_dir/$node_plat-$node_arch.tar.gz bin/
+  done
+done


### PR DESCRIPTION
This copies the Node artifact build scripts pretty much verbatim to this repo, except that it adds 1.7.0 to the list of electron versions to build for.