### PR TITLE
Update the submodule and unskip previously failing test

### DIFF
--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -683,7 +683,6 @@
         'deps/grpc/src/core/lib/http/httpcli.cc',
         'deps/grpc/src/core/lib/http/parser.cc',
         'deps/grpc/src/core/lib/iomgr/call_combiner.cc',
-        'deps/grpc/src/core/lib/iomgr/closure.cc',
         'deps/grpc/src/core/lib/iomgr/combiner.cc',
         'deps/grpc/src/core/lib/iomgr/endpoint.cc',
         'deps/grpc/src/core/lib/iomgr/endpoint_pair_posix.cc',

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -31,7 +31,7 @@
     "arguejs": "^0.2.3",
     "lodash": "^4.15.0",
     "nan": "^2.0.0",
-    "node-pre-gyp": "^0.6.39",
+    "node-pre-gyp": "^0.6.35",
     "protobufjs": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/grpc-native-core/test/channel_test.js
+++ b/packages/grpc-native-core/test/channel_test.js
@@ -132,8 +132,7 @@ describe('channel', function() {
                          grpc.connectivityState.IDLE);
     });
   });
-  // This suite test appears to be triggering grpc/grpc#12932; skipping for now
-  describe.skip('watchConnectivityState', function() {
+  describe('watchConnectivityState', function() {
     var channel;
     beforeEach(function() {
       channel = new grpc.Channel('localhost', insecureCreds, {});


### PR DESCRIPTION
This points the submodule at grpc/grpc#13433 in order to test those changes against this repo. The submodule will have to be updated again once that PR is merged.