### PR TITLE
chore: update `node-pre-gyp` to secure version

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "lodash": "^4.15.0",
     "nan": "^2.0.0",
-    "node-pre-gyp": "^0.6.39",
+    "node-pre-gyp": "^0.6.40",
     "protobufjs": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`0.6.40` of `node-pre-gyp` includes the below commit, which updates dependencies upon `hoek` to a secure version. Making a PR to this because `firebase` has an upstream dependency on this package.

https://github.com/mapbox/node-pre-gyp/commit/eda90e0a27e585c7b4df37a81d45feaca0e443ee

```
$ nsp check
(+) 1 vulnerabilities found
┌────────────┬────────────────────────────────────────────────────────────────────┐
│            │ Prototype pollution attack                                         │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Name       │ hoek                                                               │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ CVSS       │ 4 (Medium)                                                         │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Installed  │ 2.16.3                                                             │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Vulnerable │ <= 4.2.0 || >= 5.0.0 < 5.0.3                                       │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Patched    │ > 4.2.0 < 5.0.0 || >= 5.0.3                                        │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Path       │ firebase@4.10.0 > @firebase/firestore@0.3.3 >           │
│            │ grpc@1.9.1 > node-pre-gyp@0.6.39 > hawk@3.1.3 > hoek@2.16.3        │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ More Info  │ https://nodesecurity.io/advisories/566                             │
└────────────┴────────────────────────────────────────────────────────────────────┘

error Command failed with exit code 1.
```