### PR TITLE
Mark some methods of ChannelCredentials as internal

### DIFF
--- a/packages/grpc-js-core/src/call-credentials-filter.ts
+++ b/packages/grpc-js-core/src/call-credentials-filter.ts
@@ -38,7 +38,7 @@ export class CallCredentialsFilterFactory implements
     FilterFactory<CallCredentialsFilter> {
   private readonly credentials: CallCredentials;
   constructor(channel: Http2Channel) {
-    this.credentials = channel.credentials.getCallCredentials();
+    this.credentials = channel.credentials._getCallCredentials();
   }
 
   createFilter(callStream: Call): CallCredentialsFilter {

--- a/packages/grpc-js-core/src/channel-credentials.ts
+++ b/packages/grpc-js-core/src/channel-credentials.ts
@@ -61,7 +61,7 @@ export abstract class ChannelCredentials {
   /**
    * Gets the set of per-call credentials associated with this instance.
    */
-  getCallCredentials(): CallCredentials {
+  _getCallCredentials(): CallCredentials {
     return this.callCredentials;
   }
 
@@ -70,12 +70,12 @@ export abstract class ChannelCredentials {
    * instance was created with createSsl, or null if this instance was created
    * with createInsecure.
    */
-  abstract getConnectionOptions(): ConnectionOptions|null;
+  abstract _getConnectionOptions(): ConnectionOptions|null;
 
   /**
    * Indicates whether this credentials object creates a secure channel.
    */
-  abstract isSecure(): boolean;
+  abstract _isSecure(): boolean;
 
   /**
    * Return a new ChannelCredentials instance with a given set of credentials.
@@ -132,10 +132,10 @@ class InsecureChannelCredentialsImpl extends ChannelCredentials {
     throw new Error('Cannot compose insecure credentials');
   }
 
-  getConnectionOptions(): ConnectionOptions|null {
+  _getConnectionOptions(): ConnectionOptions|null {
     return null;
   }
-  isSecure(): boolean {
+  _isSecure(): boolean {
     return false;
   }
 }
@@ -155,10 +155,10 @@ class SecureChannelCredentialsImpl extends ChannelCredentials {
         this.connectionOptions, combinedCallCredentials);
   }
 
-  getConnectionOptions(): ConnectionOptions|null {
+  _getConnectionOptions(): ConnectionOptions|null {
     return this.connectionOptions;
   }
-  isSecure(): boolean {
+  _isSecure(): boolean {
     return true;
   }
 }

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -177,7 +177,7 @@ export class Http2Channel extends EventEmitter implements Channel {
   }
 
   private startConnecting(): void {
-    let connectionOptions: http2.SecureClientSessionOptions = this.credentials.getConnectionOptions() || {};
+    let connectionOptions: http2.SecureClientSessionOptions = this.credentials._getConnectionOptions() || {};
     if (connectionOptions.secureContext !== null) {
       // If provided, the value of grpc.ssl_target_name_override should be used
       // to override the target hostname when checking server identity.
@@ -233,7 +233,7 @@ export class Http2Channel extends EventEmitter implements Channel {
         }
       }
     }
-    if (credentials.isSecure()) {
+    if (credentials._isSecure()) {
       this.target = new url.URL(`https://${address}`);
     } else {
       this.target = new url.URL(`http://${address}`);

--- a/packages/grpc-js-core/test/test-channel-credentials.ts
+++ b/packages/grpc-js-core/test/test-channel-credentials.ts
@@ -48,7 +48,7 @@ describe('ChannelCredentials Implementation', () => {
        () => {
          const creds = assert2.noThrowAndReturn(
              () => ChannelCredentials.createInsecure());
-         assert.ok(!creds.getConnectionOptions());
+         assert.ok(!creds._getConnectionOptions());
        });
   });
 
@@ -56,28 +56,28 @@ describe('ChannelCredentials Implementation', () => {
     it('should work when given no arguments', () => {
       const creds: ChannelCredentials =
           assert2.noThrowAndReturn(() => ChannelCredentials.createSsl());
-      assert.ok(!!creds.getConnectionOptions());
+      assert.ok(!!creds._getConnectionOptions());
     });
 
     it('should work with just a CA override', async () => {
       const {ca} = await pFixtures;
       const creds =
           assert2.noThrowAndReturn(() => ChannelCredentials.createSsl(ca));
-      assert.ok(!!creds.getConnectionOptions());
+      assert.ok(!!creds._getConnectionOptions());
     });
 
     it('should work with just a private key and cert chain', async () => {
       const {key, cert} = await pFixtures;
       const creds = assert2.noThrowAndReturn(
           () => ChannelCredentials.createSsl(null, key, cert));
-      assert.ok(!!creds.getConnectionOptions());
+      assert.ok(!!creds._getConnectionOptions());
     });
 
     it('should work with three parameters specified', async () => {
       const {ca, key, cert} = await pFixtures;
       const creds = assert2.noThrowAndReturn(
           () => ChannelCredentials.createSsl(ca, key, cert));
-      assert.ok(!!creds.getConnectionOptions());
+      assert.ok(!!creds._getConnectionOptions());
     });
 
     it('should throw if just one of private key and cert chain are missing',
@@ -97,7 +97,7 @@ describe('ChannelCredentials Implementation', () => {
       const channelCreds = ChannelCredentials.createSsl();
       const callCreds = new CallCredentialsMock();
       const composedChannelCreds = channelCreds.compose(callCreds);
-      assert.strictEqual(composedChannelCreds.getCallCredentials(), callCreds);
+      assert.strictEqual(composedChannelCreds._getCallCredentials(), callCreds);
     });
 
     it('should be chainable', () => {
@@ -110,7 +110,7 @@ describe('ChannelCredentials Implementation', () => {
       // Build a mock object that should be an identical copy
       const composedCallCreds = callCreds1.compose(callCreds2);
       assert.ok(composedCallCreds.isEqual(
-          composedChannelCreds.getCallCredentials() as CallCredentialsMock));
+          composedChannelCreds._getCallCredentials() as CallCredentialsMock));
     });
   });
 });


### PR DESCRIPTION
This should make the `ChannelCredentials` classes in the two libraries have the same API.