### PR TITLE
grpc-js-core: add StatusBuilder support

### DIFF
--- a/packages/grpc-js-core/src/index.ts
+++ b/packages/grpc-js-core/src/index.ts
@@ -8,6 +8,7 @@ import {LogVerbosity, Status} from './constants';
 import {loadPackageDefinition, makeClientConstructor} from './make-client';
 import {Metadata} from './metadata';
 import { Channel } from './channel';
+import {StatusBuilder} from './status-builder';
 import * as logging from './logging';
 
 interface IndexedObject {
@@ -163,9 +164,7 @@ export const getClientChannel = (client: Client) => {
   return Client.prototype.getChannel.call(client);
 };
 
-export const StatusBuilder = () => {
-  throw new Error('Not yet implemented');
-};
+export {StatusBuilder};
 
 export const ListenerBuilder = () => {
   throw new Error('Not yet implemented');

--- a/packages/grpc-js-core/src/status-builder.ts
+++ b/packages/grpc-js-core/src/status-builder.ts
@@ -1,0 +1,63 @@
+import {StatusObject} from './call-stream';
+import {Status} from './constants';
+import {Metadata} from './metadata';
+
+/**
+ * A builder for gRPC status objects.
+ */
+export class StatusBuilder {
+  private code: Status|null;
+  private details: string|null;
+  private metadata: Metadata|null;
+
+  constructor() {
+    this.code = null;
+    this.details = null;
+    this.metadata = null;  
+  }
+
+  /**
+   * Adds a status code to the builder.
+   */
+  withCode(code: Status): this {
+    this.code = code;
+    return this;
+  }
+
+  /**
+   * Adds details to the builder.
+   */
+  withDetails(details: string): this {
+    this.details = details;
+    return this;
+  }
+
+  /**
+   * Adds metadata to the builder.
+   */
+  withMetadata(metadata: Metadata): this {
+    this.metadata = metadata;
+    return this;
+  }
+
+  /**
+   * Builds the status object.
+   */
+  build(): Partial<StatusObject> {
+    const status: Partial<StatusObject> = {};
+
+    if (this.code !== null) {
+      status.code = this.code;
+    }
+
+    if (this.details !== null) {
+      status.details = this.details;
+    }
+
+    if (this.metadata !== null) {
+      status.metadata = this.metadata;
+    }
+
+    return status;
+  }
+}

--- a/packages/grpc-js-core/test/test-status-builder.ts
+++ b/packages/grpc-js-core/test/test-status-builder.ts
@@ -1,0 +1,34 @@
+import * as assert from 'assert';
+
+import * as grpc from '../src';
+import {StatusBuilder} from '../src/status-builder';
+
+describe('StatusBuilder', () => {
+  it('is exported by the module', () => {
+    assert.strictEqual(StatusBuilder, grpc.StatusBuilder);
+  });
+
+  it('builds a status object', () => {
+    const builder = new StatusBuilder();
+    const metadata = new grpc.Metadata();
+    let result;
+
+    assert.deepStrictEqual(builder.build(), {});
+    result = builder.withCode(grpc.status.OK);
+    assert.strictEqual(result, builder);
+    assert.deepStrictEqual(builder.build(), { code: grpc.status.OK });
+    result = builder.withDetails('foobar');
+    assert.strictEqual(result, builder);
+    assert.deepStrictEqual(builder.build(), {
+      code: grpc.status.OK,
+      details: 'foobar'
+    });
+    result = builder.withMetadata(metadata);
+    assert.strictEqual(result, builder);
+    assert.deepStrictEqual(builder.build(), {
+      code: grpc.status.OK,
+      details: 'foobar',
+      metadata
+    });
+  });
+});


### PR DESCRIPTION
This commit ports `StatusBuilder` to TypeScript.