### PR TITLE
Pure JS: Implement public Channel API

### DIFF
--- a/PACKAGE-COMPARISON.md
+++ b/PACKAGE-COMPARISON.md
@@ -35,3 +35,5 @@ In addition, all channel arguments defined in [this header file](https://github.
  - `grpc.default_authority`
  - `grpc.keepalive_time_ms`
  - `grpc.keepalive_timeout_ms`
+ - `channelOverride`
+ - `channelFactoryOverride`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Implementations
 
-For a comparison of the features available in these two libraries, see [this document](https://github.com/grpc/grpc-node/tree/master/PACKGE-COMPARISON.md)
+For a comparison of the features available in these two libraries, see [this document](https://github.com/grpc/grpc-node/tree/master/PACKAGE-COMPARISON.md)
 
 ### C-based Client and Server
 

--- a/packages/grpc-js-core/README.md
+++ b/packages/grpc-js-core/README.md
@@ -18,5 +18,14 @@ npm install @grpc/grpc-js
  - TLS channel credentials
  - Call credentials (for auth)
  - Simple reconnection
+ - Channel API
 
 This library does not directly handle `.proto` files. To use `.proto` files with this library we recommend using the `@grpc/proto-loader` package.
+
+## Some Notes on API Guarantees
+
+The public API of this library follows semantic versioning, with some caveats:
+
+ - Some methods are prefixed with an underscore. These methods are internal and should not be considered part of the public API.
+ - The class `Call` is only exposed due to limitations of TypeScript. It should not be considered part of the public API.
+ - In general, any API that is exposed by this library but is not exposed by the `grpc` library is likely an error and should not be considered part of the public API.

--- a/packages/grpc-js-core/src/call-credentials-filter.ts
+++ b/packages/grpc-js-core/src/call-credentials-filter.ts
@@ -1,7 +1,7 @@
 import {promisify} from 'util';
 
 import {CallCredentials} from './call-credentials';
-import {CallStream} from './call-stream';
+import {Call} from './call-stream';
 import {Http2Channel} from './channel';
 import {BaseFilter, Filter, FilterFactory} from './filter';
 import {Metadata} from './metadata';
@@ -41,7 +41,7 @@ export class CallCredentialsFilterFactory implements
     this.credentials = channel.credentials.getCallCredentials();
   }
 
-  createFilter(callStream: CallStream): CallCredentialsFilter {
+  createFilter(callStream: Call): CallCredentialsFilter {
     return new CallCredentialsFilter(
         this.credentials.compose(callStream.getCredentials()),
         callStream.getHost(), callStream.getMethod());

--- a/packages/grpc-js-core/src/compression-filter.ts
+++ b/packages/grpc-js-core/src/compression-filter.ts
@@ -1,6 +1,6 @@
 import * as zlib from 'zlib';
 
-import {CallStream, WriteFlags, WriteObject} from './call-stream';
+import {Call, WriteFlags, WriteObject} from './call-stream';
 import {Channel} from './channel';
 import {Status} from './constants';
 import {BaseFilter, Filter, FilterFactory} from './filter';
@@ -189,7 +189,7 @@ export class CompressionFilter extends BaseFilter implements Filter {
 export class CompressionFilterFactory implements
     FilterFactory<CompressionFilter> {
   constructor(private readonly channel: Channel) {}
-  createFilter(callStream: CallStream): CompressionFilter {
+  createFilter(callStream: Call): CompressionFilter {
     return new CompressionFilter();
   }
 }

--- a/packages/grpc-js-core/src/filter-stack.ts
+++ b/packages/grpc-js-core/src/filter-stack.ts
@@ -1,6 +1,6 @@
 import {flow, flowRight, map} from 'lodash';
 
-import {CallStream, StatusObject, WriteObject} from './call-stream';
+import {Call, StatusObject, WriteObject} from './call-stream';
 import {Filter, FilterFactory} from './filter';
 import {Metadata} from './metadata';
 
@@ -37,7 +37,7 @@ export class FilterStack implements Filter {
 export class FilterStackFactory implements FilterFactory<FilterStack> {
   constructor(private readonly factories: Array<FilterFactory<Filter>>) {}
 
-  createFilter(callStream: CallStream): FilterStack {
+  createFilter(callStream: Call): FilterStack {
     return new FilterStack(
         map(this.factories, (factory) => factory.createFilter(callStream)));
   }

--- a/packages/grpc-js-core/src/filter.ts
+++ b/packages/grpc-js-core/src/filter.ts
@@ -1,4 +1,4 @@
-import {CallStream, StatusObject, WriteObject} from './call-stream';
+import {Call, StatusObject, WriteObject} from './call-stream';
 import {Metadata} from './metadata';
 
 /**
@@ -40,5 +40,5 @@ export abstract class BaseFilter {
 }
 
 export interface FilterFactory<T extends Filter> {
-  createFilter(callStream: CallStream): T;
+  createFilter(callStream: Call): T;
 }

--- a/packages/grpc-js-core/src/index.ts
+++ b/packages/grpc-js-core/src/index.ts
@@ -7,6 +7,7 @@ import {Client} from './client';
 import {Status} from './constants';
 import {loadPackageDefinition, makeClientConstructor} from './make-client';
 import {Metadata} from './metadata';
+import { Channel } from './channel';
 
 interface IndexedObject {
   [key: string]: any;
@@ -105,7 +106,8 @@ export {
   Client,
   loadPackageDefinition,
   makeClientConstructor,
-  makeClientConstructor as makeGenericClientConstructor
+  makeClientConstructor as makeGenericClientConstructor,
+  Channel
 };
 
 /**
@@ -116,7 +118,7 @@ export const closeClient = (client: Client) => client.close();
 
 export const waitForClientReady =
     (client: Client, deadline: Date|number,
-     callback: (error: Error|null) => void) =>
+     callback: (error?: Error) => void) =>
         client.waitForReady(deadline, callback);
 
 /**** Unimplemented function stubs ****/
@@ -155,8 +157,8 @@ export const ServerCredentials = {
   }
 };
 
-export const getClientChannel = (client: any) => {
-  throw new Error('Not available in this library');
+export const getClientChannel = (client: Client) => {
+  return Client.prototype.getChannel.call(client);
 };
 
 export const StatusBuilder = () => {

--- a/packages/grpc-js-core/src/make-client.ts
+++ b/packages/grpc-js-core/src/make-client.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 
-import {CallOptions} from './call-stream';
+import {PartialCallStreamOptions} from './call-stream';
 import {ChannelOptions} from './channel-options';
 import {ChannelCredentials} from './channel-credentials';
 import {Client, UnaryCallback} from './client';

--- a/packages/grpc-js-core/src/metadata-status-filter.ts
+++ b/packages/grpc-js-core/src/metadata-status-filter.ts
@@ -1,4 +1,4 @@
-import {CallStream} from './call-stream';
+import {Call} from './call-stream';
 import {StatusObject} from './call-stream';
 import {Channel} from './channel';
 import {Status} from './constants';
@@ -31,7 +31,7 @@ export class MetadataStatusFilter extends BaseFilter implements Filter {
 export class MetadataStatusFilterFactory implements
     FilterFactory<MetadataStatusFilter> {
   constructor(private readonly channel: Channel) {}
-  createFilter(callStream: CallStream): MetadataStatusFilter {
+  createFilter(callStream: Call): MetadataStatusFilter {
     return new MetadataStatusFilter();
   }
 }

--- a/packages/grpc-js-core/src/subchannel.ts
+++ b/packages/grpc-js-core/src/subchannel.ts
@@ -3,7 +3,7 @@ import * as url from 'url';
 
 import { EventEmitter } from "events";
 import { Metadata } from "./metadata";
-import { CallStream, CallOptions, Http2CallStream } from "./call-stream";
+import { Call, PartialCallStreamOptions, Http2CallStream } from "./call-stream";
 import { EmitterAugmentation1, EmitterAugmentation0 } from "./events";
 import { ChannelOptions } from './channel-options';
 
@@ -29,7 +29,7 @@ export interface SubChannel extends EventEmitter {
    * @param headers The headers to start the stream with
    * @param callStream The stream to start
    */
-  startCallStream(metadata: Metadata, callStream: CallStream): void;
+  startCallStream(metadata: Metadata, callStream: Call): void;
   close(): void;
 }
 

--- a/packages/grpc-js-core/test/test-call-stream.ts
+++ b/packages/grpc-js-core/test/test-call-stream.ts
@@ -6,7 +6,7 @@ import * as stream from 'stream';
 
 import {CallCredentials} from '../src/call-credentials';
 import {Http2CallStream} from '../src/call-stream';
-import {Channel} from '../src/channel';
+import {Channel, Http2Channel} from '../src/channel';
 import {CompressionFilterFactory} from '../src/compression-filter';
 import {Status} from '../src/constants';
 import {FilterStackFactory} from '../src/filter-stack';
@@ -81,9 +81,9 @@ class ClientHttp2StreamMock extends stream.Duplex implements
 describe('CallStream', () => {
   const callStreamArgs = {
     deadline: Infinity,
-    credentials: CallCredentials.createEmpty(),
     flags: 0,
-    host: ''
+    host: '',
+    parentCall: null
   };
   /* A CompressionFilter is now necessary to frame and deframe messages.
    * Currently the channel is unused, so we can replace it with an empty object,
@@ -102,7 +102,7 @@ describe('CallStream', () => {
        const responseMetadata = new Metadata();
        responseMetadata.add('key', 'value');
        const callStream =
-           new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+           new Http2CallStream('foo', <Http2Channel>{}, callStreamArgs, filterStackFactory);
 
        const http2Stream = new ClientHttp2StreamMock(
            {payload: Buffer.alloc(0), frameLengths: []});
@@ -140,7 +140,7 @@ describe('CallStream', () => {
       maybeSkip(it)(`for error code ${key}`, () => {
         return new Promise((resolve, reject) => {
           const callStream =
-              new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+              new Http2CallStream('foo', <Http2Channel>{}, callStreamArgs, filterStackFactory);
           const http2Stream = new ClientHttp2StreamMock(
               {payload: Buffer.alloc(0), frameLengths: []});
           callStream.attachHttp2Stream(http2Stream);
@@ -160,10 +160,12 @@ describe('CallStream', () => {
 
   it('should have functioning getters', (done) => {
     const callStream =
-        new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+        new Http2CallStream('foo', <Http2Channel>{}, callStreamArgs, filterStackFactory);
     assert.strictEqual(callStream.getDeadline(), callStreamArgs.deadline);
-    assert.strictEqual(callStream.getCredentials(), callStreamArgs.credentials);
     assert.strictEqual(callStream.getStatus(), null);
+    const credentials = CallCredentials.createEmpty();
+    callStream.setCredentials(credentials);
+    assert.strictEqual(callStream.getCredentials(), credentials);
     callStream.on('status', assert2.mustCall((status) => {
       assert.strictEqual(status.code, Status.CANCELLED);
       assert.strictEqual(status.details, ';)');
@@ -177,7 +179,7 @@ describe('CallStream', () => {
   describe('attachHttp2Stream', () => {
     it('should handle an empty message', (done) => {
       const callStream =
-          new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+          new Http2CallStream('foo', <Http2Channel>{}, callStreamArgs, filterStackFactory);
       const http2Stream =
           new ClientHttp2StreamMock({payload: serialize(''), frameLengths: []});
       callStream.once('data', assert2.mustCall((buffer) => {
@@ -204,7 +206,7 @@ describe('CallStream', () => {
       it(`should handle a short message where ${testCase.description}`,
          (done) => {
            const callStream =
-               new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+               new Http2CallStream('foo', <Http2Channel>{}, callStreamArgs, filterStackFactory);
            const http2Stream = new ClientHttp2StreamMock({
              payload: serialize(message),  // 21 bytes
              frameLengths: testCase.frameLengths
@@ -234,7 +236,7 @@ describe('CallStream', () => {
      }].forEach((testCase: {description: string, frameLengths: number[]}) => {
       it(`should handle two messages where ${testCase.description}`, (done) => {
         const callStream =
-            new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+            new Http2CallStream('foo', <Http2Channel>{}, callStreamArgs, filterStackFactory);
         const http2Stream = new ClientHttp2StreamMock({
           payload: Buffer.concat(
               [serialize(message), serialize(message)]),  // 42 bytes
@@ -254,7 +256,7 @@ describe('CallStream', () => {
 
     it('should send buffered writes', (done) => {
       const callStream =
-          new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+          new Http2CallStream('foo', <Http2Channel>{}, callStreamArgs, filterStackFactory);
       const http2Stream = new ClientHttp2StreamMock(
           {payload: Buffer.alloc(0), frameLengths: []});
       let streamFlushed = false;
@@ -277,7 +279,7 @@ describe('CallStream', () => {
     it('should cause data chunks in write calls afterward to be written to the given stream',
        (done) => {
          const callStream =
-             new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+             new Http2CallStream('foo', <Http2Channel>{}, callStreamArgs, filterStackFactory);
          const http2Stream = new ClientHttp2StreamMock(
              {payload: Buffer.alloc(0), frameLengths: []});
          http2Stream.once('write', assert2.mustCall((chunk: Buffer) => {
@@ -295,7 +297,7 @@ describe('CallStream', () => {
 
     it('should handle underlying stream errors', () => {
       const callStream =
-          new Http2CallStream('foo', callStreamArgs, filterStackFactory);
+          new Http2CallStream('foo', <Http2Channel>{}, callStreamArgs, filterStackFactory);
       const http2Stream = new ClientHttp2StreamMock(
           {payload: Buffer.alloc(0), frameLengths: []});
       callStream.once('status', assert2.mustCall((status) => {


### PR DESCRIPTION
This implements the [public Channel API proposal](https://github.com/grpc/proposal/blob/master/L32-node-channel-API.md) in the pure JS library. I also implemented `Client#getChannel`.

As part of this change I renamed `CallStream` to `Call` and the previously named `Call` to `SurfaceCall`, plus a couple of other changes. The naming scheme is a little confusing now, but I don't think there should be any meaningful user-visible changes.