### PR TITLE
Add Node plugin code and protobuf submodule to grpc-tools

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "packages/grpc-native-core/deps/grpc"]
 	path = packages/grpc-native-core/deps/grpc
 	url = https://github.com/grpc/grpc.git
+[submodule "packages/grpc-tools/deps/protobuf"]
+	path = packages/grpc-tools/deps/protobuf
+	url = https://github.com/protocolbuffers/protobuf

--- a/packages/grpc-tools/src/config.h
+++ b/packages/grpc-tools/src/config.h
@@ -1,0 +1,91 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef SRC_COMPILER_CONFIG_H
+#define SRC_COMPILER_CONFIG_H
+
+#include <grpcpp/impl/codegen/config_protobuf.h>
+
+#ifndef GRPC_CUSTOM_CODEGENERATOR
+#include <google/protobuf/compiler/code_generator.h>
+#define GRPC_CUSTOM_CODEGENERATOR ::google::protobuf::compiler::CodeGenerator
+#define GRPC_CUSTOM_GENERATORCONTEXT \
+  ::google::protobuf::compiler::GeneratorContext
+#endif
+
+#ifndef GRPC_CUSTOM_PRINTER
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/printer.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+#define GRPC_CUSTOM_PRINTER ::google::protobuf::io::Printer
+#define GRPC_CUSTOM_CODEDOUTPUTSTREAM ::google::protobuf::io::CodedOutputStream
+#define GRPC_CUSTOM_STRINGOUTPUTSTREAM \
+  ::google::protobuf::io::StringOutputStream
+#endif
+
+#ifndef GRPC_CUSTOM_PLUGINMAIN
+#include <google/protobuf/compiler/plugin.h>
+#define GRPC_CUSTOM_PLUGINMAIN ::google::protobuf::compiler::PluginMain
+#endif
+
+#ifndef GRPC_CUSTOM_PARSEGENERATORPARAMETER
+#include <google/protobuf/compiler/code_generator.h>
+#define GRPC_CUSTOM_PARSEGENERATORPARAMETER \
+  ::google::protobuf::compiler::ParseGeneratorParameter
+#endif
+
+#ifndef GRPC_CUSTOM_STRING
+#include <string>
+#define GRPC_CUSTOM_STRING std::string
+#endif
+
+namespace grpc {
+
+typedef GRPC_CUSTOM_STRING string;
+
+namespace protobuf {
+
+namespace compiler {
+typedef GRPC_CUSTOM_CODEGENERATOR CodeGenerator;
+typedef GRPC_CUSTOM_GENERATORCONTEXT GeneratorContext;
+static inline int PluginMain(int argc, char* argv[],
+                             const CodeGenerator* generator) {
+  return GRPC_CUSTOM_PLUGINMAIN(argc, argv, generator);
+}
+static inline void ParseGeneratorParameter(
+    const string& parameter, std::vector<std::pair<string, string> >* options) {
+  GRPC_CUSTOM_PARSEGENERATORPARAMETER(parameter, options);
+}
+
+}  // namespace compiler
+namespace io {
+typedef GRPC_CUSTOM_PRINTER Printer;
+typedef GRPC_CUSTOM_CODEDOUTPUTSTREAM CodedOutputStream;
+typedef GRPC_CUSTOM_STRINGOUTPUTSTREAM StringOutputStream;
+}  // namespace io
+}  // namespace protobuf
+}  // namespace grpc
+
+namespace grpc_cpp_generator {
+
+static const char* const kCppGeneratorMessageHeaderExt = ".pb.h";
+static const char* const kCppGeneratorServiceHeaderExt = ".grpc.pb.h";
+
+}  // namespace grpc_cpp_generator
+
+#endif  // SRC_COMPILER_CONFIG_H

--- a/packages/grpc-tools/src/config.h
+++ b/packages/grpc-tools/src/config.h
@@ -19,7 +19,7 @@
 #ifndef SRC_COMPILER_CONFIG_H
 #define SRC_COMPILER_CONFIG_H
 
-#include <grpcpp/impl/codegen/config_protobuf.h>
+#include "config_protobuf.h"
 
 #ifndef GRPC_CUSTOM_CODEGENERATOR
 #include <google/protobuf/compiler/code_generator.h>

--- a/packages/grpc-tools/src/config_protobuf.h
+++ b/packages/grpc-tools/src/config_protobuf.h
@@ -1,0 +1,95 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GRPCPP_IMPL_CODEGEN_CONFIG_PROTOBUF_H
+#define GRPCPP_IMPL_CODEGEN_CONFIG_PROTOBUF_H
+
+#define GRPC_OPEN_SOURCE_PROTO
+
+#ifndef GRPC_CUSTOM_PROTOBUF_INT64
+#include <google/protobuf/stubs/common.h>
+#define GRPC_CUSTOM_PROTOBUF_INT64 ::google::protobuf::int64
+#endif
+
+#ifndef GRPC_CUSTOM_MESSAGE
+#ifdef GRPC_USE_PROTO_LITE
+#include <google/protobuf/message_lite.h>
+#define GRPC_CUSTOM_MESSAGE ::google::protobuf::MessageLite
+#else
+#include <google/protobuf/message.h>
+#define GRPC_CUSTOM_MESSAGE ::google::protobuf::Message
+#endif
+#endif
+
+#ifndef GRPC_CUSTOM_DESCRIPTOR
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
+#define GRPC_CUSTOM_DESCRIPTOR ::google::protobuf::Descriptor
+#define GRPC_CUSTOM_DESCRIPTORPOOL ::google::protobuf::DescriptorPool
+#define GRPC_CUSTOM_FIELDDESCRIPTOR ::google::protobuf::FieldDescriptor
+#define GRPC_CUSTOM_FILEDESCRIPTOR ::google::protobuf::FileDescriptor
+#define GRPC_CUSTOM_FILEDESCRIPTORPROTO ::google::protobuf::FileDescriptorProto
+#define GRPC_CUSTOM_METHODDESCRIPTOR ::google::protobuf::MethodDescriptor
+#define GRPC_CUSTOM_SERVICEDESCRIPTOR ::google::protobuf::ServiceDescriptor
+#define GRPC_CUSTOM_SOURCELOCATION ::google::protobuf::SourceLocation
+#endif
+
+#ifndef GRPC_CUSTOM_DESCRIPTORDATABASE
+#include <google/protobuf/descriptor_database.h>
+#define GRPC_CUSTOM_DESCRIPTORDATABASE ::google::protobuf::DescriptorDatabase
+#define GRPC_CUSTOM_SIMPLEDESCRIPTORDATABASE \
+  ::google::protobuf::SimpleDescriptorDatabase
+#endif
+
+#ifndef GRPC_CUSTOM_ZEROCOPYOUTPUTSTREAM
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream.h>
+#define GRPC_CUSTOM_ZEROCOPYOUTPUTSTREAM \
+  ::google::protobuf::io::ZeroCopyOutputStream
+#define GRPC_CUSTOM_ZEROCOPYINPUTSTREAM \
+  ::google::protobuf::io::ZeroCopyInputStream
+#define GRPC_CUSTOM_CODEDINPUTSTREAM ::google::protobuf::io::CodedInputStream
+#endif
+
+namespace grpc {
+namespace protobuf {
+
+typedef GRPC_CUSTOM_MESSAGE Message;
+typedef GRPC_CUSTOM_PROTOBUF_INT64 int64;
+
+typedef GRPC_CUSTOM_DESCRIPTOR Descriptor;
+typedef GRPC_CUSTOM_DESCRIPTORPOOL DescriptorPool;
+typedef GRPC_CUSTOM_DESCRIPTORDATABASE DescriptorDatabase;
+typedef GRPC_CUSTOM_FIELDDESCRIPTOR FieldDescriptor;
+typedef GRPC_CUSTOM_FILEDESCRIPTOR FileDescriptor;
+typedef GRPC_CUSTOM_FILEDESCRIPTORPROTO FileDescriptorProto;
+typedef GRPC_CUSTOM_METHODDESCRIPTOR MethodDescriptor;
+typedef GRPC_CUSTOM_SERVICEDESCRIPTOR ServiceDescriptor;
+typedef GRPC_CUSTOM_SIMPLEDESCRIPTORDATABASE SimpleDescriptorDatabase;
+typedef GRPC_CUSTOM_SOURCELOCATION SourceLocation;
+
+namespace io {
+typedef GRPC_CUSTOM_ZEROCOPYOUTPUTSTREAM ZeroCopyOutputStream;
+typedef GRPC_CUSTOM_ZEROCOPYINPUTSTREAM ZeroCopyInputStream;
+typedef GRPC_CUSTOM_CODEDINPUTSTREAM CodedInputStream;
+}  // namespace io
+
+}  // namespace protobuf
+}  // namespace grpc
+
+#endif  // GRPCPP_IMPL_CODEGEN_CONFIG_PROTOBUF_H

--- a/packages/grpc-tools/src/generator_helpers.h
+++ b/packages/grpc-tools/src/generator_helpers.h
@@ -1,0 +1,277 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GRPC_INTERNAL_COMPILER_GENERATOR_HELPERS_H
+#define GRPC_INTERNAL_COMPILER_GENERATOR_HELPERS_H
+
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "src/compiler/config.h"
+
+namespace grpc_generator {
+
+inline bool StripSuffix(grpc::string* filename, const grpc::string& suffix) {
+  if (filename->length() >= suffix.length()) {
+    size_t suffix_pos = filename->length() - suffix.length();
+    if (filename->compare(suffix_pos, grpc::string::npos, suffix) == 0) {
+      filename->resize(filename->size() - suffix.size());
+      return true;
+    }
+  }
+
+  return false;
+}
+
+inline bool StripPrefix(grpc::string* name, const grpc::string& prefix) {
+  if (name->length() >= prefix.length()) {
+    if (name->substr(0, prefix.size()) == prefix) {
+      *name = name->substr(prefix.size());
+      return true;
+    }
+  }
+  return false;
+}
+
+inline grpc::string StripProto(grpc::string filename) {
+  if (!StripSuffix(&filename, ".protodevel")) {
+    StripSuffix(&filename, ".proto");
+  }
+  return filename;
+}
+
+inline grpc::string StringReplace(grpc::string str, const grpc::string& from,
+                                  const grpc::string& to, bool replace_all) {
+  size_t pos = 0;
+
+  do {
+    pos = str.find(from, pos);
+    if (pos == grpc::string::npos) {
+      break;
+    }
+    str.replace(pos, from.length(), to);
+    pos += to.length();
+  } while (replace_all);
+
+  return str;
+}
+
+inline grpc::string StringReplace(grpc::string str, const grpc::string& from,
+                                  const grpc::string& to) {
+  return StringReplace(str, from, to, true);
+}
+
+inline std::vector<grpc::string> tokenize(const grpc::string& input,
+                                          const grpc::string& delimiters) {
+  std::vector<grpc::string> tokens;
+  size_t pos, last_pos = 0;
+
+  for (;;) {
+    bool done = false;
+    pos = input.find_first_of(delimiters, last_pos);
+    if (pos == grpc::string::npos) {
+      done = true;
+      pos = input.length();
+    }
+
+    tokens.push_back(input.substr(last_pos, pos - last_pos));
+    if (done) return tokens;
+
+    last_pos = pos + 1;
+  }
+}
+
+inline grpc::string CapitalizeFirstLetter(grpc::string s) {
+  if (s.empty()) {
+    return s;
+  }
+  s[0] = ::toupper(s[0]);
+  return s;
+}
+
+inline grpc::string LowercaseFirstLetter(grpc::string s) {
+  if (s.empty()) {
+    return s;
+  }
+  s[0] = ::tolower(s[0]);
+  return s;
+}
+
+inline grpc::string LowerUnderscoreToUpperCamel(grpc::string str) {
+  std::vector<grpc::string> tokens = tokenize(str, "_");
+  grpc::string result = "";
+  for (unsigned int i = 0; i < tokens.size(); i++) {
+    result += CapitalizeFirstLetter(tokens[i]);
+  }
+  return result;
+}
+
+inline grpc::string FileNameInUpperCamel(
+    const grpc::protobuf::FileDescriptor* file, bool include_package_path) {
+  std::vector<grpc::string> tokens = tokenize(StripProto(file->name()), "/");
+  grpc::string result = "";
+  if (include_package_path) {
+    for (unsigned int i = 0; i < tokens.size() - 1; i++) {
+      result += tokens[i] + "/";
+    }
+  }
+  result += LowerUnderscoreToUpperCamel(tokens.back());
+  return result;
+}
+
+inline grpc::string FileNameInUpperCamel(
+    const grpc::protobuf::FileDescriptor* file) {
+  return FileNameInUpperCamel(file, true);
+}
+
+enum MethodType {
+  METHODTYPE_NO_STREAMING,
+  METHODTYPE_CLIENT_STREAMING,
+  METHODTYPE_SERVER_STREAMING,
+  METHODTYPE_BIDI_STREAMING
+};
+
+inline MethodType GetMethodType(
+    const grpc::protobuf::MethodDescriptor* method) {
+  if (method->client_streaming()) {
+    if (method->server_streaming()) {
+      return METHODTYPE_BIDI_STREAMING;
+    } else {
+      return METHODTYPE_CLIENT_STREAMING;
+    }
+  } else {
+    if (method->server_streaming()) {
+      return METHODTYPE_SERVER_STREAMING;
+    } else {
+      return METHODTYPE_NO_STREAMING;
+    }
+  }
+}
+
+inline void Split(const grpc::string& s, char delim,
+                  std::vector<grpc::string>* append_to) {
+  std::istringstream iss(s);
+  grpc::string piece;
+  while (std::getline(iss, piece)) {
+    append_to->push_back(piece);
+  }
+}
+
+enum CommentType {
+  COMMENTTYPE_LEADING,
+  COMMENTTYPE_TRAILING,
+  COMMENTTYPE_LEADING_DETACHED
+};
+
+// Get all the raw comments and append each line without newline to out.
+template <typename DescriptorType>
+inline void GetComment(const DescriptorType* desc, CommentType type,
+                       std::vector<grpc::string>* out) {
+  grpc::protobuf::SourceLocation location;
+  if (!desc->GetSourceLocation(&location)) {
+    return;
+  }
+  if (type == COMMENTTYPE_LEADING || type == COMMENTTYPE_TRAILING) {
+    const grpc::string& comments = type == COMMENTTYPE_LEADING
+                                       ? location.leading_comments
+                                       : location.trailing_comments;
+    Split(comments, '\n', out);
+  } else if (type == COMMENTTYPE_LEADING_DETACHED) {
+    for (unsigned int i = 0; i < location.leading_detached_comments.size();
+         i++) {
+      Split(location.leading_detached_comments[i], '\n', out);
+      out->push_back("");
+    }
+  } else {
+    std::cerr << "Unknown comment type " << type << std::endl;
+    abort();
+  }
+}
+
+// Each raw comment line without newline is appended to out.
+// For file level leading and detached leading comments, we return comments
+// above syntax line. Return nothing for trailing comments.
+template <>
+inline void GetComment(const grpc::protobuf::FileDescriptor* desc,
+                       CommentType type, std::vector<grpc::string>* out) {
+  if (type == COMMENTTYPE_TRAILING) {
+    return;
+  }
+  grpc::protobuf::SourceLocation location;
+  std::vector<int> path;
+  path.push_back(grpc::protobuf::FileDescriptorProto::kSyntaxFieldNumber);
+  if (!desc->GetSourceLocation(path, &location)) {
+    return;
+  }
+  if (type == COMMENTTYPE_LEADING) {
+    Split(location.leading_comments, '\n', out);
+  } else if (type == COMMENTTYPE_LEADING_DETACHED) {
+    for (unsigned int i = 0; i < location.leading_detached_comments.size();
+         i++) {
+      Split(location.leading_detached_comments[i], '\n', out);
+      out->push_back("");
+    }
+  } else {
+    std::cerr << "Unknown comment type " << type << std::endl;
+    abort();
+  }
+}
+
+// Add prefix and newline to each comment line and concatenate them together.
+// Make sure there is a space after the prefix unless the line is empty.
+inline grpc::string GenerateCommentsWithPrefix(
+    const std::vector<grpc::string>& in, const grpc::string& prefix) {
+  std::ostringstream oss;
+  for (auto it = in.begin(); it != in.end(); it++) {
+    const grpc::string& elem = *it;
+    if (elem.empty()) {
+      oss << prefix << "\n";
+    } else if (elem[0] == ' ') {
+      oss << prefix << elem << "\n";
+    } else {
+      oss << prefix << " " << elem << "\n";
+    }
+  }
+  return oss.str();
+}
+
+template <typename DescriptorType>
+inline grpc::string GetPrefixedComments(const DescriptorType* desc,
+                                        bool leading,
+                                        const grpc::string& prefix) {
+  std::vector<grpc::string> out;
+  if (leading) {
+    grpc_generator::GetComment(
+        desc, grpc_generator::COMMENTTYPE_LEADING_DETACHED, &out);
+    std::vector<grpc::string> leading;
+    grpc_generator::GetComment(desc, grpc_generator::COMMENTTYPE_LEADING,
+                               &leading);
+    out.insert(out.end(), leading.begin(), leading.end());
+  } else {
+    grpc_generator::GetComment(desc, grpc_generator::COMMENTTYPE_TRAILING,
+                               &out);
+  }
+  return GenerateCommentsWithPrefix(out, prefix);
+}
+
+}  // namespace grpc_generator
+
+#endif  // GRPC_INTERNAL_COMPILER_GENERATOR_HELPERS_H

--- a/packages/grpc-tools/src/generator_helpers.h
+++ b/packages/grpc-tools/src/generator_helpers.h
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 
-#include "src/compiler/config.h"
+#include "config.h"
 
 namespace grpc_generator {
 

--- a/packages/grpc-tools/src/node_generator.cc
+++ b/packages/grpc-tools/src/node_generator.cc
@@ -1,0 +1,278 @@
+/*
+ *
+ * Copyright 2016 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <map>
+
+#include "src/compiler/config.h"
+#include "src/compiler/generator_helpers.h"
+#include "src/compiler/node_generator.h"
+#include "src/compiler/node_generator_helpers.h"
+
+using grpc::protobuf::Descriptor;
+using grpc::protobuf::FileDescriptor;
+using grpc::protobuf::MethodDescriptor;
+using grpc::protobuf::ServiceDescriptor;
+using grpc::protobuf::io::Printer;
+using grpc::protobuf::io::StringOutputStream;
+using std::map;
+
+namespace grpc_node_generator {
+namespace {
+
+// Returns the alias we assign to the module of the given .proto filename
+// when importing. Copied entirely from
+// github:google/protobuf/src/google/protobuf/compiler/js/js_generator.cc#L154
+grpc::string ModuleAlias(const grpc::string filename) {
+  // This scheme could technically cause problems if a file includes any 2 of:
+  //   foo/bar_baz.proto
+  //   foo_bar_baz.proto
+  //   foo_bar/baz.proto
+  //
+  // We'll worry about this problem if/when we actually see it.  This name isn't
+  // exposed to users so we can change it later if we need to.
+  grpc::string basename = grpc_generator::StripProto(filename);
+  basename = grpc_generator::StringReplace(basename, "-", "$");
+  basename = grpc_generator::StringReplace(basename, "/", "_");
+  basename = grpc_generator::StringReplace(basename, ".", "_");
+  return basename + "_pb";
+}
+
+// Given a filename like foo/bar/baz.proto, returns the corresponding JavaScript
+// message file foo/bar/baz.js
+grpc::string GetJSMessageFilename(const grpc::string& filename) {
+  grpc::string name = filename;
+  return grpc_generator::StripProto(name) + "_pb.js";
+}
+
+// Given a filename like foo/bar/baz.proto, returns the root directory
+// path ../../
+grpc::string GetRootPath(const grpc::string& from_filename,
+                         const grpc::string& to_filename) {
+  if (to_filename.find("google/protobuf") == 0) {
+    // Well-known types (.proto files in the google/protobuf directory) are
+    // assumed to come from the 'google-protobuf' npm package.  We may want to
+    // generalize this exception later by letting others put generated code in
+    // their own npm packages.
+    return "google-protobuf/";
+  }
+  size_t slashes = std::count(from_filename.begin(), from_filename.end(), '/');
+  if (slashes == 0) {
+    return "./";
+  }
+  grpc::string result = "";
+  for (size_t i = 0; i < slashes; i++) {
+    result += "../";
+  }
+  return result;
+}
+
+// Return the relative path to load to_file from the directory containing
+// from_file, assuming that both paths are relative to the same directory
+grpc::string GetRelativePath(const grpc::string& from_file,
+                             const grpc::string& to_file) {
+  return GetRootPath(from_file, to_file) + to_file;
+}
+
+/* Finds all message types used in all services in the file, and returns them
+ * as a map of fully qualified message type name to message descriptor */
+map<grpc::string, const Descriptor*> GetAllMessages(
+    const FileDescriptor* file) {
+  map<grpc::string, const Descriptor*> message_types;
+  for (int service_num = 0; service_num < file->service_count();
+       service_num++) {
+    const ServiceDescriptor* service = file->service(service_num);
+    for (int method_num = 0; method_num < service->method_count();
+         method_num++) {
+      const MethodDescriptor* method = service->method(method_num);
+      const Descriptor* input_type = method->input_type();
+      const Descriptor* output_type = method->output_type();
+      message_types[input_type->full_name()] = input_type;
+      message_types[output_type->full_name()] = output_type;
+    }
+  }
+  return message_types;
+}
+
+grpc::string MessageIdentifierName(const grpc::string& name) {
+  return grpc_generator::StringReplace(name, ".", "_");
+}
+
+grpc::string NodeObjectPath(const Descriptor* descriptor) {
+  grpc::string module_alias = ModuleAlias(descriptor->file()->name());
+  grpc::string name = descriptor->full_name();
+  grpc_generator::StripPrefix(&name, descriptor->file()->package() + ".");
+  return module_alias + "." + name;
+}
+
+// Prints out the message serializer and deserializer functions
+void PrintMessageTransformer(const Descriptor* descriptor, Printer* out,
+                             const Parameters& params) {
+  map<grpc::string, grpc::string> template_vars;
+  grpc::string full_name = descriptor->full_name();
+  template_vars["identifier_name"] = MessageIdentifierName(full_name);
+  template_vars["name"] = full_name;
+  template_vars["node_name"] = NodeObjectPath(descriptor);
+  // Print the serializer
+  out->Print(template_vars, "function serialize_$identifier_name$(arg) {\n");
+  out->Indent();
+  out->Print(template_vars, "if (!(arg instanceof $node_name$)) {\n");
+  out->Indent();
+  out->Print(template_vars,
+             "throw new Error('Expected argument of type $name$');\n");
+  out->Outdent();
+  out->Print("}\n");
+  if (params.minimum_node_version > 5) {
+    // Node version is > 5, we should use Buffer.from
+    out->Print("return Buffer.from(arg.serializeBinary());\n");
+  } else {
+    out->Print("return new Buffer(arg.serializeBinary());\n");
+  }
+  out->Outdent();
+  out->Print("}\n\n");
+
+  // Print the deserializer
+  out->Print(template_vars,
+             "function deserialize_$identifier_name$(buffer_arg) {\n");
+  out->Indent();
+  out->Print(
+      template_vars,
+      "return $node_name$.deserializeBinary(new Uint8Array(buffer_arg));\n");
+  out->Outdent();
+  out->Print("}\n\n");
+}
+
+void PrintMethod(const MethodDescriptor* method, Printer* out) {
+  const Descriptor* input_type = method->input_type();
+  const Descriptor* output_type = method->output_type();
+  map<grpc::string, grpc::string> vars;
+  vars["service_name"] = method->service()->full_name();
+  vars["name"] = method->name();
+  vars["input_type"] = NodeObjectPath(input_type);
+  vars["input_type_id"] = MessageIdentifierName(input_type->full_name());
+  vars["output_type"] = NodeObjectPath(output_type);
+  vars["output_type_id"] = MessageIdentifierName(output_type->full_name());
+  vars["client_stream"] = method->client_streaming() ? "true" : "false";
+  vars["server_stream"] = method->server_streaming() ? "true" : "false";
+  out->Print("{\n");
+  out->Indent();
+  out->Print(vars, "path: '/$service_name$/$name$',\n");
+  out->Print(vars, "requestStream: $client_stream$,\n");
+  out->Print(vars, "responseStream: $server_stream$,\n");
+  out->Print(vars, "requestType: $input_type$,\n");
+  out->Print(vars, "responseType: $output_type$,\n");
+  out->Print(vars, "requestSerialize: serialize_$input_type_id$,\n");
+  out->Print(vars, "requestDeserialize: deserialize_$input_type_id$,\n");
+  out->Print(vars, "responseSerialize: serialize_$output_type_id$,\n");
+  out->Print(vars, "responseDeserialize: deserialize_$output_type_id$,\n");
+  out->Outdent();
+  out->Print("}");
+}
+
+// Prints out the service descriptor object
+void PrintService(const ServiceDescriptor* service, Printer* out) {
+  map<grpc::string, grpc::string> template_vars;
+  out->Print(GetNodeComments(service, true).c_str());
+  template_vars["name"] = service->name();
+  out->Print(template_vars, "var $name$Service = exports.$name$Service = {\n");
+  out->Indent();
+  for (int i = 0; i < service->method_count(); i++) {
+    grpc::string method_name =
+        grpc_generator::LowercaseFirstLetter(service->method(i)->name());
+    out->Print(GetNodeComments(service->method(i), true).c_str());
+    out->Print("$method_name$: ", "method_name", method_name);
+    PrintMethod(service->method(i), out);
+    out->Print(",\n");
+    out->Print(GetNodeComments(service->method(i), false).c_str());
+  }
+  out->Outdent();
+  out->Print("};\n\n");
+  out->Print(template_vars,
+             "exports.$name$Client = "
+             "grpc.makeGenericClientConstructor($name$Service);\n");
+  out->Print(GetNodeComments(service, false).c_str());
+}
+
+void PrintImports(const FileDescriptor* file, Printer* out) {
+  out->Print("var grpc = require('grpc');\n");
+  if (file->message_type_count() > 0) {
+    grpc::string file_path =
+        GetRelativePath(file->name(), GetJSMessageFilename(file->name()));
+    out->Print("var $module_alias$ = require('$file_path$');\n", "module_alias",
+               ModuleAlias(file->name()), "file_path", file_path);
+  }
+
+  for (int i = 0; i < file->dependency_count(); i++) {
+    grpc::string file_path = GetRelativePath(
+        file->name(), GetJSMessageFilename(file->dependency(i)->name()));
+    out->Print("var $module_alias$ = require('$file_path$');\n", "module_alias",
+               ModuleAlias(file->dependency(i)->name()), "file_path",
+               file_path);
+  }
+  out->Print("\n");
+}
+
+void PrintTransformers(const FileDescriptor* file, Printer* out,
+                       const Parameters& params) {
+  map<grpc::string, const Descriptor*> messages = GetAllMessages(file);
+  for (std::map<grpc::string, const Descriptor*>::iterator it =
+           messages.begin();
+       it != messages.end(); it++) {
+    PrintMessageTransformer(it->second, out, params);
+  }
+  out->Print("\n");
+}
+
+void PrintServices(const FileDescriptor* file, Printer* out) {
+  for (int i = 0; i < file->service_count(); i++) {
+    PrintService(file->service(i), out);
+  }
+}
+}  // namespace
+
+grpc::string GenerateFile(const FileDescriptor* file,
+                          const Parameters& params) {
+  grpc::string output;
+  {
+    StringOutputStream output_stream(&output);
+    Printer out(&output_stream, '$');
+
+    if (file->service_count() == 0) {
+      return output;
+    }
+    out.Print("// GENERATED CODE -- DO NOT EDIT!\n\n");
+
+    grpc::string leading_comments = GetNodeComments(file, true);
+    if (!leading_comments.empty()) {
+      out.Print("// Original file comments:\n");
+      out.PrintRaw(leading_comments.c_str());
+    }
+
+    out.Print("'use strict';\n");
+
+    PrintImports(file, &out);
+
+    PrintTransformers(file, &out, params);
+
+    PrintServices(file, &out);
+
+    out.Print(GetNodeComments(file, false).c_str());
+  }
+  return output;
+}
+
+}  // namespace grpc_node_generator

--- a/packages/grpc-tools/src/node_generator.cc
+++ b/packages/grpc-tools/src/node_generator.cc
@@ -18,10 +18,10 @@
 
 #include <map>
 
-#include "src/compiler/config.h"
-#include "src/compiler/generator_helpers.h"
-#include "src/compiler/node_generator.h"
-#include "src/compiler/node_generator_helpers.h"
+#include "config.h"
+#include "generator_helpers.h"
+#include "node_generator.h"
+#include "node_generator_helpers.h"
 
 using grpc::protobuf::Descriptor;
 using grpc::protobuf::FileDescriptor;

--- a/packages/grpc-tools/src/node_generator.h
+++ b/packages/grpc-tools/src/node_generator.h
@@ -1,0 +1,37 @@
+/*
+ *
+ * Copyright 2016 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GRPC_INTERNAL_COMPILER_NODE_GENERATOR_H
+#define GRPC_INTERNAL_COMPILER_NODE_GENERATOR_H
+
+#include "src/compiler/config.h"
+
+namespace grpc_node_generator {
+
+// Contains all the parameters that are parsed from the command line.
+struct Parameters {
+  // Sets the earliest version of nodejs that needs to be supported.
+  int minimum_node_version;
+};
+
+grpc::string GenerateFile(const grpc::protobuf::FileDescriptor* file,
+                          const Parameters& params);
+
+}  // namespace grpc_node_generator
+
+#endif  // GRPC_INTERNAL_COMPILER_NODE_GENERATOR_H

--- a/packages/grpc-tools/src/node_generator.h
+++ b/packages/grpc-tools/src/node_generator.h
@@ -19,7 +19,7 @@
 #ifndef GRPC_INTERNAL_COMPILER_NODE_GENERATOR_H
 #define GRPC_INTERNAL_COMPILER_NODE_GENERATOR_H
 
-#include "src/compiler/config.h"
+#include "config.h"
 
 namespace grpc_node_generator {
 

--- a/packages/grpc-tools/src/node_generator_helpers.h
+++ b/packages/grpc-tools/src/node_generator_helpers.h
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright 2016 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GRPC_INTERNAL_COMPILER_NODE_GENERATOR_HELPERS_H
+#define GRPC_INTERNAL_COMPILER_NODE_GENERATOR_HELPERS_H
+
+#include <algorithm>
+
+#include "src/compiler/config.h"
+#include "src/compiler/generator_helpers.h"
+
+namespace grpc_node_generator {
+
+inline grpc::string GetJSServiceFilename(const grpc::string& filename) {
+  return grpc_generator::StripProto(filename) + "_grpc_pb.js";
+}
+
+// Get leading or trailing comments in a string. Comment lines start with "// ".
+// Leading detached comments are put in in front of leading comments.
+template <typename DescriptorType>
+inline grpc::string GetNodeComments(const DescriptorType* desc, bool leading) {
+  return grpc_generator::GetPrefixedComments(desc, leading, "//");
+}
+
+}  // namespace grpc_node_generator
+
+#endif  // GRPC_INTERNAL_COMPILER_NODE_GENERATOR_HELPERS_H

--- a/packages/grpc-tools/src/node_generator_helpers.h
+++ b/packages/grpc-tools/src/node_generator_helpers.h
@@ -21,8 +21,8 @@
 
 #include <algorithm>
 
-#include "src/compiler/config.h"
-#include "src/compiler/generator_helpers.h"
+#include "config.h"
+#include "generator_helpers.h"
 
 namespace grpc_node_generator {
 

--- a/packages/grpc-tools/src/node_plugin.cc
+++ b/packages/grpc-tools/src/node_plugin.cc
@@ -1,0 +1,78 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Generates Node gRPC service interface out of Protobuf IDL.
+
+#include <memory>
+
+#include "src/compiler/config.h"
+#include "src/compiler/node_generator.h"
+#include "src/compiler/node_generator_helpers.h"
+
+using grpc_node_generator::GenerateFile;
+using grpc_node_generator::GetJSServiceFilename;
+
+class NodeGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
+ public:
+  NodeGrpcGenerator() {}
+  ~NodeGrpcGenerator() {}
+
+  bool Generate(const grpc::protobuf::FileDescriptor* file,
+                const grpc::string& parameter,
+                grpc::protobuf::compiler::GeneratorContext* context,
+                grpc::string* error) const {
+    grpc_node_generator::Parameters generator_parameters;
+    generator_parameters.minimum_node_version = 4;
+
+    if (!parameter.empty()) {
+      std::vector<grpc::string> parameters_list =
+          grpc_generator::tokenize(parameter, ",");
+      for (auto parameter_string = parameters_list.begin();
+           parameter_string != parameters_list.end(); parameter_string++) {
+        std::vector<grpc::string> param =
+            grpc_generator::tokenize(*parameter_string, "=");
+        if (param[0] == "minimum_node_version") {
+          sscanf(param[1].c_str(), "%d",
+                 &generator_parameters.minimum_node_version);
+        } else {
+          *error = grpc::string("Unknown parameter: ") + *parameter_string;
+          return false;
+        }
+      }
+    }
+
+    grpc::string code = GenerateFile(file, generator_parameters);
+    if (code.size() == 0) {
+      return true;
+    }
+
+    // Get output file name
+    grpc::string file_name = GetJSServiceFilename(file->name());
+
+    std::unique_ptr<grpc::protobuf::io::ZeroCopyOutputStream> output(
+        context->Open(file_name));
+    grpc::protobuf::io::CodedOutputStream coded_out(output.get());
+    coded_out.WriteRaw(code.data(), code.size());
+    return true;
+  }
+};
+
+int main(int argc, char* argv[]) {
+  NodeGrpcGenerator generator;
+  return grpc::protobuf::compiler::PluginMain(argc, argv, &generator);
+}

--- a/packages/grpc-tools/src/node_plugin.cc
+++ b/packages/grpc-tools/src/node_plugin.cc
@@ -20,9 +20,9 @@
 
 #include <memory>
 
-#include "src/compiler/config.h"
-#include "src/compiler/node_generator.h"
-#include "src/compiler/node_generator_helpers.h"
+#include "config.h"
+#include "node_generator.h"
+#include "node_generator_helpers.h"
 
 using grpc_node_generator::GenerateFile;
 using grpc_node_generator::GetJSServiceFilename;


### PR DESCRIPTION
We're going to need this if we ever want to publish another version of grpc-tools. This doesn't build yet, but I think it has all of the pieces that we need to build it.