### PR TITLE
Package comparison documentation

### DIFF
--- a/PACKAGE-COMPARISON.md
+++ b/PACKAGE-COMPARISON.md
@@ -1,0 +1,29 @@
+# Feature comparison of `grpc` and `@grpc/grpc-js` packages
+
+Feature | `grpc` | `@grpc/grpc-js`
+--------|--------|----------
+Client | :heavy_check_mark: | :heavy_check_mark:
+Server | :heavy_check_mark: | :x:
+Unary RPCs | :heavy_check_mark: | :heavy_check_mark:
+Streaming RPCs | :heavy_check_mark: | :heavy_check_mark:
+Deadlines | :heavy_check_mark: | :heavy_check_mark:
+Cancellation | :heavy_check_mark: | :heavy_check_mark:
+Automatic Reconnection | :heavy_check_mark: | :heavy_check_mark:
+Per-message Compression | :heavy_check_mark: | only for response messages
+Channel State | :heavy_check_mark: | :heavy_check_mark:
+JWT Access and Service Account Credentials | provided by the [Google Auth Library](https://www.npmjs.com/package/google-auth-library) | provided by the [Google Auth Library](https://www.npmjs.com/package/google-auth-library)
+Interceptors | :heavy_check_mark: | :x:
+Connection Keepalives | :heavy_check_mark: | :heavy_check_mark:
+HTTP Connect Support | :heavy_check_mark: | :x:
+Retries | :heavy_check_mark: | :x:
+Stats/tracing/monitoring | :heavy_check_mark: | :x:
+Load Balancing | :heavy_check_mark: | :x:
+
+In addition, all channel arguments defined in [this header file](https://github.com/grpc/grpc/blob/master/include/grpc/impl/codegen/grpc_types.h) are handled by the `grpc` library. Of those, the following are handled by the `@grpc/grpc-js` library:
+
+ - `grpc.ssl_target_name_override`
+ - `grpc.primary_user_agent`
+ - `grpc.secondary_user_agent`
+ - `grpc.default_authority`
+ - `grpc.keepalive_time_ms`
+ - `grpc.keepalive_timeout_ms`

--- a/PACKAGE-COMPARISON.md
+++ b/PACKAGE-COMPARISON.md
@@ -19,6 +19,14 @@ Retries | :heavy_check_mark: | :x:
 Stats/tracing/monitoring | :heavy_check_mark: | :x:
 Load Balancing | :heavy_check_mark: | :x:
 
+Other Properties | `grpc` | `@grpc/grpc-js`
+-----------------|--------|----------------
+Binary Addon | :heavy_check_mark: | :x:
+Supported Node Versions | >= 4 | ^8.11.2 or >=9.4
+Supported Electron Versions | All | >= 3
+Supported Platforms | Linux, Windows, MacOS | All
+Supported Architectures | x86, x86-64, ARM | All
+
 In addition, all channel arguments defined in [this header file](https://github.com/grpc/grpc/blob/master/include/grpc/impl/codegen/grpc_types.h) are handled by the `grpc` library. Of those, the following are handled by the `@grpc/grpc-js` library:
 
  - `grpc.ssl_target_name_override`

--- a/PACKAGE-COMPARISON.md
+++ b/PACKAGE-COMPARISON.md
@@ -21,11 +21,11 @@ Load Balancing | :heavy_check_mark: | :x:
 
 Other Properties | `grpc` | `@grpc/grpc-js`
 -----------------|--------|----------------
-Binary Addon | :heavy_check_mark: | :x:
+Pure JavaScript Code | :x: | :heavy_check_mark:
 Supported Node Versions | >= 4 | ^8.11.2 or >=9.4
 Supported Electron Versions | All | >= 3
 Supported Platforms | Linux, Windows, MacOS | All
-Supported Architectures | x86, x86-64, ARM | All
+Supported Architectures | x86, x86-64, ARM7+ | All
 
 In addition, all channel arguments defined in [this header file](https://github.com/grpc/grpc/blob/master/include/grpc/impl/codegen/grpc_types.h) are handled by the `grpc` library. Of those, the following are handled by the `@grpc/grpc-js` library:
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 ## Implementations
 
+For a comparison of the features available in these two libraries, see [this document](https://github.com/grpc/grpc-node/tree/master/PACKGE-COMPARISON.md)
+
 ### C-based Client and Server
 
 Directory: [`packages/grpc-native-core`](https://github.com/grpc/grpc-node/tree/master/packages/grpc-native-core) (see here for installation information)
@@ -15,15 +17,19 @@ This is the existing, feature-rich implementation of gRPC using a C++ addon. It 
 
 Directory: [`packages/grpc-js-core`](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js-core)
 
+npm package: [@grpc/grpc-js](https://www.npmjs.com/package/@grpc/grpc-js)
+
 **This library is currently incomplete and experimental, built on the [experimental http2 Node module](https://nodejs.org/api/http2.html).**
 
-This library implements the core functionality of gRPC purely in JavaScript, without a C++ addon. It works on the latest version of Node.js (with the `--expose-http2` flag set) on all platforms that Node.js runs on.
+This library implements the core functionality of gRPC purely in JavaScript, without a C++ addon. It works on the latest version of Node.js on all platforms that Node.js runs on.
 
 ## Other Packages
 
 ### gRPC Protobuf Loader
 
 Directory: [`packages/grpc-protobufjs`](https://github.com/grpc/grpc-node/tree/master/packages/grpc-protobufjs)
+
+npm package: [@grpc/proto-loader](https://www.npmjs.com/package/@grpc/proto-loader)
 
 This library loads `.proto` files into objects that can be passed to the gRPC libraries.
 


### PR DESCRIPTION
Make sure to look at the rich diff. It looks a lot better than the markdown text does.

I took the feature list directly from our internal document (and omitted a couple of features that neither library has). I also guessed at a couple of `grpc` features that I think are implemented in the C Core, but I'm not entirely sure. The new link in the README links to the new document.

I'm unsure about the wording of the "Binary Addon" line. I think the green and red makes it look like a positive on the `grpc` side, which is not what we want to communicate, but I can't think of a good way to word it to switch them. "Just an npm package without a binary addon" seems convoluted and contrived.