### PR TITLE
session.unref(v9.4.0+ ) replace with socket.unref(v0.3.4+)

### DIFF
--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -263,7 +263,10 @@ export class Http2Channel extends EventEmitter implements Channel {
             const session: http2.ClientHttp2Session = this.subChannel!;
             // Prevent the HTTP/2 session from keeping the process alive.
             // Note: this function is only available in Node 9
-            session.unref();
+            // session.unref();
+            if (session.socket){
+              session.socket.unref();
+            }
             stream.attachHttp2Stream(session.request(headers));
           } else {
             /* In this case, we lost the connection while finalizing


### PR DESCRIPTION
session.unref(v9.4.0+ ) replace with socket.unref(v0.3.4+)

see: [https://github.com/nodejs/node/blob/master/lib/internal/http2/core.js#L1263](https://github.com/nodejs/node/blob/master/lib/internal/http2/core.js#L1263)