### PR TITLE
grpc-js: add google credentials implementation

### DIFF
--- a/packages/grpc-js-core/src/call-credentials-filter.ts
+++ b/packages/grpc-js-core/src/call-credentials-filter.ts
@@ -12,8 +12,8 @@ export class CallCredentialsFilter extends BaseFilter implements Filter {
   }
 
   async sendMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
-    // TODO(murgatroid99): pass real options to generateMetadata
-    let credsMetadata = this.credentials.generateMetadata({});
+    // TODO(kjin): pass real service URL to generateMetadata
+    let credsMetadata = this.credentials.generateMetadata({ service_url: '' });
     let resultMetadata = await metadata;
     resultMetadata.merge(await credsMetadata);
     return resultMetadata;

--- a/packages/grpc-js-core/src/call-credentials.ts
+++ b/packages/grpc-js-core/src/call-credentials.ts
@@ -2,7 +2,7 @@ import {map, reduce} from 'lodash';
 
 import {Metadata} from './metadata';
 
-export type CallMetadataOptions = { service_url?: string; };
+export type CallMetadataOptions = { service_url: string; };
 
 export type CallMetadataGenerator =
     (options: CallMetadataOptions, cb: (err: Error|null, metadata?: Metadata) => void) =>

--- a/packages/grpc-js-core/src/call-stream.ts
+++ b/packages/grpc-js-core/src/call-stream.ts
@@ -271,9 +271,6 @@ export class Http2CallStream extends Duplex implements CallStream {
         let code: Status;
         let details = '';
         switch (errorCode) {
-          case http2.constants.NGHTTP2_NO_ERROR:
-            code = Status.OK;
-            break;
           case http2.constants.NGHTTP2_REFUSED_STREAM:
             code = Status.UNAVAILABLE;
             break;

--- a/packages/grpc-js-core/src/channel-credentials.ts
+++ b/packages/grpc-js-core/src/channel-credentials.ts
@@ -7,19 +7,19 @@ import {CallCredentials} from './call-credentials';
  * as a set of per-call credentials, which are applied to every method call made
  * over a channel initialized with an instance of this class.
  */
-export interface ChannelCredentials {
+export interface ChannelCredentials<T extends {} = {}> {
   /**
    * Returns a copy of this object with the included set of per-call credentials
    * expanded to include callCredentials.
    * @param callCredentials A CallCredentials object to associate with this
    * instance.
    */
-  compose(callCredentials: CallCredentials): ChannelCredentials;
+  compose<S>(callCredentials: CallCredentials<S>): ChannelCredentials<S&T>;
 
   /**
    * Gets the set of per-call credentials associated with this instance.
    */
-  getCallCredentials(): CallCredentials;
+  getCallCredentials(): CallCredentials<T>;
 
   /**
    * Gets a SecureContext object generated from input parameters if this
@@ -29,28 +29,28 @@ export interface ChannelCredentials {
   getSecureContext(): SecureContext|null;
 }
 
-abstract class ChannelCredentialsImpl implements ChannelCredentials {
-  protected callCredentials: CallCredentials;
+abstract class ChannelCredentialsImpl<T> implements ChannelCredentials<T> {
+  protected callCredentials: CallCredentials<T>;
 
-  protected constructor(callCredentials?: CallCredentials) {
+  protected constructor(callCredentials?: CallCredentials<T>) {
     this.callCredentials = callCredentials || CallCredentials.createEmpty();
   }
 
-  abstract compose(callCredentials: CallCredentials): ChannelCredentialsImpl;
+  abstract compose<S>(callCredentials: CallCredentials<S>): ChannelCredentialsImpl<S&T>;
 
-  getCallCredentials(): CallCredentials {
+  getCallCredentials(): CallCredentials<T> {
     return this.callCredentials;
   }
 
   abstract getSecureContext(): SecureContext|null;
 }
 
-class InsecureChannelCredentialsImpl extends ChannelCredentialsImpl {
-  constructor(callCredentials?: CallCredentials) {
+class InsecureChannelCredentialsImpl<T> extends ChannelCredentialsImpl<T> {
+  constructor(callCredentials?: CallCredentials<T>) {
     super(callCredentials);
   }
 
-  compose(callCredentials: CallCredentials): ChannelCredentialsImpl {
+  compose<S>(callCredentials: CallCredentials<S>): ChannelCredentialsImpl<S&T> {
     throw new Error('Cannot compose insecure credentials');
   }
 
@@ -59,15 +59,15 @@ class InsecureChannelCredentialsImpl extends ChannelCredentialsImpl {
   }
 }
 
-class SecureChannelCredentialsImpl extends ChannelCredentialsImpl {
+class SecureChannelCredentialsImpl<T> extends ChannelCredentialsImpl<T> {
   secureContext: SecureContext;
 
-  constructor(secureContext: SecureContext, callCredentials?: CallCredentials) {
+  constructor(secureContext: SecureContext, callCredentials?: CallCredentials<T>) {
     super(callCredentials);
     this.secureContext = secureContext;
   }
 
-  compose(callCredentials: CallCredentials): ChannelCredentialsImpl {
+  compose<S>(callCredentials: CallCredentials<S>): ChannelCredentialsImpl<S&T> {
     const combinedCallCredentials =
         this.callCredentials.compose(callCredentials);
     return new SecureChannelCredentialsImpl(
@@ -86,7 +86,6 @@ function verifyIsBufferOrNull(obj: any, friendlyName: string): void {
 }
 
 export namespace ChannelCredentials {
-
   /**
    * Return a new ChannelCredentials instance with a given set of credentials.
    * The resulting instance can be used to construct a Channel that communicates
@@ -97,7 +96,7 @@ export namespace ChannelCredentials {
    */
   export function createSsl(
       rootCerts?: Buffer|null, privateKey?: Buffer|null,
-      certChain?: Buffer|null): ChannelCredentials {
+      certChain?: Buffer|null): ChannelCredentials<{}> {
     verifyIsBufferOrNull(rootCerts, 'Root certificate');
     verifyIsBufferOrNull(privateKey, 'Private key');
     verifyIsBufferOrNull(certChain, 'Certificate chain');
@@ -120,7 +119,7 @@ export namespace ChannelCredentials {
   /**
    * Return a new ChannelCredentials instance with no credentials.
    */
-  export function createInsecure(): ChannelCredentials {
+  export function createInsecure(): ChannelCredentials<{}> {
     return new InsecureChannelCredentialsImpl();
   }
 }

--- a/packages/grpc-js-core/src/client.ts
+++ b/packages/grpc-js-core/src/client.ts
@@ -16,6 +16,10 @@ export interface UnaryCallback<ResponseType> {
   (err: ServiceError|null, value?: ResponseType): void;
 }
 
+/**
+ * A generic gRPC client. Primarily useful as a base class for all generated
+ * clients.
+ */
 export class Client {
   private readonly [kChannel]: Channel;
   constructor(

--- a/packages/grpc-js-core/src/index.ts
+++ b/packages/grpc-js-core/src/index.ts
@@ -5,31 +5,76 @@ import { Client } from './client';
 import { Status} from './constants';
 import { makeClientConstructor, loadPackageDefinition } from './make-client';
 import { Metadata } from './metadata';
+import { IncomingHttpHeaders } from 'http';
 
-const notImplementedFn = () => { throw new Error('Not implemented'); };
+export interface OAuth2Client {
+  getRequestMetadata: (url: string) => Promise<{ Authorization: string }>;
+}
 
-// Metadata
+export type GoogleCallCredentials = CallCredentials<{ service_url: string }>;
+
+/**** Client Credentials ****/
+
+// Using assign only copies enumerable properties, which is what we want
+export const credentials = Object.assign({
+  /**
+   * Create a gRPC credential from a Google credential object.
+   * @param googleCredentials The authentication client to use.
+   * @return The resulting CallCredentials object.
+   */
+  createFromGoogleCredential: (googleCredentials: OAuth2Client): GoogleCallCredentials => {
+    return CallCredentials.createFromMetadataGenerator(async (options, callback) => {
+      let header;
+      try {
+        header = await googleCredentials.getRequestMetadata(options.service_url);
+      } catch (err) {
+        callback(err);
+        return;
+      }
+      const metadata = new Metadata();
+      metadata.add('authorization', header.Authorization);
+      callback(null, metadata);
+    });
+  },
+
+  /**
+   * Combine a ChannelCredentials with any number of CallCredentials into a
+   * single ChannelCredentials object.
+   * @param channelCredentials The ChannelCredentials object.
+   * @param callCredentials Any number of CallCredentials objects.
+   * @return The resulting ChannelCredentials object.
+   */
+  combineChannelCredentials: <S, T>(
+      channelCredentials: ChannelCredentials<S>,
+      ...callCredentials: CallCredentials<T>[]): ChannelCredentials<S&T> => {
+    return callCredentials.reduce((acc, other) => acc.compose(other), channelCredentials);
+  },
+
+  /**
+   * Combine any number of CallCredentials into a single CallCredentials object.
+   * @param first The first CallCredentials object.
+   * @param additional Any number of additional CallCredentials objects.
+   * @return The resulting CallCredentials object.
+   */
+  combineCallCredentials: <S, T>(
+      first: CallCredentials<S>,
+      ...additional: CallCredentials<T>[]): CallCredentials<S&T> => {
+    return additional.reduce((acc, other) => acc.compose(other), first);
+  }
+}, ChannelCredentials, CallCredentials);
+
+/**** Metadata ****/
+
 export { Metadata };
 
-// Client credentials
-
-export const credentials = {
-  createSsl: ChannelCredentials.createSsl,
-  createFromMetadataGenerator: CallCredentials.createFromMetadataGenerator,
-  createFromGoogleCredential: notImplementedFn /*TODO*/,
-  combineChannelCredentials: (first: ChannelCredentials, ...additional: CallCredentials[]) => additional.reduce((acc, other) => acc.compose(other), first),
-  combineCallCredentials: (first: CallCredentials, ...additional: CallCredentials[]) => additional.reduce((acc, other) => acc.compose(other), first),
-  createInsecure: ChannelCredentials.createInsecure
-};
-
-// Constants
+/**** Constants ****/
 
 export {
   Status as status
   // TODO: Other constants as well
 };
 
-// Client
+/**** Client ****/
 
 export {
   Client,
@@ -37,4 +82,9 @@ export {
   makeClientConstructor,
   makeClientConstructor as makeGenericClientConstructor
 };
+
+/**
+ * Close a Client object.
+ * @param client The client to close.
+ */
 export const closeClient = (client: Client) => client.close();

--- a/packages/grpc-js-core/src/index.ts
+++ b/packages/grpc-js-core/src/index.ts
@@ -22,7 +22,7 @@ export const credentials = Object.assign({
    */
   createFromGoogleCredential: (googleCredentials: OAuth2Client): CallCredentials => {
     return CallCredentials.createFromMetadataGenerator((options, callback) => {
-      googleCredentials.getRequestMetadata(options.service_url!, (err, headers) => {
+      googleCredentials.getRequestMetadata(options.service_url, (err, headers) => {
         if (err) {
           callback(err);
           return;

--- a/packages/grpc-js-core/src/make-client.ts
+++ b/packages/grpc-js-core/src/make-client.ts
@@ -130,7 +130,12 @@ export type GrpcObject = {
   [index: string]: GrpcObject | ServiceClientConstructor;
 };
 
-export function loadPackageDefinition(packageDef: PackageDefinition) {
+/**
+ * Load a gRPC package definition as a gRPC object hierarchy.
+ * @param packageDef The package definition object.
+ * @return The resulting gRPC object.
+ */
+export function loadPackageDefinition(packageDef: PackageDefinition): GrpcObject {
   const result: GrpcObject = {};
   for (const serviceFqn in packageDef) {
     const service = packageDef[serviceFqn];


### PR DESCRIPTION
This PR:

1. Fixes a unit test for CallStream to reflect event name changes in a previous PR
2. Makes Call/ChannelCredentials generic on options type (defaults to {})
3. Implements `createFromGoogleCredential`
4. Documents public API