### PR TITLE
grpc-protobufjs: add d.ts to package

### DIFF
--- a/packages/grpc-protobufjs/package.json
+++ b/packages/grpc-protobufjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/protobufjs",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "build/src/index.js",
   "scripts": {
@@ -26,6 +26,7 @@
     "url": "https://github.com/grpc/grpc-node/issues"
   },
   "files": [
+    "build/src/*.d.ts",
     "build/src/*.js"
   ],
   "dependencies": {


### PR DESCRIPTION
Just adding the d.ts file to the package exports so we can access types from outside (and lowering the version number)

@murgatroid99 Can you publish a placeholder for this package?