### PR TITLE
Update to newest version of node-pre-gyp

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "lodash": "^4.15.0",
     "nan": "^2.0.0",
-    "node-pre-gyp": "^0.6.39",
+    "node-pre-gyp": "^0.9.0",
     "protobufjs": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -32,7 +32,7 @@
     "dependencies": {
       "lodash": "^4.15.0",
       "nan": "^2.0.0",
-      "node-pre-gyp": "^0.6.39",
+      "node-pre-gyp": "^0.9.0",
       "protobufjs": "^5.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
node-pre-gyp has had a few improvements since 0.6.x, and we won't get them automatically.