### PR TITLE
Add error code name to status error messages

### DIFF
--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -61,10 +61,11 @@ var version = require('../package.json').version;
  */
 function createStatusError(status) {
   let statusName = _.invert(constants.status)[status.code];
-  let message = `${status.code} ${status.name}: ${status.details}`;
+  let message = `${status.code} ${statusName}: ${status.details}`;
   let error = new Error(message);
   error.code = status.code;
   error.metadata = status.metadata;
+  error.details = status.details;
   return error;
 }
 

--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -64,7 +64,7 @@ function createStatusError(status) {
   let message = `${status.code} ${status.name}: ${status.details}`;
   let error = new Error(message);
   error.code = status.code;
-  error.details = status.details;
+  error.metadata = status.metadata;
   return error;
 }
 

--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -54,6 +54,21 @@ var util = require('util');
 var version = require('../package.json').version;
 
 /**
+ * Create an Error object from a status object
+ * @private
+ * @param {grpc~StatusObject} status The status object
+ * @return {Error} The resulting Error
+ */
+function createStatusError(status) {
+  let statusName = _.invert(constants.status)[status.code];
+  let message = `${status.code} ${status.name}: ${status.details}`;
+  let error = new Error(message);
+  error.code = status.code;
+  error.details = status.details;
+  return error;
+}
+
+/**
  * Initial response metadata sent by the server when it starts processing the
  * call
  * @event grpc~ClientUnaryCall#metadata
@@ -252,9 +267,7 @@ function _emitStatusIfDone() {
     if (status.code === constants.status.OK) {
       this.push(null);
     } else {
-      var error = new Error(status.details);
-      error.code = status.code;
-      error.metadata = status.metadata;
+      var error = createStatusError(status);
       this.emit('error', error);
     }
     this.emit('status', status);
@@ -551,9 +564,7 @@ Client.prototype.makeUnaryRequest = function(method, serialize, deserialize,
       }
     }
     if (status.code !== constants.status.OK) {
-      error = new Error(status.details);
-      error.code = status.code;
-      error.metadata = status.metadata;
+      error = new createStatusError(status);
       args.callback(error);
     } else {
       args.callback(null, deserialized);
@@ -634,9 +645,7 @@ Client.prototype.makeClientStreamRequest = function(method, serialize,
       }
     }
     if (status.code !== constants.status.OK) {
-      error = new Error(response.status.details);
-      error.code = status.code;
-      error.metadata = status.metadata;
+      error = createStatusError(status);
       args.callback(error);
     } else {
       args.callback(null, deserialized);

--- a/test/api/credentials_test.js
+++ b/test/api/credentials_test.js
@@ -319,7 +319,7 @@ describe('client credentials', function() {
                             client_options);
     client.unary({}, function(err, data) {
       assert(err);
-      assert.strictEqual(err.message,
+      assert.strictEqual(err.details,
                          'Getting metadata from plugin failed with error: ' +
                          'Authentication error');
       assert.strictEqual(err.code, grpc.status.UNAUTHENTICATED);
@@ -369,7 +369,7 @@ describe('client credentials', function() {
                             client_options);
     client.unary({}, function(err, data) {
       assert(err);
-      assert.strictEqual(err.message,
+      assert.strictEqual(err.details,
                          'Getting metadata from plugin failed with error: ' +
                          'Authentication failure');
       done();

--- a/test/api/surface_test.js
+++ b/test/api/surface_test.js
@@ -981,7 +981,7 @@ describe('Other conditions', function() {
       client.unary({error: true}, function(err, data) {
         assert(err);
         assert.strictEqual(err.code, grpc.status.UNKNOWN);
-        assert.strictEqual(err.message, 'Requested error');
+        assert.strictEqual(err.details, 'Requested error');
         done();
       });
     });
@@ -989,7 +989,7 @@ describe('Other conditions', function() {
       var call = client.clientStream(function(err, data) {
         assert(err);
         assert.strictEqual(err.code, grpc.status.UNKNOWN);
-        assert.strictEqual(err.message, 'Requested error');
+        assert.strictEqual(err.details, 'Requested error');
         done();
       });
       call.write({error: false});
@@ -1001,7 +1001,7 @@ describe('Other conditions', function() {
       call.on('data', function(){});
       call.on('error', function(error) {
         assert.strictEqual(error.code, grpc.status.UNKNOWN);
-        assert.strictEqual(error.message, 'Requested error');
+        assert.strictEqual(error.details, 'Requested error');
         done();
       });
     });
@@ -1013,7 +1013,7 @@ describe('Other conditions', function() {
       call.on('data', function(){});
       call.on('error', function(error) {
         assert.strictEqual(error.code, grpc.status.UNKNOWN);
-        assert.strictEqual(error.message, 'Requested error');
+        assert.strictEqual(error.details, 'Requested error');
         done();
       });
     });

--- a/test/interop/interop_client.js
+++ b/test/interop/interop_client.js
@@ -347,7 +347,7 @@ function statusCodeAndMessage(client, done) {
   client.unaryCall(arg, function(err, resp) {
     assert(err);
     assert.strictEqual(err.code, 2);
-    assert.strictEqual(err.message, 'test status message');
+    assert.strictEqual(err.details, 'test status message');
     done();
   });
   var duplex = client.fullDuplexCall();


### PR DESCRIPTION
We frequently get questions that reference status errors, but they almost never realize that the `code` is important or know what it means. This adds the status code number and name to the error message.