### PR TITLE
grpc-js-core: fixes and update to use node 9.4 http2 api

### DIFF
--- a/packages/grpc-js-core/package.json
+++ b/packages/grpc-js-core/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/lodash": "^4.14.77",
     "@types/mocha": "^2.2.43",
-    "@types/node": "^8.0.55",
+    "@types/node": "^9.4.6",
     "clang-format": "^1.0.55",
     "gts": "^0.5.1",
     "typescript": "~2.7.0"

--- a/packages/grpc-js-core/src/call-stream.ts
+++ b/packages/grpc-js-core/src/call-stream.ts
@@ -156,7 +156,7 @@ export class Http2CallStream extends Duplex implements CallStream {
 
   attachHttp2Stream(stream: http2.ClientHttp2Stream): void {
     if (this.finalStatus !== null) {
-      (stream as any).close(NGHTTP2_CANCEL);
+      stream.close(NGHTTP2_CANCEL);
     } else {
       this.http2Stream = stream;
       stream.on('response', (headers, flags) => {
@@ -328,7 +328,7 @@ export class Http2CallStream extends Duplex implements CallStream {
     if (this.http2Stream !== null && !this.http2Stream.destroyed) {
       /* TODO(murgatroid99): Determine if we want to send different RST_STREAM
        * codes based on the status code */
-      (this.http2Stream as any).close(NGHTTP2_CANCEL);
+      this.http2Stream.close(NGHTTP2_CANCEL);
     }
   }
 

--- a/packages/grpc-js-core/src/call-stream.ts
+++ b/packages/grpc-js-core/src/call-stream.ts
@@ -9,7 +9,7 @@ import {FilterStackFactory} from './filter-stack';
 import {Metadata} from './metadata';
 import {ObjectDuplex} from './object-stream';
 
-const {HTTP2_HEADER_STATUS, HTTP2_HEADER_CONTENT_TYPE} = http2.constants;
+const {HTTP2_HEADER_STATUS, HTTP2_HEADER_CONTENT_TYPE, NGHTTP2_CANCEL} = http2.constants;
 
 export type Deadline = Date | number;
 
@@ -156,7 +156,7 @@ export class Http2CallStream extends Duplex implements CallStream {
 
   attachHttp2Stream(stream: http2.ClientHttp2Stream): void {
     if (this.finalStatus !== null) {
-      stream.rstWithCancel();
+      (stream as any).close(NGHTTP2_CANCEL);
     } else {
       this.http2Stream = stream;
       stream.on('response', (headers, flags) => {
@@ -328,7 +328,7 @@ export class Http2CallStream extends Duplex implements CallStream {
     if (this.http2Stream !== null && !this.http2Stream.destroyed) {
       /* TODO(murgatroid99): Determine if we want to send different RST_STREAM
        * codes based on the status code */
-      this.http2Stream.rstWithCancel();
+      (this.http2Stream as any).close(NGHTTP2_CANCEL);
     }
   }
 

--- a/packages/grpc-js-core/src/call-stream.ts
+++ b/packages/grpc-js-core/src/call-stream.ts
@@ -19,6 +19,8 @@ export interface CallStreamOptions {
   flags: number;
 }
 
+export type CallOptions = Partial<CallStreamOptions>;
+
 export interface StatusObject {
   code: Status;
   details: string;

--- a/packages/grpc-js-core/src/call-stream.ts
+++ b/packages/grpc-js-core/src/call-stream.ts
@@ -19,8 +19,6 @@ export interface CallStreamOptions {
   flags: number;
 }
 
-export type CallOptions = Partial<CallStreamOptions>;
-
 export interface StatusObject {
   code: Status;
   details: string;

--- a/packages/grpc-js-core/src/call.ts
+++ b/packages/grpc-js-core/src/call.ts
@@ -7,16 +7,17 @@ import {Status} from './constants';
 import {Metadata} from './metadata';
 import {ObjectReadable, ObjectWritable} from './object-stream';
 
-export interface ServiceError extends Error {
+/**
+ * A type extending the built-in Error object with additional fields.
+ */
+export type ServiceError = {
   code?: number;
   metadata?: Metadata;
-}
+} & Error;
 
-export class ServiceErrorImpl extends Error implements ServiceError {
-  code?: number;
-  metadata?: Metadata;
-}
-
+/**
+ * A base type for all user-facing values returned by client-side method calls.
+ */
 export type Call = {
   cancel(): void;
   getPeer(): string;
@@ -24,16 +25,28 @@ export type Call = {
   & EmitterAugmentation1<'status', StatusObject>
   & EventEmitter;
 
+/**
+ * A type representing the return value of a unary method call.
+ */
 export type ClientUnaryCall = Call;
 
+/**
+ * A type representing the return value of a server stream method call.
+ */
 export type ClientReadableStream<ResponseType> = {
   deserialize: (chunk: Buffer) => ResponseType;
 } & Call & ObjectReadable<ResponseType>;
 
+/**
+ * A type representing the return value of a client stream method call.
+ */
 export type ClientWritableStream<RequestType> = {
   serialize: (value: RequestType) => Buffer;
 } & Call & ObjectWritable<RequestType>;
 
+/**
+ * A type representing the return value of a bidirectional stream method call.
+ */
 export type ClientDuplexStream<RequestType, ResponseType> =
   ClientWritableStream<RequestType> & ClientReadableStream<ResponseType>;
 
@@ -78,7 +91,7 @@ function setUpReadableStream<ResponseType>(
   call.on('status', (status: StatusObject) => {
     stream.emit('status', status);
     if (status.code !== Status.OK) {
-      const error = new ServiceErrorImpl(status.details);
+      const error: ServiceError = new Error(status.details);
       error.code = status.code;
       error.metadata = status.metadata;
       stream.emit('error', error);

--- a/packages/grpc-js-core/src/call.ts
+++ b/packages/grpc-js-core/src/call.ts
@@ -6,14 +6,12 @@ import {CallStream, StatusObject, WriteObject} from './call-stream';
 import {Status} from './constants';
 import {Metadata} from './metadata';
 import {ObjectReadable, ObjectWritable} from './object-stream';
+import * as _ from 'lodash';
 
 /**
  * A type extending the built-in Error object with additional fields.
  */
-export type ServiceError = {
-  code?: number;
-  metadata?: Metadata;
-} & Error;
+export type ServiceError = StatusObject & Error;
 
 /**
  * A base type for all user-facing values returned by client-side method calls.
@@ -91,9 +89,9 @@ function setUpReadableStream<ResponseType>(
   call.on('status', (status: StatusObject) => {
     stream.emit('status', status);
     if (status.code !== Status.OK) {
-      const error: ServiceError = new Error(status.details);
-      error.code = status.code;
-      error.metadata = status.metadata;
+      const statusName = _.invert(Status)[status.code];
+      const message: string = `${status.code} ${statusName}: ${status.details}`;
+      const error: ServiceError = Object.assign(new Error(status.details), status);
       stream.emit('error', error);
     }
   });

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -207,7 +207,7 @@ export class Http2Channel extends EventEmitter implements Channel {
   private startHttp2Stream(
       methodName: string, stream: Http2CallStream, metadata: Metadata) {
     let finalMetadata: Promise<Metadata> =
-        stream.filterStack.sendMetadata(Promise.resolve(metadata));
+        stream.filterStack.sendMetadata(Promise.resolve(metadata.clone()));
     Promise.all([finalMetadata, this.connect()])
       .then(([metadataValue]) => {
         let headers = metadataValue.toHttp2Headers();

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -14,6 +14,8 @@ import {FilterStackFactory} from './filter-stack';
 import {Metadata, MetadataObject} from './metadata';
 import { MetadataStatusFilterFactory } from './metadata-status-filter';
 
+const { version: clientVersion } = require('../../package');
+
 const IDLE_TIMEOUT_MS = 300000;
 
 const MIN_CONNECT_TIMEOUT_MS = 20000;
@@ -28,7 +30,8 @@ const {
   HTTP2_HEADER_METHOD,
   HTTP2_HEADER_PATH,
   HTTP2_HEADER_SCHEME,
-  HTTP2_HEADER_TE
+  HTTP2_HEADER_TE,
+  HTTP2_HEADER_USER_AGENT
 } = http2.constants;
 
 /**
@@ -209,6 +212,7 @@ export class Http2Channel extends EventEmitter implements Channel {
       .then(([metadataValue]) => {
         let headers = metadataValue.toHttp2Headers();
         headers[HTTP2_HEADER_AUTHORITY] = this.authority.hostname;
+        headers[HTTP2_HEADER_USER_AGENT] = `grpc-node/${clientVersion}`;
         headers[HTTP2_HEADER_CONTENT_TYPE] = 'application/grpc';
         headers[HTTP2_HEADER_METHOD] = 'POST';
         headers[HTTP2_HEADER_PATH] = methodName;

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -3,16 +3,26 @@ import * as http2 from 'http2';
 import {checkServerIdentity, SecureContext, PeerCertificate} from 'tls';
 import * as url from 'url';
 
+import {Call} from './call';
 import {CallCredentials} from './call-credentials';
 import {CallCredentialsFilterFactory} from './call-credentials-filter';
-import {CallOptions, CallStream, CallStreamOptions, Http2CallStream} from './call-stream';
+import {CallStream, CallStreamOptions, Http2CallStream} from './call-stream';
 import {ChannelCredentials} from './channel-credentials';
 import {CompressionFilterFactory} from './compression-filter';
+import {EmitterAugmentation0} from './events';
 import {Status} from './constants';
 import {DeadlineFilterFactory} from './deadline-filter';
 import {FilterStackFactory} from './filter-stack';
 import {Metadata, MetadataObject} from './metadata';
 import { MetadataStatusFilterFactory } from './metadata-status-filter';
+import { PropagateFlags } from './index';
+
+export type CallOptions = {
+  // Represents a parent server call.
+  // For our purposes we only need to know of the 'cancelled' event.
+  parent?: EmitterAugmentation0<'cancelled'> & EventEmitter;
+  propagate_flags?: number;
+} & Partial<CallStreamOptions>;
 
 const IDLE_TIMEOUT_MS = 300000;
 
@@ -249,6 +259,19 @@ export class Http2Channel extends EventEmitter implements Channel {
     let stream: Http2CallStream =
         new Http2CallStream(methodName, finalOptions, this.filterStackFactory);
     this.startHttp2Stream(methodName, stream, metadata);
+
+    // handle propagation flags
+    const propagateFlags = typeof options.propagate_flags === 'number' ?
+        options.propagate_flags : PropagateFlags.DEFAULTS;
+    if (options.parent) {
+      // TODO(kjin): Implement other propagation flags.
+      if (propagateFlags & PropagateFlags.CANCELLATION) {
+        options.parent.on('cancelled', () => {
+          stream.cancelWithStatus(Status.CANCELLED, 'Cancellation propagated from parent call');
+        });
+      }
+    }
+
     return stream;
   }
 

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -121,7 +121,7 @@ export class Http2Channel extends EventEmitter implements Channel {
     case ConnectivityState.IDLE:
     case ConnectivityState.SHUTDOWN:
       if (this.subChannel) {
-        (this.subChannel as any).close({graceful: true});
+        this.subChannel.close();
         this.subChannel.removeListener('connect', this.subChannelConnectCallback);
         this.subChannel.removeListener('close', this.subChannelCloseCallback);
         this.subChannel = null;
@@ -168,7 +168,7 @@ export class Http2Channel extends EventEmitter implements Channel {
       MIN_CONNECT_TIMEOUT_MS);
     let connectionTimerId: NodeJS.Timer = setTimeout(() => {
       // This should trigger the 'close' event, which will send us back to TRANSIENT_FAILURE
-      (subChannel as any).close();
+      subChannel.close();
     }, connectionTimeout);
     this.subChannelConnectCallback = () => {
       // Connection succeeded
@@ -234,7 +234,7 @@ export class Http2Channel extends EventEmitter implements Channel {
           if (this.connectivityState === ConnectivityState.READY) {
             const session: http2.ClientHttp2Session = this.subChannel!;
             // Prevent the HTTP/2 session from keeping the process alive.
-            (session as any).unref();
+            session.unref();
             stream.attachHttp2Stream(session.request(headers));
           } else {
             /* In this case, we lost the connection while finalizing

--- a/packages/grpc-js-core/src/client.ts
+++ b/packages/grpc-js-core/src/client.ts
@@ -16,14 +16,7 @@ export class Client {
   private readonly channel: Channel;
   constructor(
       address: string, credentials: ChannelCredentials,
-      options: ChannelOptions = {}) {
-    if (options['grpc.primary_user_agent']) {
-      options['grpc.primary_user_agent'] += ' ';
-    } else {
-      options['grpc.primary_user_agent'] = '';
-    }
-    // TODO(murgatroid99): Figure out how to get version number
-    // options['grpc.primary_user_agent'] += 'grpc-node/' + version;
+      options: Partial<ChannelOptions> = {}) {
     this.channel = new Http2Channel(address, credentials, options);
   }
 
@@ -87,9 +80,7 @@ export class Client {
       if (status.code === Status.OK) {
         callback(null, responseMessage as ResponseType);
       } else {
-        const error: ServiceError = new Error(status.details);
-        error.code = status.code;
-        error.metadata = status.metadata;
+        const error: ServiceError = Object.assign(new Error(status.details), status);
         callback(error);
       }
     });

--- a/packages/grpc-js-core/src/client.ts
+++ b/packages/grpc-js-core/src/client.ts
@@ -35,7 +35,11 @@ export class Client {
       void {
     let cb: (error: Error|null) => void = once(callback);
     let callbackCalled = false;
+    let timer: NodeJS.Timer | null = null;
     this.channel.connect().then(() => {
+      if (timer) {
+        clearTimeout(timer);
+      }
       cb(null);
     });
     if (deadline !== Infinity) {
@@ -49,7 +53,7 @@ export class Client {
       if (timeout < 0) {
         timeout = 0;
       }
-      setTimeout(() => {
+      timer = setTimeout(() => {
         cb(new Error('Failed to connect before the deadline'));
       }, timeout);
     }

--- a/packages/grpc-js-core/src/client.ts
+++ b/packages/grpc-js-core/src/client.ts
@@ -2,8 +2,8 @@ import {once} from 'lodash';
 import {URL} from 'url';
 
 import {ClientDuplexStream, ClientDuplexStreamImpl, ClientReadableStream, ClientReadableStreamImpl, ClientUnaryCall, ClientUnaryCallImpl, ClientWritableStream, ClientWritableStreamImpl, ServiceError} from './call';
-import {CallOptions, CallStream, StatusObject, WriteObject} from './call-stream';
-import {Channel, ChannelOptions, Http2Channel} from './channel';
+import {CallStream, StatusObject, WriteObject} from './call-stream';
+import {CallOptions, Channel, ChannelOptions, Http2Channel} from './channel';
 import {ChannelCredentials} from './channel-credentials';
 import {Status} from './constants';
 import {Metadata} from './metadata';

--- a/packages/grpc-js-core/src/client.ts
+++ b/packages/grpc-js-core/src/client.ts
@@ -1,7 +1,7 @@
 import {once} from 'lodash';
 import {URL} from 'url';
 
-import {ClientDuplexStream, ClientDuplexStreamImpl, ClientReadableStream, ClientReadableStreamImpl, ClientUnaryCall, ClientUnaryCallImpl, ClientWritableStream, ClientWritableStreamImpl, ServiceError, ServiceErrorImpl} from './call';
+import {ClientDuplexStream, ClientDuplexStreamImpl, ClientReadableStream, ClientReadableStreamImpl, ClientUnaryCall, ClientUnaryCallImpl, ClientWritableStream, ClientWritableStreamImpl, ServiceError} from './call';
 import {CallOptions, CallStream, StatusObject, WriteObject} from './call-stream';
 import {Channel, ChannelOptions, Http2Channel} from './channel';
 import {ChannelCredentials} from './channel-credentials';
@@ -83,7 +83,7 @@ export class Client {
       if (status.code === Status.OK) {
         callback(null, responseMessage as ResponseType);
       } else {
-        const error = new ServiceErrorImpl(status.details);
+        const error: ServiceError = new Error(status.details);
         error.code = status.code;
         error.metadata = status.metadata;
         callback(error);

--- a/packages/grpc-js-core/src/client.ts
+++ b/packages/grpc-js-core/src/client.ts
@@ -2,8 +2,8 @@ import {once} from 'lodash';
 import {URL} from 'url';
 
 import {ClientDuplexStream, ClientDuplexStreamImpl, ClientReadableStream, ClientReadableStreamImpl, ClientUnaryCall, ClientUnaryCallImpl, ClientWritableStream, ClientWritableStreamImpl, ServiceError} from './call';
-import {CallStream, StatusObject, WriteObject} from './call-stream';
-import {CallOptions, Channel, ChannelOptions, Http2Channel} from './channel';
+import {CallOptions, CallStream, StatusObject, WriteObject} from './call-stream';
+import {Channel, ChannelOptions, Http2Channel} from './channel';
 import {ChannelCredentials} from './channel-credentials';
 import {Status} from './constants';
 import {Metadata} from './metadata';

--- a/packages/grpc-js-core/src/constants.ts
+++ b/packages/grpc-js-core/src/constants.ts
@@ -17,11 +17,3 @@ export enum Status {
   DATA_LOSS,
   UNAUTHENTICATED
 }
-
-export enum PropagateFlags {
-  DEADLINE = 1,
-  CENSUS_STATS_CONTEXT = 2,
-  CENSUS_TRACING_CONTEXT = 4,
-  CANCELLATION = 8,
-  DEFAULTS = 65535
-}

--- a/packages/grpc-js-core/src/constants.ts
+++ b/packages/grpc-js-core/src/constants.ts
@@ -17,3 +17,11 @@ export enum Status {
   DATA_LOSS,
   UNAUTHENTICATED
 }
+
+export enum PropagateFlags {
+  DEADLINE = 1,
+  CENSUS_STATS_CONTEXT = 2,
+  CENSUS_TRACING_CONTEXT = 4,
+  CANCELLATION = 8,
+  DEFAULTS = 65535
+}

--- a/packages/grpc-js-core/src/deadline-filter.ts
+++ b/packages/grpc-js-core/src/deadline-filter.ts
@@ -20,6 +20,7 @@ function getDeadline(deadline: number) {
 }
 
 export class DeadlineFilter extends BaseFilter implements Filter {
+  private timer: NodeJS.Timer | null = null;
   private deadline: number;
   constructor(
       private readonly channel: Http2Channel,
@@ -37,10 +38,11 @@ export class DeadlineFilter extends BaseFilter implements Filter {
       timeout = 0;
     }
     if (this.deadline !== Infinity) {
-      setTimeout(() => {
+      this.timer = setTimeout(() => {
         callStream.cancelWithStatus(
             Status.DEADLINE_EXCEEDED, 'Deadline exceeded');
       }, timeout);
+      callStream.on('status', () => clearTimeout(this.timer as NodeJS.Timer));
     }
   }
 

--- a/packages/grpc-js-core/src/metadata.ts
+++ b/packages/grpc-js-core/src/metadata.ts
@@ -181,6 +181,11 @@ export class Metadata {
     });
     return result;
   }
+  
+  // For compatibility with the other Metadata implementation
+  private _getCoreRepresentation() {
+    return this.internalRepr;
+  }
 
   /**
    * Returns a new Metadata object based fields in a given IncomingHttpHeaders
@@ -196,7 +201,8 @@ export class Metadata {
             result.add(key, Buffer.from(value, 'base64'));
           });
         } else if (values !== undefined) {
-          result.add(key, Buffer.from(values, 'base64'));
+          values.split(',').map(v => v.trim()).forEach(v =>
+            result.add(key, Buffer.from(v, 'base64')));
         }
       } else {
         if (Array.isArray(values)) {
@@ -204,7 +210,8 @@ export class Metadata {
             result.add(key, value);
           });
         } else if (values !== undefined) {
-          result.add(key, values);
+          values.split(',').map(v => v.trim()).forEach(v =>
+            result.add(key, v));
         }
       }
     });

--- a/packages/grpc-js-core/test/test-call-stream.ts
+++ b/packages/grpc-js-core/test/test-call-stream.ts
@@ -39,10 +39,13 @@ class ClientHttp2StreamMock extends stream.Duplex implements http2.ClientHttp2St
   bytesRead = 0;
   dataFrame = 0;
   aborted: boolean = false;
+  closed: boolean = false;
   destroyed: boolean = false;
+  pending: boolean = false;
   rstCode: number = 0;
   session: http2.Http2Session = {} as any;
   state: http2.StreamState = {} as any;
+  close = mockFunction;
   priority = mockFunction;
   rstStream = mockFunction;
   rstWithNoError = mockFunction;


### PR DESCRIPTION
#### `docs for call.ts`
* Adds a few docs for classes
* Removes `ServiceErrorImpl`, as we can accomplish the same with the `Error` constructor
#### ~~`support propagation cancellation`~~
* ~~Adds support for cancellation propagation~~
#### `split incoming headers on comma for metadata`
* If an incoming metadata value is a single string, split it on the comma delimiter to get multiple values. This appears to be the behavior of the native implementation, as not doing this will fail tests.
#### `add user-agent`
* Self-explanatory
#### `keep up-to-date with node-master`
* Replaces `shutdown` with `close` (this was changed in Node 9.4, and I believe will be backported to Node 8 as well if not already)
#### `clone local metadata before applying filters`
* Self-explanatory
#### `clear deadline timers`
* Timers set to expire actions are now cleared when the actions are completed first
#### `change rstStream to close`
* Accounts for another change that was made in Node 9.4