### PR TITLE
Don't upgrade npm in Windows tests

### DIFF
--- a/run-tests.bat
+++ b/run-tests.bat
@@ -39,7 +39,6 @@ SET FAILED=0
 for %%v in (4 6 7 8 9) do (
   call nvm install %%v
   call nvm use %%v
-  call npm install -g npm
   @rem https://github.com/mapbox/node-pre-gyp/issues/362
   call npm install -g node-gyp
   node -e "console.log(process.versions)"

--- a/run-tests.bat
+++ b/run-tests.bat
@@ -39,6 +39,9 @@ SET FAILED=0
 for %%v in (4 6 7 8 9) do (
   call nvm install %%v
   call nvm use %%v
+  if "%%v"=="4" (
+    npm install -g npm@5
+  )
   @rem https://github.com/mapbox/node-pre-gyp/issues/362
   call npm install -g node-gyp
   node -e "console.log(process.versions)"


### PR DESCRIPTION
We already don't do this on other platforms, and it looks like the newest version of npm doesn't work on Node 4 (see #295 test failures)