### PR TITLE
Added a 100MB maxBuffer since the default 200kb is too small

### DIFF
--- a/packages/grpc-tools/bin/protoc_plugin.js
+++ b/packages/grpc-tools/bin/protoc_plugin.js
@@ -32,7 +32,7 @@ var exe_ext = process.platform === 'win32' ? '.exe' : '';
 
 var plugin = path.resolve(__dirname, 'grpc_node_plugin' + exe_ext);
 
-var child_process = execFile(plugin, process.argv.slice(2), {encoding: 'buffer'}, function(error, stdout, stderr) {
+var child_process = execFile(plugin, process.argv.slice(2), {encoding: 'buffer', maxBuffer: 1024 * 1000}, function(error, stdout, stderr) {
   if (error) {
     throw error;
   }

--- a/packages/grpc-tools/bin/protoc_plugin.js
+++ b/packages/grpc-tools/bin/protoc_plugin.js
@@ -32,7 +32,7 @@ var exe_ext = process.platform === 'win32' ? '.exe' : '';
 
 var plugin = path.resolve(__dirname, 'grpc_node_plugin' + exe_ext);
 
-var child_process = execFile(plugin, process.argv.slice(2), {encoding: 'buffer', maxBuffer: 1024 * 1000}, function(error, stdout, stderr) {
+var child_process = execFile(plugin, process.argv.slice(2), {encoding: 'buffer', maxBuffer: 1024 * 1024 * 100}, function(error, stdout, stderr) {
   if (error) {
     throw error;
   }


### PR DESCRIPTION
Hi guys,

I ran into this issue where stdout maxBuffer is too small on a large proto codebase. This fixes the issue, 1MB is fair but I can adjust it per your liking.

Also, was not sure if master is the good branch, let me know and I'll re-submit