### PR TITLE
stronger checking for functions in client.js

### DIFF
--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -429,7 +429,7 @@ exports.Client = Client;
 Client.prototype.makeUnaryRequest = function(path, serialize, deserialize,
                                              argument, metadata, options,
                                              callback) {
-  if (options instanceof Function) {
+  if (_.isFunction(options)) {
     callback = options;
     if (metadata instanceof Metadata) {
       options = {};
@@ -437,7 +437,7 @@ Client.prototype.makeUnaryRequest = function(path, serialize, deserialize,
       options = metadata;
       metadata = new Metadata();
     }
-  } else if (metadata instanceof Function) {
+  } else if (_.isFunction(metadata)) {
     callback = metadata;
     metadata = new Metadata();
     options = {};
@@ -450,7 +450,7 @@ Client.prototype.makeUnaryRequest = function(path, serialize, deserialize,
   }
   if (!((metadata instanceof Metadata) &&
         (options instanceof Object) &&
-        (callback instanceof Function))) {
+        (_.isFunction(callback)))) {
     throw new Error('Argument mismatch in makeUnaryRequest');
   }
 
@@ -508,7 +508,7 @@ Client.prototype.makeUnaryRequest = function(path, serialize, deserialize,
 Client.prototype.makeClientStreamRequest = function(path, serialize,
                                                     deserialize, metadata,
                                                     options, callback) {
-  if (options instanceof Function) {
+  if (_.isFunction(options)) {
     callback = options;
     if (metadata instanceof Metadata) {
       options = {};
@@ -516,7 +516,7 @@ Client.prototype.makeClientStreamRequest = function(path, serialize,
       options = metadata;
       metadata = new Metadata();
     }
-  } else if (metadata instanceof Function) {
+  } else if (_.isFunction(metadata)) {
     callback = metadata;
     metadata = new Metadata();
     options = {};
@@ -529,7 +529,7 @@ Client.prototype.makeClientStreamRequest = function(path, serialize,
   }
   if (!((metadata instanceof Metadata) &&
        (options instanceof Object) &&
-       (callback instanceof Function))) {
+       (_.isFunction(callback)))) {
     throw new Error('Argument mismatch in makeClientStreamRequest');
   }
 


### PR DESCRIPTION
checking for functions simply by instanceof would render library usesless in vm or REPL contexts. because if client is created in another V8 context, typeof would still return "function" but instanceof Function would fail and return false for functions and arrow functions. thus it would be impossible to create client before starting a REPL context.

Mainly I ran into problem using [grpcc](https://github.com/njpatel/grpcc) with following error:

```
Error: Argument mismatch in makeClientStreamRequest
    at ServiceClient.Client.makeClientStreamRequest (/usr/local/lib/node_modules/grpcc/node_modules/grpc/src/client.js:640:11)
    at apply (/usr/local/lib/node_modules/grpcc/node_modules/lodash/lodash.js:470:17)
    at ServiceClient.wrapper [as add] (/usr/local/lib/node_modules/grpcc/node_modules/lodash/lodash.js:5329:16)
```

After inspecting the problem and reading node docs about V8 contexts and so forth I concluded that "instanceof" is not evaluated properly because when a callback is created in REPL context, it is treated as when functions are created in another window and instanceof would fail.