### PR TITLE
Fix potential segmentation fault.

### DIFF
--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -720,13 +720,23 @@ Client.prototype.waitForReady = function(deadline, callback) {
       callback(new Error('Failed to connect before the deadline'));
       return;
     }
-    var new_state = self.$channel.getConnectivityState(true);
+    var new_state;
+    try {
+      new_state = self.$channel.getConnectivityState(true);
+    } catch (e) {
+      callback(new Error('The channel has been closed'));
+      return;
+    }
     if (new_state === grpc.connectivityState.READY) {
       callback();
     } else if (new_state === grpc.connectivityState.FATAL_FAILURE) {
       callback(new Error('Failed to connect to server'));
     } else {
-      self.$channel.watchConnectivityState(new_state, deadline, checkState);
+      try {
+        self.$channel.watchConnectivityState(new_state, deadline, checkState);
+      } catch (e) {
+        callback(new Error('The channel has been closed'));
+      }
     }
   };
   /* Force a single round of polling to ensure that the channel state is up


### PR DESCRIPTION
Described in #490.

The testcase described there now yields the following error instead of segfaulting:

```
Error: Cannot call getConnectivityState on a closed Channel
    at Immediate.checkState [as _onImmediate] (/home/pixel/sources/example_for_issue_grpc/node_modules/grpc/src/client.js:723:35)
    at runCallback (timers.js:810:20)
    at tryOnImmediate (timers.js:768:5)
    at processImmediate [as _immediateCallback] (timers.js:745:5)
```

We may also want to add testcases for this, but let's stop the bleeding first.