### PR TITLE
Manually link packages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,14 +44,8 @@ gulp.task('lint', 'Emit linting errors in source and test files',
 
 gulp.task('build', 'Build packages', ['js.core.compile', 'native.core.build']);
 
-gulp.task('core.link.create', 'Initialize npm links to core packages',
-          ['native.core.link.create', 'js.core.link.create', 'surface.link.create']);
-
 gulp.task('core.link', 'Add links to core packages without rebuilding',
           ['js.link.add', 'native.link.add']);
-
-gulp.task('surface.link.create', 'Create links to surface packages',
-          ['js.link.create', 'native.link.create']);
 
 gulp.task('surface.link', 'Link to surface packages',
           ['health-check.link.add', 'internal.test.link.add']);
@@ -63,7 +57,7 @@ gulp.task('link', 'Link together packages', (callback) => {
    * This also means that 'core.link' is not needed, and the item
    * 'native.core.link.create' should actually be 'core.link.create'
    */
-  runSequence('native.core.link.create', /* 'core.link', 'surface.link.create', */ 'surface.link',
+  runSequence('core.link', 'surface.link',
               callback);
 });
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp-util": "^3.0.8",
     "jsdoc": "^3.3.2",
     "jshint": "^2.9.5",
+    "make-dir": "^1.1.0",
     "merge2": "^1.1.0",
     "mocha": "^3.5.3",
     "mocha-jenkins-reporter": "^0.3.9",

--- a/packages/grpc-health-check/gulpfile.js
+++ b/packages/grpc-health-check/gulpfile.js
@@ -41,7 +41,7 @@ gulp.task('health-check.install', 'Install health check dependencies', () => {
 });
 
 gulp.task('health-check.link.add', 'Link local copy of grpc', () => {
-  linkSync(healthCheckDir, './node_modules/@grpc/native', '../grpc-native');
+  linkSync(healthCheckDir, './node_modules/grpc', '../grpc-native-core');
 });
 
 gulp.task('health-check.test', 'Run health check tests',

--- a/packages/grpc-health-check/gulpfile.js
+++ b/packages/grpc-health-check/gulpfile.js
@@ -21,6 +21,7 @@ const mocha = require('gulp-mocha');
 const execa = require('execa');
 const path = require('path');
 const del = require('del');
+const linkSync = require('../../util').linkSync;
 
 const gulp = help(_gulp);
 
@@ -39,8 +40,8 @@ gulp.task('health-check.install', 'Install health check dependencies', () => {
   return execa('npm', ['install', '--unsafe-perm'], {cwd: healthCheckDir, stdio: 'inherit'});
 });
 
-gulp.task('health-check.link.add', 'Link local copy of grpc', ['health-check.install'], () => {
-  return execa('npm', ['link', 'grpc'], {cwd: healthCheckDir, stdio: 'inherit'});
+gulp.task('health-check.link.add', 'Link local copy of grpc', () => {
+  linkSync(healthCheckDir, './node_modules/@grpc/native', '../grpc-native');
 });
 
 gulp.task('health-check.test', 'Run health check tests',

--- a/packages/grpc-js-core/gulpfile.js
+++ b/packages/grpc-js-core/gulpfile.js
@@ -101,10 +101,6 @@ gulp.task('js.core.install', 'Install native core dependencies', () => {
   return execa('npm', ['install', '--unsafe-perm'], {cwd: jsCoreDir, stdio: 'inherit'});
 });
 
-gulp.task('js.core.link.create', 'Create npm link', () => {
-  return execa('npm', ['link'], {cwd: jsCoreDir, stdio: 'inherit'});
-});
-
 /**
  * Runs tslint on files in src/, with linting rules defined in tslint.json.
  */

--- a/packages/grpc-js/gulpfile.js
+++ b/packages/grpc-js/gulpfile.js
@@ -24,6 +24,7 @@ const gulp = help(_gulp);
 const execa = require('execa');
 const path = require('path');
 const del = require('del');
+const linkSync = require('../../util').linkSync;
 
 const jsDir = __dirname;
 
@@ -39,11 +40,7 @@ gulp.task('js.install', 'Install dependencies', () => {
   return execa('npm', ['install', '--unsafe-perm'], {cwd: jsDir, stdio: 'inherit'});
 });
 
-gulp.task('js.link.create', 'Create npm link', () => {
-  return execa('npm', ['link'], {cwd: jsDir, stdio: 'inherit'});
-});
-
 gulp.task('js.link.add', 'Link local copies of dependencies', () => {
-  return execa('npm', ['link', '@grpc/js-core'], {cwd: jsDir, stdio: 'inherit'}).then(
-      execa('npm', ['link', '@grpc/surface'], {cwd: jsDir, stdio: 'inherit'}));
+  linkSync(jsDir, './node_modules/@grpc/js-core', '../grpc-js-core');
+  linkSync(jsDir, './node_modules/@grpc/surface', '../grpc-surface');
 });

--- a/packages/grpc-native-core/gulpfile.js
+++ b/packages/grpc-native-core/gulpfile.js
@@ -57,10 +57,6 @@ execa('npm', ['install', '--build-from-source'],
                ))
 });
 
-gulp.task('native.core.link.create', 'Create npm link', () => {
-  return execa('npm', ['link'], {cwd: nativeCoreDir, stdio: 'inherit'});
-});
-
 gulp.task('native.core.lint', 'Emits linting errors', () => {
   return gulp.src([`${nativeCoreDir}/index.js`, `${srcDir}/*.js`, `${testDir}/*.js`])
       .pipe(jshint(pkg.jshintConfig))

--- a/packages/grpc-native/gulpfile.js
+++ b/packages/grpc-native/gulpfile.js
@@ -24,6 +24,7 @@ const gulp = help(_gulp);
 const execa = require('execa');
 const path = require('path');
 const del = require('del');
+const linkSync = require('../../util').linkSync;
 
 const nativeDir = __dirname;
 
@@ -35,16 +36,11 @@ gulp.task('native.clean.links', 'Delete npm links', () => {
 gulp.task('native.clean.all', 'Delete all files created by tasks',
           ['native.clean.links']);
 
-gulp.task('native.link.create', 'Create npm link', () => {
-  return execa('npm', ['link'], {cwd: nativeDir, stdio: 'inherit'});
-});
-
 gulp.task('native.install', 'Install dependencies', () => {
   return execa('npm', ['install', '--unsafe-perm'], {cwd: nativeDir, stdio: 'inherit'});
 });
 
 gulp.task('native.link.add', 'Link local copies of dependencies', () => {
-  // Note: this should be 'grpc-native-core', when we change that package name
-  return execa('npm', ['link', 'grpc'], {cwd: nativeDir, stdio: 'inherit'}).then(
-      execa('npm', ['link', '@grpc/surface'], {cwd: nativeDir, stdio: 'inherit'}));
+  linkSync(nativeDir, './node_modules/grpc', '../grpc-native-core');
+  linkSync(nativeDir, './node_modules/@grpc/surface', '../grpc-surface');
 });

--- a/packages/grpc-surface/gulpfile.js
+++ b/packages/grpc-surface/gulpfile.js
@@ -25,6 +25,4 @@ const execa = require('execa');
 
 const surfaceDir = __dirname;
 
-gulp.task('surface.link.create', 'Create npm link', () => {
-  return execa('npm', ['link'], {cwd: surfaceDir, stdio: 'inherit'});
-});
+// more to come

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -45,7 +45,7 @@ gulp.task('internal.test.clean.all', 'Delete all files created by tasks',
 
 gulp.task('internal.test.link.add', 'Link local copies of dependencies', () => {
   linkSync(testDir, './node_modules/@grpc/js', '../packages/grpc-js');
-  linkSync(testDir, './node_modules/@grpc/native', '../packages/grpc-native');
+  linkSync(testDir, './node_modules/grpc', '../packages/grpc-native-core');
 });
 
 gulp.task('internal.test.test', 'Run API-level tests', () => {

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -21,6 +21,7 @@ const mocha = require('gulp-mocha');
 const execa = require('execa');
 const path = require('path');
 const del = require('del');
+const linkSync = require('../util').linkSync;
 
 // gulp-help monkeypatches tasks to have an additional description parameter
 const gulp = help(_gulp);
@@ -29,7 +30,10 @@ const testDir = __dirname;
 const apiTestDir = path.resolve(testDir, 'api');
 
 gulp.task('internal.test.clean.links', 'Delete npm links', () => {
-  return del(path.resolve(testDir, 'node_modules/grpc'));
+  return del([
+    path.resolve(testDir, 'node_modules/@grpc/js'),
+    path.resolve(testDir, 'node_modules/@grpc/native')
+  ]);
 });
 
 gulp.task('internal.test.install', 'Install test dependencies', () => {
@@ -39,8 +43,9 @@ gulp.task('internal.test.install', 'Install test dependencies', () => {
 gulp.task('internal.test.clean.all', 'Delete all files created by tasks',
 	  ['internal.test.clean.links']);
 
-gulp.task('internal.test.link.add', 'Link local copies of grpc packages', () => {
-  return execa('npm', ['link', 'grpc'], {cwd: testDir, stdio: 'inherit'});
+gulp.task('internal.test.link.add', 'Link local copies of dependencies', () => {
+  linkSync(testDir, './node_modules/@grpc/js', '../packages/grpc-js');
+  linkSync(testDir, './node_modules/@grpc/native', '../packages/grpc-native');
 });
 
 gulp.task('internal.test.test', 'Run API-level tests', () => {

--- a/util.js
+++ b/util.js
@@ -9,11 +9,11 @@ const linkSync = (base, from, to) => {
   to = path.resolve(base, to);
   try {
     fs.lstatSync(from);
-  } catch (e) {
     console.log('link: deleting', from);
     del.sync(from);
+  } catch (e) {
+    makeDir.sync(path.dirname(from));
   }
-  makeDir.sync(path.dirname(from));
   console.log('link: linking', from, '->', to);
   fs.symlinkSync(to, from, 'junction');
 };

--- a/util.js
+++ b/util.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const del = require('del');
+const fs = require('fs');
+const makeDir = require('make-dir');
+
+// synchronously link a module
+const linkSync = (base, from, to) => {
+  from = path.resolve(base, from);
+  to = path.resolve(base, to);
+  try {
+    fs.lstatSync(from);
+  } catch (e) {
+    console.log('link: deleting', from);
+    del.sync(from);
+  }
+  makeDir.sync(path.dirname(from));
+  console.log('link: linking', from, '->', to);
+  fs.symlinkSync(to, from, 'junction');
+};
+
+module.exports = {
+  linkSync
+};


### PR DESCRIPTION
This change removes `npm link` calls in favor of single-link-chain symlinks between modules.