### PR TITLE
Build different binaries for different libc’s (a.k.a. support alpine linux)

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -31,7 +31,7 @@
     "arguejs": "^0.2.3",
     "lodash": "^4.15.0",
     "nan": "^2.0.0",
-    "node-pre-gyp": "^0.6.35",
+    "node-pre-gyp": "^0.6.39",
     "protobufjs": "^5.0.0"
   },
   "devDependencies": {
@@ -43,10 +43,10 @@
   },
   "binary": {
     "module_name": "grpc_node",
-    "module_path": "src/node/extension_binary/{node_abi}-{platform}-{arch}",
+    "module_path": "src/node/extension_binary/{node_abi}-{platform}-{arch}-{libc}",
     "host": "https://storage.googleapis.com/",
     "remote_path": "grpc-precompiled-binaries/node/{name}/v{version}",
-    "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
+    "package_name": "{node_abi}-{platform}-{arch}-{libc}.tar.gz"
   },
   "files": [
     "LICENSE",

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -45,10 +45,10 @@
     },
     "binary": {
       "module_name": "grpc_node",
-      "module_path": "src/node/extension_binary/{node_abi}-{platform}-{arch}",
+      "module_path": "src/node/extension_binary/{node_abi}-{platform}-{arch}-{libc}",
       "host": "https://storage.googleapis.com/",
       "remote_path": "grpc-precompiled-binaries/node/{name}/v{version}",
-      "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
+      "package_name": "{node_abi}-{platform}-{arch}-{libc}.tar.gz"
     },
     "files": [
       "LICENSE",


### PR DESCRIPTION
The latest version of node-pre-gyp supports using `libc` as a variable for binary names, making it possible to differentiate between glibc and musl of alpine linux.

Fixes #81.

