### PR TITLE
test: enable testing for grpc-js

### DIFF
--- a/test/api/async_test.js
+++ b/test/api/async_test.js
@@ -20,8 +20,8 @@
 
 var assert = require('assert');
 
-var grpc = require('../any_grpc');
-var math = grpc.load(
+var anyGrpc = require('../any_grpc');
+var math = anyGrpc.client.load(
     __dirname + '/../../packages/grpc-native-core/deps/grpc/src/proto/math/math.proto').math;
 
 
@@ -33,21 +33,21 @@ var math_client;
 /**
  * Server to test against
  */
-var getServer = require('./math/math_server.js');
+var getServer = anyGrpc.requireAsServer('./math/math_server.js');
 
 var server = getServer();
 
 describe('Async functionality', function() {
   before(function(done) {
     var port_num = server.bind('0.0.0.0:0',
-                               grpc.ServerCredentials.createInsecure());
+                               anyGrpc.server.ServerCredentials.createInsecure());
     server.start();
     math_client = new math.Math('localhost:' + port_num,
-                                grpc.credentials.createInsecure());
+                                anyGrpc.client.credentials.createInsecure());
     done();
   });
   after(function() {
-    grpc.closeClient(math_client);
+    anyGrpc.client.closeClient(math_client);
     server.forceShutdown();
   });
   it('should not hang', function(done) {
@@ -77,7 +77,7 @@ describe('Async functionality', function() {
     });
 
     call.on('status', function checkStatus(status) {
-      assert.strictEqual(status.code, grpc.status.OK);
+      assert.strictEqual(status.code, anyGrpc.client.status.OK);
       done();
     });
   });

--- a/test/api/credentials_api_test.js
+++ b/test/api/credentials_api_test.js
@@ -22,7 +22,7 @@ var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
 
-var grpc = require('../any_grpc');
+var anyGrpc = require('../any_grpc');
 
 var key_data, pem_data, ca_data;
 
@@ -36,6 +36,7 @@ before(function() {
 });
 
 describe('channel credentials', function() {
+  var grpc = anyGrpc.requireAsClient('grpc');
   describe('#createSsl', function() {
     it('works with no arguments', function() {
       var creds;
@@ -92,6 +93,7 @@ describe('channel credentials', function() {
 });
 
 describe('server credentials', function() {
+  var grpc = anyGrpc.requireAsServer('grpc');
   describe('#createSsl', function() {
     it('accepts a buffer and array as the first 2 arguments', function() {
       var creds;

--- a/test/api/file_load_test.js
+++ b/test/api/file_load_test.js
@@ -19,7 +19,7 @@
 'use strict';
 
 var assert = require('assert');
-var grpc = require('../any_grpc');
+var grpc = require('../any_grpc').requireAsClient('grpc');
 
 describe('File loader', function() {
   it('Should load a proto file by default', function() {

--- a/test/api/interop_sanity_test.js
+++ b/test/api/interop_sanity_test.js
@@ -18,8 +18,9 @@
 
 'use strict';
 
-var interop_server = require('../interop/interop_server.js');
-var interop_client = require('../interop/interop_client.js');
+var anyGrpc = require('../any_grpc');
+var interop_server = anyGrpc.requireAsServer('../interop/interop_server.js');
+var interop_client = anyGrpc.requireAsClient('../interop/interop_client.js');
 
 var server;
 

--- a/test/api/math/math_client.js
+++ b/test/api/math/math_client.js
@@ -1,0 +1,10 @@
+const proxyquire = require('proxyquire');
+
+module.exports = function getMathClientConstructor(grpc) {
+  const makeGenericClientConstructor = proxyquire('./math_grpc_pb', {
+    // note: this mutates the incoming grpc object.
+    // for or purposes it's unlikely to matter, though.
+    grpc: Object.assign(grpc, {'@noCallThru': true})
+  });
+  return makeGenericClientConstructor();
+}

--- a/test/api/math/math_grpc_pb.js
+++ b/test/api/math/math_grpc_pb.js
@@ -16,7 +16,7 @@
 // limitations under the License.
 //
 'use strict';
-var grpc = require('../../any_grpc.js');
+var grpc = require('grpc');
 var math_math_pb = require('../math/math_pb.js');
 
 function serialize_DivArgs(arg) {

--- a/test/api/math/math_server.js
+++ b/test/api/math/math_server.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-var grpc = require('../../any_grpc.js');
+var grpc = require('grpc');
 var grpcMath = require('./math_grpc_pb');
 var math = require('./math_pb');
 

--- a/test/api/math_client_test.js
+++ b/test/api/math_client_test.js
@@ -20,9 +20,9 @@
 
 var assert = require('assert');
 
-var grpc = require('../any_grpc');
+var anyGrpc = require('../any_grpc');
 var math = require('./math/math_pb');
-var MathClient = require('./math/math_grpc_pb').MathClient;
+var MathClient = anyGrpc.requireAsClient('./math/math_grpc_pb').MathClient;
 
 /**
  * Client to use to make requests to a running server.
@@ -32,17 +32,17 @@ var math_client;
 /**
  * Server to test against
  */
-var getServer = require('./math/math_server.js');
+var getServer = anyGrpc.requireAsServer('./math/math_server.js');
 
 var server = getServer();
 
 describe('Math client', function() {
   before(function(done) {
     var port_num = server.bind('0.0.0.0:0',
-                               grpc.ServerCredentials.createInsecure());
+        anyGrpc.server.ServerCredentials.createInsecure());
     server.start();
     math_client = new MathClient('localhost:' + port_num,
-                                 grpc.credentials.createInsecure());
+        anyGrpc.client.credentials.createInsecure());
     done();
   });
   after(function() {
@@ -79,7 +79,7 @@ describe('Math client', function() {
       next_expected += 1;
     });
     call.on('status', function checkStatus(status) {
-      assert.strictEqual(status.code, grpc.status.OK);
+      assert.strictEqual(status.code, anyGrpc.client.status.OK);
       done();
     });
   });
@@ -95,7 +95,7 @@ describe('Math client', function() {
     }
     call.end();
     call.on('status', function checkStatus(status) {
-      assert.strictEqual(status.code, grpc.status.OK);
+      assert.strictEqual(status.code, anyGrpc.client.status.OK);
       done();
     });
   });
@@ -118,7 +118,7 @@ describe('Math client', function() {
     }
     call.end();
     call.on('status', function checkStatus(status) {
-      assert.strictEqual(status.code, grpc.status.OK);
+      assert.strictEqual(status.code, anyGrpc.client.status.OK);
       done();
     });
   });

--- a/test/api/metadata_test.js
+++ b/test/api/metadata_test.js
@@ -18,7 +18,9 @@
 
 'use strict';
 
-var Metadata = require('../any_grpc').Metadata;
+var anyGrpc = require('../any_grpc');
+// require as client since grpc-js client was implemented first.
+var Metadata = anyGrpc.requireAsClient('grpc').Metadata;
 
 var assert = require('assert');
 

--- a/test/api/surface_server_test.js
+++ b/test/api/surface_server_test.js
@@ -1,0 +1,147 @@
+var anyGrpc = require('../any_grpc');
+var assert = require('assert');
+var grpc = anyGrpc.requireAsServer('grpc');
+
+var mathProtoPath = __dirname +
+    '/../../packages/grpc-native-core/deps/grpc/src/proto/math/math.proto';
+
+var MathClient = grpc.load(mathProtoPath).math.Math;
+var mathServiceAttrs = MathClient.service;
+
+describe('surface Server', function() {
+  var server;
+  beforeEach(function() {
+    server = new grpc.Server();
+  });
+  afterEach(function() {
+    server.forceShutdown();
+  });
+  it('should error if started twice', function() {
+    server.start();
+    assert.throws(function() {
+      server.start();
+    });
+  });
+  it('should error if a port is bound after the server starts', function() {
+    server.start();
+    assert.throws(function() {
+      server.bind('localhost:0', grpc.ServerCredentials.createInsecure());
+    });
+  });
+  it('should successfully shutdown if tryShutdown is called', function(done) {
+    server.start();
+    server.tryShutdown(done);
+  });
+});
+
+describe('Server.prototype.addService', function() {
+  var server;
+  var dummyImpls = {
+    'div': function() {},
+    'divMany': function() {},
+    'fib': function() {},
+    'sum': function() {}
+  };
+  beforeEach(function() {
+    server = new grpc.Server();
+  });
+  afterEach(function() {
+    server.forceShutdown();
+  });
+  it('Should succeed with a single service', function() {
+    assert.doesNotThrow(function() {
+      server.addService(mathServiceAttrs, dummyImpls);
+    });
+  });
+  it('Should fail with conflicting method names', function() {
+    server.addService(mathServiceAttrs, dummyImpls);
+    assert.throws(function() {
+      server.addService(mathServiceAttrs, dummyImpls);
+    });
+  });
+  it('Should allow method names as originally written', function() {
+    var altDummyImpls = {
+      'Div': function() {},
+      'DivMany': function() {},
+      'Fib': function() {},
+      'Sum': function() {}
+    };
+    assert.doesNotThrow(function() {
+      server.addService(mathServiceAttrs, altDummyImpls);
+    });
+  });
+  it('Should have a conflict between name variations', function() {
+    /* This is really testing that both name variations are actually used,
+      by checking that the method actually gets registered, for the
+      corresponding function, in both cases */
+    var altDummyImpls = {
+      'Div': function() {},
+      'DivMany': function() {},
+      'Fib': function() {},
+      'Sum': function() {}
+    };
+    server.addProtoService(mathServiceAttrs, altDummyImpls);
+    assert.throws(function() {
+      server.addProtoService(mathServiceAttrs, dummyImpls);
+    });
+  });
+  it('Should fail if the server has been started', function() {
+    server.start();
+    assert.throws(function() {
+      server.addService(mathServiceAttrs, dummyImpls);
+    });
+  });
+  describe('Default handlers', function() {
+    var client;
+    beforeEach(function() {
+      server.addService(mathServiceAttrs, {});
+      var port = server.bind('localhost:0',
+                             grpc.ServerCredentials.createInsecure());
+      server.start();
+
+      anyGrpc.runAsClient((grpc) => {
+        var MathClient = grpc.load(mathProtoPath).math.Math;
+        client = new MathClient('localhost:' + port,
+                                grpc.credentials.createInsecure());
+      });
+    });
+    it('should respond to a unary call with UNIMPLEMENTED', function(done) {
+      client.div({divisor: 4, dividend: 3}, function(error, response) {
+        assert(error);
+        assert.strictEqual(error.code, grpc.status.UNIMPLEMENTED);
+        done();
+      });
+    });
+    it('should respond to a client stream with UNIMPLEMENTED', function(done) {
+      var call = client.sum(function(error, respones) {
+        assert(error);
+        assert.strictEqual(error.code, grpc.status.UNIMPLEMENTED);
+        done();
+      });
+      call.end();
+    });
+    it('should respond to a server stream with UNIMPLEMENTED', function(done) {
+      var call = client.fib({limit: 5});
+      call.on('data', function(value) {
+        assert.fail('No messages expected');
+      });
+      call.on('error', function(err) {
+        assert.strictEqual(err.code, grpc.status.UNIMPLEMENTED);
+        done();
+      });
+      call.on('error', function(status) { /* Do nothing */ });
+    });
+    it('should respond to a bidi call with UNIMPLEMENTED', function(done) {
+      var call = client.divMany();
+      call.on('data', function(value) {
+        assert.fail('No messages expected');
+      });
+      call.on('error', function(err) {
+        assert.strictEqual(err.code, grpc.status.UNIMPLEMENTED);
+        done();
+      });
+      call.on('error', function(status) { /* Do nothing */ });
+      call.end();
+    });
+  });
+});

--- a/test/fixtures/native_js.js
+++ b/test/fixtures/native_js.js
@@ -1,2 +1,2 @@
-global._server_implementation = 'js';
-global._client_implementation = 'native';
+global._server_implementation = 'native';
+global._client_implementation = 'js';

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -21,6 +21,7 @@ const mocha = require('gulp-mocha');
 const execa = require('execa');
 const path = require('path');
 const del = require('del');
+const semver = require('semver');
 const linkSync = require('../util').linkSync;
 
 // gulp-help monkeypatches tasks to have an additional description parameter
@@ -51,12 +52,10 @@ gulp.task('test', 'Run API-level tests', () => {
       .on('end', resolve)
       .on('error', reject);
   });
-  const runTestsArgPairs = [
-    ['native', 'native'],
-    // ['native', 'js'],
-    // ['js', 'native'],
-    // ['js', 'js']
-  ];
+  const runTestsArgPairs = [['native', 'native']];
+  if (semver.satisfies(process.version, '8.x')) {
+    runTestsArgPairs.push(['native', 'js']);
+  }
   return runTestsArgPairs.reduce((previousPromise, argPair) => {
     return previousPromise.then(runTestsWithFixture.bind(null, argPair[0], argPair[1]));
   }, Promise.resolve());

--- a/test/interop/interop_client.js
+++ b/test/interop/interop_client.js
@@ -20,7 +20,7 @@
 
 var fs = require('fs');
 var path = require('path');
-var grpc = require('../any_grpc')['$implementationInfo'].client.surface;
+var grpc = require('grpc');
 var testProto = grpc.load({
   root: __dirname + '/../../packages/grpc-native-core/deps/grpc',
   file: 'src/proto/grpc/testing/test.proto'}).grpc.testing;

--- a/test/interop/interop_server.js
+++ b/test/interop/interop_server.js
@@ -22,7 +22,7 @@ var fs = require('fs');
 var path = require('path');
 var _ = require('lodash');
 var AsyncDelayQueue = require('./async_delay_queue');
-var grpc = require('../any_grpc')['$implementationInfo'].server.surface;
+var grpc = require('grpc');
 var testProto = grpc.load({
   root: __dirname + '/../../packages/grpc-native-core/deps/grpc',
   file: 'src/proto/grpc/testing/test.proto'}).grpc.testing;

--- a/test/package.json
+++ b/test/package.json
@@ -16,11 +16,14 @@
   "dependencies": {
     "async": "^2.0.1",
     "body-parser": "^1.15.2",
+    "caller-id": "^0.1.0",
     "express": "^4.14.0",
     "google-auth-library": "^0.9.2",
     "google-protobuf": "^3.0.0",
     "lodash": "^4.17.4",
     "minimist": "^1.1.0",
-    "poisson-process": "^0.2.1"
+    "mocha": "^4.0.1",
+    "poisson-process": "^0.2.1",
+    "shimmer": "^1.2.0"
   }
 }


### PR DESCRIPTION
__do not review__

This change re-writes some tests (as well as the `any_grpc.js` helper file) to test the pure js client against the native server. It should fail until a few pending PRs (#128, #131, #132, and two other future ones) are landed.

### Skipped tests

Tests for Google credentials and deadline propagation are currently skipped for the JS client.

### large removals in `credentials_test.js` and `surface_test.js`

The large removal in `credentials_test.js` is code I had previously copied into `credentials_api_test.js` and forgotten to delete.

The large removal in `surface_test.js` is what is now `surface_server_test.js`.

### `any_grpc.js`

I've changed this file to export `requireAs*` and `runAs*` (* means either client or server) functions. The former functions as `require` but any nested calls to `require('grpc')` will be intercepted to return the relevant implementation instead. The latter simply takes a function and runs it with a single argument, which is the relevant grpc implementation. This is primarily useful for separating client and server implementations in the same scope, as I can turn

```js
// fake api for illustrative purposes

const server = grpc.createServer();
// do something with server

const client = grpc.createClient();
// do something with client
```

into

```js
// runAs* allows us to re-define 'grpc' in the scope of the passed callback

anyGrpc.runAsServer((grpc) => {
  const server = grpc.createServer();
  // do something with server
});

anyGrpc.runAsClient((grpc) => {
  const client = grpc.createClient();
  // do something with client
});
```

This allows us to change tests back to using `require('grpc')` and be relatively unencumbered by changes specific to dual implementations of grpc.