### PR TITLE
Update error msg for Protobuf.js detection options

### DIFF
--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -81,7 +81,7 @@ exports.loadObject = function loadObject(value, options) {
       protobufjsVersion = 5;
     } else {
       var error_message = 'Could not detect ProtoBuf.js version. Please ' +
-          'specify the version number with the "protobufjs_version" option';
+          'specify the version number with the "protobufjsVersion" option';
       throw new Error(error_message);
     }
   } else {


### PR DESCRIPTION
Updates incorrect option name in error msg from 'protobufjs_version' to 'protobufjsVersion'.