### PR TITLE
Fixed name of ServerCredentials.createSsl in native docs & types.

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -527,7 +527,7 @@ declare module "grpc" {
      * Defaults to `false`.
      * @return The ServerCredentials
      */
-    static createInsecure(rootCerts: Buffer | null, keyCertPairs: KeyCertPair[], checkClientCertificate?: boolean): ServerCredentials;
+    static createSsl(rootCerts: Buffer | null, keyCertPairs: KeyCertPair[], checkClientCertificate?: boolean): ServerCredentials;
   }
 
   /**

--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -225,7 +225,7 @@ exports.ServerCredentials = grpc.ServerCredentials;
 
 /**
  * Create SSL server credentials
- * @name grpc.ServerCredentials.createInsecure
+ * @name grpc.ServerCredentials.createSsl
  * @kind function
  * @param {?Buffer} rootCerts Root CA certificates for validating client
  *     certificates


### PR DESCRIPTION
The docs and typings had a duplicate method on ServerCredentials, both called `createInsecure`. I've updated them to have the correct name (createSsl).
