### PR TITLE
Restored protobuf.js Message type as generic

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -66,7 +66,7 @@ declare module "grpc" {
    * - Anything else becomes the relevant reflection object that ProtoBuf.js would create
    */
   export interface GrpcObject {
-    [name: string]: GrpcObject | typeof Client | Message;
+    [name: string]: GrpcObject | typeof Client | Message<any>;
   }
 
   /**


### PR DESCRIPTION
Fix the error 
```
error TS2314: Generic type 'Message<T>' requires 1 type argument(s).
```
Message type is defined in the protobufjs package as below
```
export class Message<T extends object> {
    ...
}
```
so it should be a generic