### PR TITLE
Add checkServerIdentity callback to pure js library

### DIFF
--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -213,9 +213,9 @@ export class Http2Channel extends EventEmitter implements Channel {
       private readonly options: Partial<ChannelOptions>) {
     super();
     if (credentials.isSecure()) {
-      this.target = new url.URL(`http://${address}`);
-    } else {
       this.target = new url.URL(`https://${address}`);
+    } else {
+      this.target = new url.URL(`http://${address}`);
     }
     // TODO(murgatroid99): Add more centralized handling of channel options
     if (this.options['grpc.default_authority']) {

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -163,10 +163,8 @@ export class Http2Channel extends EventEmitter implements Channel {
   }
 
   private startConnecting(): void {
-    const secureContext = this.credentials.getSecureContext();
-    let connectionOptions: http2.SecureClientSessionOptions = {};
-    if (secureContext !== null) {
-      connectionOptions.secureContext = secureContext;
+    let connectionOptions: http2.SecureClientSessionOptions = this.credentials.getConnectionOptions() || {};
+    if (connectionOptions.secureContext !== null) {
       // If provided, the value of grpc.ssl_target_name_override should be used
       // to override the target hostname when checking server identity.
       // This option is used for testing only.
@@ -214,7 +212,7 @@ export class Http2Channel extends EventEmitter implements Channel {
       address: string, readonly credentials: ChannelCredentials,
       private readonly options: Partial<ChannelOptions>) {
     super();
-    if (credentials.getSecureContext() === null) {
+    if (credentials.isSecure()) {
       this.target = new url.URL(`http://${address}`);
     } else {
       this.target = new url.URL(`https://${address}`);

--- a/packages/grpc-js-core/test/test-channel-credentials.ts
+++ b/packages/grpc-js-core/test/test-channel-credentials.ts
@@ -48,7 +48,7 @@ describe('ChannelCredentials Implementation', () => {
        () => {
          const creds = assert2.noThrowAndReturn(
              () => ChannelCredentials.createInsecure());
-         assert.ok(!creds.getSecureContext());
+         assert.ok(!creds.getConnectionOptions());
        });
   });
 
@@ -56,28 +56,28 @@ describe('ChannelCredentials Implementation', () => {
     it('should work when given no arguments', () => {
       const creds: ChannelCredentials =
           assert2.noThrowAndReturn(() => ChannelCredentials.createSsl());
-      assert.ok(!!creds.getSecureContext());
+      assert.ok(!!creds.getConnectionOptions());
     });
 
     it('should work with just a CA override', async () => {
       const {ca} = await pFixtures;
       const creds =
           assert2.noThrowAndReturn(() => ChannelCredentials.createSsl(ca));
-      assert.ok(!!creds.getSecureContext());
+      assert.ok(!!creds.getConnectionOptions());
     });
 
     it('should work with just a private key and cert chain', async () => {
       const {key, cert} = await pFixtures;
       const creds = assert2.noThrowAndReturn(
           () => ChannelCredentials.createSsl(null, key, cert));
-      assert.ok(!!creds.getSecureContext());
+      assert.ok(!!creds.getConnectionOptions());
     });
 
-    it('should work with all three parameters specified', async () => {
+    it('should work with three parameters specified', async () => {
       const {ca, key, cert} = await pFixtures;
       const creds = assert2.noThrowAndReturn(
           () => ChannelCredentials.createSsl(ca, key, cert));
-      assert.ok(!!creds.getSecureContext());
+      assert.ok(!!creds.getConnectionOptions());
     });
 
     it('should throw if just one of private key and cert chain are missing',


### PR DESCRIPTION
Basically, port #403 to the pure JavaScript library. I had to change a couple of the internal parts of the API.

CC @JackOfMostTrades 