### PR TITLE
Improve performance of batch operation serializer

### DIFF
--- a/packages/grpc-native-core/src/client_interceptors.js
+++ b/packages/grpc-native-core/src/client_interceptors.js
@@ -740,9 +740,14 @@ function _areBatchRequirementsMet(batch_ops, completed_ops) {
   var dependencies = _.flatMap(batch_ops, function(op) {
     return OP_DEPENDENCIES[op] || [];
   });
-  var dependencies_met = _.intersection(dependencies,
-                                        batch_ops.concat(completed_ops));
-  return _.isEqual(dependencies_met.sort(), dependencies.sort());
+  for (var i = 0; i < dependencies.length; i++) {
+    var required_dep = dependencies[i];
+    if (batch_ops.indexOf(required_dep) === -1 &&
+        completed_ops.indexOf(required_dep) === -1) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
This is a follow-up to #59, addressing the performance penalties of the code I wrote to enforce a certain order in batch operations, as discussed here: https://github.com/grpc/grpc-node/pull/59#issuecomment-369114921

This replaces the worst-performing lodash and standard library calls. In micro-benchmarks, _startBatchIfReady runs in about half the time after these changes are applied.