### PR TITLE
Restore Protobuf.Types to GrpcObject tree

### DIFF
--- a/packages/grpc-protobufjs/package.json
+++ b/packages/grpc-protobufjs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@TIN/proto-loader",
+  "name": "grpc-alt-proto-loader",
   "version": "0.4.0",
   "author": "Google Inc.",
   "contributors": [

--- a/packages/grpc-protobufjs/package.json
+++ b/packages/grpc-protobufjs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@grpc/proto-loader",
+  "name": "@TIN/proto-loader",
   "version": "0.3.0",
   "author": "Google Inc.",
   "contributors": [

--- a/packages/grpc-protobufjs/package.json
+++ b/packages/grpc-protobufjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@TIN/proto-loader",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Google Inc.",
   "contributors": [
     {

--- a/packages/grpc-protobufjs/src/index.ts
+++ b/packages/grpc-protobufjs/src/index.ts
@@ -127,11 +127,13 @@ function createServiceDefinition(service: Protobuf.Service, name: string, option
   return def;
 }
 
-function createPackageDefinition(root: Protobuf.Root, options: Options): PackageDefinition {
+function createPackageDefinition(
+  root: Protobuf.Root,
+  options: Options,
+  services: Array<[string, Protobuf.Service]>
+): PackageDefinition {
   const def: PackageDefinition = {};
-  const servicesAndMessages = getAllServicesAndMessages(root, '')
-  console.log('found services and messages:', servicesAndMessages)
-  for (const [name, service] of servicesAndMessages.services) {
+  for (const [name, service] of services) {
     def[name] = createServiceDefinition(service, name, options);
   }
   return def;
@@ -187,7 +189,9 @@ export function load(filename: string, options?: Options): Promise<PackageDefini
   }
   return root.load(filename, options).then((loadedRoot) => {
     loadedRoot.resolveAll();
-    return createPackageDefinition(root, options!);
+    const servicesAndMessages = getAllServicesAndMessages(root, '');
+    console.log('found services and messages:', servicesAndMessages);
+    return createPackageDefinition(root, options!, servicesAndMessages.services);
   });
 }
 
@@ -202,5 +206,7 @@ export function loadSync(filename: string, options?: Options): PackageDefinition
   }
   const loadedRoot = root.loadSync(filename, options);
   loadedRoot.resolveAll();
-  return createPackageDefinition(root, options!);
+  const servicesAndMessages = getAllServicesAndMessages(root, '');
+  console.log('found services and messages:', servicesAndMessages);
+  return createPackageDefinition(root, options!, servicesAndMessages.services);
 }

--- a/packages/grpc-protobufjs/src/index.ts
+++ b/packages/grpc-protobufjs/src/index.ts
@@ -59,9 +59,13 @@ function joinName(baseName: string, name: string): string {
   }
 }
 
+function isService(obj: Protobuf.NamespaceBase) {
+  return obj.hasOwnProperty('methods')
+}
+
 function getAllServices(obj: Protobuf.NamespaceBase, parentName: string): Array<[string, Protobuf.Service]> {
   const objName = joinName(parentName, obj.name);
-  if (obj.hasOwnProperty('methods')) {
+  if (isService(obj)) {
     return [[objName, obj as Protobuf.Service]];
   } else {
     return obj.nestedArray.map((child) => {


### PR DESCRIPTION
`@grpc/proto-loader` hides protobufjs' message types from users, making them inaccessible.

This PR suggests a possible approach for making them accessible again.

I'm given to understand that because protobufjs is non-semver and `grpc-node` would like to remain semver, this has not be done.

I wanted to create this PR as a place to document the details of this decision and explore the possibility of finding some way to do this. I am doubtful this PR will be merged, but hopefully it will accomplish its other goals :)