### PR TITLE
fix: avoid using deprecated Nan APIs

### DIFF
--- a/packages/grpc-native-core/ext/call.h
+++ b/packages/grpc-native-core/ext/call.h
@@ -103,6 +103,7 @@ struct tag {
       v8::Local<v8::Value> call_value);
   ~tag();
   Nan::Callback *callback;
+  Nan::AsyncResource *async_resource;
   OpVec *ops;
   Call *call;
   Nan::Persistent<v8::Value, Nan::CopyablePersistentTraits<v8::Value>>

--- a/packages/grpc-native-core/ext/call_credentials.cc
+++ b/packages/grpc-native-core/ext/call_credentials.cc
@@ -233,7 +233,7 @@ NAUV_WORK_CB(SendPluginCallback) {
         // Get Local<Function> from Nan::Callback*
         **plugin_callback};
     Nan::Callback *callback = state->callback;
-    callback->Call(argc, argv);
+    callback->Call(argc, argv, data->async_resource);
     delete data;
   }
 }
@@ -245,11 +245,10 @@ int plugin_get_metadata(
     grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
     size_t *num_creds_md, grpc_status_code *status,
     const char **error_details) {
+  HandleScope scope;
   plugin_state *p_state = reinterpret_cast<plugin_state *>(state);
-  plugin_callback_data *data = new plugin_callback_data;
-  data->service_url = context.service_url;
-  data->cb = cb;
-  data->user_data = user_data;
+  plugin_callback_data *data =
+      new plugin_callback_data(context.service_url, cb, user_data);
 
   uv_mutex_lock(&p_state->plugin_mutex);
   p_state->pending_callbacks->push(data);

--- a/packages/grpc-native-core/ext/call_credentials.h
+++ b/packages/grpc-native-core/ext/call_credentials.h
@@ -62,9 +62,24 @@ class CallCredentials : public Nan::ObjectWrap {
 /* Auth metadata plugin functionality */
 
 typedef struct plugin_callback_data {
+  plugin_callback_data(const char *service_url_,
+                       grpc_credentials_plugin_metadata_cb cb_,
+                       void *user_data_)
+      : service_url(service_url_),
+        cb(cb_),
+        user_data(user_data_),
+        async_resource(NULL) {
+    Nan::HandleScope scope;
+    async_resource = new Nan::AsyncResource("grpc:plugin_callback_data");
+  }
+  ~plugin_callback_data() {
+    delete async_resource;
+  }
+
   const char *service_url;
   grpc_credentials_plugin_metadata_cb cb;
   void *user_data;
+  Nan::AsyncResource *async_resource;
 } plugin_callback_data;
 
 typedef struct plugin_state {

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "lodash": "^4.15.0",
-    "nan": "^2.0.0",
+    "nan": "^2.10.0",
     "node-pre-gyp": "0.7.0",
     "protobufjs": "^5.0.0"
   },


### PR DESCRIPTION
WIP, but opening early to get early feedback, and to kick off the CI. I intend to revert the `-Wno-deprecated-declarations` removal before this lands.

Starting with Nan 2.9.x certain Nan::Callback::Call APIs are
deprecated. Instead there are mechanisms in place that allow native
modules to preserve async context across async calls.