### PR TITLE
grpc-js-core: ignore reserved headers in fromHttp2Headers()

### DIFF
--- a/packages/grpc-js-core/src/call-stream.ts
+++ b/packages/grpc-js-core/src/call-stream.ts
@@ -233,8 +233,7 @@ export class Http2CallStream extends Duplex implements Call {
           default:
             this.mappedStatusCode = Status.UNKNOWN;
         }
-        delete headers[HTTP2_HEADER_STATUS];
-        delete headers[HTTP2_HEADER_CONTENT_TYPE];
+
         if (flags & http2.constants.NGHTTP2_FLAG_END_STREAM) {
           this.handleTrailers(headers);
         } else {

--- a/packages/grpc-js-core/src/metadata.ts
+++ b/packages/grpc-js-core/src/metadata.ts
@@ -197,6 +197,11 @@ export class Metadata {
   static fromHttp2Headers(headers: http2.IncomingHttpHeaders): Metadata {
     const result = new Metadata();
     forOwn(headers, (values, key) => {
+      // Reserved headers (beginning with `:`) are not valid keys.
+      if (key.charAt(0) === ':') {
+        return;
+      }
+
       if (isBinaryKey(key)) {
         if (Array.isArray(values)) {
           values.forEach((value) => {


### PR DESCRIPTION
`Metadata.fromHttp2Headers()` throws if any reserved headers are passed. Instead of deleting headers before calling the function, this commit causes the function to ignore reserved headers.

As a side note, this should make `Metadata.fromHttp2Headers()` easier to use on the server side, where clients may send a wider variety of headers.