### PR TITLE
Update protobufjs => 6.8.6

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -31,7 +31,7 @@
     "lodash": "^4.17.5",
     "nan": "^2.0.0",
     "node-pre-gyp": "^0.10.0",
-    "protobufjs": "^5.0.0"
+    "protobufjs": "^6.8.6"
   },
   "devDependencies": {
     "async": "^2.0.1",


### PR DESCRIPTION
https://nodesecurity.io/advisories/605

I think this is a bigger issue than the lodash one, since this is a major version difference, and even after removing node_modules / package-lock, still persists. Let me know if this isn't the right one to update or if tests fail.