### PR TITLE
Fix object lifetime and memory management problems in server code

### DIFF
--- a/packages/grpc-native-core/ext/channel_credentials.cc
+++ b/packages/grpc-native-core/ext/channel_credentials.cc
@@ -21,6 +21,7 @@
 #include "call.h"
 #include "call_credentials.h"
 #include "channel_credentials.h"
+#include "util.h"
 #include "grpc/grpc.h"
 #include "grpc/grpc_security.h"
 #include "grpc/support/log.h"
@@ -120,33 +121,35 @@ NAN_METHOD(ChannelCredentials::New) {
 }
 
 NAN_METHOD(ChannelCredentials::CreateSsl) {
-  char *root_certs = NULL;
-  grpc_ssl_pem_key_cert_pair key_cert_pair = {NULL, NULL};
+  StringOrNull root_certs;
+  StringOrNull private_key;
+  StringOrNull cert_chain;
   if (::node::Buffer::HasInstance(info[0])) {
-    root_certs = ::node::Buffer::Data(info[0]);
+    root_certs.assign(info[0]);
   } else if (!(info[0]->IsNull() || info[0]->IsUndefined())) {
     return Nan::ThrowTypeError("createSsl's first argument must be a Buffer");
   }
   if (::node::Buffer::HasInstance(info[1])) {
-    key_cert_pair.private_key = ::node::Buffer::Data(info[1]);
+    private_key.assign(info[1]);
   } else if (!(info[1]->IsNull() || info[1]->IsUndefined())) {
     return Nan::ThrowTypeError(
         "createSSl's second argument must be a Buffer if provided");
   }
   if (::node::Buffer::HasInstance(info[2])) {
-    key_cert_pair.cert_chain = ::node::Buffer::Data(info[2]);
+    cert_chain.assign(info[2]);
   } else if (!(info[2]->IsNull() || info[2]->IsUndefined())) {
     return Nan::ThrowTypeError(
         "createSSl's third argument must be a Buffer if provided");
   }
-  if ((key_cert_pair.private_key == NULL) !=
-      (key_cert_pair.cert_chain == NULL)) {
+  grpc_ssl_pem_key_cert_pair key_cert_pair = {private_key.get(),
+                                              cert_chain.get()};
+  if (private_key.isAssigned() != cert_chain.isAssigned()) {
     return Nan::ThrowError(
         "createSsl's second and third arguments must be"
         " provided or omitted together");
   }
   grpc_channel_credentials *creds = grpc_ssl_credentials_create(
-      root_certs, key_cert_pair.private_key == NULL ? NULL : &key_cert_pair,
+      root_certs.get(), private_key.isAssigned() ? &key_cert_pair : NULL,
       NULL);
   if (creds == NULL) {
     info.GetReturnValue().SetNull();

--- a/packages/grpc-native-core/ext/server.h
+++ b/packages/grpc-native-core/ext/server.h
@@ -61,7 +61,6 @@ class Server : public Nan::ObjectWrap {
   Nan::Persistent<v8::Value> running_self_ref;
 
   grpc_server *wrapped_server;
-  grpc_completion_queue *shutdown_queue;
   bool is_shutdown;
 };
 

--- a/packages/grpc-native-core/ext/server.h
+++ b/packages/grpc-native-core/ext/server.h
@@ -38,7 +38,7 @@ class Server : public Nan::ObjectWrap {
      JavaScript constructor */
   static bool HasInstance(v8::Local<v8::Value> val);
 
-  void DestroyWrappedServer();
+  void FinishShutdown();
 
  private:
   explicit Server(grpc_server *server);
@@ -58,9 +58,11 @@ class Server : public Nan::ObjectWrap {
   static NAN_METHOD(ForceShutdown);
   static Nan::Callback *constructor;
   static Nan::Persistent<v8::FunctionTemplate> fun_tpl;
+  Nan::Persistent<v8::Value> running_self_ref;
 
   grpc_server *wrapped_server;
   grpc_completion_queue *shutdown_queue;
+  bool is_shutdown;
 };
 
 }  // namespace node

--- a/packages/grpc-native-core/ext/server_credentials.cc
+++ b/packages/grpc-native-core/ext/server_credentials.cc
@@ -16,6 +16,8 @@
  *
  */
 
+#include <vector>
+
 #include <nan.h>
 #include <node.h>
 
@@ -148,8 +150,8 @@ NAN_METHOD(ServerCredentials::CreateSsl) {
   Local<Array> pair_list = Local<Array>::Cast(info[1]);
   uint32_t key_cert_pair_count = pair_list->Length();
   grpc_ssl_pem_key_cert_pair key_cert_pairs[key_cert_pair_count];
-  StringOrNull key_strings[key_cert_pair_count];
-  StringOrNull cert_strings[key_cert_pair_count];
+  std::vector<StringOrNull> key_strings(key_cert_pair_count);
+  std::vector<StringOrNull> cert_strings(key_cert_pair_count);
   Local<String> key_key = Nan::New("private_key").ToLocalChecked();
   Local<String> cert_key = Nan::New("cert_chain").ToLocalChecked();
 

--- a/packages/grpc-native-core/ext/server_credentials.cc
+++ b/packages/grpc-native-core/ext/server_credentials.cc
@@ -16,12 +16,14 @@
  *
  */
 
+#include <nan.h>
 #include <node.h>
 
 #include "grpc/grpc.h"
 #include "grpc/grpc_security.h"
 #include "grpc/support/log.h"
 #include "server_credentials.h"
+#include "util.h"
 
 namespace grpc {
 namespace node {
@@ -119,9 +121,9 @@ NAN_METHOD(ServerCredentials::New) {
 
 NAN_METHOD(ServerCredentials::CreateSsl) {
   Nan::HandleScope scope;
-  char *root_certs = NULL;
+  StringOrNull root_certs;
   if (::node::Buffer::HasInstance(info[0])) {
-    root_certs = ::node::Buffer::Data(info[0]);
+    root_certs.assign(info[0]);
   } else if (!(info[0]->IsNull() || info[0]->IsUndefined())) {
     return Nan::ThrowTypeError(
         "createSSl's first argument must be a Buffer if provided");
@@ -145,36 +147,34 @@ NAN_METHOD(ServerCredentials::CreateSsl) {
   }
   Local<Array> pair_list = Local<Array>::Cast(info[1]);
   uint32_t key_cert_pair_count = pair_list->Length();
-  grpc_ssl_pem_key_cert_pair *key_cert_pairs =
-      new grpc_ssl_pem_key_cert_pair[key_cert_pair_count];
-
+  grpc_ssl_pem_key_cert_pair key_cert_pairs[key_cert_pair_count];
+  StringOrNull key_strings[key_cert_pair_count];
+  StringOrNull cert_strings[key_cert_pair_count];
   Local<String> key_key = Nan::New("private_key").ToLocalChecked();
   Local<String> cert_key = Nan::New("cert_chain").ToLocalChecked();
 
   for (uint32_t i = 0; i < key_cert_pair_count; i++) {
     Local<Value> pair_val = Nan::Get(pair_list, i).ToLocalChecked();
     if (!pair_val->IsObject()) {
-      delete[] key_cert_pairs;
       return Nan::ThrowTypeError("Key/cert pairs must be objects");
     }
     Local<Object> pair_obj = Nan::To<Object>(pair_val).ToLocalChecked();
     Local<Value> maybe_key = Nan::Get(pair_obj, key_key).ToLocalChecked();
     Local<Value> maybe_cert = Nan::Get(pair_obj, cert_key).ToLocalChecked();
     if (!::node::Buffer::HasInstance(maybe_key)) {
-      delete[] key_cert_pairs;
       return Nan::ThrowTypeError("private_key must be a Buffer");
     }
     if (!::node::Buffer::HasInstance(maybe_cert)) {
-      delete[] key_cert_pairs;
       return Nan::ThrowTypeError("cert_chain must be a Buffer");
     }
-    key_cert_pairs[i].private_key = ::node::Buffer::Data(maybe_key);
-    key_cert_pairs[i].cert_chain = ::node::Buffer::Data(maybe_cert);
+    key_strings[i].assign(maybe_key);
+    cert_strings[i].assign(maybe_cert);
+    key_cert_pairs[i].private_key = key_strings[i].get();
+    key_cert_pairs[i].cert_chain = cert_strings[i].get();
   }
   grpc_server_credentials *creds = grpc_ssl_server_credentials_create_ex(
-      root_certs, key_cert_pairs, key_cert_pair_count,
+      root_certs.get(), key_cert_pairs, key_cert_pair_count,
       client_certificate_request, NULL);
-  delete[] key_cert_pairs;
   if (creds == NULL) {
     info.GetReturnValue().SetNull();
   } else {

--- a/packages/grpc-native-core/ext/server_credentials.cc
+++ b/packages/grpc-native-core/ext/server_credentials.cc
@@ -149,7 +149,7 @@ NAN_METHOD(ServerCredentials::CreateSsl) {
   }
   Local<Array> pair_list = Local<Array>::Cast(info[1]);
   uint32_t key_cert_pair_count = pair_list->Length();
-  grpc_ssl_pem_key_cert_pair key_cert_pairs[key_cert_pair_count];
+  std::vector<grpc_ssl_pem_key_cert_pair> key_cert_pairs(key_cert_pair_count);
   std::vector<StringOrNull> key_strings(key_cert_pair_count);
   std::vector<StringOrNull> cert_strings(key_cert_pair_count);
   Local<String> key_key = Nan::New("private_key").ToLocalChecked();
@@ -175,7 +175,7 @@ NAN_METHOD(ServerCredentials::CreateSsl) {
     key_cert_pairs[i].cert_chain = cert_strings[i].get();
   }
   grpc_server_credentials *creds = grpc_ssl_server_credentials_create_ex(
-      root_certs.get(), key_cert_pairs, key_cert_pair_count,
+      root_certs.get(), key_cert_pairs.data(), key_cert_pair_count,
       client_certificate_request, NULL);
   if (creds == NULL) {
     info.GetReturnValue().SetNull();

--- a/packages/grpc-native-core/ext/util.h
+++ b/packages/grpc-native-core/ext/util.h
@@ -1,0 +1,52 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NET_GRPC_NODE_UTIL_H_
+#define NET_GRPC_NODE_UTIL_H_
+
+#include <node.h>
+#include <nan.h>
+
+#include <string>
+
+namespace grpc {
+namespace node {
+
+class StringOrNull {
+ public:
+  StringOrNull() : assigned(false) { }
+  void assign(v8::Local<v8::Value> buffer) {
+    str_ = std::string(::node::Buffer::Data(buffer),
+                       ::node::Buffer::Length(buffer));
+    assigned = true;
+  }
+  const char * get() {
+    return assigned ? str_.c_str() : NULL;
+  }
+  bool isAssigned() {
+    return assigned;
+  }
+ private:
+  std::string str_;
+  bool assigned;
+};
+
+}  // namespace node
+}  // namespace grpc
+
+#endif  // NET_GRPC_NODE_UTIL_H_

--- a/packages/grpc-native-core/test/server_test.js
+++ b/packages/grpc-native-core/test/server_test.js
@@ -62,6 +62,10 @@ describe('server', function() {
     before(function() {
       server = new grpc.Server();
     });
+    after(function() {
+      server.start();
+      server.forceShutdown();
+    });
     it('should bind to an unused port', function() {
       var port;
       assert.doesNotThrow(function() {
@@ -83,12 +87,6 @@ describe('server', function() {
         port = server.addHttp2Port('0.0.0.0:0', creds);
       });
       assert(port > 0);
-    });
-  });
-  describe('addSecureHttp2Port', function() {
-    var server;
-    before(function() {
-      server = new grpc.Server();
     });
   });
   describe('start', function() {


### PR DESCRIPTION
This includes a few fixes:

 - Ensure that client and server credentials construction arguments are null-terminated.
 - Ensure that the callback for `Server#tryShutdown` is always called asynchronously.
 - Ensure that the server doesn't get garbage collected while it is running, and remove server destructor code the server down.