### PR TITLE
Fix stream.write type incompatibility

### DIFF
--- a/packages/grpc-js-core/src/call-stream.ts
+++ b/packages/grpc-js-core/src/call-stream.ts
@@ -7,7 +7,7 @@ import {EmitterAugmentation1} from './events';
 import {Filter} from './filter';
 import {FilterStackFactory} from './filter-stack';
 import {Metadata} from './metadata';
-import {ObjectDuplex} from './object-stream';
+import {ObjectDuplex, WriteCallback} from './object-stream';
 
 const {HTTP2_HEADER_STATUS, HTTP2_HEADER_CONTENT_TYPE, NGHTTP2_CANCEL} =
     http2.constants;
@@ -71,7 +71,7 @@ export class Http2CallStream extends Duplex implements CallStream {
   private http2Stream: http2.ClientHttp2Stream|null = null;
   private pendingRead = false;
   private pendingWrite: Buffer|null = null;
-  private pendingWriteCallback: Function|null = null;
+  private pendingWriteCallback: WriteCallback | null = null;
   private pendingFinalCallback: Function|null = null;
 
   private readState: ReadState = ReadState.NO_DATA;
@@ -441,7 +441,7 @@ export class Http2CallStream extends Duplex implements CallStream {
     }
   }
 
-  _write(chunk: WriteObject, encoding: string, cb: Function) {
+  _write(chunk: WriteObject, encoding: string, cb: WriteCallback) {
     this.filterStack.sendMessage(Promise.resolve(chunk)).then((message) => {
       if (this.http2Stream === null) {
         this.pendingWrite = message.message;

--- a/packages/grpc-js-core/src/object-stream.ts
+++ b/packages/grpc-js-core/src/object-stream.ts
@@ -3,6 +3,8 @@ import {EmitterAugmentation1} from './events';
 
 // tslint:disable:no-any
 
+export type WriteCallback = (error: Error | null | undefined) => void;
+
 export interface IntermediateObjectReadable<T> extends Readable {
   read(size?: number): any&T;
 }
@@ -13,8 +15,8 @@ export type ObjectReadable<T> = {
 
 export interface IntermediateObjectWritable<T> extends Writable {
   _write(chunk: any&T, encoding: string, callback: Function): void;
-  write(chunk: any&T, cb?: Function): boolean;
-  write(chunk: any&T, encoding?: any, cb?: Function): boolean;
+  write(chunk: any&T, cb?: WriteCallback): boolean;
+  write(chunk: any&T, encoding?: any, cb?: WriteCallback): boolean;
   setDefaultEncoding(encoding: string): this;
   end(): void;
   end(chunk: any&T, cb?: Function): void;


### PR DESCRIPTION
Backport #473 to 1.14 to make sure the tests stay green.

There's a chance that this actually breaks the tests. It is possible that the original breakage was caused by upgrading `@types/node` on master, in which case this change isn't necessary on the branch.