### PR TITLE
Fix lint errors and formatting

### DIFF
--- a/packages/grpc-js-core/src/call-credentials-filter.ts
+++ b/packages/grpc-js-core/src/call-credentials-filter.ts
@@ -10,11 +10,10 @@ export class CallCredentialsFilter extends BaseFilter implements Filter {
   private serviceUrl: string;
   constructor(
       private readonly credentials: CallCredentials,
-      private readonly host: string,
-      private readonly path: string) {
+      private readonly host: string, private readonly path: string) {
     super();
-    let splitPath: string[] = path.split('/');
-    let serviceName: string = '';
+    const splitPath: string[] = path.split('/');
+    let serviceName = '';
     /* The standard path format is "/{serviceName}/{methodName}", so if we split
      * by '/', the first item should be empty and the second should be the
      * service name */
@@ -27,8 +26,9 @@ export class CallCredentialsFilter extends BaseFilter implements Filter {
   }
 
   async sendMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
-    let credsMetadata = this.credentials.generateMetadata({ service_url: this.serviceUrl });
-    let resultMetadata = await metadata;
+    const credsMetadata =
+        this.credentials.generateMetadata({service_url: this.serviceUrl});
+    const resultMetadata = await metadata;
     resultMetadata.merge(await credsMetadata);
     return resultMetadata;
   }
@@ -43,8 +43,7 @@ export class CallCredentialsFilterFactory implements
 
   createFilter(callStream: CallStream): CallCredentialsFilter {
     return new CallCredentialsFilter(
-      this.credentials.compose(callStream.getCredentials()),
-      callStream.getHost(),
-      callStream.getMethod());
+        this.credentials.compose(callStream.getCredentials()),
+        callStream.getHost(), callStream.getMethod());
   }
 }

--- a/packages/grpc-js-core/src/call-credentials.ts
+++ b/packages/grpc-js-core/src/call-credentials.ts
@@ -2,39 +2,59 @@ import {map, reduce} from 'lodash';
 
 import {Metadata} from './metadata';
 
-export type CallMetadataOptions = { service_url: string; };
+export type CallMetadataOptions = {
+  service_url: string;
+};
 
 export type CallMetadataGenerator =
-    (options: CallMetadataOptions, cb: (err: Error|null, metadata?: Metadata) => void) =>
-        void;
+    (options: CallMetadataOptions,
+     cb: (err: Error|null, metadata?: Metadata) => void) => void;
 
 /**
  * A class that represents a generic method of adding authentication-related
  * metadata on a per-request basis.
  */
-export interface CallCredentials {
+export abstract class CallCredentials {
   /**
    * Asynchronously generates a new Metadata object.
    * @param options Options used in generating the Metadata object.
    */
-  generateMetadata(options: CallMetadataOptions): Promise<Metadata>;
+  abstract generateMetadata(options: CallMetadataOptions): Promise<Metadata>;
   /**
    * Creates a new CallCredentials object from properties of both this and
    * another CallCredentials object. This object's metadata generator will be
    * called first.
    * @param callCredentials The other CallCredentials object.
    */
-  compose(callCredentials: CallCredentials): CallCredentials;
+  abstract compose(callCredentials: CallCredentials): CallCredentials;
+
+  /**
+   * Creates a new CallCredentials object from a given function that generates
+   * Metadata objects.
+   * @param metadataGenerator A function that accepts a set of options, and
+   * generates a Metadata object based on these options, which is passed back
+   * to the caller via a supplied (err, metadata) callback.
+   */
+  static createFromMetadataGenerator(metadataGenerator: CallMetadataGenerator):
+      CallCredentials {
+    return new SingleCallCredentials(metadataGenerator);
+  }
+
+  static createEmpty(): CallCredentials {
+    return new EmptyCallCredentials();
+  }
 }
 
-class ComposedCallCredentials implements CallCredentials {
-  constructor(private creds: CallCredentials[]) {}
+class ComposedCallCredentials extends CallCredentials {
+  constructor(private creds: CallCredentials[]) {
+    super();
+  }
 
   async generateMetadata(options: CallMetadataOptions): Promise<Metadata> {
-    let base: Metadata = new Metadata();
-    let generated: Metadata[] = await Promise.all(
+    const base: Metadata = new Metadata();
+    const generated: Metadata[] = await Promise.all(
         map(this.creds, (cred) => cred.generateMetadata(options)));
-    for (let gen of generated) {
+    for (const gen of generated) {
       base.merge(gen);
     }
     return base;
@@ -45,8 +65,10 @@ class ComposedCallCredentials implements CallCredentials {
   }
 }
 
-class SingleCallCredentials implements CallCredentials {
-  constructor(private metadataGenerator: CallMetadataGenerator) {}
+class SingleCallCredentials extends CallCredentials {
+  constructor(private metadataGenerator: CallMetadataGenerator) {
+    super();
+  }
 
   generateMetadata(options: CallMetadataOptions): Promise<Metadata> {
     return new Promise<Metadata>((resolve, reject) => {
@@ -65,30 +87,12 @@ class SingleCallCredentials implements CallCredentials {
   }
 }
 
-class EmptyCallCredentials implements CallCredentials {
+class EmptyCallCredentials extends CallCredentials {
   generateMetadata(options: CallMetadataOptions): Promise<Metadata> {
     return Promise.resolve(new Metadata());
   }
 
   compose(other: CallCredentials): CallCredentials {
     return other;
-  }
-}
-
-export namespace CallCredentials {
-  /**
-   * Creates a new CallCredentials object from a given function that generates
-   * Metadata objects.
-   * @param metadataGenerator A function that accepts a set of options, and
-   * generates a Metadata object based on these options, which is passed back
-   * to the caller via a supplied (err, metadata) callback.
-   */
-  export function createFromMetadataGenerator(
-      metadataGenerator: CallMetadataGenerator): CallCredentials {
-    return new SingleCallCredentials(metadataGenerator);
-  }
-
-  export function createEmpty(): CallCredentials {
-    return new EmptyCallCredentials();
   }
 }

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -1,6 +1,6 @@
 import {EventEmitter} from 'events';
 import * as http2 from 'http2';
-import {checkServerIdentity, SecureContext, PeerCertificate} from 'tls';
+import {checkServerIdentity, PeerCertificate, SecureContext} from 'tls';
 import * as url from 'url';
 
 import {CallCredentials} from './call-credentials';
@@ -12,9 +12,9 @@ import {Status} from './constants';
 import {DeadlineFilterFactory} from './deadline-filter';
 import {FilterStackFactory} from './filter-stack';
 import {Metadata, MetadataObject} from './metadata';
-import { MetadataStatusFilterFactory } from './metadata-status-filter';
+import {MetadataStatusFilterFactory} from './metadata-status-filter';
 
-const { version: clientVersion } = require('../../package');
+const {version: clientVersion} = require('../../package');
 
 const IDLE_TIMEOUT_MS = 300000;
 
@@ -42,7 +42,7 @@ export interface ChannelOptions {
   'grpc.primary_user_agent': string;
   'grpc.secondary_user_agent': string;
   'grpc.default_authority': string;
-  [key: string]: string | number;
+  [key: string]: string|number;
 }
 
 export enum ConnectivityState {
@@ -53,7 +53,7 @@ export enum ConnectivityState {
   SHUTDOWN
 }
 
-function uniformRandom(min:number, max: number) {
+function uniformRandom(min: number, max: number) {
   return Math.random() * (max - min) + min;
 }
 
@@ -71,6 +71,7 @@ export interface Channel extends EventEmitter {
   getConnectivityState(): ConnectivityState;
   close(): void;
 
+  /* tslint:disable:no-any */
   addListener(event: string, listener: Function): this;
   emit(event: string|symbol, ...args: any[]): boolean;
   on(event: string, listener: Function): this;
@@ -78,6 +79,7 @@ export interface Channel extends EventEmitter {
   prependListener(event: string, listener: Function): this;
   prependOnceListener(event: string, listener: Function): this;
   removeListener(event: string, listener: Function): this;
+  /* tslint:enable:no-any */
 }
 
 export class Http2Channel extends EventEmitter implements Channel {
@@ -92,54 +94,65 @@ export class Http2Channel extends EventEmitter implements Channel {
   private subChannel: http2.ClientHttp2Session|null = null;
   private filterStackFactory: FilterStackFactory;
 
-  private subChannelConnectCallback: ()=>void = () => {};
-  private subChannelCloseCallback: ()=>void = () => {};
+  private subChannelConnectCallback: () => void = () => {};
+  private subChannelCloseCallback: () => void = () => {};
 
   private backoffTimerId: NodeJS.Timer;
   private currentBackoff: number = INITIAL_BACKOFF_MS;
   private currentBackoffDeadline: Date;
 
-  private handleStateChange(oldState: ConnectivityState, newState: ConnectivityState): void {
-    let now: Date = new Date();
-    switch(newState) {
-    case ConnectivityState.CONNECTING:
-      if (oldState === ConnectivityState.IDLE) {
-        this.currentBackoff = INITIAL_BACKOFF_MS;
-        this.currentBackoffDeadline = new Date(now.getTime() + INITIAL_BACKOFF_MS);
-      } else if (oldState === ConnectivityState.TRANSIENT_FAILURE) {
-        this.currentBackoff = Math.min(this.currentBackoff * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
-        let jitterMagnitude: number = BACKOFF_JITTER * this.currentBackoff;
-        this.currentBackoffDeadline = new Date(now.getTime() + this.currentBackoff + uniformRandom(-jitterMagnitude, jitterMagnitude));
-      }
-      this.startConnecting();
-      break;
-    case ConnectivityState.READY:
-      this.emit('connect');
-      break;
-    case ConnectivityState.TRANSIENT_FAILURE:
-      this.subChannel = null;
-      this.backoffTimerId = setTimeout(() => {
-        this.transitionToState([ConnectivityState.TRANSIENT_FAILURE], ConnectivityState.CONNECTING);
-      }, this.currentBackoffDeadline.getTime() - now.getTime());
-      break;
-    case ConnectivityState.IDLE:
-    case ConnectivityState.SHUTDOWN:
-      if (this.subChannel) {
-        this.subChannel.close();
-        this.subChannel.removeListener('connect', this.subChannelConnectCallback);
-        this.subChannel.removeListener('close', this.subChannelCloseCallback);
+  private handleStateChange(
+      oldState: ConnectivityState, newState: ConnectivityState): void {
+    const now: Date = new Date();
+    switch (newState) {
+      case ConnectivityState.CONNECTING:
+        if (oldState === ConnectivityState.IDLE) {
+          this.currentBackoff = INITIAL_BACKOFF_MS;
+          this.currentBackoffDeadline =
+              new Date(now.getTime() + INITIAL_BACKOFF_MS);
+        } else if (oldState === ConnectivityState.TRANSIENT_FAILURE) {
+          this.currentBackoff = Math.min(
+              this.currentBackoff * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
+          const jitterMagnitude: number = BACKOFF_JITTER * this.currentBackoff;
+          this.currentBackoffDeadline = new Date(
+              now.getTime() + this.currentBackoff +
+              uniformRandom(-jitterMagnitude, jitterMagnitude));
+        }
+        this.startConnecting();
+        break;
+      case ConnectivityState.READY:
+        this.emit('connect');
+        break;
+      case ConnectivityState.TRANSIENT_FAILURE:
         this.subChannel = null;
-        this.emit('shutdown');
-        clearTimeout(this.backoffTimerId);
-      }
-      break;
+        this.backoffTimerId = setTimeout(() => {
+          this.transitionToState(
+              [ConnectivityState.TRANSIENT_FAILURE],
+              ConnectivityState.CONNECTING);
+        }, this.currentBackoffDeadline.getTime() - now.getTime());
+        break;
+      case ConnectivityState.IDLE:
+      case ConnectivityState.SHUTDOWN:
+        if (this.subChannel) {
+          this.subChannel.close();
+          this.subChannel.removeListener(
+              'connect', this.subChannelConnectCallback);
+          this.subChannel.removeListener('close', this.subChannelCloseCallback);
+          this.subChannel = null;
+          this.emit('shutdown');
+          clearTimeout(this.backoffTimerId);
+        }
+        break;
+      default:
+        throw new Error('This should never happen');
     }
   }
 
   // Transition from any of a set of oldStates to a specific newState
-  private transitionToState(oldStates: ConnectivityState[], newState: ConnectivityState): void {
+  private transitionToState(
+      oldStates: ConnectivityState[], newState: ConnectivityState): void {
     if (oldStates.indexOf(this.connectivityState) > -1) {
-      let oldState: ConnectivityState = this.connectivityState;
+      const oldState: ConnectivityState = this.connectivityState;
       this.connectivityState = newState;
       this.handleStateChange(oldState, newState);
       this.emit('connectivityStateChanged', newState);
@@ -148,54 +161,58 @@ export class Http2Channel extends EventEmitter implements Channel {
 
   private startConnecting(): void {
     let subChannel: http2.ClientHttp2Session;
-    let secureContext = this.credentials.getSecureContext();
+    const secureContext = this.credentials.getSecureContext();
     if (secureContext === null) {
       subChannel = http2.connect(this.target);
     } else {
       const connectionOptions: http2.SecureClientSessionOptions = {
         secureContext,
-      }
+      };
       // If provided, the value of grpc.ssl_target_name_override should be used
       // to override the target hostname when checking server identity.
       // This option is used for testing only.
       if (this.options['grpc.ssl_target_name_override']) {
-        const sslTargetNameOverride = this.options['grpc.ssl_target_name_override']!;
-        connectionOptions.checkServerIdentity = (host: string, cert: PeerCertificate): Error | undefined => {
-          return checkServerIdentity(sslTargetNameOverride, cert);
-        }
+        const sslTargetNameOverride =
+            this.options['grpc.ssl_target_name_override']!;
+        connectionOptions.checkServerIdentity =
+            (host: string, cert: PeerCertificate): Error|undefined => {
+              return checkServerIdentity(sslTargetNameOverride, cert);
+            };
         connectionOptions.servername = sslTargetNameOverride;
       }
       subChannel = http2.connect(this.target, connectionOptions);
     }
     this.subChannel = subChannel;
-    let now = new Date();
-    let connectionTimeout: number = Math.max(
-      this.currentBackoffDeadline.getTime() - now.getTime(),
-      MIN_CONNECT_TIMEOUT_MS);
-    let connectionTimerId: NodeJS.Timer = setTimeout(() => {
-      // This should trigger the 'close' event, which will send us back to TRANSIENT_FAILURE
+    const now = new Date();
+    const connectionTimeout: number = Math.max(
+        this.currentBackoffDeadline.getTime() - now.getTime(),
+        MIN_CONNECT_TIMEOUT_MS);
+    const connectionTimerId: NodeJS.Timer = setTimeout(() => {
+      // This should trigger the 'close' event, which will send us back to
+      // TRANSIENT_FAILURE
       subChannel.close();
     }, connectionTimeout);
     this.subChannelConnectCallback = () => {
       // Connection succeeded
       clearTimeout(connectionTimerId);
-      this.transitionToState([ConnectivityState.CONNECTING], ConnectivityState.READY);
+      this.transitionToState(
+          [ConnectivityState.CONNECTING], ConnectivityState.READY);
     };
     subChannel.once('connect', this.subChannelConnectCallback);
     this.subChannelCloseCallback = () => {
       // Connection failed
       clearTimeout(connectionTimerId);
-      /* TODO(murgatroid99): verify that this works for CONNECTING->TRANSITIVE_FAILURE
-       * see nodejs/node#16645 */
-      this.transitionToState([ConnectivityState.CONNECTING, ConnectivityState.READY],
-                             ConnectivityState.TRANSIENT_FAILURE);
+      /* TODO(murgatroid99): verify that this works for
+       * CONNECTING->TRANSITIVE_FAILURE see nodejs/node#16645 */
+      this.transitionToState(
+          [ConnectivityState.CONNECTING, ConnectivityState.READY],
+          ConnectivityState.TRANSIENT_FAILURE);
     };
     subChannel.once('close', this.subChannelCloseCallback);
   }
 
   constructor(
-      address: string,
-      public readonly credentials: ChannelCredentials,
+      address: string, readonly credentials: ChannelCredentials,
       private readonly options: Partial<ChannelOptions>) {
     super();
     if (credentials.getSecureContext() === null) {
@@ -211,8 +228,7 @@ export class Http2Channel extends EventEmitter implements Channel {
     }
     this.filterStackFactory = new FilterStackFactory([
       new CompressionFilterFactory(this),
-      new CallCredentialsFilterFactory(this),
-      new DeadlineFilterFactory(this),
+      new CallCredentialsFilterFactory(this), new DeadlineFilterFactory(this),
       new MetadataStatusFilterFactory(this)
     ]);
     this.currentBackoffDeadline = new Date();
@@ -223,60 +239,60 @@ export class Http2Channel extends EventEmitter implements Channel {
 
     // Build user-agent string.
     this.userAgent = [
-      options['grpc.primary_user_agent'],
-      `grpc-node-js/${clientVersion}`,
+      options['grpc.primary_user_agent'], `grpc-node-js/${clientVersion}`,
       options['grpc.secondary_user_agent']
-    ].filter(e => e).join(' '); // remove falsey values first
+    ].filter(e => e).join(' ');  // remove falsey values first
   }
 
   private startHttp2Stream(
-      authority: string,
-      methodName: string,
-      stream: Http2CallStream,
+      authority: string, methodName: string, stream: Http2CallStream,
       metadata: Metadata) {
-    let finalMetadata: Promise<Metadata> =
+    const finalMetadata: Promise<Metadata> =
         stream.filterStack.sendMetadata(Promise.resolve(metadata.clone()));
     Promise.all([finalMetadata, this.connect()])
-      .then(([metadataValue]) => {
-        let headers = metadataValue.toHttp2Headers();
-        headers[HTTP2_HEADER_AUTHORITY] = authority;
-        headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;
-        headers[HTTP2_HEADER_CONTENT_TYPE] = 'application/grpc';
-        headers[HTTP2_HEADER_METHOD] = 'POST';
-        headers[HTTP2_HEADER_PATH] = methodName;
-        headers[HTTP2_HEADER_TE] = 'trailers';
-        if (this.connectivityState === ConnectivityState.READY) {
-          const session: http2.ClientHttp2Session = this.subChannel!;
-          // Prevent the HTTP/2 session from keeping the process alive.
-          // Note: this function is only available in Node 9
-          session.unref();
-          stream.attachHttp2Stream(session.request(headers));
-        } else {
-          /* In this case, we lost the connection while finalizing
-           * metadata. That should be very unusual */
-          setImmediate(() => {
-            this.startHttp2Stream(authority, methodName, stream, metadata);
-          });
-        }
-      }).catch((error: Error & { code: number }) => {
-        // We assume the error code isn't 0 (Status.OK)
-        stream.cancelWithStatus(error.code || Status.UNKNOWN,
-          `Getting metadata from plugin failed with error: ${error.message}`);
-      });
+        .then(([metadataValue]) => {
+          const headers = metadataValue.toHttp2Headers();
+          headers[HTTP2_HEADER_AUTHORITY] = authority;
+          headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;
+          headers[HTTP2_HEADER_CONTENT_TYPE] = 'application/grpc';
+          headers[HTTP2_HEADER_METHOD] = 'POST';
+          headers[HTTP2_HEADER_PATH] = methodName;
+          headers[HTTP2_HEADER_TE] = 'trailers';
+          if (this.connectivityState === ConnectivityState.READY) {
+            const session: http2.ClientHttp2Session = this.subChannel!;
+            // Prevent the HTTP/2 session from keeping the process alive.
+            // Note: this function is only available in Node 9
+            session.unref();
+            stream.attachHttp2Stream(session.request(headers));
+          } else {
+            /* In this case, we lost the connection while finalizing
+             * metadata. That should be very unusual */
+            setImmediate(() => {
+              this.startHttp2Stream(authority, methodName, stream, metadata);
+            });
+          }
+        })
+        .catch((error: Error&{code: number}) => {
+          // We assume the error code isn't 0 (Status.OK)
+          stream.cancelWithStatus(
+              error.code || Status.UNKNOWN,
+              `Getting metadata from plugin failed with error: ${
+                  error.message}`);
+        });
   }
 
   createStream(methodName: string, metadata: Metadata, options: CallOptions):
-  CallStream {
+      CallStream {
     if (this.connectivityState === ConnectivityState.SHUTDOWN) {
       throw new Error('Channel has been shut down');
     }
-    let finalOptions: CallStreamOptions = {
+    const finalOptions: CallStreamOptions = {
       deadline: options.deadline === undefined ? Infinity : options.deadline,
       credentials: options.credentials || CallCredentials.createEmpty(),
       flags: options.flags || 0,
       host: options.host || this.defaultAuthority
     };
-    let stream: Http2CallStream =
+    const stream: Http2CallStream =
         new Http2CallStream(methodName, finalOptions, this.filterStackFactory);
     this.startHttp2Stream(finalOptions.host, methodName, stream, metadata);
     return stream;
@@ -297,7 +313,8 @@ export class Http2Channel extends EventEmitter implements Channel {
       // been (connectivityState === IDLE).
       if (!this.connecting) {
         this.connecting = new Promise((resolve, reject) => {
-          this.transitionToState([ConnectivityState.IDLE], ConnectivityState.CONNECTING);
+          this.transitionToState(
+              [ConnectivityState.IDLE], ConnectivityState.CONNECTING);
           const onConnect = () => {
             this.connecting = null;
             this.removeListener('shutdown', onShutdown);
@@ -324,9 +341,11 @@ export class Http2Channel extends EventEmitter implements Channel {
     if (this.connectivityState === ConnectivityState.SHUTDOWN) {
       throw new Error('Channel has been shut down');
     }
-    this.transitionToState([ConnectivityState.CONNECTING,
-                            ConnectivityState.READY,
-                            ConnectivityState.TRANSIENT_FAILURE,
-                            ConnectivityState.IDLE], ConnectivityState.SHUTDOWN);
+    this.transitionToState(
+        [
+          ConnectivityState.CONNECTING, ConnectivityState.READY,
+          ConnectivityState.TRANSIENT_FAILURE, ConnectivityState.IDLE
+        ],
+        ConnectivityState.SHUTDOWN);
   }
 }

--- a/packages/grpc-js-core/src/client.ts
+++ b/packages/grpc-js-core/src/client.ts
@@ -21,7 +21,7 @@ export interface UnaryCallback<ResponseType> {
  * clients.
  */
 export class Client {
-  private readonly [kChannel]: Channel;
+  private readonly[kChannel]: Channel;
   constructor(
       address: string, credentials: ChannelCredentials,
       options: Partial<ChannelOptions> = {}) {
@@ -34,24 +34,26 @@ export class Client {
 
   waitForReady(deadline: Date|number, callback: (error: Error|null) => void):
       void {
-    let cb: (error: Error|null) => void = once(callback);
-    let callbackCalled = false;
-    let timer: NodeJS.Timer | null = null;
-    this[kChannel].connect().then(() => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-      cb(null);
-    }, (err: Error) => {
-      // Rejection occurs if channel is shut down first.
-      if (timer) {
-        clearTimeout(timer);
-      }
-      cb(err);
-    });
+    const cb: (error: Error|null) => void = once(callback);
+    const callbackCalled = false;
+    let timer: NodeJS.Timer|null = null;
+    this[kChannel].connect().then(
+        () => {
+          if (timer) {
+            clearTimeout(timer);
+          }
+          cb(null);
+        },
+        (err: Error) => {
+          // Rejection occurs if channel is shut down first.
+          if (timer) {
+            clearTimeout(timer);
+          }
+          cb(err);
+        });
     if (deadline !== Infinity) {
       let timeout: number;
-      let now: number = (new Date).getTime();
+      const now: number = (new Date()).getTime();
       if (deadline instanceof Date) {
         timeout = deadline.getTime() - now;
       } else {
@@ -94,7 +96,8 @@ export class Client {
       if (status.code === Status.OK) {
         callback(null, responseMessage as ResponseType);
       } else {
-        const error: ServiceError = Object.assign(new Error(status.details), status);
+        const error: ServiceError =
+            Object.assign(new Error(status.details), status);
         callback(error);
       }
     });
@@ -156,7 +159,7 @@ export class Client {
     const call: CallStream =
         this[kChannel].createStream(method, metadata, options);
     const message: Buffer = serialize(argument);
-    const writeObj: WriteObject = {message: message};
+    const writeObj: WriteObject = {message};
     writeObj.flags = options.flags;
     call.write(writeObj);
     call.end();
@@ -238,7 +241,7 @@ export class Client {
     const call: CallStream =
         this[kChannel].createStream(method, metadata, options);
     const message: Buffer = serialize(argument);
-    const writeObj: WriteObject = {message: message};
+    const writeObj: WriteObject = {message};
     writeObj.flags = options.flags;
     call.write(writeObj);
     call.end();

--- a/packages/grpc-js-core/src/deadline-filter.ts
+++ b/packages/grpc-js-core/src/deadline-filter.ts
@@ -4,14 +4,14 @@ import {Status} from './constants';
 import {BaseFilter, Filter, FilterFactory} from './filter';
 import {Metadata} from './metadata';
 
-const units: [string, number][] =
+const units: Array<[string, number]> =
     [['m', 1], ['S', 1000], ['M', 60 * 1000], ['H', 60 * 60 * 1000]];
 
 function getDeadline(deadline: number) {
-  let now = (new Date()).getTime();
-  let timeoutMs = Math.max(deadline - now, 0);
-  for (let [unit, factor] of units) {
-    let amount = timeoutMs / factor;
+  const now = (new Date()).getTime();
+  const timeoutMs = Math.max(deadline - now, 0);
+  for (const [unit, factor] of units) {
+    const amount = timeoutMs / factor;
     if (amount < 1e8) {
       return String(Math.ceil(amount)) + unit;
     }
@@ -20,19 +20,19 @@ function getDeadline(deadline: number) {
 }
 
 export class DeadlineFilter extends BaseFilter implements Filter {
-  private timer: NodeJS.Timer | null = null;
+  private timer: NodeJS.Timer|null = null;
   private deadline: number;
   constructor(
       private readonly channel: Http2Channel,
       private readonly callStream: CallStream) {
     super();
-    let callDeadline = callStream.getDeadline();
+    const callDeadline = callStream.getDeadline();
     if (callDeadline instanceof Date) {
       this.deadline = callDeadline.getTime();
     } else {
       this.deadline = callDeadline;
     }
-    let now: number = (new Date()).getTime();
+    const now: number = (new Date()).getTime();
     let timeout = this.deadline - now;
     if (timeout < 0) {
       timeout = 0;

--- a/packages/grpc-js-core/src/events.ts
+++ b/packages/grpc-js-core/src/events.ts
@@ -23,7 +23,9 @@ export interface EmitterAugmentation2<Name extends string|symbol, Arg1, Arg2> {
   emit(event: Name, arg1: Arg1, arg2: Arg2): boolean;
   on(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void): this;
   once(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void): this;
-  prependListener(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void): this;
-  prependOnceListener(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void): this;
+  prependListener(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void):
+      this;
+  prependOnceListener(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void):
+      this;
   removeListener(event: Name, listener: (arg1: Arg1, arg2: Arg2) => void): this;
 }

--- a/packages/grpc-js-core/src/filter-stack.ts
+++ b/packages/grpc-js-core/src/filter-stack.ts
@@ -25,7 +25,7 @@ export class FilterStack implements Filter {
 }
 
 export class FilterStackFactory implements FilterFactory<FilterStack> {
-  constructor(private readonly factories: FilterFactory<any>[]) {}
+  constructor(private readonly factories: Array<FilterFactory<Filter>>) {}
 
   createFilter(callStream: CallStream): FilterStack {
     return new FilterStack(

--- a/packages/grpc-js-core/src/index.ts
+++ b/packages/grpc-js-core/src/index.ts
@@ -1,68 +1,78 @@
 
-import { CallCredentials } from './call-credentials';
-import { ChannelCredentials } from './channel-credentials';
-import { Client } from './client';
-import { Status} from './constants';
-import { makeClientConstructor, loadPackageDefinition } from './make-client';
-import { Metadata } from './metadata';
-import { IncomingHttpHeaders } from 'http';
+import {IncomingHttpHeaders} from 'http';
+
+import {CallCredentials} from './call-credentials';
+import {ChannelCredentials} from './channel-credentials';
+import {Client} from './client';
+import {Status} from './constants';
+import {loadPackageDefinition, makeClientConstructor} from './make-client';
+import {Metadata} from './metadata';
 
 export interface OAuth2Client {
-  getRequestMetadata: (url: string, callback: (err: Error|null, headers?: { Authorization: string }) => void) => void;
+  getRequestMetadata: (url: string, callback: (err: Error|null, headers?: {
+                                      Authorization: string
+                                    }) => void) => void;
 }
 
 /**** Client Credentials ****/
 
 // Using assign only copies enumerable properties, which is what we want
-export const credentials = Object.assign({
-  /**
-   * Create a gRPC credential from a Google credential object.
-   * @param googleCredentials The authentication client to use.
-   * @return The resulting CallCredentials object.
-   */
-  createFromGoogleCredential: (googleCredentials: OAuth2Client): CallCredentials => {
-    return CallCredentials.createFromMetadataGenerator((options, callback) => {
-      googleCredentials.getRequestMetadata(options.service_url, (err, headers) => {
-        if (err) {
-          callback(err);
-          return;
-        }
-        const metadata = new Metadata();
-        metadata.add('authorization', headers!.Authorization);
-        callback(null, metadata);
-      });
-    });
-  },
+export const credentials = Object.assign(
+    {
+      /**
+       * Create a gRPC credential from a Google credential object.
+       * @param googleCredentials The authentication client to use.
+       * @return The resulting CallCredentials object.
+       */
+      createFromGoogleCredential: (googleCredentials: OAuth2Client):
+          CallCredentials => {
+            return CallCredentials.createFromMetadataGenerator(
+                (options, callback) => {
+                  googleCredentials.getRequestMetadata(
+                      options.service_url, (err, headers) => {
+                        if (err) {
+                          callback(err);
+                          return;
+                        }
+                        const metadata = new Metadata();
+                        metadata.add('authorization', headers!.Authorization);
+                        callback(null, metadata);
+                      });
+                });
+          },
 
-  /**
-   * Combine a ChannelCredentials with any number of CallCredentials into a
-   * single ChannelCredentials object.
-   * @param channelCredentials The ChannelCredentials object.
-   * @param callCredentials Any number of CallCredentials objects.
-   * @return The resulting ChannelCredentials object.
-   */
-  combineChannelCredentials: (
-      channelCredentials: ChannelCredentials,
-      ...callCredentials: CallCredentials[]): ChannelCredentials => {
-    return callCredentials.reduce((acc, other) => acc.compose(other), channelCredentials);
-  },
+      /**
+       * Combine a ChannelCredentials with any number of CallCredentials into a
+       * single ChannelCredentials object.
+       * @param channelCredentials The ChannelCredentials object.
+       * @param callCredentials Any number of CallCredentials objects.
+       * @return The resulting ChannelCredentials object.
+       */
+      combineChannelCredentials:
+          (channelCredentials: ChannelCredentials,
+           ...callCredentials: CallCredentials[]): ChannelCredentials => {
+            return callCredentials.reduce(
+                (acc, other) => acc.compose(other), channelCredentials);
+          },
 
-  /**
-   * Combine any number of CallCredentials into a single CallCredentials object.
-   * @param first The first CallCredentials object.
-   * @param additional Any number of additional CallCredentials objects.
-   * @return The resulting CallCredentials object.
-   */
-  combineCallCredentials: (
-      first: CallCredentials,
-      ...additional: CallCredentials[]): CallCredentials => {
-    return additional.reduce((acc, other) => acc.compose(other), first);
-  }
-}, ChannelCredentials, CallCredentials);
+      /**
+       * Combine any number of CallCredentials into a single CallCredentials
+       * object.
+       * @param first The first CallCredentials object.
+       * @param additional Any number of additional CallCredentials objects.
+       * @return The resulting CallCredentials object.
+       */
+      combineCallCredentials: (
+          first: CallCredentials, ...additional: CallCredentials[]):
+          CallCredentials => {
+            return additional.reduce((acc, other) => acc.compose(other), first);
+          }
+    },
+    ChannelCredentials, CallCredentials);
 
 /**** Metadata ****/
 
-export { Metadata };
+export {Metadata};
 
 /**** Constants ****/
 
@@ -86,47 +96,63 @@ export {
  */
 export const closeClient = (client: Client) => client.close();
 
-export const waitForClientReady = (client: Client, deadline: Date|number, callback: (error: Error | null) => void) => client.waitForReady(deadline, callback);
+export const waitForClientReady =
+    (client: Client, deadline: Date|number,
+     callback: (error: Error|null) => void) =>
+        client.waitForReady(deadline, callback);
 
 /**** Unimplemented function stubs ****/
 
+/* tslint:disable:no-any variable-name */
+
 export const loadObject = (value: any, options: any) => {
-  throw new Error('Not available in this library. Use @grpc/proto-loader and loadPackageDefinition instead');
-}
+  throw new Error(
+      'Not available in this library. Use @grpc/proto-loader and loadPackageDefinition instead');
+};
 
 export const load = (filename: any, format: any, options: any) => {
-  throw new Error('Not available in this library. Use @grpc/proto-loader and loadPackageDefinition instead');
-}
+  throw new Error(
+      'Not available in this library. Use @grpc/proto-loader and loadPackageDefinition instead');
+};
 
 export const setLogger = (logger: any) => {
   throw new Error('Not yet implemented');
-}
+};
 
 export const setLogVerbosity = (verbosity: any) => {
   throw new Error('Not yet implemented');
-}
+};
 
 export const Server = (options: any) => {
   throw new Error('Not yet implemented');
-}
+};
 
 export const ServerCredentials = {
-  createSsl: (rootCerts: any, keyCertPairs: any, checkClientCertificate: any) => {
-    throw new Error('Not yet implemented');
-  },
+  createSsl:
+      (rootCerts: any, keyCertPairs: any, checkClientCertificate: any) => {
+        throw new Error('Not yet implemented');
+      },
   createInsecure: () => {
     throw new Error('Not yet implemented');
   }
-}
+};
 
 export const getClientChannel = (client: any) => {
   throw new Error('Not available in this library');
-}
+};
 
-export const StatusBuilder = () => { throw new Error('Not yet implemented'); }
+export const StatusBuilder = () => {
+  throw new Error('Not yet implemented');
+};
 
-export const ListenerBuilder = () => { throw new Error('Not yet implemented'); }
+export const ListenerBuilder = () => {
+  throw new Error('Not yet implemented');
+};
 
-export const InterceptorBuilder = () => { throw new Error('Not yet implemented'); }
+export const InterceptorBuilder = () => {
+  throw new Error('Not yet implemented');
+};
 
-export const InterceptingCall = () => { throw new Error('Not yet implemented'); }
+export const InterceptingCall = () => {
+  throw new Error('Not yet implemented');
+};

--- a/packages/grpc-js-core/src/metadata-status-filter.ts
+++ b/packages/grpc-js-core/src/metadata-status-filter.ts
@@ -1,19 +1,20 @@
 import {CallStream} from './call-stream';
-import {Channel} from './channel';
-import {BaseFilter, Filter, FilterFactory} from './filter';
 import {StatusObject} from './call-stream';
+import {Channel} from './channel';
 import {Status} from './constants';
+import {BaseFilter, Filter, FilterFactory} from './filter';
 
 export class MetadataStatusFilter extends BaseFilter implements Filter {
   async receiveTrailers(status: Promise<StatusObject>): Promise<StatusObject> {
-    let { code, details, metadata } = await status;
+    // tslint:disable-next-line:prefer-const
+    let {code, details, metadata} = await status;
     if (code !== Status.UNKNOWN) {
       // we already have a known status, so don't assign a new one.
-      return { code, details, metadata };
+      return {code, details, metadata};
     }
     const metadataMap = metadata.getMap();
     if (typeof metadataMap['grpc-status'] === 'string') {
-      let receivedCode = Number(metadataMap['grpc-status']);
+      const receivedCode = Number(metadataMap['grpc-status']);
       if (receivedCode in Status) {
         code = receivedCode;
       }
@@ -23,7 +24,7 @@ export class MetadataStatusFilter extends BaseFilter implements Filter {
       details = decodeURI(metadataMap['grpc-message'] as string);
       metadata.remove('grpc-message');
     }
-    return { code, details, metadata };
+    return {code, details, metadata};
   }
 }
 

--- a/packages/grpc-js-core/src/metadata.ts
+++ b/packages/grpc-js-core/src/metadata.ts
@@ -1,9 +1,9 @@
 import * as http2 from 'http2';
 import {forOwn} from 'lodash';
 
-export type MetadataValue = string | Buffer;
+export type MetadataValue = string|Buffer;
 
-export interface MetadataObject { [key: string]: Array<MetadataValue>; }
+export interface MetadataObject { [key: string]: MetadataValue[]; }
 
 function cloneMetadataObject(repr: MetadataObject): MetadataObject {
   const result: MetadataObject = {};
@@ -113,7 +113,7 @@ export class Metadata {
    * @param key The key whose value should be retrieved.
    * @return A list of values associated with the given key.
    */
-  get(key: string): Array<MetadataValue> {
+  get(key: string): MetadataValue[] {
     key = normalizeKey(key);
     validate(key);
     if (Object.prototype.hasOwnProperty.call(this.internalRepr, key)) {
@@ -144,7 +144,7 @@ export class Metadata {
    * @return The newly cloned object.
    */
   clone(): Metadata {
-    let newMetadata = new Metadata();
+    const newMetadata = new Metadata();
     newMetadata.internalRepr = cloneMetadataObject(this.internalRepr);
     return newMetadata;
   }
@@ -181,7 +181,7 @@ export class Metadata {
     });
     return result;
   }
-  
+
   // For compatibility with the other Metadata implementation
   private _getCoreRepresentation() {
     return this.internalRepr;
@@ -201,8 +201,9 @@ export class Metadata {
             result.add(key, Buffer.from(value, 'base64'));
           });
         } else if (values !== undefined) {
-          values.split(',').map(v => v.trim()).forEach(v =>
-            result.add(key, Buffer.from(v, 'base64')));
+          values.split(',')
+              .map(v => v.trim())
+              .forEach(v => result.add(key, Buffer.from(v, 'base64')));
         }
       } else {
         if (Array.isArray(values)) {
@@ -210,8 +211,7 @@ export class Metadata {
             result.add(key, value);
           });
         } else if (values !== undefined) {
-          values.split(',').map(v => v.trim()).forEach(v =>
-            result.add(key, v));
+          values.split(',').map(v => v.trim()).forEach(v => result.add(key, v));
         }
       }
     });

--- a/packages/grpc-js-core/src/object-stream.ts
+++ b/packages/grpc-js-core/src/object-stream.ts
@@ -1,14 +1,15 @@
 import {Duplex, Readable, Writable} from 'stream';
 import {EmitterAugmentation1} from './events';
 
+// tslint:disable:no-any
+
 export interface IntermediateObjectReadable<T> extends Readable {
   read(size?: number): any&T;
 }
 
 export type ObjectReadable<T> = {
   read(size?: number): T;
-} & EmitterAugmentation1<'data', T>
-  & IntermediateObjectReadable<T>;
+}&EmitterAugmentation1<'data', T>&IntermediateObjectReadable<T>;
 
 export interface IntermediateObjectWritable<T> extends Writable {
   _write(chunk: any&T, encoding: string, callback: Function): void;
@@ -39,4 +40,4 @@ export type ObjectDuplex<T, U> = {
   end(): void;
   end(chunk: T, cb?: Function): void;
   end(chunk: T, encoding?: any, cb?: Function): void;
-} & Duplex & ObjectWritable<T> & ObjectReadable<U>;
+}&Duplex&ObjectWritable<T>&ObjectReadable<U>;

--- a/packages/grpc-js-core/test/common.ts
+++ b/packages/grpc-js-core/test/common.ts
@@ -4,6 +4,7 @@ export function mockFunction(): never {
   throw new Error('Not implemented');
 }
 
+// tslint:disable-next-line:no-namespace
 export namespace assert2 {
   const toCall = new Map<() => void, number>();
   const afterCallsQueue: Array<() => void> = [];
@@ -17,7 +18,9 @@ export namespace assert2 {
     try {
       return fn();
     } catch (e) {
-      assert.throws(() => {throw e});
+      assert.throws(() => {
+        throw e;
+      });
       throw e;  // for type safety only
     }
   }
@@ -42,7 +45,9 @@ export namespace assert2 {
    * Wraps a function to keep track of whether it was called or not.
    * @param fn The function to wrap.
    */
-  export function mustCall<T>(fn: (...args: any[]) => T): (...args: any[]) => T {
+  // tslint:disable:no-any
+  export function mustCall<T>(fn: (...args: any[]) => T):
+      (...args: any[]) => T {
     const existingValue = toCall.get(fn);
     if (existingValue !== undefined) {
       toCall.set(fn, existingValue + 1);
@@ -62,6 +67,7 @@ export namespace assert2 {
       return result;
     };
   }
+  // tslint:enable:no-any
 
   /**
    * Calls the given function when every function that was wrapped with

--- a/packages/grpc-js-core/test/test-call-credentials.ts
+++ b/packages/grpc-js-core/test/test-call-credentials.ts
@@ -27,7 +27,8 @@ describe('CallCredentials', () => {
   describe('createFromMetadataGenerator', () => {
     it('should accept a metadata generator', () => {
       assert.doesNotThrow(
-          () => CallCredentials.createFromMetadataGenerator(generateFromServiceURL));
+          () => CallCredentials.createFromMetadataGenerator(
+              generateFromServiceURL));
     });
   });
 
@@ -58,11 +59,12 @@ describe('CallCredentials', () => {
   describe('generateMetadata', () => {
     it('should call the function passed to createFromMetadataGenerator',
        async () => {
-         const callCredentials =
-             CallCredentials.createFromMetadataGenerator(generateFromServiceURL);
+         const callCredentials = CallCredentials.createFromMetadataGenerator(
+             generateFromServiceURL);
          let metadata: Metadata;
          try {
-           metadata = await callCredentials.generateMetadata({service_url: 'foo'});
+           metadata =
+               await callCredentials.generateMetadata({service_url: 'foo'});
          } catch (err) {
            throw err;
          }

--- a/packages/grpc-js-core/test/test-call-stream.ts
+++ b/packages/grpc-js-core/test/test-call-stream.ts
@@ -1,32 +1,33 @@
 import * as assert from 'assert';
-import { CallCredentials } from '../src/call-credentials';
-import { Http2CallStream } from '../src/call-stream';
-import { mockFunction, assert2 } from './common';
-import { Status } from '../src/constants';
-import { EventEmitter } from 'events';
-import { FilterStackFactory } from '../src/filter-stack';
+import {EventEmitter} from 'events';
 import * as http2 from 'http2';
-import { forOwn, range } from 'lodash';
-import { Metadata } from '../src/metadata';
+import {forOwn, range} from 'lodash';
 import * as stream from 'stream';
 
+import {CallCredentials} from '../src/call-credentials';
+import {Http2CallStream} from '../src/call-stream';
+import {Status} from '../src/constants';
+import {FilterStackFactory} from '../src/filter-stack';
+import {Metadata} from '../src/metadata';
+
+import {assert2, mockFunction} from './common';
+
 interface DataFrames {
-  payload: Buffer,
-  frameLengths: number[]
+  payload: Buffer;
+  frameLengths: number[];
 }
 
-const {
-  HTTP2_HEADER_STATUS
-} = http2.constants;
+const {HTTP2_HEADER_STATUS} = http2.constants;
 
 function serialize(data: string): Buffer {
   const header: Buffer = Buffer.alloc(5);
-  header.writeUInt8(0, 0); // TODO: Uncompressed only
+  header.writeUInt8(0, 0);  // TODO: Uncompressed only
   header.writeInt32BE(data.length, 1);
   return Buffer.concat([header, Buffer.from(data, 'utf8')]);
 }
 
-class ClientHttp2StreamMock extends stream.Duplex implements http2.ClientHttp2Stream {
+class ClientHttp2StreamMock extends stream.Duplex implements
+    http2.ClientHttp2Stream {
   constructor(private readonly dataFrames: DataFrames) {
     super();
   }
@@ -38,13 +39,15 @@ class ClientHttp2StreamMock extends stream.Duplex implements http2.ClientHttp2St
   }
   bytesRead = 0;
   dataFrame = 0;
-  aborted: boolean = false;
-  closed: boolean = false;
-  destroyed: boolean = false;
-  pending: boolean = false;
-  rstCode: number = 0;
+  aborted = false;
+  closed = false;
+  destroyed = false;
+  pending = false;
+  rstCode = 0;
+  // tslint:disable:no-any
   session: http2.Http2Session = {} as any;
   state: http2.StreamState = {} as any;
+  // tslint:enable:no-any
   close = mockFunction;
   priority = mockFunction;
   rstStream = mockFunction;
@@ -58,7 +61,7 @@ class ClientHttp2StreamMock extends stream.Duplex implements http2.ClientHttp2St
     if (this.dataFrame === this.dataFrames.frameLengths.length) {
       if (this.bytesRead < this.dataFrames.payload.length) {
         this.push(this.dataFrames.payload.slice(
-          this.bytesRead, this.dataFrames.payload.length));
+            this.bytesRead, this.dataFrames.payload.length));
       }
       this.push(null);
       return;
@@ -66,7 +69,7 @@ class ClientHttp2StreamMock extends stream.Duplex implements http2.ClientHttp2St
     const from = this.bytesRead;
     this.bytesRead += this.dataFrames.frameLengths[this.dataFrame++];
     this.push(this.dataFrames.payload.slice(from, this.bytesRead));
-  };
+  }
   _write(chunk: Buffer, encoding: string, cb: Function) {
     this.emit('write', chunk);
     cb();
@@ -81,28 +84,28 @@ describe('CallStream', () => {
     host: ''
   };
   const filterStackFactory = new FilterStackFactory([]);
-  const message = 'eat this message'; // 16 bytes
+  const message = 'eat this message';  // 16 bytes
 
   beforeEach(() => {
     assert2.clearMustCalls();
   });
 
-  it('should emit a metadata event when it receives a response event', (done) => {
-    const responseMetadata = new Metadata();
-    responseMetadata.add('key', 'value');
-    const callStream = new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+  it('should emit a metadata event when it receives a response event',
+     (done) => {
+       const responseMetadata = new Metadata();
+       responseMetadata.add('key', 'value');
+       const callStream =
+           new Http2CallStream('foo', callStreamArgs, filterStackFactory);
 
-    const http2Stream = new ClientHttp2StreamMock({
-      payload: Buffer.alloc(0),
-      frameLengths: []
-    });
-    callStream.once('metadata', assert2.mustCall((metadata) => {
-      assert.deepStrictEqual(metadata.get('key'), ['value']);
-    }));
-    callStream.attachHttp2Stream(http2Stream);
-    http2Stream.emitResponse(200, responseMetadata);
-    assert2.afterMustCallsSatisfied(done);
-  });
+       const http2Stream = new ClientHttp2StreamMock(
+           {payload: Buffer.alloc(0), frameLengths: []});
+       callStream.once('metadata', assert2.mustCall((metadata) => {
+         assert.deepStrictEqual(metadata.get('key'), ['value']);
+       }));
+       callStream.attachHttp2Stream(http2Stream);
+       http2Stream.emitResponse(200, responseMetadata);
+       assert2.afterMustCallsSatisfied(done);
+     });
 
   describe('should end a call with an error if a stream was closed', () => {
     const c = http2.constants;
@@ -126,14 +129,13 @@ describe('CallStream', () => {
     keys.forEach((key) => {
       const value = errorCodeMapping[key];
       // A null value indicates: behavior isn't specified, so skip this test.
-      let maybeSkip = (fn: typeof it) => value ? fn : fn.skip;
+      const maybeSkip = (fn: typeof it) => value ? fn : fn.skip;
       maybeSkip(it)(`for error code ${key}`, () => {
         return new Promise((resolve, reject) => {
-          const callStream = new Http2CallStream('foo', callStreamArgs, filterStackFactory);
-          const http2Stream = new ClientHttp2StreamMock({
-            payload: Buffer.alloc(0),
-            frameLengths: []
-          });
+          const callStream =
+              new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+          const http2Stream = new ClientHttp2StreamMock(
+              {payload: Buffer.alloc(0), frameLengths: []});
           callStream.attachHttp2Stream(http2Stream);
           callStream.once('status', (status) => {
             try {
@@ -150,7 +152,8 @@ describe('CallStream', () => {
   });
 
   it('should have functioning getters', (done) => {
-    const callStream = new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+    const callStream =
+        new Http2CallStream('foo', callStreamArgs, filterStackFactory);
     assert.strictEqual(callStream.getDeadline(), callStreamArgs.deadline);
     assert.strictEqual(callStream.getCredentials(), callStreamArgs.credentials);
     assert.strictEqual(callStream.getStatus(), null);
@@ -166,11 +169,10 @@ describe('CallStream', () => {
 
   describe('attachHttp2Stream', () => {
     it('should handle an empty message', (done) => {
-      const callStream = new Http2CallStream('foo', callStreamArgs, filterStackFactory);
-      const http2Stream = new ClientHttp2StreamMock({
-        payload: serialize(''),
-        frameLengths: []
-      });
+      const callStream =
+          new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+      const http2Stream =
+          new ClientHttp2StreamMock({payload: serialize(''), frameLengths: []});
       callStream.once('data', assert2.mustCall((buffer) => {
         assert.strictEqual(buffer.toString('utf8'), '');
       }));
@@ -178,65 +180,57 @@ describe('CallStream', () => {
       assert2.afterMustCallsSatisfied(done);
     });
 
-    [
-      {
-        description: 'all data is supplied in a single frame',
-        frameLengths: []
-      },
-      {
-        description: 'frames are split along header field delimiters',
-        frameLengths: [1, 4]
-      },
-      {
-        description: 'portions of header fields are split between different frames',
-        frameLengths: [2, 1, 1, 4]
-      },
-      {
-        description: 'frames are split into bytes',
-        frameLengths: range(0, 20).map(() => 1)
-      }
-    ].forEach((testCase: { description: string, frameLengths: number[] }) => {
-      it(`should handle a short message where ${testCase.description}`, (done) => {
-        const callStream = new Http2CallStream('foo', callStreamArgs, filterStackFactory);
-        const http2Stream = new ClientHttp2StreamMock({
-          payload: serialize(message), // 21 bytes
-          frameLengths: testCase.frameLengths
-        });
-        callStream.once('data', assert2.mustCall((buffer) => {
-          assert.strictEqual(buffer.toString('utf8'), message);
-        }));
-        callStream.once('end', assert2.mustCall(() => {}));
-        callStream.attachHttp2Stream(http2Stream);
-        assert2.afterMustCallsSatisfied(done);
-      });
+    [{description: 'all data is supplied in a single frame', frameLengths: []},
+     {
+       description: 'frames are split along header field delimiters',
+       frameLengths: [1, 4]
+     },
+     {
+       description:
+           'portions of header fields are split between different frames',
+       frameLengths: [2, 1, 1, 4]
+     },
+     {
+       description: 'frames are split into bytes',
+       frameLengths: range(0, 20).map(() => 1)
+     }].forEach((testCase: {description: string, frameLengths: number[]}) => {
+      it(`should handle a short message where ${testCase.description}`,
+         (done) => {
+           const callStream =
+               new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+           const http2Stream = new ClientHttp2StreamMock({
+             payload: serialize(message),  // 21 bytes
+             frameLengths: testCase.frameLengths
+           });
+           callStream.once('data', assert2.mustCall((buffer) => {
+             assert.strictEqual(buffer.toString('utf8'), message);
+           }));
+           callStream.once('end', assert2.mustCall(() => {}));
+           callStream.attachHttp2Stream(http2Stream);
+           assert2.afterMustCallsSatisfied(done);
+         });
     });
 
-    [
-      {
-        description: 'all data is supplied in a single frame',
-        frameLengths: []
-      },
-      {
-        description: 'frames are split between delimited messages',
-        frameLengths: [21]
-      },
-      {
-        description: 'frames are split within messages',
-        frameLengths: [10, 22]
-      },
-      {
-        description: 'part of 2nd message\'s header is in first frame',
-        frameLengths: [24]
-      },
-      {
-        description: 'frames are split into bytes',
-        frameLengths: range(0, 41).map(() => 1)
-      }
-    ].forEach((testCase: { description: string, frameLengths: number[] }) => {
+    [{description: 'all data is supplied in a single frame', frameLengths: []},
+     {
+       description: 'frames are split between delimited messages',
+       frameLengths: [21]
+     },
+     {description: 'frames are split within messages', frameLengths: [10, 22]},
+     {
+       description: 'part of 2nd message\'s header is in first frame',
+       frameLengths: [24]
+     },
+     {
+       description: 'frames are split into bytes',
+       frameLengths: range(0, 41).map(() => 1)
+     }].forEach((testCase: {description: string, frameLengths: number[]}) => {
       it(`should handle two messages where ${testCase.description}`, (done) => {
-        const callStream = new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+        const callStream =
+            new Http2CallStream('foo', callStreamArgs, filterStackFactory);
         const http2Stream = new ClientHttp2StreamMock({
-          payload: Buffer.concat([serialize(message), serialize(message)]), // 42 bytes
+          payload: Buffer.concat(
+              [serialize(message), serialize(message)]),  // 42 bytes
           frameLengths: testCase.frameLengths
         });
         callStream.once('data', assert2.mustCall((buffer) => {
@@ -252,11 +246,10 @@ describe('CallStream', () => {
     });
 
     it('should send buffered writes', (done) => {
-      const callStream = new Http2CallStream('foo', callStreamArgs, filterStackFactory);
-      const http2Stream = new ClientHttp2StreamMock({
-        payload: Buffer.alloc(0),
-        frameLengths: []
-      });
+      const callStream =
+          new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+      const http2Stream = new ClientHttp2StreamMock(
+          {payload: Buffer.alloc(0), frameLengths: []});
       let streamFlushed = false;
       http2Stream.once('write', assert2.mustCall((chunk: Buffer) => {
         const dataLength = chunk.readInt32BE(1);
@@ -265,9 +258,7 @@ describe('CallStream', () => {
         assert.strictEqual(encodedMessage, message);
         streamFlushed = true;
       }));
-      callStream.write({
-        message: Buffer.from(message)
-      }, assert2.mustCall(() => {
+      callStream.write({message: Buffer.from(message)}, assert2.mustCall(() => {
         // Ensure this is called only after contents are written to http2Stream
         assert.ok(streamFlushed);
       }));
@@ -276,32 +267,30 @@ describe('CallStream', () => {
       assert2.afterMustCallsSatisfied(done);
     });
 
-    it('should cause data chunks in write calls afterward to be written to the given stream', (done) => {
-      const callStream = new Http2CallStream('foo', callStreamArgs, filterStackFactory);
-      const http2Stream = new ClientHttp2StreamMock({
-        payload: Buffer.alloc(0),
-        frameLengths: []
-      });
-      http2Stream.once('write', assert2.mustCall((chunk: Buffer) => {
-        const dataLength = chunk.readInt32BE(1);
-        const encodedMessage = chunk.slice(5).toString('utf8');
-        assert.strictEqual(dataLength, message.length);
-        assert.strictEqual(encodedMessage, message);
-      }));
-      callStream.attachHttp2Stream(http2Stream);
-      callStream.write({
-        message: Buffer.from(message)
-      }, assert2.mustCall(() => {}));
-      callStream.end(assert2.mustCall(() => {}));
-      assert2.afterMustCallsSatisfied(done);
-    });
+    it('should cause data chunks in write calls afterward to be written to the given stream',
+       (done) => {
+         const callStream =
+             new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+         const http2Stream = new ClientHttp2StreamMock(
+             {payload: Buffer.alloc(0), frameLengths: []});
+         http2Stream.once('write', assert2.mustCall((chunk: Buffer) => {
+           const dataLength = chunk.readInt32BE(1);
+           const encodedMessage = chunk.slice(5).toString('utf8');
+           assert.strictEqual(dataLength, message.length);
+           assert.strictEqual(encodedMessage, message);
+         }));
+         callStream.attachHttp2Stream(http2Stream);
+         callStream.write(
+             {message: Buffer.from(message)}, assert2.mustCall(() => {}));
+         callStream.end(assert2.mustCall(() => {}));
+         assert2.afterMustCallsSatisfied(done);
+       });
 
     it('should handle underlying stream errors', () => {
-      const callStream = new Http2CallStream('foo', callStreamArgs, filterStackFactory);
-      const http2Stream = new ClientHttp2StreamMock({
-        payload: Buffer.alloc(0),
-        frameLengths: []
-      });
+      const callStream =
+          new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+      const http2Stream = new ClientHttp2StreamMock(
+          {payload: Buffer.alloc(0), frameLengths: []});
       callStream.once('status', assert2.mustCall((status) => {
         assert.strictEqual(status.code, Status.INTERNAL);
       }));

--- a/packages/grpc-js-core/test/test-channel-credentials.ts
+++ b/packages/grpc-js-core/test/test-channel-credentials.ts
@@ -32,6 +32,7 @@ class CallCredentialsMock implements CallCredentials {
   }
 }
 
+// tslint:disable-next-line:no-any
 const readFile: (...args: any[]) => Promise<Buffer> = promisify(fs.readFile);
 // A promise which resolves to loaded files in the form { ca, key, cert }
 const pFixtures = Promise


### PR DESCRIPTION
This is using the default gts linting and formatting rules. There are a couple of substantial changes in here: `CallCredentials` and `ChannelCredentials` are now abstract classes instead of interfaces extended by namespaces, because the linter doesn't like namespaces, and semantically they have static methods, which belong on classes.