### PR TITLE
grpc-js-core: metadata cleanup

### DIFF
--- a/packages/grpc-js-core/src/metadata.ts
+++ b/packages/grpc-js-core/src/metadata.ts
@@ -1,5 +1,7 @@
 import * as http2 from 'http2';
 import {forOwn} from 'lodash';
+const LEGAL_KEY_REGEX = /^[0-9a-z_.-]+$/;
+const LEGAL_NON_BINARY_VALUE_REGEX = /^[ -~]*$/;
 
 export type MetadataValue = string|Buffer;
 
@@ -24,11 +26,11 @@ function cloneMetadataObject(repr: MetadataObject): MetadataObject {
 }
 
 function isLegalKey(key: string): boolean {
-  return !!key.match(/^[0-9a-z_.-]+$/);
+  return LEGAL_KEY_REGEX.test(key);
 }
 
 function isLegalNonBinaryValue(value: string): boolean {
-  return !!value.match(/^[ -~]*$/);
+  return LEGAL_NON_BINARY_VALUE_REGEX.test(value);
 }
 
 function isBinaryKey(key: string): boolean {

--- a/packages/grpc-js-core/src/metadata.ts
+++ b/packages/grpc-js-core/src/metadata.ts
@@ -205,9 +205,9 @@ export class Metadata {
             result.add(key, Buffer.from(value, 'base64'));
           });
         } else if (values !== undefined) {
-          values.split(',')
-              .map(v => v.trim())
-              .forEach(v => result.add(key, Buffer.from(v, 'base64')));
+          values.split(',').forEach(v => {
+            result.add(key, Buffer.from(v.trim(), 'base64'));
+          });
         }
       } else {
         if (Array.isArray(values)) {
@@ -215,7 +215,7 @@ export class Metadata {
             result.add(key, value);
           });
         } else if (values !== undefined) {
-          values.split(',').map(v => v.trim()).forEach(v => result.add(key, v));
+          values.split(',').forEach(v => result.add(key, v.trim()));
         }
       }
     });

--- a/packages/grpc-js-core/src/metadata.ts
+++ b/packages/grpc-js-core/src/metadata.ts
@@ -43,7 +43,7 @@ function normalizeKey(key: string): string {
 
 function validate(key: string, value?: MetadataValue): void {
   if (!isLegalKey(key)) {
-    throw new Error('Metadata key"' + key + '" contains illegal characters');
+    throw new Error('Metadata key "' + key + '" contains illegal characters');
   }
   if (value != null) {
     if (isBinaryKey(key)) {

--- a/packages/grpc-js-core/test/test-metadata.ts
+++ b/packages/grpc-js-core/test/test-metadata.ts
@@ -52,7 +52,7 @@ describe('Metadata', () => {
       });
       assert.throws(() => {
         metadata.set('key$', 'value');
-      });
+      }, /Error: Metadata key "key\$" contains illegal characters/);
       assert.throws(() => {
         metadata.set('', 'value');
       });


### PR DESCRIPTION
This PR:
- Simplifies regular expression usage.
- Adds a missing space to an error message.
- Caches `Object.prototype.hasOwnProperty()` to prevent tampering.
- Simplifies the code in `fromHttp2Headers()`.

Another simplification (that would get rid of the `hasOwnProperty()` usage) would be to make `internalRepr` a `Map`, but I wanted to check with the maintainers first.