### PR TITLE
auth_context support.

### DIFF
--- a/packages/grpc-native-core/ext/auth_context.cc
+++ b/packages/grpc-native-core/ext/auth_context.cc
@@ -1,0 +1,141 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "auth_context.h"
+
+namespace grpc {
+namespace node {
+
+using Nan::Callback;
+using Nan::EscapableHandleScope;
+using Nan::HandleScope;
+using Nan::Maybe;
+using Nan::MaybeLocal;
+using Nan::ObjectWrap;
+using Nan::Persistent;
+using Nan::Utf8String;
+
+using v8::Array;
+using v8::Boolean;
+using v8::Exception;
+using v8::External;
+using v8::Function;
+using v8::FunctionTemplate;
+using v8::Integer;
+using v8::Local;
+using v8::Number;
+using v8::Object;
+using v8::ObjectTemplate;
+using v8::Uint32;
+using v8::String;
+using v8::Value;
+
+Callback *AuthContext::constructor;
+Persistent<FunctionTemplate> AuthContext::fun_tpl;
+
+void AuthContext::Init(Local<Object> exports) {
+  HandleScope scope;
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("AuthContext").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  Nan::SetPrototypeMethod(tpl, "getProperty", GetProperty);
+  Nan::SetPrototypeMethod(tpl, "getProperties", GetProperties);
+
+  fun_tpl.Reset(tpl);
+  Local<Function> ctr = Nan::GetFunction(tpl).ToLocalChecked();
+  Nan::Set(exports, Nan::New("AuthContext").ToLocalChecked(), ctr);
+  constructor = new Callback(ctr);
+}
+
+bool AuthContext::HasInstance(Local<Value> val) {
+  HandleScope scope;
+  return Nan::New(fun_tpl)->HasInstance(val);
+}
+
+AuthContext::AuthContext(grpc_auth_context *auth_context) : wrapped_auth_context(auth_context) {
+}
+
+AuthContext::~AuthContext() {
+  if (wrapped_auth_context) {
+    grpc_auth_context_release(wrapped_auth_context);
+  }
+}
+
+NAN_METHOD(AuthContext::New) {
+  if (info[0]->IsExternal()) {
+    Local<External> ext = info[0].As<External>();
+    // This option is used for wrapping an existing call
+    grpc_auth_context *auth_context_ptr = reinterpret_cast<grpc_auth_context *>(ext->Value());
+    AuthContext *auth_context = new AuthContext(auth_context_ptr);
+
+    auth_context->Wrap(info.This());
+    info.GetReturnValue().Set(info.This());
+  } else {
+    return Nan::ThrowError("Don't try to call AuthContext's constructor directly.");
+  }
+}
+
+NAN_METHOD(AuthContext::GetProperty) {
+  Nan::HandleScope scope;
+  if (!HasInstance(info.This())) {
+    return Nan::ThrowTypeError("getProperty can only be called on AuthContext objects");
+  }
+
+  AuthContext *auth_context_obj = ObjectWrap::Unwrap<AuthContext>(info.This());
+  grpc_auth_context *auth_context = auth_context_obj->wrapped_auth_context;
+
+  Utf8String name(info[0]);
+  grpc_auth_property_iterator it = grpc_auth_context_find_properties_by_name(auth_context, *name);
+  const grpc_auth_property *property = grpc_auth_property_iterator_next(&it);
+  if (property) {
+    info.GetReturnValue().Set(
+      Nan::CopyBuffer(property->value, property->value_length).ToLocalChecked()
+    );
+  }
+}
+
+NAN_METHOD(AuthContext::GetProperties) {
+  Nan::HandleScope scope;
+  if (!HasInstance(info.This())) {
+    return Nan::ThrowTypeError("getProperties can only be called on AuthContext objects");
+  }
+
+  AuthContext *auth_context_obj = ObjectWrap::Unwrap<AuthContext>(info.This());
+  grpc_auth_context *auth_context = auth_context_obj->wrapped_auth_context;
+
+  grpc_auth_property_iterator it = grpc_auth_context_property_iterator(auth_context);
+
+  Local<Object> ret = Nan::New<Object>();
+
+  while (true) {
+    const grpc_auth_property *property = grpc_auth_property_iterator_next(&it);
+    if (!property) break;
+
+    ret->Set(
+      Nan::New(property->name).ToLocalChecked(),
+      Nan::CopyBuffer(property->value, property->value_length).ToLocalChecked()
+    );
+  }
+
+  info.GetReturnValue().Set(ret);
+}
+
+
+}  // namespace node
+}  // namespace grpc

--- a/packages/grpc-native-core/ext/auth_context.h
+++ b/packages/grpc-native-core/ext/auth_context.h
@@ -1,0 +1,61 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NET_GRPC_NODE_AUTH_CONTEXT_H_
+#define NET_GRPC_NODE_AUTH_CONTEXT_H_
+
+#include <nan.h>
+#include <node.h>
+#include "grpc/grpc_security.h"
+
+namespace grpc {
+namespace node {
+
+using std::unique_ptr;
+using std::shared_ptr;
+
+/* Wrapper class for grpc_auth_context. */
+class AuthContext : public Nan::ObjectWrap {
+ public:
+  static void Init(v8::Local<v8::Object> exports);
+  static bool HasInstance(v8::Local<v8::Value> val);
+
+ private:
+  friend class Call;
+  AuthContext(grpc_auth_context *auth_context);
+  ~AuthContext();
+
+  // Prevent copying
+  AuthContext(const AuthContext &);
+  AuthContext &operator=(const AuthContext &);
+
+  static NAN_METHOD(New);
+  static NAN_METHOD(GetProperty);
+  static NAN_METHOD(GetProperties);
+
+  static Nan::Callback *constructor;
+  // Used for typechecking instances of this javascript class
+  static Nan::Persistent<v8::FunctionTemplate> fun_tpl;
+
+  grpc_auth_context *wrapped_auth_context;
+};
+
+}  // namespace node
+}  // namespace grpc
+
+#endif  // NET_GRPC_NODE_AUTH_CONTEXT_H_

--- a/packages/grpc-native-core/ext/call.cc
+++ b/packages/grpc-native-core/ext/call.cc
@@ -23,6 +23,7 @@
 #include <node.h>
 
 #include "byte_buffer.h"
+#include "auth_context.h"
 #include "call.h"
 #include "call_credentials.h"
 #include "channel.h"
@@ -525,6 +526,7 @@ void Call::Init(Local<Object> exports) {
   Nan::SetPrototypeMethod(tpl, "cancel", Cancel);
   Nan::SetPrototypeMethod(tpl, "cancelWithStatus", CancelWithStatus);
   Nan::SetPrototypeMethod(tpl, "getPeer", GetPeer);
+  Nan::SetPrototypeMethod(tpl, "getAuthContext", GetAuthContext);
   Nan::SetPrototypeMethod(tpl, "setCredentials", SetCredentials);
   fun_tpl.Reset(tpl);
   Local<Function> ctr = Nan::GetFunction(tpl).ToLocalChecked();
@@ -789,6 +791,27 @@ NAN_METHOD(Call::GetPeer) {
   Call *call = ObjectWrap::Unwrap<Call>(info.This());
   Local<Value> peer_value = Nan::New(call->peer).ToLocalChecked();
   info.GetReturnValue().Set(peer_value);
+}
+
+NAN_METHOD(Call::GetAuthContext) {
+  Nan::HandleScope scope;
+  if (!HasInstance(info.This())) {
+    return Nan::ThrowTypeError("getAuthContext can only be called on Call objects");
+  }
+
+  Call *call = ObjectWrap::Unwrap<Call>(info.This());
+  grpc_auth_context *auth_ctx = grpc_call_auth_context(call->wrapped_call);
+  if (auth_ctx) {
+    const int argc = 1;
+    Local<Value> argv[argc] = {
+        Nan::New<External>(reinterpret_cast<void *>(auth_ctx))};
+    MaybeLocal<Object> maybe_instance =
+        Nan::NewInstance(AuthContext::constructor->GetFunction(), argc, argv);
+
+    if (!maybe_instance.IsEmpty()) {
+      info.GetReturnValue().Set(maybe_instance.ToLocalChecked());
+    }
+  }
 }
 
 NAN_METHOD(Call::SetCredentials) {

--- a/packages/grpc-native-core/ext/call.h
+++ b/packages/grpc-native-core/ext/call.h
@@ -69,6 +69,7 @@ class Call : public Nan::ObjectWrap {
   static NAN_METHOD(Cancel);
   static NAN_METHOD(CancelWithStatus);
   static NAN_METHOD(GetPeer);
+  static NAN_METHOD(GetAuthContext);
   static NAN_METHOD(SetCredentials);
   static Nan::Callback *constructor;
   // Used for typechecking instances of this javascript class

--- a/packages/grpc-native-core/ext/node_grpc.cc
+++ b/packages/grpc-native-core/ext/node_grpc.cc
@@ -30,6 +30,7 @@
 // TODO(murgatroid99): Remove this when the endpoint API becomes public
 #include "src/core/lib/iomgr/pollset_uv.h"
 
+#include "auth_context.h"
 #include "call.h"
 #include "call_credentials.h"
 #include "channel.h"
@@ -280,6 +281,7 @@ void init(Local<Object> exports) {
 
   grpc_pollset_work_run_loop = 0;
 
+  grpc::node::AuthContext::Init(exports);
   grpc::node::Call::Init(exports);
   grpc::node::CallCredentials::Init(exports);
   grpc::node::Channel::Init(exports);

--- a/packages/grpc-native-core/src/server.js
+++ b/packages/grpc-native-core/src/server.js
@@ -504,7 +504,13 @@ function getPeer() {
   return this.call.getPeer();
 }
 
+function getAuthContext() {
+  /* jshint validthis: true */
+  return this.call.getAuthContext();
+}
+
 ServerUnaryCall.prototype.getPeer = getPeer;
+ServerUnaryCall.prototype.getAuthContext = getAuthContext;
 ServerReadableStream.prototype.getPeer = getPeer;
 ServerWritableStream.prototype.getPeer = getPeer;
 ServerDuplexStream.prototype.getPeer = getPeer;


### PR DESCRIPTION
This pull request can solve this [issue](https://github.com/grpc/grpc/issues/7834#issuecomment-288785780), Call object can now call getAuthContext to get a AuthContext, then we can read the properties in AuthContext.

## Usage
```js
server.addService(proto.TestService.service, {
  unary: function (call, cb) {
    const authContext = call.getAuthContext();
    if (authContext) {
      const properties = authContext.getProperties();
      console.log(properties);

      const pem = authContext.getProperty('x509_pem_cert');
      pem && console.log(pem.toString());
    }

    call.sendMetadata(call.metadata);
    cb(null, {});
  }
});
```