### PR TITLE
Increasing mocha timeout to 5s up from 2s.

### DIFF
--- a/packages/grpc-native-core/gulpfile.js
+++ b/packages/grpc-native-core/gulpfile.js
@@ -68,7 +68,7 @@ gulp.task('build', 'Build native package', () => {
 });
 
 gulp.task('test', 'Run all tests', ['build'], () => {
-  return gulp.src(`${testDir}/*.js`).pipe(mocha({reporter: 'mocha-jenkins-reporter'}));
+  return gulp.src(`${testDir}/*.js`).pipe(mocha({timeout: 5000, reporter: 'mocha-jenkins-reporter'}));
 });
 
 gulp.task('doc.gen', 'Generate docs', (cb) => {


### PR DESCRIPTION
Our fleet of macos is a bit less powerful than the rest, so we
regularly flake tests there due to this timeout.