### PR TITLE
client library integration: adjust options

### DIFF
--- a/packages/grpc-protobufjs/src/index.ts
+++ b/packages/grpc-protobufjs/src/index.ts
@@ -97,14 +97,14 @@ function createMethodDefinition(method: Protobuf.Method, serviceName: string, op
     responseSerialize: createSerializer(method.resolvedResponseType as Protobuf.Type),
     responseDeserialize: createDeserializer(method.resolvedResponseType as Protobuf.Type, options),
     // TODO(murgatroid99): Find a better way to handle this
-    originalName: _.camelCase(method.name)
+    originalName: method.name
   };
 }
 
 function createServiceDefinition(service: Protobuf.Service, name: string, options: Options): ServiceDefinition {
   const def: ServiceDefinition = {};
   for (const method of service.methodsArray) {
-    def[method.name] = createMethodDefinition(method, name, options);
+    def[_.camelCase(method.name)] = createMethodDefinition(method, name, options);
   }
   return def;
 }

--- a/packages/grpc-protobufjs/src/index.ts
+++ b/packages/grpc-protobufjs/src/index.ts
@@ -97,14 +97,14 @@ function createMethodDefinition(method: Protobuf.Method, serviceName: string, op
     responseSerialize: createSerializer(method.resolvedResponseType as Protobuf.Type),
     responseDeserialize: createDeserializer(method.resolvedResponseType as Protobuf.Type, options),
     // TODO(murgatroid99): Find a better way to handle this
-    originalName: method.name
+    originalName: _.camelCase(method.name)
   };
 }
 
 function createServiceDefinition(service: Protobuf.Service, name: string, options: Options): ServiceDefinition {
   const def: ServiceDefinition = {};
   for (const method of service.methodsArray) {
-    def[_.camelCase(method.name)] = createMethodDefinition(method, name, options);
+    def[method.name] = createMethodDefinition(method, name, options);
   }
   return def;
 }


### PR DESCRIPTION
This PR contains changes that help client libraries pass when using methods on the new gRPC protobuf package.

- ~~The move of `_.camelCase` seemed appropriate as it matches what I see here: https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/src/protobuf_js_6_common.js#L106-L121~~
- I've updated the monkeypatch implementations of methods accessing `grpc.load[Object]` to have more thorough conversion options. `oneofs: true` in particular seemed to allow Datastore tests to pass.