### PR TITLE
grpc-native-core: do not use deprecated getRequestMetadata

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -39,7 +39,7 @@
     "body-parser": "^1.15.2",
     "electron-mocha": "^3.1.1",
     "express": "^4.14.0",
-    "google-auth-library": "^0.9.2",
+    "google-auth-library": "^2.0.0",
     "google-protobuf": "^3.0.0",
     "istanbul": "^0.4.4",
     "lodash": "^4.17.4",

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -39,7 +39,7 @@
     "body-parser": "^1.15.2",
     "electron-mocha": "^3.1.1",
     "express": "^4.14.0",
-    "google-auth-library": "^2.0.0",
+    "google-auth-library": "^0.9.2",
     "google-protobuf": "^3.0.0",
     "istanbul": "^0.4.4",
     "lodash": "^4.17.4",

--- a/packages/grpc-native-core/src/credentials.js
+++ b/packages/grpc-native-core/src/credentials.js
@@ -196,8 +196,7 @@ function getAuthorizationHeaderFromGoogleCredential(google_credential, url, call
         callback(err);
         return;
       });
-  }
-  else {
+  } else {
     google_credential.getRequestMetadata(url, function(err, header) {
       if (err) {
         callback(err);

--- a/packages/grpc-native-core/src/credentials.js
+++ b/packages/grpc-native-core/src/credentials.js
@@ -195,16 +195,17 @@ exports.createFromMetadataGenerator = function(metadata_generator) {
 exports.createFromGoogleCredential = function(google_credential) {
   return exports.createFromMetadataGenerator(function(auth_context, callback) {
     var service_url = auth_context.service_url;
-    google_credential.getRequestMetadata(service_url, function(err, header) {
-      if (err) {
+    google_credential.getRequestHeaders(service_url)
+      .then(function(header) {
+        var metadata = new Metadata();
+        metadata.add('authorization', header.Authorization);
+        callback(null, metadata);
+      })
+      .catch(function(err) {
         common.log(constants.logVerbosity.INFO, 'Auth error:' + err);
         callback(err);
         return;
-      }
-      var metadata = new Metadata();
-      metadata.add('authorization', header.Authorization);
-      callback(null, metadata);
-    });
+      });
   });
 };
 


### PR DESCRIPTION
Fixes #545.

Since `getRequestMetadata` is now [deprecated](https://github.com/googleapis/google-auth-library-nodejs/blob/6e3bc6ebe06bd476c0588d11d5e5666fd5e24f36/CHANGELOG.md#the-getrequestmetadata-method-has-been-deprecated) in `google-auth-library`, we are getting deprecation warnings in Google Cloud client libraries.

Since there is no good way to tell if the user passed old or new `googleCredentials` object, we can check if it has `getRequestHeaders` method or not, and if it has one, use it, otherwise fallback to the old `getRequestMetadata`. Ugly but works.