### PR TITLE
Add macro definition to gyp file

### DIFF
--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -82,6 +82,7 @@
       'deps/grpc/third_party/abseil-cpp'
     ],
     'defines': [
+      'PB_FIELD_16BIT',
       'GPR_BACKWARDS_COMPATIBILITY_MODE',
       'GRPC_ARES=0',
       'GRPC_UV'

--- a/packages/grpc-native-core/templates/binding.gyp.template
+++ b/packages/grpc-native-core/templates/binding.gyp.template
@@ -78,6 +78,7 @@
         'deps/grpc/third_party/abseil-cpp'
       ],
       'defines': [
+        'PB_FIELD_16BIT',
         'GPR_BACKWARDS_COMPATIBILITY_MODE',
         'GRPC_ARES=0',
         'GRPC_UV'


### PR DESCRIPTION
This gets this repo working with grpc/grpc#14400. In theory, the correct way to do this would be to use the per-target default compilation flags specified in the `build.yaml` file, but that section is too heavily tied to the Makefile build system to use here in general.