### PR TITLE
requestCallback: optional value for covenience

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -1243,7 +1243,7 @@ declare module "grpc" {
    * @param value The response value, if the call succeeded
    */
   export type requestCallback<ResponseType> =
-    (error: ServiceError | null, value: ResponseType | undefined) => void;
+    (error: ServiceError | null, value?: ResponseType) => void;
 
   /**
    * Return the underlying channel object for the specified client


### PR DESCRIPTION
When I'm calling a `grpc.requestCallback`, currently, I have to specify an `undefined` to the args, like the following.

```ts
        callback({
            code: grpc.status.NOT_FOUND,
            message: 'Not found',
            name: 'name',
        }, undefined)
```

after this PR, this callback could be able to change to this:

```diff
        callback({
            code: grpc.status.NOT_FOUND,
            message: 'Not found',
            name: 'name',
-         }, undefined)
+         })
```
