### PR TITLE
Don't handle already-finished call in channel

### DIFF
--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -239,20 +239,18 @@ export class Http2Channel extends EventEmitter implements Channel {
         headers[HTTP2_HEADER_METHOD] = 'POST';
         headers[HTTP2_HEADER_PATH] = methodName;
         headers[HTTP2_HEADER_TE] = 'trailers';
-        if (stream.getStatus() === null) {
-          if (this.connectivityState === ConnectivityState.READY) {
-            const session: http2.ClientHttp2Session = this.subChannel!;
-            // Prevent the HTTP/2 session from keeping the process alive.
-            // Note: this function is only available in Node 9
-            session.unref();
-            stream.attachHttp2Stream(session.request(headers));
-          } else {
-            /* In this case, we lost the connection while finalizing
-              * metadata. That should be very unusual */
-            setImmediate(() => {
-              this.startHttp2Stream(methodName, stream, metadata);
-            });
-          }
+        if (this.connectivityState === ConnectivityState.READY) {
+          const session: http2.ClientHttp2Session = this.subChannel!;
+          // Prevent the HTTP/2 session from keeping the process alive.
+          // Note: this function is only available in Node 9
+          session.unref();
+          stream.attachHttp2Stream(session.request(headers));
+        } else {
+          /* In this case, we lost the connection while finalizing
+           * metadata. That should be very unusual */
+          setImmediate(() => {
+            this.startHttp2Stream(methodName, stream, metadata);
+          });
         }
       }).catch((error: Error & { code: number }) => {
         // We assume the error code isn't 0 (Status.OK)

--- a/test/any_grpc.js
+++ b/test/any_grpc.js
@@ -11,7 +11,6 @@ function getImplementation(globalField) {
       'If running from the command line, please --require a fixture first.'
     ].join(' '));
   }
-  console.error(globalField, global[globalField]);
   const impl = global[globalField];
   return require(`../packages/grpc-${impl}-core`);
 }


### PR DESCRIPTION
The case where the stream status is non-null (i.e. the call has already completed on the client side). is handled in `stream.attachHttp2Stream`. So the channel should call that in either case.

The way this change is written right now, it also means that the channel will keep trying to connect even if the call is cancelled. I think that's fine.