### PR TITLE
grpc-{surface, protobufjs, js}: help JS client pass tests

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -18,4 +18,48 @@
 
 'use strict';
 
-module.exports = require('@grpc/surface')(require('@grpc/js-core'));
+import {
+  CallCredentials,
+  ChannelCredentials,
+  Metadata,
+  Status,
+  PropagateFlags,
+  Client
+} from '@grpc/js-core';
+
+const compose = <S extends { compose: (other: T) => S }, T>(a: S, b: T) => a.compose(b);
+
+const notImplementedFn = () => { throw new Error('Not implemented'); }
+
+module.exports = require('@grpc/surface')({
+  Client,
+  Metadata,
+  propagate: PropagateFlags,
+  status: Status,
+  credentials: {
+    createSsl: ChannelCredentials.createSsl,
+    createFromMetadataGenerator: CallCredentials.createFromMetadataGenerator,
+    createFromGoogleCredential: notImplementedFn,
+    combineChannelCredentials: (channelCredentials: ChannelCredentials,
+        ...callCredentialsList: CallCredentials[]): ChannelCredentials => {
+      return callCredentialsList.reduce(compose, channelCredentials);
+    },
+    combineCallCredentials: (...callCredentialsList: CallCredentials[]): CallCredentials => {
+      return callCredentialsList.slice(1).reduce(compose, callCredentialsList[0]);
+    },
+    createInsecure: ChannelCredentials.createInsecure
+  },
+  get setLogger() { return notImplementedFn; },
+  get setLogVerbosity() { return notImplementedFn; },
+  get ServerCredentials() { return notImplementedFn; },
+  get callError() { return notImplementedFn; },
+  get writeFlags() { return notImplementedFn; },
+  get logVerbosity() { return notImplementedFn; },
+  getClientChannel(client: Client) {
+    return client.getChannel();
+  },
+  waitForClientReady(client: Client, deadline: number|Date, callback: (err: Error|null) => {}) {
+    client.waitForReady(deadline, callback);
+  },
+  closeClient(client: Client) { return client.close(); }
+});

--- a/packages/grpc-protobufjs/index.js
+++ b/packages/grpc-protobufjs/index.js
@@ -27,8 +27,8 @@ module.exports = function(grpc) {
 
   let exports = {};
 
-  const protobuf_js_5_common = require('protobuf_js_5_common')(grpc);
-  const protobuf_js_6_common = require('protobuf_js_6_common')(grpc);
+  const protobuf_js_5_common = require('./protobuf_js_5_common')(grpc);
+  const protobuf_js_6_common = require('./protobuf_js_6_common')(grpc);
 
   /**
    * Default options for loading proto files into gRPC

--- a/packages/grpc-protobufjs/protobuf_js_6_common.js
+++ b/packages/grpc-protobufjs/protobuf_js_6_common.js
@@ -70,7 +70,7 @@ module.exports = function(grpc) {
      * @return {Buffer} The serialized object
      */
     return function serialize(arg) {
-      var message = cls.fromObject(arg);
+      var message = arg ? cls.fromObject(arg) : {};
       return cls.encode(message).finish();
     };
   };
@@ -134,7 +134,7 @@ module.exports = function(grpc) {
     if (value.hasOwnProperty('methods')) {
       // It's a service object
       var service_attrs = getProtobufServiceAttrs(value, options);
-      return grpc..makeGenericClientConstructor(service_attrs);
+      return grpc.makeGenericClientConstructor(service_attrs);
     }
 
     if (value.hasOwnProperty('nested')) {

--- a/packages/grpc-surface/index.js
+++ b/packages/grpc-surface/index.js
@@ -143,5 +143,7 @@ module.exports = function(grpc) {
     return ServiceClient;
   };
 
+  exports.makeGenericClientConstructor = exports.makeClientConstructor;
+
   return Object.assign(exports, grpc);
 };


### PR DESCRIPTION
__DNR__

`PropagateFlags` and `client.getChannel` are added in future PRs.