### PR TITLE
Remove now-incorrect assertion in completion queue wrapper

### DIFF
--- a/packages/grpc-native-core/ext/completion_queue.cc
+++ b/packages/grpc-native-core/ext/completion_queue.cc
@@ -64,7 +64,6 @@ grpc_completion_queue *GetCompletionQueue() { return queue; }
 
 void CompletionQueueNext() {
   if (pending_batches == 0) {
-    GPR_ASSERT(!uv_is_active((uv_handle_t *)&prepare));
     uv_prepare_start(&prepare, drain_completion_queue);
   }
   pending_batches++;


### PR DESCRIPTION
After adding the `CompletionQueueForcePoll` method to make `waitForReady` work properly, this assertion is no longer correct.

This fixes #91.