### PR TITLE
grpc-js-core: use Buffer.from in metadata cloning

### DIFF
--- a/packages/grpc-js-core/src/metadata.ts
+++ b/packages/grpc-js-core/src/metadata.ts
@@ -10,11 +10,9 @@ export interface MetadataObject { [key: string]: MetadataValue[]; }
 function cloneMetadataObject(repr: MetadataObject): MetadataObject {
   const result: MetadataObject = {};
   forOwn(repr, (value, key) => {
-    // v.slice copies individual buffer values in value.
-    // TODO(kjin): Is this necessary
     result[key] = value.map(v => {
       if (v instanceof Buffer) {
-        return v.slice();
+        return Buffer.from(v);
       } else {
         return v;
       }

--- a/packages/grpc-js-core/test/test-metadata.ts
+++ b/packages/grpc-js-core/test/test-metadata.ts
@@ -202,6 +202,16 @@ describe('Metadata', () => {
       copy.add('key', 'value2');
       assert.deepEqual(metadata.get('key'), ['value1']);
     });
+
+    it('Copy cannot modify binary values in the original', () => {
+      const buf = Buffer.from('value-bin');
+      metadata.add('key-bin', buf);
+      const copy = metadata.clone();
+      const copyBuf = copy.get('key-bin')[0] as Buffer;
+      assert.deepStrictEqual(copyBuf, buf);
+      copyBuf.fill(0);
+      assert.notDeepEqual(copyBuf, buf);
+    });
   });
 
   describe('merge', () => {


### PR DESCRIPTION
When cloning binary metadata, use `Buffer.from()` instead of `Buffer.prototype.slice()`, as the latter creates a new `Buffer` that shares the same underlying bytes.

If a true clone is not needed, then the same `Buffer` instance should be returned, and I can update the test. Note that the existing test suite (minus the test added in this PR) passes with `v.slice()`, `v`, and `Buffer.from(v)`.