### PR TITLE
grpc-js-core: only listen for channel connect event once

### DIFF
--- a/packages/grpc-js-core/src/call.ts
+++ b/packages/grpc-js-core/src/call.ts
@@ -87,13 +87,13 @@ function setUpReadableStream<ResponseType>(
     stream.push(null);
   });
   call.on('status', (status: StatusObject) => {
-    stream.emit('status', status);
     if (status.code !== Status.OK) {
       const statusName = _.invert(Status)[status.code];
       const message: string = `${status.code} ${statusName}: ${status.details}`;
       const error: ServiceError = Object.assign(new Error(status.details), status);
       stream.emit('error', error);
     }
+    stream.emit('status', status);
   });
   call.pause();
 }

--- a/packages/grpc-js-core/src/client.ts
+++ b/packages/grpc-js-core/src/client.ts
@@ -42,6 +42,12 @@ export class Client {
         clearTimeout(timer);
       }
       cb(null);
+    }, (err: Error) => {
+      // Rejection occurs if channel is shut down first.
+      if (timer) {
+        clearTimeout(timer);
+      }
+      cb(err);
     });
     if (deadline !== Infinity) {
       let timeout: number;


### PR DESCRIPTION
This PR makes a change so that only one `'connect'` handler is registered when `Http2Channel#connect()` is called. This prevents Node from warning that there might be an EventEmitter leak because too many listeners are added on the `'connect'` event. (This was observed during Firestore client library testing.)

To accomplish this, a class member `connecting` Promise is cached and returned when `connect()` is called more than once.

In addition to the above, I added a rejection condition for `connect()` for when the channel shuts down. This hadn't been causing problems before but might help in the future.

Also, I've reversed the order in which `Call` events are emitted; `'status'` events are now always emitted after `'error'` events. The PubSub client library appears to depend on this particular order.