### PR TITLE
Replace argue.js usage with inline argument checking

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -28,7 +28,6 @@
     "node-pre-gyp"
   ],
   "dependencies": {
-    "arguejs": "^0.2.3",
     "lodash": "^4.15.0",
     "nan": "^2.0.0",
     "node-pre-gyp": "^0.6.39",

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -30,7 +30,6 @@
       "node-pre-gyp"
     ],
     "dependencies": {
-      "arguejs": "^0.2.3",
       "lodash": "^4.15.0",
       "nan": "^2.0.0",
       "node-pre-gyp": "^0.6.39",


### PR DESCRIPTION
This fixes #133 and #161. The error messages will be a little less helpful right now, but we can improve that later and I think it's good to get the fix out now.

The dependency on argue.js was actually removed a while ago in grpc/grpc#11707, but for some reason that change never made it out of the v1.4.x branch. So this is also correcting that error.