### PR TITLE
Make gulp setup idempotent

### DIFF
--- a/packages/grpc-health-check/gulpfile.js
+++ b/packages/grpc-health-check/gulpfile.js
@@ -36,7 +36,7 @@ gulp.task('clean.links', 'Delete npm links', () => {
 gulp.task('clean.all', 'Delete all code created by tasks',
 	  ['clean.links']);
 
-gulp.task('install', 'Install health check dependencies', () => {
+gulp.task('install', 'Install health check dependencies', ['clean.links'], () => {
   return execa('npm', ['install', '--unsafe-perm'], {cwd: healthCheckDir, stdio: 'inherit'});
 });
 


### PR DESCRIPTION
The link that we still have in the health check directory that still points to the main grpc directory is the only think that causes problems with multiple runs of `gulp setup`. So, we delete it before touching the rest of that directory.