### PR TITLE
Add compression handling to grpc-js

### DIFF
--- a/packages/grpc-js-core/gulpfile.ts
+++ b/packages/grpc-js-core/gulpfile.ts
@@ -72,10 +72,12 @@ gulp.task('copy-test-fixtures', 'Copy test fixtures.', () => {
  * Transpiles src/ and test/, and then runs all tests.
  */
 gulp.task('test', 'Runs all tests.', ['copy-test-fixtures'], () => {
-  if (semver.satisfies(process.version, '>=9.4')) {
+  if (semver.satisfies(process.version, '^8.11.2 || >=9.4')) {
     return gulp.src(`${outDir}/test/**/*.js`)
-      .pipe(mocha({reporter: 'mocha-jenkins-reporter'}));
+      .pipe(mocha({reporter: 'mocha-jenkins-reporter',
+                   require: ['ts-node/register']}));
   } else {
     console.log(`Skipping grpc-js tests for Node ${process.version}`);
+    return Promise.resolve(null);
   }
 });

--- a/packages/grpc-js-core/src/call-stream.ts
+++ b/packages/grpc-js-core/src/call-stream.ts
@@ -143,7 +143,7 @@ export class Http2CallStream extends Duplex implements CallStream {
     }
   }
 
-  private filterReceivedMessage(framedMessage: Buffer | null) {
+  private filterReceivedMessage(framedMessage: Buffer|null) {
     if (framedMessage === null) {
       if (this.canPush) {
         this.push(null);
@@ -153,12 +153,13 @@ export class Http2CallStream extends Duplex implements CallStream {
       return;
     }
     this.isReadFilterPending = true;
-    this.filterStack.receiveMessage(Promise.resolve(framedMessage)).then(
-      this.handleFilteredRead.bind(this),
-      this.handleFilterError.bind(this));
+    this.filterStack.receiveMessage(Promise.resolve(framedMessage))
+        .then(
+            this.handleFilteredRead.bind(this),
+            this.handleFilterError.bind(this));
   }
 
-  private tryPush(messageBytes: Buffer | null): void {
+  private tryPush(messageBytes: Buffer|null): void {
     if (this.isReadFilterPending) {
       this.unfilteredReadMessages.push(messageBytes);
     } else {
@@ -268,7 +269,7 @@ export class Http2CallStream extends Duplex implements CallStream {
         while (readHead < data.length) {
           switch (this.readState) {
             case ReadState.NO_DATA:
-              this.readCompressFlag = data.slice(readHead, readHead+1);
+              this.readCompressFlag = data.slice(readHead, readHead + 1);
               readHead += 1;
               this.readState = ReadState.READING_SIZE;
               this.readPartialSize.fill(0);
@@ -291,7 +292,8 @@ export class Http2CallStream extends Duplex implements CallStream {
                 if (this.readMessageRemaining > 0) {
                   this.readState = ReadState.READING_MESSAGE;
                 } else {
-                  this.tryPush(Buffer.concat([this.readCompressFlag, this.readPartialSize]));
+                  this.tryPush(Buffer.concat(
+                      [this.readCompressFlag, this.readPartialSize]));
                   this.readState = ReadState.NO_DATA;
                 }
               }
@@ -306,8 +308,11 @@ export class Http2CallStream extends Duplex implements CallStream {
               // readMessageRemaining >=0 here
               if (this.readMessageRemaining === 0) {
                 // At this point, we have read a full message
-                const framedMessageBuffers = [this.readCompressFlag, this.readPartialSize].concat(this.readPartialMessage);
-                const framedMessage = Buffer.concat(framedMessageBuffers, this.readMessageSize + 5);
+                const framedMessageBuffers = [
+                  this.readCompressFlag, this.readPartialSize
+                ].concat(this.readPartialMessage);
+                const framedMessage = Buffer.concat(
+                    framedMessageBuffers, this.readMessageSize + 5);
                 this.tryPush(framedMessage);
                 this.readState = ReadState.NO_DATA;
               }

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -237,9 +237,8 @@ export class Http2Channel extends EventEmitter implements Channel {
       this.defaultAuthority = this.target.host;
     }
     this.filterStackFactory = new FilterStackFactory([
-      new CompressionFilterFactory(this),
       new CallCredentialsFilterFactory(this), new DeadlineFilterFactory(this),
-      new MetadataStatusFilterFactory(this)
+      new MetadataStatusFilterFactory(this), new CompressionFilterFactory(this)
     ]);
     this.currentBackoffDeadline = new Date();
     /* The only purpose of these lines is to ensure that this.backoffTimerId has

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -84,7 +84,7 @@ export interface Channel extends EventEmitter {
 
 /* This should be a real subchannel class that contains a ClientHttp2Session,
  * but for now this serves its purpose */
-type Http2SubChannel = http2.ClientHttp2Session & {
+type Http2SubChannel = http2.ClientHttp2Session&{
   /* Count the number of currently active streams associated with the session.
    * The purpose of this is to keep the session reffed if and only if there
    * is at least one active stream */

--- a/packages/grpc-js-core/src/compression-filter.ts
+++ b/packages/grpc-js-core/src/compression-filter.ts
@@ -1,21 +1,189 @@
-import {CallStream} from './call-stream';
+import {CallStream, WriteObject, WriteFlags} from './call-stream';
 import {Channel} from './channel';
 import {BaseFilter, Filter, FilterFactory} from './filter';
-import {Metadata} from './metadata';
+import {Metadata, MetadataValue} from './metadata';
+import {Status} from './constants';
+import * as zlib from 'zlib';
+
+abstract class CompressionHandler {
+  protected abstract compressMessage(message: Buffer): Promise<Buffer>;
+  protected abstract decompressMessage(data: Buffer): Promise<Buffer>;
+  /**
+   * @param message Raw uncompressed message bytes
+   * @param compress Indicates whether the message should be compressed
+   * @return Framed message, compressed if applicable
+   */
+  async writeMessage(message: Buffer, compress: boolean): Promise<Buffer> {
+    let messageBuffer = message;
+    if (compress) {
+      messageBuffer = await this.compressMessage(messageBuffer);
+    }
+    let output = Buffer.allocUnsafe(messageBuffer.length + 5);
+    output.writeUInt8(compress ? 1 : 0, 0);
+    output.writeUInt32BE(messageBuffer.length, 1);
+    messageBuffer.copy(output, 5);
+    return output;
+  }
+  /**
+   * @param data Framed message, possibly compressed
+   * @return Uncompressed message
+   */
+  async readMessage(data: Buffer): Promise<Buffer> {
+    const compressed = data.readUInt8(1) === 1;
+    let messageBuffer = data.slice(5);
+    if (compressed) {
+      messageBuffer = await this.decompressMessage(messageBuffer);
+    }
+    return messageBuffer;
+  }
+}
+
+class IdentityHandler extends CompressionHandler{
+  async compressMessage(message: Buffer) {
+    return message;
+  }
+
+  async writeMessage(message: Buffer, compress: boolean): Promise<Buffer> {
+    let output = Buffer.allocUnsafe(message.length + 5);
+    /* With "identity" compression, messages should always be marked as
+     * uncompressed */
+    output.writeUInt8(0, 0);
+    output.writeUInt32BE(message.length, 1);
+    message.copy(output, 5);
+    return output;
+  }
+
+  decompressMessage(message: Buffer) : Promise<Buffer> {
+    return Promise.reject<Buffer>(new Error(
+      'Received compressed message but "grpc-encoding" header was identity'));
+  }
+}
+
+class DeflateHandler extends CompressionHandler {
+  compressMessage(message: Buffer) {
+    return new Promise<Buffer>((resolve, reject) => {
+      zlib.deflate(message, (err, output) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(output);
+        }
+      })
+    });
+  }
+
+  decompressMessage(message: Buffer) {
+    return new Promise<Buffer>((resolve, reject) => {
+      zlib.inflate(message, (err, output) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(output);
+        }
+      })
+    });
+  }
+}
+
+class GzipHandler extends CompressionHandler {
+  compressMessage(message: Buffer) {
+    return new Promise<Buffer>((resolve, reject) => {
+      zlib.gzip(message, (err, output) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(output);
+        }
+      })
+    });
+  }
+
+  decompressMessage(message: Buffer) {
+    return new Promise<Buffer>((resolve, reject) => {
+      zlib.unzip(message, (err, output) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(output);
+        }
+      })
+    });
+  }
+}
+
+class UnknownHandler extends CompressionHandler {
+  constructor(private readonly compressionName: string) {
+    super();
+  }
+  compressMessage(message: Buffer): Promise<Buffer> {
+    return Promise.reject<Buffer>(new Error(
+      `Received message compressed wth unsupported compression method ${this.compressionName}`));
+  }
+
+  decompressMessage(message: Buffer): Promise<Buffer> {
+    // This should be unreachable
+    return Promise.reject<Buffer>(new Error(
+      `Compression method not supported: ${this.compressionName}`));
+  }
+}
+
+function getCompressionHandler(compressionName: string): CompressionHandler {
+  switch (compressionName) {
+  case 'identity':
+    return new IdentityHandler();
+  case 'deflate':
+    return new DeflateHandler();
+  case 'gzip':
+    return new GzipHandler();
+  default:
+    return new UnknownHandler(compressionName);
+  }
+}
 
 export class CompressionFilter extends BaseFilter implements Filter {
+  private sendCompression: CompressionHandler = new IdentityHandler();
+  private receiveCompression: CompressionHandler = new IdentityHandler();
   async sendMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
     const headers: Metadata = await metadata;
     headers.set('grpc-encoding', 'identity');
-    headers.set('grpc-accept-encoding', 'identity');
+    headers.set('grpc-accept-encoding', 'identity,deflate,gzip');
     return headers;
   }
 
   async receiveMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
     const headers: Metadata = await metadata;
+    let receiveEncoding: MetadataValue[] = headers.get('grpc-encoding');
+    if (receiveEncoding.length > 0) {
+      const encoding: MetadataValue = receiveEncoding[0];
+      if (typeof encoding === 'string') {
+        this.receiveCompression = getCompressionHandler(encoding);
+      }
+    }
     headers.remove('grpc-encoding');
     headers.remove('grpc-accept-encoding');
     return headers;
+  }
+
+  async sendMessage(message: Promise<WriteObject>): Promise<WriteObject> {
+    
+    /* This filter is special. The input message is the bare message bytes,
+     * and the output is a framed and possibly compressed message. For this
+     * reason, this filter should be at the bottom of the filter stack */
+    const resolvedMessage: WriteObject = await message;
+    const compress = resolvedMessage.flags === undefined ? false :
+      (resolvedMessage.flags & WriteFlags.NoCompress) === 0;
+    return {
+      message: await this.sendCompression.writeMessage(resolvedMessage.message, compress),
+      flags: resolvedMessage.flags
+    };
+  }
+
+  async receiveMessage(message: Promise<Buffer>) {
+    /* This filter is also special. The input message is framed and possibly
+     * compressed, and the output message is deframed and uncompressed. So
+     * this is another reason that this filter should be at the bottom of the
+     * filter stack. */
+    return await this.receiveCompression.readMessage(await message);
   }
 }
 

--- a/packages/grpc-js-core/src/filter-stack.ts
+++ b/packages/grpc-js-core/src/filter-stack.ts
@@ -19,14 +19,13 @@ export class FilterStack implements Filter {
   }
 
   sendMessage(message: Promise<WriteObject>): Promise<WriteObject> {
-    return flow(map(
-        this.filters, (filter) => filter.sendMessage.bind(filter)))(message);
+    return flow(map(this.filters, (filter) => filter.sendMessage.bind(filter)))(
+        message);
   }
 
   receiveMessage(message: Promise<Buffer>): Promise<Buffer> {
-    return flowRight(
-        map(this.filters, (filter) => filter.receiveMessage.bind(filter)))(
-        message);
+    return flowRight(map(
+        this.filters, (filter) => filter.receiveMessage.bind(filter)))(message);
   }
 
   receiveTrailers(status: Promise<StatusObject>): Promise<StatusObject> {

--- a/packages/grpc-js-core/src/filter-stack.ts
+++ b/packages/grpc-js-core/src/filter-stack.ts
@@ -1,6 +1,6 @@
 import {flow, flowRight, map} from 'lodash';
 
-import {CallStream, StatusObject} from './call-stream';
+import {CallStream, StatusObject, WriteObject} from './call-stream';
 import {Filter, FilterFactory} from './filter';
 import {Metadata} from './metadata';
 
@@ -16,6 +16,17 @@ export class FilterStack implements Filter {
     return flowRight(
         map(this.filters, (filter) => filter.receiveMetadata.bind(filter)))(
         metadata);
+  }
+
+  sendMessage(message: Promise<WriteObject>): Promise<WriteObject> {
+    return flow(map(
+        this.filters, (filter) => filter.sendMessage.bind(filter)))(message);
+  }
+
+  receiveMessage(message: Promise<Buffer>): Promise<Buffer> {
+    return flowRight(
+        map(this.filters, (filter) => filter.receiveMessage.bind(filter)))(
+        message);
   }
 
   receiveTrailers(status: Promise<StatusObject>): Promise<StatusObject> {

--- a/packages/grpc-js-core/src/filter.ts
+++ b/packages/grpc-js-core/src/filter.ts
@@ -1,4 +1,4 @@
-import {CallStream, StatusObject} from './call-stream';
+import {CallStream, StatusObject, WriteObject} from './call-stream';
 import {Metadata} from './metadata';
 
 /**
@@ -10,6 +10,10 @@ export interface Filter {
 
   receiveMetadata(metadata: Promise<Metadata>): Promise<Metadata>;
 
+  sendMessage(message: Promise<WriteObject>): Promise<WriteObject>;
+
+  receiveMessage(message: Promise<Buffer>): Promise<Buffer>;
+
   receiveTrailers(status: Promise<StatusObject>): Promise<StatusObject>;
 }
 
@@ -20,6 +24,14 @@ export abstract class BaseFilter {
 
   async receiveMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
     return await metadata;
+  }
+
+  async sendMessage(message: Promise<WriteObject>): Promise<WriteObject> {
+    return await message;
+  }
+
+  async receiveMessage(message: Promise<Buffer>): Promise<Buffer> {
+    return await message;
   }
 
   async receiveTrailers(status: Promise<StatusObject>): Promise<StatusObject> {

--- a/packages/grpc-js-core/src/index.ts
+++ b/packages/grpc-js-core/src/index.ts
@@ -15,8 +15,8 @@ interface IndexedObject {
 
 function mixin(...sources: IndexedObject[]) {
   const result: {[key: string]: Function} = {};
-  for(const source of sources) {
-    for(const propName of Object.getOwnPropertyNames(source)) {
+  for (const source of sources) {
+    for (const propName of Object.getOwnPropertyNames(source)) {
       const property: any = source[propName];
       if (typeof property === 'function') {
         result[propName] = property;
@@ -35,7 +35,8 @@ export interface OAuth2Client {
 /**** Client Credentials ****/
 
 // Using assign only copies enumerable properties, which is what we want
-export const credentials = mixin({
+export const credentials = mixin(
+    {
       /**
        * Create a gRPC credential from a Google credential object.
        * @param googleCredentials The authentication client to use.
@@ -84,7 +85,8 @@ export const credentials = mixin({
           CallCredentials => {
             return additional.reduce((acc, other) => acc.compose(other), first);
           }
-    }, ChannelCredentials, CallCredentials);
+    },
+    ChannelCredentials, CallCredentials);
 
 /**** Metadata ****/
 

--- a/packages/grpc-js-core/src/index.ts
+++ b/packages/grpc-js-core/src/index.ts
@@ -8,6 +8,24 @@ import {Status} from './constants';
 import {loadPackageDefinition, makeClientConstructor} from './make-client';
 import {Metadata} from './metadata';
 
+interface IndexedObject {
+  [key: string]: any;
+  [key: number]: any;
+}
+
+function mixin(...sources: IndexedObject[]) {
+  const result: {[key: string]: Function} = {};
+  for(const source of sources) {
+    for(const propName of Object.getOwnPropertyNames(source)) {
+      const property: any = source[propName];
+      if (typeof property === 'function') {
+        result[propName] = property;
+      }
+    }
+  }
+  return result;
+}
+
 export interface OAuth2Client {
   getRequestMetadata: (url: string, callback: (err: Error|null, headers?: {
                                       Authorization: string
@@ -17,8 +35,7 @@ export interface OAuth2Client {
 /**** Client Credentials ****/
 
 // Using assign only copies enumerable properties, which is what we want
-export const credentials = Object.assign(
-    {
+export const credentials = mixin({
       /**
        * Create a gRPC credential from a Google credential object.
        * @param googleCredentials The authentication client to use.
@@ -67,8 +84,7 @@ export const credentials = Object.assign(
           CallCredentials => {
             return additional.reduce((acc, other) => acc.compose(other), first);
           }
-    },
-    ChannelCredentials, CallCredentials);
+    }, ChannelCredentials, CallCredentials);
 
 /**** Metadata ****/
 

--- a/packages/grpc-js-core/src/make-client.ts
+++ b/packages/grpc-js-core/src/make-client.ts
@@ -6,9 +6,13 @@ import {ChannelCredentials} from './channel-credentials';
 import {Client, UnaryCallback} from './client';
 import {Metadata} from './metadata';
 
-export interface Serialize<T> { (value: T): Buffer; }
+export interface Serialize<T> {
+  (value: T): Buffer;
+}
 
-export interface Deserialize<T> { (bytes: Buffer): T; }
+export interface Deserialize<T> {
+  (bytes: Buffer): T;
+}
 
 export interface MethodDefinition<RequestType, ResponseType> {
   path: string;
@@ -25,7 +29,9 @@ export interface ServiceDefinition {
   [index: string]: MethodDefinition<object, object>;
 }
 
-export interface PackageDefinition { [index: string]: ServiceDefinition; }
+export interface PackageDefinition {
+  [index: string]: ServiceDefinition;
+}
 
 function getDefaultValues<T>(metadata?: Metadata, options?: T):
     {metadata: Metadata; options: Partial<T>;} {

--- a/packages/grpc-js-core/src/metadata.ts
+++ b/packages/grpc-js-core/src/metadata.ts
@@ -3,7 +3,9 @@ import {forOwn} from 'lodash';
 
 export type MetadataValue = string|Buffer;
 
-export interface MetadataObject { [key: string]: MetadataValue[]; }
+export interface MetadataObject {
+  [key: string]: MetadataValue[];
+}
 
 function cloneMetadataObject(repr: MetadataObject): MetadataObject {
   const result: MetadataObject = {};

--- a/packages/grpc-js-core/test/test-call-stream.ts
+++ b/packages/grpc-js-core/test/test-call-stream.ts
@@ -6,11 +6,13 @@ import * as stream from 'stream';
 
 import {CallCredentials} from '../src/call-credentials';
 import {Http2CallStream} from '../src/call-stream';
+import {CompressionFilterFactory} from '../src/compression-filter';
 import {Status} from '../src/constants';
 import {FilterStackFactory} from '../src/filter-stack';
 import {Metadata} from '../src/metadata';
 
 import {assert2, mockFunction} from './common';
+import { Channel } from '../src/channel';
 
 interface DataFrames {
   payload: Buffer;
@@ -83,7 +85,11 @@ describe('CallStream', () => {
     flags: 0,
     host: ''
   };
-  const filterStackFactory = new FilterStackFactory([]);
+  /* A CompressionFilter is now necessary to frame and deframe messages.
+   * Currently the channel is unused, so we can replace it with an empty object,
+   * but this might break if we start checking channel arguments, in which case
+   * we will need a more sophisticated fake */
+  const filterStackFactory = new FilterStackFactory([new CompressionFilterFactory(<Channel>{})]);
   const message = 'eat this message';  // 16 bytes
 
   beforeEach(() => {

--- a/packages/grpc-js-core/test/test-call-stream.ts
+++ b/packages/grpc-js-core/test/test-call-stream.ts
@@ -6,13 +6,13 @@ import * as stream from 'stream';
 
 import {CallCredentials} from '../src/call-credentials';
 import {Http2CallStream} from '../src/call-stream';
+import {Channel} from '../src/channel';
 import {CompressionFilterFactory} from '../src/compression-filter';
 import {Status} from '../src/constants';
 import {FilterStackFactory} from '../src/filter-stack';
 import {Metadata} from '../src/metadata';
 
 import {assert2, mockFunction} from './common';
-import { Channel } from '../src/channel';
 
 interface DataFrames {
   payload: Buffer;
@@ -89,7 +89,8 @@ describe('CallStream', () => {
    * Currently the channel is unused, so we can replace it with an empty object,
    * but this might break if we start checking channel arguments, in which case
    * we will need a more sophisticated fake */
-  const filterStackFactory = new FilterStackFactory([new CompressionFilterFactory(<Channel>{})]);
+  const filterStackFactory =
+      new FilterStackFactory([new CompressionFilterFactory(<Channel>{})]);
   const message = 'eat this message';  // 16 bytes
 
   beforeEach(() => {

--- a/packages/grpc-js-core/tsconfig.json
+++ b/packages/grpc-js-core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build"
+    "outDir": "build",
+    "target": "es6"
   },
   "include": [
     "src/*.ts",

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -57,7 +57,7 @@ gulp.task('test', 'Run API-level tests', () => {
       .on('error', reject);
   });
   var runTestsArgPairs;
-  if (semver.satisfies(process.version, '>=9.4')) {
+  if (semver.satisfies(process.version, '^ 8.11.2 || >=9.4')) {
     runTestsArgPairs = [
       ['native', 'native'],
       ['native', 'js'],


### PR DESCRIPTION
This passes all of the existing tests, but I haven't added new ones. This mirrors the existing library, which also doesn't have substantial compression test coverage. In a future PR I will add the applicable compression interop tests.