### PR TITLE
grpc-native-core: Update CallOptions type to allow custom options (#433)

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -1116,6 +1116,11 @@ declare module "grpc" {
      * The credentials that should be used to make this particular call.
      */
     credentials: CallCredentials;
+    /**
+     * Additional custom call options. These can be used to pass additional
+     * data per-call to client interceptors
+     */
+    [key: string]: any;
   }
 
   /**


### PR DESCRIPTION
Allow custom options as a means of passing data per call to client interceptors

Resolves https://github.com/grpc/grpc-node/issues/433