### PR TITLE
Pure JS: Pass real service_url to call credentials

### DIFF
--- a/packages/grpc-js-core/src/call-credentials-filter.ts
+++ b/packages/grpc-js-core/src/call-credentials-filter.ts
@@ -9,7 +9,7 @@ import {Metadata} from './metadata';
 export class CallCredentialsFilter extends BaseFilter implements Filter {
   private serviceUrl: string;
   constructor(
-      private readonly channel: Http2Channel,
+      private readonly credentials: CallCredentials,
       private readonly host: string,
       private readonly path: string) {
     super();
@@ -27,7 +27,7 @@ export class CallCredentialsFilter extends BaseFilter implements Filter {
   }
 
   async sendMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
-    let credsMetadata = this.credentials.generateMetadata({ service_url: serviceUrl });
+    let credsMetadata = this.credentials.generateMetadata({ service_url: this.serviceUrl });
     let resultMetadata = await metadata;
     resultMetadata.merge(await credsMetadata);
     return resultMetadata;
@@ -43,6 +43,8 @@ export class CallCredentialsFilterFactory implements
 
   createFilter(callStream: CallStream): CallCredentialsFilter {
     return new CallCredentialsFilter(
-        this.credentials.compose(callStream.getCredentials()));
+      this.credentials.compose(callStream.getCredentials()),
+      callStream.getHost(),
+      callStream.getMethod());
   }
 }

--- a/packages/grpc-js-core/src/call-credentials-filter.ts
+++ b/packages/grpc-js-core/src/call-credentials-filter.ts
@@ -7,13 +7,27 @@ import {BaseFilter, Filter, FilterFactory} from './filter';
 import {Metadata} from './metadata';
 
 export class CallCredentialsFilter extends BaseFilter implements Filter {
-  constructor(private readonly credentials: CallCredentials) {
+  private serviceUrl: string;
+  constructor(
+      private readonly channel: Http2Channel,
+      private readonly host: string,
+      private readonly path: string) {
     super();
+    let splitPath: string[] = path.split('/');
+    let serviceName: string = '';
+    /* The standard path format is "/{serviceName}/{methodName}", so if we split
+     * by '/', the first item should be empty and the second should be the
+     * service name */
+    if (splitPath.length >= 2) {
+      serviceName = splitPath[1];
+    }
+    /* Currently, call credentials are only allowed on HTTPS connections, so we
+     * can assume that the scheme is "https" */
+    this.serviceUrl = `https://${host}/${serviceName}`;
   }
 
   async sendMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
-    // TODO(kjin): pass real service URL to generateMetadata
-    let credsMetadata = this.credentials.generateMetadata({ service_url: '' });
+    let credsMetadata = this.credentials.generateMetadata({ service_url: serviceUrl });
     let resultMetadata = await metadata;
     resultMetadata.merge(await credsMetadata);
     return resultMetadata;

--- a/packages/grpc-js-core/src/call-stream.ts
+++ b/packages/grpc-js-core/src/call-stream.ts
@@ -45,6 +45,8 @@ export type CallStream =  {
   /* If the return value is null, the call has not ended yet. Otherwise, it has
    * ended with the specified status */
   getStatus(): StatusObject|null;
+  getMethod(): string;
+  getHost(): string;
 } & EmitterAugmentation1<'metadata', Metadata>
   & EmitterAugmentation1<'status', StatusObject>
   & ObjectDuplex<WriteObject, Buffer>;
@@ -358,6 +360,10 @@ export class Http2CallStream extends Duplex implements CallStream {
 
   getMethod(): string {
     return this.methodName;
+  }
+
+  getHost(): string {
+    return this.options.host;
   }
 
   _read(size: number) {

--- a/packages/grpc-js-core/src/call-stream.ts
+++ b/packages/grpc-js-core/src/call-stream.ts
@@ -17,6 +17,7 @@ export interface CallStreamOptions {
   deadline: Deadline;
   credentials: CallCredentials;
   flags: number;
+  host: string;
 }
 
 export type CallOptions = Partial<CallStreamOptions>;
@@ -353,6 +354,10 @@ export class Http2CallStream extends Duplex implements CallStream {
 
   getPeer(): string {
     throw new Error('Not yet implemented');
+  }
+
+  getMethod(): string {
+    return this.methodName;
   }
 
   _read(size: number) {

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -202,7 +202,7 @@ export class Http2Channel extends EventEmitter implements Channel {
     }
     // TODO(murgatroid99): Add more centralized handling of channel options
     if (this.options['grpc.default_authority']) {
-      this.defaultAuthority = this.options['grpc.default_authority'];
+      this.defaultAuthority = this.options['grpc.default_authority'] as string;
     } else {
       this.defaultAuthority = this.target.host;
     }
@@ -271,7 +271,7 @@ export class Http2Channel extends EventEmitter implements Channel {
       deadline: options.deadline === undefined ? Infinity : options.deadline,
       credentials: options.credentials || CallCredentials.createEmpty(),
       flags: options.flags || 0,
-      host: options.host || defaultAuthority
+      host: options.host || this.defaultAuthority
     };
     let stream: Http2CallStream =
         new Http2CallStream(methodName, finalOptions, this.filterStackFactory);

--- a/packages/grpc-js-core/test/test-call-stream.ts
+++ b/packages/grpc-js-core/test/test-call-stream.ts
@@ -77,7 +77,8 @@ describe('CallStream', () => {
   const callStreamArgs = {
     deadline: Infinity,
     credentials: CallCredentials.createEmpty(),
-    flags: 0
+    flags: 0,
+    host: ''
   };
   const filterStackFactory = new FilterStackFactory([]);
   const message = 'eat this message'; // 16 bytes


### PR DESCRIPTION
I also added the `host` call option, because that impacts the same code paths.