### PR TITLE
Make Protobuf.js Message type non-generic

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -66,7 +66,7 @@ declare module "grpc" {
    * - Anything else becomes the relevant reflection object that ProtoBuf.js would create
    */
   export interface GrpcObject {
-    [name: string]: GrpcObject | typeof Client | Message<any>;
+    [name: string]: GrpcObject | typeof Client | Message;
   }
 
   /**


### PR DESCRIPTION
Fixes #176 

@respinha-ribeiro FYI... Please comment on #176 on why this didn't work for you earlier. (As far as can tell `Message` is non-generic.)