### PR TITLE
Pure JS: add warnings for unhandled channel options

### DIFF
--- a/packages/grpc-js-core/src/channel-options.ts
+++ b/packages/grpc-js-core/src/channel-options.ts
@@ -1,0 +1,25 @@
+/**
+ * An interface that contains options used when initializing a Channel instance.
+ */
+export interface ChannelOptions {
+  'grpc.ssl_target_name_override': string;
+  'grpc.primary_user_agent': string;
+  'grpc.secondary_user_agent': string;
+  'grpc.default_authority': string;
+  'grpc.keepalive_time_ms': number;
+  'grpc.keepalive_timeout_ms': number;
+  [key: string]: string|number;
+}
+
+/**
+ * This is for checking provided options at runtime. This is an object for
+ * easier membership checking.
+ */
+export const recognizedOptions = {
+  'grpc.ssl_target_name_override': true,
+  'grpc.primary_user_agent': true,
+  'grpc.secondary_user_agent': true,
+  'grpc.default_authority': true,
+  'grpc.keepalive_time_ms': true,
+  'grpc.keepalive_timeout_ms': true
+};

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -14,6 +14,7 @@ import {FilterStackFactory} from './filter-stack';
 import {Metadata, MetadataObject} from './metadata';
 import {MetadataStatusFilterFactory} from './metadata-status-filter';
 import { Http2SubChannel } from './subchannel';
+import {ChannelOptions, recognizedOptions} from './channel-options';
 
 const {version: clientVersion} = require('../../package');
 
@@ -34,19 +35,6 @@ const {
   HTTP2_HEADER_TE,
   HTTP2_HEADER_USER_AGENT
 } = http2.constants;
-
-/**
- * An interface that contains options used when initializing a Channel instance.
- */
-export interface ChannelOptions {
-  'grpc.ssl_target_name_override': string;
-  'grpc.primary_user_agent': string;
-  'grpc.secondary_user_agent': string;
-  'grpc.default_authority': string;
-  'grpc.keepalive_time_ms': number;
-  'grpc.keepalive_timeout_ms': number;
-  [key: string]: string|number;
-}
 
 export enum ConnectivityState {
   CONNECTING,
@@ -212,6 +200,13 @@ export class Http2Channel extends EventEmitter implements Channel {
       address: string, readonly credentials: ChannelCredentials,
       private readonly options: Partial<ChannelOptions>) {
     super();
+    for (let option in options) {
+      if (options.hasOwnProperty(option)) {
+        if (!recognizedOptions.hasOwnProperty(option)) {
+          console.warn(`Unrecognized channel argument '${option}' will be ignored.`);
+        }
+      }
+    }
     if (credentials.isSecure()) {
       this.target = new url.URL(`https://${address}`);
     } else {

--- a/packages/grpc-js-core/src/client.ts
+++ b/packages/grpc-js-core/src/client.ts
@@ -3,10 +3,11 @@ import {URL} from 'url';
 
 import {ClientDuplexStream, ClientDuplexStreamImpl, ClientReadableStream, ClientReadableStreamImpl, ClientUnaryCall, ClientUnaryCallImpl, ClientWritableStream, ClientWritableStreamImpl, ServiceError} from './call';
 import {CallOptions, CallStream, StatusObject, WriteObject} from './call-stream';
-import {Channel, ChannelOptions, Http2Channel} from './channel';
+import {Channel, Http2Channel} from './channel';
 import {ChannelCredentials} from './channel-credentials';
 import {Status} from './constants';
 import {Metadata} from './metadata';
+import {ChannelOptions} from './channel-options';
 
 // This symbol must be exported (for now).
 // See: https://github.com/Microsoft/TypeScript/issues/20080

--- a/packages/grpc-js-core/src/make-client.ts
+++ b/packages/grpc-js-core/src/make-client.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 
 import {CallOptions} from './call-stream';
-import {ChannelOptions} from './channel';
+import {ChannelOptions} from './channel-options';
 import {ChannelCredentials} from './channel-credentials';
 import {Client, UnaryCallback} from './client';
 import {Metadata} from './metadata';

--- a/packages/grpc-js-core/src/subchannel.ts
+++ b/packages/grpc-js-core/src/subchannel.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from "events";
 import { Metadata } from "./metadata";
 import { CallStream, CallOptions, Http2CallStream } from "./call-stream";
 import { EmitterAugmentation1, EmitterAugmentation0 } from "./events";
-import { ChannelOptions } from './channel';
+import { ChannelOptions } from './channel-options';
 
 const {
   HTTP2_HEADER_AUTHORITY,


### PR DESCRIPTION
For now at least I think this is a better solution than throwing an error for unrecognized arguments that we know that the core handles, particularly because this solution won't automatically break some existing users that try to switch over transparently.