### PR TITLE
Fix benchmark proto loading

### DIFF
--- a/test/performance/benchmark_client.js
+++ b/test/performance/benchmark_client.js
@@ -39,12 +39,12 @@ var genericService = require('./generic_service');
 var grpc = require('../any_grpc').client;
 var protoLoader = require('../../packages/grpc-protobufjs');
 var protoPackage = protoLoader.loadSync(
-    'src/proto/grpc/testing/services.proto',
+    'src/proto/grpc/testing/benchmark_service.proto',
     {keepCase: true,
      defaults: true,
      enums: String,
      oneofs: true,
-     include: [__dirname + '/../../packages/grpc-native-core/deps/grpc']});
+     includeDirs: [__dirname + '/../../packages/grpc-native-core/deps/grpc']});
 var serviceProto = grpc.loadPackageDefinition(protoPackage).grpc.testing;
 
 /**

--- a/test/performance/benchmark_server.js
+++ b/test/performance/benchmark_server.js
@@ -33,12 +33,12 @@ var genericService = require('./generic_service');
 var grpc = require('../any_grpc').server;
 var protoLoader = require('../../packages/grpc-protobufjs');
 var protoPackage = protoLoader.loadSync(
-    'src/proto/grpc/testing/services.proto',
+    'src/proto/grpc/testing/benchmark_service.proto',
     {keepCase: true,
      defaults: true,
      enums: String,
      oneofs: true,
-     include: [__dirname + '/../../packages/grpc-native-core/deps/grpc']});
+     includeDirs: [__dirname + '/../../packages/grpc-native-core/deps/grpc']});
 var serviceProto = grpc.loadPackageDefinition(protoPackage).grpc.testing;
 
 /**

--- a/test/performance/worker.js
+++ b/test/performance/worker.js
@@ -24,12 +24,12 @@ var WorkerServiceImpl = require('./worker_service_impl');
 var grpc = require('../any_grpc').server;
 var protoLoader = require('../../packages/grpc-protobufjs');
 var protoPackage = protoLoader.loadSync(
-    'src/proto/grpc/testing/services.proto',
+    'src/proto/grpc/testing/worker_service.proto',
     {keepCase: true,
      defaults: true,
      enums: String,
      oneofs: true,
-     include: [__dirname + '/../../packages/grpc-native-core/deps/grpc']});
+     includeDirs: [__dirname + '/../../packages/grpc-native-core/deps/grpc']});
 var serviceProto = grpc.loadPackageDefinition(protoPackage).grpc.testing;
 
 function runServer(port, benchmark_impl) {


### PR DESCRIPTION
This fixes both the incorrect `include` argument and the proto paths that changed at some point.