### PR TITLE
grpc-js-core: add ListenerBuilder support

### DIFF
--- a/packages/grpc-js-core/src/index.ts
+++ b/packages/grpc-js-core/src/index.ts
@@ -5,6 +5,7 @@ import {Channel} from './channel';
 import {ChannelCredentials} from './channel-credentials';
 import {Client} from './client';
 import {LogVerbosity, Status} from './constants';
+import {ListenerBuilder} from './listener-builder';
 import * as logging from './logging';
 import {loadPackageDefinition, makeClientConstructor} from './make-client';
 import {Metadata} from './metadata';
@@ -170,9 +171,7 @@ export const getClientChannel = (client: Client) => {
 
 export {StatusBuilder};
 
-export const ListenerBuilder = () => {
-  throw new Error('Not yet implemented');
-};
+export {ListenerBuilder};
 
 export const InterceptorBuilder = () => {
   throw new Error('Not yet implemented');

--- a/packages/grpc-js-core/src/listener-builder.ts
+++ b/packages/grpc-js-core/src/listener-builder.ts
@@ -1,0 +1,61 @@
+import {Listener, MessageListener, MetadataListener, StatusListener} from './listener';
+
+/**
+ * A builder for listener interceptors.
+ */
+export class ListenerBuilder {
+  private metadata: MetadataListener|null;
+  private message: MessageListener|null;
+  private status: StatusListener|null;
+
+  constructor() {
+    this.metadata = null;
+    this.message = null;
+    this.status = null;
+  }
+
+  /**
+   * Adds an onReceiveMetadata method to the builder.
+   */
+  withOnReceiveMetadata(onReceiveMetadata: MetadataListener): this {
+    this.metadata = onReceiveMetadata;
+    return this;
+  }
+
+  /**
+   * Adds an onReceiveMessage method to the builder.
+   */
+  withOnReceiveMessage(onReceiveMessage: MessageListener): this {
+    this.message = onReceiveMessage;
+    return this;
+  }
+
+  /**
+   * Adds an onReceiveStatus method to the builder.
+   */
+  withOnReceiveStatus(onReceiveStatus: StatusListener): this {
+    this.status = onReceiveStatus;
+    return this;
+  }
+
+  /**
+   * Builds the call listener.
+   */
+  build(): Listener {
+    const listener: Listener = {};
+
+    if (this.metadata !== null) {
+      listener.onReceiveMetadata = this.metadata;
+    }
+
+    if (this.message !== null) {
+      listener.onReceiveMessage = this.message;
+    }
+
+    if (this.status !== null) {
+      listener.onReceiveStatus = this.status;
+    }
+
+    return listener;
+  }
+}

--- a/packages/grpc-js-core/src/listener.ts
+++ b/packages/grpc-js-core/src/listener.ts
@@ -1,0 +1,13 @@
+import {StatusObject} from './call-stream';
+import {Metadata} from './metadata';
+
+export type MetadataListener = (metadata: Metadata, next: Function) => void;
+// tslint:disable-next-line no-any
+export type MessageListener = (message: any, next: Function) => void;
+export type StatusListener = (status: StatusObject, next: Function) => void;
+
+export interface Listener {
+  onReceiveMetadata?: MetadataListener;
+  onReceiveMessage?: MessageListener;
+  onReceiveStatus?: StatusListener;
+}

--- a/packages/grpc-js-core/test/test-listener-builder.ts
+++ b/packages/grpc-js-core/test/test-listener-builder.ts
@@ -1,0 +1,33 @@
+import * as assert from 'assert';
+
+import * as grpc from '../src';
+import {MessageListener, MetadataListener, StatusListener} from '../src/listener';
+import {ListenerBuilder} from '../src/listener-builder';
+
+describe('ListenerBuilder', () => {
+  it('is exported by the module', () => {
+    assert.strictEqual(ListenerBuilder, grpc.ListenerBuilder);
+  });
+
+  it('builds a listener object', () => {
+    const builder = new ListenerBuilder();
+    const onReceiveMetadata: MetadataListener = () => {};
+    const onReceiveMessage: MessageListener = () => {};
+    const onReceiveStatus: StatusListener = () => {};
+    let result;
+
+    assert.deepStrictEqual(builder.build(), {});
+    result = builder.withOnReceiveMetadata(onReceiveMetadata);
+    assert.strictEqual(result, builder);
+    assert.deepStrictEqual(builder.build(), {onReceiveMetadata});
+    result = builder.withOnReceiveMessage(onReceiveMessage);
+    assert.strictEqual(result, builder);
+    assert.deepStrictEqual(
+        builder.build(), {onReceiveMetadata, onReceiveMessage});
+    result = builder.withOnReceiveStatus(onReceiveStatus);
+    assert.strictEqual(result, builder);
+    assert.deepStrictEqual(
+        builder.build(),
+        {onReceiveMetadata, onReceiveMessage, onReceiveStatus});
+  });
+});


### PR DESCRIPTION
This commit ports `ListenerBuilder` to TypeScript.