### PR TITLE
grpc-js-core: remove use of return await

### DIFF
--- a/packages/grpc-js-core/src/compression-filter.ts
+++ b/packages/grpc-js-core/src/compression-filter.ts
@@ -185,7 +185,7 @@ export class CompressionFilter extends BaseFilter implements Filter {
      * compressed, and the output message is deframed and uncompressed. So
      * this is another reason that this filter should be at the bottom of the
      * filter stack. */
-    return await this.receiveCompression.readMessage(await message);
+    return this.receiveCompression.readMessage(await message);
   }
 }
 

--- a/packages/grpc-js-core/src/filter.ts
+++ b/packages/grpc-js-core/src/filter.ts
@@ -19,23 +19,23 @@ export interface Filter {
 
 export abstract class BaseFilter {
   async sendMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
-    return await metadata;
+    return metadata;
   }
 
   async receiveMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
-    return await metadata;
+    return metadata;
   }
 
   async sendMessage(message: Promise<WriteObject>): Promise<WriteObject> {
-    return await message;
+    return message;
   }
 
   async receiveMessage(message: Promise<Buffer>): Promise<Buffer> {
-    return await message;
+    return message;
   }
 
   async receiveTrailers(status: Promise<StatusObject>): Promise<StatusObject> {
-    return await status;
+    return status;
   }
 }
 


### PR DESCRIPTION
`return await` isn't typically useful in `async` functions. Split out of #536