### PR TITLE
Add package definition loader function to native package

### DIFF
--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -156,13 +156,13 @@ exports.loadPackageDefinition = function loadPackageDefintion(packageDef) {
   for (const serviceFqn in packageDef) {
     const service = packageDef[serviceFqn];
     const nameComponents = serviceFqn.split('.');
-    const serviceName = nameComponents[-1];
+    const serviceName = nameComponents[nameComponents.length-1];
     let current = result;
-    for (const package in nameComponents.slice(0, -1)) {
-      if (!current[package]) {
-        current[package] = {};
+    for (const packageName in nameComponents.slice(0, -1)) {
+      if (!current[packageName]) {
+        current[packageName] = {};
       }
-      current = current[package];
+      current = current[packageName];
     }
     current[serviceName] = client.makeClientConstructor(service, serviceName, {});
   }

--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -146,6 +146,29 @@ exports.load = function load(filename, format, options) {
   return loadObject(builder.ns, options);
 };
 
+/**
+ * Load a gRPC package definition as a gRPC object hierarchy
+ * @param packageDef grpc~PackageDefinition The package definition object
+ * @return {Object<string, *>} The resulting gRPC object
+ */
+exports.loadPackageDefinition = function loadPackageDefintion(packageDef) {
+  const result = {};
+  for (const serviceFqn in packageDef) {
+    const service = packageDef[serviceFqn];
+    const nameComponents = serviceFqn.split('.');
+    const serviceName = nameComponents[-1];
+    let current = result;
+    for (const package in nameComponents.slice(0, -1)) {
+      if (!current[package]) {
+        current[package] = {};
+      }
+      current = current[package];
+    }
+    current[serviceName] = client.makeClientConstructor(service, serviceName, {});
+  }
+  return result;
+};
+
 var log_template = _.template(
     '{severity} {timestamp}\t{file}:{line}]\t{message}',
     {interpolate: /{([\s\S]+?)}/g});

--- a/packages/grpc-native-core/src/common.js
+++ b/packages/grpc-native-core/src/common.js
@@ -170,3 +170,8 @@ exports.defaultGrpcOptions = {
  * An object that completely defines a service.
  * @typedef {Object.<string, grpc~MethodDefinition>} grpc~ServiceDefinition
  */
+
+/**
+ * An object that defines a package hierarchy with multiple services
+ * @typedef {Object.<string, grpc~ServiceDefinition>} grpc~PackageDefinition
+ */


### PR DESCRIPTION
@kjin This is the implementation in the existing native library of the function to load the "package definition" from the protobuf library. As you can see, it calls `makeClientConstructor`, which is the other function that is not currently implemented in the pure JavaScript implementation.

The result type for this looks something like

```typescript
type GrpcPackage = {
  [name: string]: GrpcPackage | typeof Client
}
```