### PR TITLE
Revert "Add coverage reporting for JavaScript and TypeScript files"

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -102,7 +102,7 @@ gulp.task('test.only', 'Run tests without rebuilding anything',
           ['js.core.test', 'native.test.only']);
 
 gulp.task('test', 'Run all tests', (callback) => {
-  runSequence('build', 'test.only', 'internal.test.test', callback);
+  runSequence('build', 'test.only', callback);
 });
 
 gulp.task('doc.gen', 'Generate documentation', ['native.core.doc.gen']);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@types/node": "^8.0.32",
     "@types/pify": "^3.0.0",
     "@types/semver": "^5.5.0",
-    "coveralls": "^3.0.1",
     "del": "^3.0.0",
     "execa": "^0.8.0",
     "gulp": "^3.9.1",
@@ -36,11 +35,8 @@
     "mocha": "^3.5.3",
     "mocha-jenkins-reporter": "^0.3.9",
     "ncp": "^2.0.0",
-    "nyc": "^11.7.2",
     "pify": "^3.0.0",
-    "run-sequence": "^2.2.0",
     "semver": "^5.5.0",
-    "symlink": "^2.1.0",
     "through2": "^2.0.3",
     "ts-node": "^3.3.0",
     "tslint": "^5.5.0",
@@ -52,19 +48,8 @@
       "name": "Google Inc."
     }
   ],
-  "nyc": {
-    "include": [
-      "packages/grpc-health-check/health.js",
-      "packages/grpc-js-core/build/src/*",
-      "packages/grpc-native-core/index.js",
-      "packages/grpc-native-core/src/*.js",
-      "packages/grpc-protobufjs/build/src/*"
-    ],
-    "cache": true,
-    "all": true
-  },
-  "scripts": {
-    "test": "nyc gulp test",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+  "dependencies": {
+    "run-sequence": "^2.2.0",
+    "symlink": "^2.1.0"
   }
 }

--- a/packages/grpc-protobufjs/package.json
+++ b/packages/grpc-protobufjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "author": "Google Inc.",
   "contributors": [
     {
@@ -47,8 +47,5 @@
     "clang-format": "^1.2.2",
     "gts": "^0.5.3",
     "typescript": "~2.7.2"
-  },
-  "engines": {
-    "node": ">=6"
   }
 }

--- a/test/api/interop_sanity_test.js
+++ b/test/api/interop_sanity_test.js
@@ -68,7 +68,7 @@ describe('Interop tests', function() {
 	  throw new Error(`Server exited with signal ${signal}`);
 	}
       }
-    });
+    })
   });
   after(function() {
     serverProcess.send({});

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -21,7 +21,6 @@ const mocha = require('gulp-mocha');
 const execa = require('execa');
 const path = require('path');
 const del = require('del');
-const semver = require('semver');
 const linkSync = require('../util').linkSync;
 
 // gulp-help monkeypatches tasks to have an additional description parameter
@@ -39,10 +38,6 @@ gulp.task('clean.all', 'Delete all files created by tasks', () => {});
 gulp.task('test', 'Run API-level tests', () => {
   // run mocha tests matching a glob with a pre-required fixture,
   // returning the associated gulp stream
-  if (!semver.satisfies(process.version, '>=9.4')) {
-    console.log(`Skipping cross-implementation tests for Node ${process.version}`);
-    return;
-  }
   const apiTestGlob = `${apiTestDir}/*.js`;
   const runTestsWithFixture = (server, client) => new Promise((resolve, reject) => {
     const fixture = `${server}_${client}`;
@@ -56,19 +51,12 @@ gulp.task('test', 'Run API-level tests', () => {
       .on('end', resolve)
       .on('error', reject);
   });
-  var runTestsArgPairs;
-  if (semver.satisfies(process.version, '>=9.4')) {
-    runTestsArgPairs = [
-      ['native', 'native'],
-      ['native', 'js'],
-      // ['js', 'native'],
-      // ['js', 'js']
-    ];
-  } else {
-    runTestsArgPairs = [
-      ['native', 'native']
-    ];
-  }
+  const runTestsArgPairs = [
+    ['native', 'native'],
+    ['native', 'js'],
+    // ['js', 'native'],
+    // ['js', 'js']
+  ];
   return runTestsArgPairs.reduce((previousPromise, argPair) => {
     return previousPromise.then(runTestsWithFixture.bind(null, argPair[0], argPair[1]));
   }, Promise.resolve());

--- a/test/interop/interop_client.js
+++ b/test/interop/interop_client.js
@@ -616,12 +616,8 @@ if (require.main === module) {
   };
   runTest(argv.server_host + ':' + argv.server_port, argv.server_host_override,
           argv.test_case, argv.use_tls === 'true', argv.use_test_ca === 'true',
-          function (err) {
-            if (err) {
-              throw err;
-            } else {
-              console.log('OK:', argv.test_case);
-            }
+          function () {
+            console.log('OK:', argv.test_case);
           }, extra_args);
 }
 


### PR DESCRIPTION
Reverts grpc/grpc-node#332

Looks like the PR has broken grpc/grpc tests on master.

https://source.cloud.google.com/results/invocations/707c0572-1a9c-495e-aabe-81a92504fd21/targets/github%2Fgrpc/tests

```
gsutil cp gs://grpc-testing-secrets/coveralls_credentials/grpc-node.rc /tmp
./run-tests.sh: 48: ./run-tests.sh: gsutil: not found
```