### PR TITLE
Include index.d.ts in the published npm package

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -16,7 +16,7 @@
     }
   ],
   "directories": {
-    "lib": "src/node/src"
+    "lib": "src"
   },
   "scripts": {
     "build": "./node_modules/.bin/node-pre-gyp build",
@@ -53,6 +53,7 @@
     "README.md",
     "deps/grpc/etc/",
     "index.js",
+    "index.d.ts",
     "src/*.js",
     "ext/*.{cc,h}",
     "deps/grpc/include/grpc/**/*.h",
@@ -66,7 +67,7 @@
     "binding.gyp"
   ],
   "main": "index.js",
-  "typings": "src/index.d.ts",
+  "typings": "index.d.ts",
   "license": "Apache-2.0",
   "jshintConfig": {
     "bitwise": true,


### PR DESCRIPTION
I tried using `grpc@1.7.0-pre1` expecting to use the types written for #52, but `index.d.ts` isn't published.

I also did another couple of minor corrections in `package.json`.