### PR TITLE
grpc-js-core: tidy up use of promises

### DIFF
--- a/packages/grpc-js-core/src/call-credentials-filter.ts
+++ b/packages/grpc-js-core/src/call-credentials-filter.ts
@@ -23,12 +23,11 @@ export class CallCredentialsFilter extends BaseFilter implements Filter {
     this.serviceUrl = `https://${host}/${serviceName}`;
   }
 
-  async sendMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
+  async sendMetadata(metadata: Metadata): Promise<Metadata> {
     const credsMetadata =
         this.credentials.generateMetadata({service_url: this.serviceUrl});
-    const resultMetadata = await metadata;
-    resultMetadata.merge(await credsMetadata);
-    return resultMetadata;
+    metadata.merge(await credsMetadata);
+    return metadata;
   }
 }
 

--- a/packages/grpc-js-core/src/channel.ts
+++ b/packages/grpc-js-core/src/channel.ts
@@ -269,7 +269,7 @@ export class Http2Channel extends EventEmitter implements Channel {
       authority: string, methodName: string, stream: Http2CallStream,
       metadata: Metadata) {
     const finalMetadata: Promise<Metadata> =
-        stream.filterStack.sendMetadata(Promise.resolve(metadata.clone()));
+        stream.filterStack.sendMetadata(metadata.clone());
     Promise.all([finalMetadata, this.connect()])
         .then(([metadataValue]) => {
           const headers = metadataValue.toHttp2Headers();

--- a/packages/grpc-js-core/src/deadline-filter.ts
+++ b/packages/grpc-js-core/src/deadline-filter.ts
@@ -46,10 +46,11 @@ export class DeadlineFilter extends BaseFilter implements Filter {
     }
   }
 
-  sendMetadata(metadata: Promise<Metadata>) {
+  async sendMetadata(metadata: Metadata): Promise<Metadata> {
     if (this.deadline === Infinity) {
       return metadata;
     }
+
     return new Promise<Metadata>((resolve, reject) => {
              if (this.channel.getConnectivityState(false) ===
                  ConnectivityState.READY) {

--- a/packages/grpc-js-core/src/filter-stack.ts
+++ b/packages/grpc-js-core/src/filter-stack.ts
@@ -7,28 +7,28 @@ import {Metadata} from './metadata';
 export class FilterStack implements Filter {
   constructor(private readonly filters: Filter[]) {}
 
-  sendMetadata(metadata: Promise<Metadata>) {
+  sendMetadata(metadata: Metadata) {
     return flow(map(
         this.filters, (filter) => filter.sendMetadata.bind(filter)))(metadata);
   }
 
-  receiveMetadata(metadata: Promise<Metadata>) {
+  receiveMetadata(metadata: Metadata) {
     return flowRight(
         map(this.filters, (filter) => filter.receiveMetadata.bind(filter)))(
         metadata);
   }
 
-  sendMessage(message: Promise<WriteObject>): Promise<WriteObject> {
+  sendMessage(message: WriteObject): Promise<WriteObject> {
     return flow(map(this.filters, (filter) => filter.sendMessage.bind(filter)))(
         message);
   }
 
-  receiveMessage(message: Promise<Buffer>): Promise<Buffer> {
+  receiveMessage(message: Buffer): Promise<Buffer> {
     return flowRight(map(
         this.filters, (filter) => filter.receiveMessage.bind(filter)))(message);
   }
 
-  receiveTrailers(status: Promise<StatusObject>): Promise<StatusObject> {
+  receiveTrailers(status: StatusObject): Promise<StatusObject> {
     return flowRight(map(
         this.filters, (filter) => filter.receiveTrailers.bind(filter)))(status);
   }

--- a/packages/grpc-js-core/src/filter.ts
+++ b/packages/grpc-js-core/src/filter.ts
@@ -6,36 +6,36 @@ import {Metadata} from './metadata';
  * used to modify incoming and outgoing data
  */
 export interface Filter {
-  sendMetadata(metadata: Promise<Metadata>): Promise<Metadata>;
+  sendMetadata(metadata: Metadata): Promise<Metadata>;
 
-  receiveMetadata(metadata: Promise<Metadata>): Promise<Metadata>;
+  receiveMetadata(metadata: Metadata): Promise<Metadata>;
 
-  sendMessage(message: Promise<WriteObject>): Promise<WriteObject>;
+  sendMessage(message: WriteObject): Promise<WriteObject>;
 
-  receiveMessage(message: Promise<Buffer>): Promise<Buffer>;
+  receiveMessage(message: Buffer): Promise<Buffer>;
 
-  receiveTrailers(status: Promise<StatusObject>): Promise<StatusObject>;
+  receiveTrailers(status: StatusObject): Promise<StatusObject>;
 }
 
 export abstract class BaseFilter {
-  async sendMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
-    return await metadata;
+  async sendMetadata(metadata: Metadata): Promise<Metadata> {
+    return metadata;
   }
 
-  async receiveMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
-    return await metadata;
+  async receiveMetadata(metadata: Metadata): Promise<Metadata> {
+    return metadata;
   }
 
-  async sendMessage(message: Promise<WriteObject>): Promise<WriteObject> {
-    return await message;
+  async sendMessage(message: WriteObject): Promise<WriteObject> {
+    return message;
   }
 
-  async receiveMessage(message: Promise<Buffer>): Promise<Buffer> {
-    return await message;
+  async receiveMessage(message: Buffer): Promise<Buffer> {
+    return message;
   }
 
-  async receiveTrailers(status: Promise<StatusObject>): Promise<StatusObject> {
-    return await status;
+  async receiveTrailers(status: StatusObject): Promise<StatusObject> {
+    return status;
   }
 }
 

--- a/packages/grpc-js-core/src/metadata-status-filter.ts
+++ b/packages/grpc-js-core/src/metadata-status-filter.ts
@@ -5,9 +5,9 @@ import {Status} from './constants';
 import {BaseFilter, Filter, FilterFactory} from './filter';
 
 export class MetadataStatusFilter extends BaseFilter implements Filter {
-  async receiveTrailers(status: Promise<StatusObject>): Promise<StatusObject> {
+  async receiveTrailers(status: StatusObject): Promise<StatusObject> {
     // tslint:disable-next-line:prefer-const
-    let {code, details, metadata} = await status;
+    let {code, details, metadata} = status;
     if (code !== Status.UNKNOWN) {
       // we already have a known status, so don't assign a new one.
       return {code, details, metadata};


### PR DESCRIPTION
This commit removes many unnecessary wrapping and unwrapping of values in `Promise`s. This should simplify both the source code and generated code, as well as help performance.