### PR TITLE
Pure js: fix engines field, add runtime check

### DIFF
--- a/packages/grpc-js-core/package.json
+++ b/packages/grpc-js-core/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js-core",
   "main": "build/src/index.js",
   "engines": {
-    "node": ">=8.4"
+    "node": "^8.11.2 || >=9.4"
   },
   "keywords": [],
   "author": {
@@ -20,6 +20,7 @@
     "@types/node": "^10.5.4",
     "clang-format": "^1.0.55",
     "gts": "^0.5.1",
+    "semver": "^5.5.0",
     "typescript": "~2.7.0"
   },
   "contributors": [

--- a/packages/grpc-js-core/src/index.ts
+++ b/packages/grpc-js-core/src/index.ts
@@ -9,6 +9,12 @@ import {loadPackageDefinition, makeClientConstructor} from './make-client';
 import {Metadata} from './metadata';
 import { Channel } from './channel';
 import * as logging from './logging';
+import * as semver from 'semver';
+
+const supportedNodeVersions = '^8.11.2 || >=9.4';
+if (!semver.satisfies(process.version, supportedNodeVersions)) {
+  throw new Error(`@grpc/grpc-js only works on Node ${supportedNodeVersions}`);
+}
 
 interface IndexedObject {
   [key: string]: any;


### PR DESCRIPTION
This fixes the engines field in the `package.json` file to match what we actually need, and also add a check at library load time to fix #382.