### PR TITLE
Improve module load error message when the directory does not exist

### DIFF
--- a/packages/grpc-native-core/src/grpc_extension.js
+++ b/packages/grpc-native-core/src/grpc_extension.js
@@ -31,17 +31,27 @@ var binding;
 try {
   binding = require(binding_path);
 } catch (e) {
-  var fs = require('fs');
-  var searchPath = path.dirname(path.dirname(binding_path));
-  var searchName = path.basename(path.dirname(binding_path));
-  var foundNames = fs.readdirSync(searchPath);
+  let fs = require('fs');
+  let searchPath = path.dirname(path.dirname(binding_path));
+  let searchName = path.basename(path.dirname(binding_path));
+  let foundNames;
+  try {
+    foundNames = fs.readdirSync(searchPath);
+  } catch (readDirError) {
+    let message = `The gRPC binary module was not installed
+This may be fixed by running "npm rebuild"
+Original error: ${e.message}`;
+    let error = new Error(message);
+    error.code = e.code;
+    throw error;
+  }
   if (foundNames.indexOf(searchName) === -1) {
-    var message = `Failed to load gRPC binary module because it was not installed for the current system
+    let message = `Failed to load gRPC binary module because it was not installed for the current system
 Expected directory: ${searchName}
 Found: [${foundNames.join(', ')}]
 This problem can often be fixed by running "npm rebuild" on the current system
 Original error: ${e.message}`;
-    var error = new Error(message);
+    let error = new Error(message);
     error.code = e.code;
     throw error;
   } else {

--- a/packages/grpc-native-core/src/grpc_extension.js
+++ b/packages/grpc-native-core/src/grpc_extension.js
@@ -38,8 +38,7 @@ try {
   try {
     foundNames = fs.readdirSync(searchPath);
   } catch (readDirError) {
-    let message = `The gRPC binary module was not installed
-This may be fixed by running "npm rebuild"
+    let message = `The gRPC binary module was not installed. This may be fixed by running "npm rebuild"
 Original error: ${e.message}`;
     let error = new Error(message);
     error.code = e.code;


### PR DESCRIPTION
A couple of times, e.g. in grpc/grpc#6435, people have reported errors indicating that the binary module directory doesn't exist at all, which isn't communicated well. This fixes that.