### PR TITLE
grpc-js-core: merge all eventemitter overloads

### DIFF
--- a/packages/grpc-js-core/src/call-stream.ts
+++ b/packages/grpc-js-core/src/call-stream.ts
@@ -3,6 +3,7 @@ import {Duplex} from 'stream';
 
 import {CallCredentials} from './call-credentials';
 import {Status} from './constants';
+import {EmitterAugmentation1} from './events';
 import {Filter} from './filter';
 import {FilterStackFactory} from './filter-stack';
 import {Metadata} from './metadata';
@@ -34,7 +35,7 @@ export interface WriteObject {
 /**
  * This interface represents a duplex stream associated with a single gRPC call.
  */
-export interface CallStream extends ObjectDuplex<WriteObject, Buffer> {
+export type CallStream =  {
   cancelWithStatus(status: Status, details: string): void;
   getPeer(): string;
 
@@ -43,37 +44,9 @@ export interface CallStream extends ObjectDuplex<WriteObject, Buffer> {
   /* If the return value is null, the call has not ended yet. Otherwise, it has
    * ended with the specified status */
   getStatus(): StatusObject|null;
-
-  addListener(event: string, listener: Function): this;
-  emit(event: string|symbol, ...args: any[]): boolean;
-  on(event: string, listener: Function): this;
-  once(event: string, listener: Function): this;
-  prependListener(event: string, listener: Function): this;
-  prependOnceListener(event: string, listener: Function): this;
-  removeListener(event: string, listener: Function): this;
-
-  addListener(event: 'metadata', listener: (metadata: Metadata) => void): this;
-  emit(event: 'metadata', metadata: Metadata): boolean;
-  on(event: 'metadata', listener: (metadata: Metadata) => void): this;
-  once(event: 'metadata', listener: (metadata: Metadata) => void): this;
-  prependListener(event: 'metadata', listener: (metadata: Metadata) => void):
-      this;
-  prependOnceListener(
-      event: 'metadata', listener: (metadata: Metadata) => void): this;
-  removeListener(event: 'metadata', listener: (metadata: Metadata) => void):
-      this;
-
-  addListener(event: 'status', listener: (status: StatusObject) => void): this;
-  emit(event: 'status', status: StatusObject): boolean;
-  on(event: 'status', listener: (status: StatusObject) => void): this;
-  once(event: 'status', listener: (status: StatusObject) => void): this;
-  prependListener(event: 'status', listener: (status: StatusObject) => void):
-      this;
-  prependOnceListener(
-      event: 'status', listener: (status: StatusObject) => void): this;
-  removeListener(event: 'status', listener: (status: StatusObject) => void):
-      this;
-}
+} & EmitterAugmentation1<'metadata', Metadata>
+  & EmitterAugmentation1<'status', StatusObject>
+  & ObjectDuplex<WriteObject, Buffer>;
 
 enum ReadState {
   NO_DATA,

--- a/packages/grpc-js-core/src/client.ts
+++ b/packages/grpc-js-core/src/client.ts
@@ -152,9 +152,7 @@ export class Client {
     call.write(writeObj);
     call.end();
     this.handleUnaryResponse<ResponseType>(call, deserialize, callback);
-
-    const emitter: ClientUnaryCall = new ClientUnaryCallImpl(call);
-    return emitter;
+    return new ClientUnaryCallImpl(call);
   }
 
   makeClientStreamRequest<RequestType, ResponseType>(
@@ -187,10 +185,7 @@ export class Client {
     const call: CallStream =
         this.channel.createStream(method, metadata, options);
     this.handleUnaryResponse<ResponseType>(call, deserialize, callback);
-
-    const stream: ClientWritableStream<RequestType> =
-        new ClientWritableStreamImpl<RequestType>(call, serialize);
-    return stream;
+    return new ClientWritableStreamImpl<RequestType>(call, serialize);
   }
 
   private checkMetadataAndOptions(
@@ -238,10 +233,7 @@ export class Client {
     writeObj.flags = options.flags;
     call.write(writeObj);
     call.end();
-
-    const stream: ClientReadableStream<ResponseType> =
-        new ClientReadableStreamImpl<ResponseType>(call, deserialize);
-    return stream;
+    return new ClientReadableStreamImpl<ResponseType>(call, deserialize);
   }
 
   makeBidiStreamRequest<RequestType, ResponseType>(
@@ -260,10 +252,7 @@ export class Client {
     ({metadata, options} = this.checkMetadataAndOptions(metadata, options));
     const call: CallStream =
         this.channel.createStream(method, metadata, options);
-
-    const stream: ClientDuplexStream<RequestType, ResponseType> =
-        new ClientDuplexStreamImpl<RequestType, ResponseType>(
-            call, serialize, deserialize);
-    return stream;
+    return new ClientDuplexStreamImpl<RequestType, ResponseType>(
+        call, serialize, deserialize);
   }
 }

--- a/packages/grpc-js-core/src/events.ts
+++ b/packages/grpc-js-core/src/events.ts
@@ -1,0 +1,29 @@
+export interface EmitterAugmentation0<Name extends string|symbol> {
+  addListener(event: Name, listener: () => void): this;
+  emit(event: Name): boolean;
+  on(event: Name, listener: () => void): this;
+  once(event: Name, listener: () => void): this;
+  prependListener(event: Name, listener: () => void): this;
+  prependOnceListener(event: Name, listener: () => void): this;
+  removeListener(event: Name, listener: () => void): this;
+}
+
+export interface EmitterAugmentation1<Name extends string|symbol, Arg> {
+  addListener(event: Name, listener: (arg1: Arg) => void): this;
+  emit(event: Name, arg1: Arg): boolean;
+  on(event: Name, listener: (arg1: Arg) => void): this;
+  once(event: Name, listener: (arg1: Arg) => void): this;
+  prependListener(event: Name, listener: (arg1: Arg) => void): this;
+  prependOnceListener(event: Name, listener: (arg1: Arg) => void): this;
+  removeListener(event: Name, listener: (arg1: Arg) => void): this;
+}
+
+export interface EmitterAugmentation2<Name extends string|symbol, Arg1, Arg2> {
+  addListener(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void): this;
+  emit(event: Name, arg1: Arg1, arg2: Arg2): boolean;
+  on(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void): this;
+  once(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void): this;
+  prependListener(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void): this;
+  prependOnceListener(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void): this;
+  removeListener(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void): this;
+}

--- a/packages/grpc-js-core/src/object-stream.ts
+++ b/packages/grpc-js-core/src/object-stream.ts
@@ -1,28 +1,14 @@
 import {Duplex, Readable, Writable} from 'stream';
+import {EmitterAugmentation1} from './events';
 
 export interface IntermediateObjectReadable<T> extends Readable {
   read(size?: number): any&T;
 }
 
-export interface ObjectReadable<T> extends IntermediateObjectReadable<T> {
+export type ObjectReadable<T> = {
   read(size?: number): T;
-
-  addListener(event: string, listener: Function): this;
-  emit(event: string|symbol, ...args: any[]): boolean;
-  on(event: string, listener: Function): this;
-  once(event: string, listener: Function): this;
-  prependListener(event: string, listener: Function): this;
-  prependOnceListener(event: string, listener: Function): this;
-  removeListener(event: string, listener: Function): this;
-
-  addListener(event: 'data', listener: (chunk: T) => void): this;
-  emit(event: 'data', chunk: T): boolean;
-  on(event: 'data', listener: (chunk: T) => void): this;
-  once(event: 'data', listener: (chunk: T) => void): this;
-  prependListener(event: 'data', listener: (chunk: T) => void): this;
-  prependOnceListener(event: 'data', listener: (chunk: T) => void): this;
-  removeListener(event: 'data', listener: (chunk: T) => void): this;
-}
+} & EmitterAugmentation1<'data', T>
+  & IntermediateObjectReadable<T>;
 
 export interface IntermediateObjectWritable<T> extends Writable {
   _write(chunk: any&T, encoding: string, callback: Function): void;
@@ -44,8 +30,7 @@ export interface ObjectWritable<T> extends IntermediateObjectWritable<T> {
   end(chunk: T, encoding?: any, cb?: Function): void;
 }
 
-export interface ObjectDuplex<T, U> extends Duplex, ObjectWritable<T>,
-                                            ObjectReadable<U> {
+export type ObjectDuplex<T, U> = {
   read(size?: number): U;
 
   _write(chunk: T, encoding: string, callback: Function): void;
@@ -54,13 +39,4 @@ export interface ObjectDuplex<T, U> extends Duplex, ObjectWritable<T>,
   end(): void;
   end(chunk: T, cb?: Function): void;
   end(chunk: T, encoding?: any, cb?: Function): void;
-
-
-  addListener(event: string, listener: Function): this;
-  emit(event: string|symbol, ...args: any[]): boolean;
-  on(event: string, listener: Function): this;
-  once(event: string, listener: Function): this;
-  prependListener(event: string, listener: Function): this;
-  prependOnceListener(event: string, listener: Function): this;
-  removeListener(event: string, listener: Function): this;
-}
+} & Duplex & ObjectWritable<T> & ObjectReadable<U>;


### PR DESCRIPTION
This is a non-logical change (there are slight re-orderings of statements that should have no visible effect) to reduce the boilerplate `EventEmitter` type overloads.