### PR TITLE
grpc-js-core: compiler error and http2-facing fixes

### DIFF
--- a/packages/grpc-js-core/src/call-credentials.ts
+++ b/packages/grpc-js-core/src/call-credentials.ts
@@ -3,7 +3,7 @@ import {map, reduce} from 'lodash';
 import {Metadata} from './metadata';
 
 export type CallMetadataGenerator =
-    (options: Object, cb: (err: Error|null, metadata?: Metadata) => void) =>
+    (options: {}, cb: (err: Error|null, metadata?: Metadata) => void) =>
         void;
 
 /**
@@ -15,7 +15,7 @@ export interface CallCredentials {
    * Asynchronously generates a new Metadata object.
    * @param options Options used in generating the Metadata object.
    */
-  generateMetadata(options: Object): Promise<Metadata>;
+  generateMetadata(options: {}): Promise<Metadata>;
   /**
    * Creates a new CallCredentials object from properties of both this and
    * another CallCredentials object. This object's metadata generator will be
@@ -28,7 +28,7 @@ export interface CallCredentials {
 class ComposedCallCredentials implements CallCredentials {
   constructor(private creds: CallCredentials[]) {}
 
-  async generateMetadata(options: Object): Promise<Metadata> {
+  async generateMetadata(options: {}): Promise<Metadata> {
     let base: Metadata = new Metadata();
     let generated: Metadata[] = await Promise.all(
         map(this.creds, (cred) => cred.generateMetadata(options)));
@@ -46,7 +46,7 @@ class ComposedCallCredentials implements CallCredentials {
 class SingleCallCredentials implements CallCredentials {
   constructor(private metadataGenerator: CallMetadataGenerator) {}
 
-  async generateMetadata(options: Object): Promise<Metadata> {
+  async generateMetadata(options: {}): Promise<Metadata> {
     return new Promise<Metadata>((resolve, reject) => {
       this.metadataGenerator(options, (err, metadata) => {
         if (metadata !== undefined) {
@@ -64,7 +64,7 @@ class SingleCallCredentials implements CallCredentials {
 }
 
 class EmptyCallCredentials implements CallCredentials {
-  async generateMetadata(options: Object): Promise<Metadata> {
+  async generateMetadata(options: {}): Promise<Metadata> {
     return new Metadata();
   }
 

--- a/packages/grpc-js-core/src/client.ts
+++ b/packages/grpc-js-core/src/client.ts
@@ -24,7 +24,7 @@ export class Client {
     }
     // TODO(murgatroid99): Figure out how to get version number
     // options['grpc.primary_user_agent'] += 'grpc-node/' + version;
-    this.channel = new Http2Channel(new URL(address), credentials, options);
+    this.channel = new Http2Channel(address, credentials, options);
   }
 
   close(): void {

--- a/packages/grpc-js-core/src/metadata.ts
+++ b/packages/grpc-js-core/src/metadata.ts
@@ -166,6 +166,7 @@ export class Metadata {
    * Creates an OutgoingHttpHeaders object that can be used with the http2 API.
    */
   toHttp2Headers(): http2.OutgoingHttpHeaders {
+    // NOTE: Node <8.9 formats http2 headers incorrectly.
     const result: http2.OutgoingHttpHeaders = {};
     forOwn(this.internalRepr, (values, key) => {
       // We assume that the user's interaction with this object is limited to

--- a/packages/grpc-js-core/src/metadata.ts
+++ b/packages/grpc-js-core/src/metadata.ts
@@ -194,7 +194,7 @@ export class Metadata {
           values.forEach((value) => {
             result.add(key, Buffer.from(value, 'base64'));
           });
-        } else {
+        } else if (values !== undefined) {
           result.add(key, Buffer.from(values, 'base64'));
         }
       } else {
@@ -202,7 +202,7 @@ export class Metadata {
           values.forEach((value) => {
             result.add(key, value);
           });
-        } else {
+        } else if (values !== undefined) {
           result.add(key, values);
         }
       }


### PR DESCRIPTION
`channel.ts` - We need to append the protocol to the incoming address parameter before it's turned into a `URL` (instead of after) - otherwise the hostname will be parsed as the protocol.

`call-credentials.ts`/`client.ts` - Google TS style guide prohibits use of `Object` types

`call-stream.ts` - `headers` doesn't have `Object` prototype functions, so `headers.hasOwnProperty` fails. Also, destroying an http2 stream twice causes problems

`metadata.ts` - compiler complains about `values` being undefined, also I added a note on Node 8.8 serializing headers incorrectly