### PR TITLE
Add checkServerIdentity callback

### DIFF
--- a/packages/grpc-native-core/ext/channel_credentials.cc
+++ b/packages/grpc-native-core/ext/channel_credentials.cc
@@ -78,9 +78,15 @@ static int verify_peer_callback_wrapper(const char* servername, const char* cert
     argv[1] = Nan::New<v8::String>(cert).ToLocalChecked();
   }
 
-  callback->Call(argc, argv);
+  Local<Value> result = callback->Call(argc, argv);
 
+  // Catch any exception and return with a distinct status code which indicates this
   if (try_catch.HasCaught()) {
+    return 2;
+  }
+
+  // If the result is an error, return a failure
+  if (result->IsNativeError()) {
     return 1;
   }
 

--- a/packages/grpc-native-core/ext/channel_credentials.cc
+++ b/packages/grpc-native-core/ext/channel_credentials.cc
@@ -186,35 +186,21 @@ NAN_METHOD(ChannelCredentials::CreateSsl) {
   verify_peer_options verify_options = {NULL, NULL, NULL};
   if (!info[3]->IsUndefined()) {
     if (!info[3]->IsObject()) {
-      return Nan::ThrowTypeError("createSsl's fourth argument must be an "
-          "object");
+      return Nan::ThrowTypeError("createSsl's fourth argument must be an object");
     }
-    Local<Context> context = Nan::New<Context>();
     Local<Object> object = info[3]->ToObject();
-    MaybeLocal<Array> maybe_props = object->GetOwnPropertyNames(context);
-    if (!maybe_props.IsEmpty()) {
-      Local<Array> props = maybe_props.ToLocalChecked();
-      for(uint32_t i=0; i < props->Length(); i++) {
-        Local<Value> key = props->Get(i);
-        Local<Value> value = object->Get(key);
 
-        if (key->IsString()) {
-          Nan::Utf8String keyStr(key->ToString());
-
-          if (strcmp("checkServerIdentity", (const char*)(*keyStr)) == 0) {
-
-            if (!value->IsFunction()) {
-                return Nan::ThrowError("Value of checkServerIdentity must be a function.");
-            }
-            Nan::Callback *callback = new Callback(Local<Function>::Cast(value));
-            verify_options.verify_peer_callback = verify_peer_callback_wrapper;
-            verify_options.verify_peer_callback_userdata = (void*)callback;
-            verify_options.verify_peer_destruct = verify_peer_callback_destruct;
-
-          }
-        }
-        // do stuff with key / value
+    Local<Value> checkServerIdentityValue = Nan::Get(object,
+        Nan::New("checkServerIdentity").ToLocalChecked()).ToLocalChecked();
+    if (!checkServerIdentityValue->IsUndefined()) {
+      if (!checkServerIdentityValue->IsFunction()) {
+        return Nan::ThrowTypeError("Value of checkServerIdentity must be a function.");
       }
+      Nan::Callback *callback = new Callback(Local<Function>::Cast(
+        checkServerIdentityValue));
+      verify_options.verify_peer_callback = verify_peer_callback_wrapper;
+      verify_options.verify_peer_callback_userdata = (void*)callback;
+      verify_options.verify_peer_destruct = verify_peer_callback_destruct;
     }
   }
 

--- a/packages/grpc-native-core/ext/channel_credentials.cc
+++ b/packages/grpc-native-core/ext/channel_credentials.cc
@@ -189,7 +189,11 @@ NAN_METHOD(ChannelCredentials::CreateSsl) {
   }
 
   verify_peer_options verify_options = {NULL, NULL, NULL};
-  if (info.Length() >= 4 && info[3]->IsObject()) {
+  if (!info[3]->IsUndefined()) {
+    if (!info[3]->IsObject()) {
+      return Nan::ThrowTypeError("createSsl's fourth argument must be an "
+          "object");
+    }
     Local<Context> context = Nan::New<Context>();
     Local<Object> object = info[3]->ToObject();
     MaybeLocal<Array> maybe_props = object->GetOwnPropertyNames(context);

--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -794,13 +794,17 @@ declare module "grpc" {
     ERROR,
   }
 
+  export interface Certificate {
+    raw: Buffer;
+  }
+
   /**
    * A callback that will receive the expected hostname and presented peer
    * certificate as parameters. The callback should return an error to
    * indicate that the presented certificate is considered invalid and
    * otherwise returned undefined.
    */
-  export type CheckServerIdentityCallback = (hostname: string, cert: string) => Error | undefined;
+  export type CheckServerIdentityCallback = (hostname: string, cert: Certificate) => Error | undefined;
 
   /**
    * Additional peer verification options that can be set when creating

--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -796,10 +796,11 @@ declare module "grpc" {
 
   /**
    * A callback that will receive the expected hostname and presented peer
-   * certificate as parameters. The callback should throw an error to
-   * indicate that the presented certificate is considered invalid.
+   * certificate as parameters. The callback should return an error to
+   * indicate that the presented certificate is considered invalid and
+   * otherwise returned undefined.
    */
-  export type CheckServerIdentityCallback = (hostname: string, cert: string) => void;
+  export type CheckServerIdentityCallback = (hostname: string, cert: string) => Error | undefined;
 
   /**
    * Additional peer verification options that can be set when creating

--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -795,6 +795,25 @@ declare module "grpc" {
   }
 
   /**
+   * A callback that will receive the expected hostname and presented peer
+   * certificate as parameters. The callback should throw an error to
+   * indicate that the presented certificate is considered invalid.
+   */
+  export type CheckServerIdentityCallback = (hostname: string, cert: string) => void;
+
+  /**
+   * Additional peer verification options that can be set when creating
+   * SSL credentials.
+   */
+  export interface VerifyOptions: {
+    /**
+     * If set, this callback will be invoked after the usual hostname verification
+     * has been performed on the peer certificate.
+     */
+    checkServerIdentity?: CheckServerIdentityCallback;
+  }
+
+  /**
    * Credentials module
    *
    * This module contains factory methods for two different credential types:
@@ -828,9 +847,10 @@ declare module "grpc" {
      * @param rootCerts The root certificate data
      * @param privateKey The client certificate private key, if applicable
      * @param certChain The client certificate cert chain, if applicable
+     * @param verifyOptions Additional peer verification options, if desired
      * @return The SSL Credentials object
      */
-    createSsl(rootCerts?: Buffer, privateKey?: Buffer, certChain?: Buffer): ChannelCredentials;
+    createSsl(rootCerts?: Buffer, privateKey?: Buffer, certChain?: Buffer, verifyOptions?: VerifyOptions): ChannelCredentials;
 
     /**
      * Create a gRPC credentials object from a metadata generation function. This

--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -794,7 +794,13 @@ declare module "grpc" {
     ERROR,
   }
 
+  /**
+   * A certificate as received by the checkServerIdentity callback.
+   */
   export interface Certificate {
+    /**
+     * The raw certificate in DER form.
+     */
     raw: Buffer;
   }
 

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -44,6 +44,7 @@
     "istanbul": "^0.4.4",
     "lodash": "^4.17.4",
     "minimist": "^1.1.0",
+    "node-forge": "^0.7.5",
     "poisson-process": "^0.2.1"
   },
   "engines": {

--- a/packages/grpc-native-core/src/credentials.js
+++ b/packages/grpc-native-core/src/credentials.js
@@ -87,18 +87,10 @@ var _ = require('lodash');
  * @param {Buffer=} private_key The client certificate private key, if
  *     applicable
  * @param {Buffer=} cert_chain The client certificate cert chain, if applicable
- * @param {Object} verify_options Additional peer verification options. Can
- *     be undefined, in which case default behavior is preserved.
- *     Supported options are: "checkServerIdentity": (servername, cert) => {}
- *     The callback passed to checkServerIdentity will be invoked when the
- *     channel is opened in order to provide an opportunity to perform
- *     additional verification of the peer certificate as passed to the
- *     callback in the second parameter. The expected hostname is passed as
- *     the first parameter. If the callback considers the peer certificate
- *     invalid it should throw an error which will cause the handshake to
- *     be terminated. Note that supplying this callback does not disable
- *     the usual hostname verification which will also be performed on the
- *     certificate before this callback is invoked.
+ * @param {Function} verify_options.checkServerIdentity Optional callback
+ *     receiving the expected hostname and peer certificate for additional
+ *     verification. The callback should return an Error if verification
+ *     fails and otherwise return undefined.
  * @return {grpc.credentials~ChannelCredentials} The SSL Credentials object
  */
 exports.createSsl = ChannelCredentials.createSsl;

--- a/packages/grpc-native-core/src/credentials.js
+++ b/packages/grpc-native-core/src/credentials.js
@@ -78,7 +78,8 @@ var _ = require('lodash');
 
 /**
  * Create an SSL Credentials object. If using a client-side certificate, both
- * the second and third arguments must be passed.
+ * the second and third arguments must be passed. Additional peer verification
+ * options can be passed in the fourth argument as described below.
  * @memberof grpc.credentials
  * @alias grpc.credentials.createSsl
  * @kind function
@@ -86,6 +87,18 @@ var _ = require('lodash');
  * @param {Buffer=} private_key The client certificate private key, if
  *     applicable
  * @param {Buffer=} cert_chain The client certificate cert chain, if applicable
+ * @param {Object} verify_options Additional peer verification options. Can
+ *     be undefined, in which case default behavior is preserved.
+ *     Supported options are: "checkServerIdentity": (servername, cert) => {}
+ *     The callback passed to checkServerIdentity will be invoked when the
+ *     channel is opened in order to provide an opportunity to perform
+ *     additional verification of the peer certificate as passed to the
+ *     callback in the second parameter. The expected hostname is passed as
+ *     the first parameter. If the callback considers the peer certificate
+ *     invalid it should throw an error which will cause the handshake to
+ *     be terminated. Note that supplying this callback does not disable
+ *     the usual hostname verification which will also be performed on the
+ *     certificate before this callback is invoked.
  * @return {grpc.credentials~ChannelCredentials} The SSL Credentials object
  */
 exports.createSsl = ChannelCredentials.createSsl;

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -46,6 +46,7 @@
       "istanbul": "^0.4.4",
       "lodash": "^4.17.4",
       "minimist": "^1.1.0",
+      "node-forge": "^0.7.5",
       "poisson-process": "^0.2.1"
     },
     "engines": {

--- a/packages/grpc-native-core/test/credentials_test.js
+++ b/packages/grpc-native-core/test/credentials_test.js
@@ -128,6 +128,25 @@ describe('channel credentials', function() {
         grpc.credentials.createSsl(null, null, pem_data);
       });
     });
+    it('works if the fourth argument is an empty object', function() {
+      var creds;
+      assert.doesNotThrow(function() {
+        creds = grpc.credentials.createSsl(ca_data, null, null, {});
+      });
+      assert.notEqual(creds, null);
+    });
+    it('fails if the fourth argument is a non-object value', function() {
+      assert.throws(function() {
+        grpc.credentials.createSsl(ca_data, null, null, 'test');
+      }, TypeError);
+    });
+    it('fails if the checkServerIdentity is a non-function', function() {
+      assert.throws(function() {
+        grpc.credentials.createSsl(ca_data, null, null, {
+          "checkServerIdentity": 'test'
+        });
+      }, TypeError);
+    });
   });
 });
 

--- a/packages/grpc-native-core/test/credentials_test.js
+++ b/packages/grpc-native-core/test/credentials_test.js
@@ -309,6 +309,19 @@ describe('client credentials', function() {
       done();
     });
   });
+  it('Verify callback returning an Error causes connection failure', function(done) {
+    var client_ssl_creds = grpc.credentials.createSsl(ca_data, null, null, {
+      "checkServerIdentity": function(host, cert) {
+        return new Error("Verification error");
+      }
+    });
+    var client = new Client('localhost:' + port, client_ssl_creds,
+                            client_options);
+    client.unary({}, function(err, data) {
+      assert.ok(err, "Should have raised an error");
+      done();
+    });
+  });
   it('Should update metadata with SSL creds', function(done) {
     var metadataUpdater = function(service_url, callback) {
       var metadata = new grpc.Metadata();


### PR DESCRIPTION
Core [PR 15274](https://github.com/grpc/grpc/pull/15274) added an option to provide a callback during peer certificate verification in order to perform additional validation. This PR exposes that option in node as a "checkServerIdentity" function that has the same semantics as the option of the same name available in the [node TLS library](https://nodejs.org/api/tls.html#tls_tls_checkserveridentity_host_cert) (except that it does not replace regular hostname; it is in addition to it).

Example usage:

```
grpc.credentials.createSsl(
    fs.readFileSync("truststore.pem"),
    fs.readFileSync("client.pem.key"),
    fs.readFileSync("clent.pem.crt"),
    {
      "checkServerIdentity": function(host, cert) {
        if (fingerprint(cert) !== expectedFingerprint) {
          throw "Invalid server certificate presented";
        }
      }
    });
```