### PR TITLE
Don't refer to node-pre-gyp with a relative path

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -19,10 +19,10 @@
     "lib": "src"
   },
   "scripts": {
-    "build": "./node_modules/.bin/node-pre-gyp build",
-    "electron-build": "./node_modules/.bin/node-pre-gyp configure build --runtime=electron --disturl=https://atom.io/download/atom-shell",
-    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha test",
-    "install": "./node_modules/.bin/node-pre-gyp install --fallback-to-build --library=static_library",
+    "build": "node-pre-gyp build",
+    "electron-build": "node-pre-gyp configure build --runtime=electron --disturl=https://atom.io/download/atom-shell",
+    "coverage": "istanbul cover ./node_modules/.bin/_mocha test",
+    "install": "node-pre-gyp install --fallback-to-build --library=static_library",
     "prepack": "git submodule update --init --recursive && npm install"
   },
   "bundledDependencies": [

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -21,10 +21,10 @@
       "lib": "src"
     },
     "scripts": {
-      "build": "./node_modules/.bin/node-pre-gyp build",
-      "electron-build": "./node_modules/.bin/node-pre-gyp configure build --runtime=electron --disturl=https://atom.io/download/atom-shell",
-      "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha test",
-      "install": "./node_modules/.bin/node-pre-gyp install --fallback-to-build --library=static_library",
+      "build": "node-pre-gyp build",
+      "electron-build": "node-pre-gyp configure build --runtime=electron --disturl=https://atom.io/download/atom-shell",
+      "coverage": "istanbul cover ./node_modules/.bin/_mocha test",
+      "install": "node-pre-gyp install --fallback-to-build --library=static_library",
       "prepack": "git submodule update --init --recursive && npm install"
     },
     "bundledDependencies": [


### PR DESCRIPTION
Hopefully this should fix grpc/grpc#16164, at least for 1.14. We can backport if the fix works