### PR TITLE
Fix missing property in ClientHttp2StreamMock

### DIFF
--- a/packages/grpc-js-core/test/test-call-stream.ts
+++ b/packages/grpc-js-core/test/test-call-stream.ts
@@ -43,6 +43,7 @@ class ClientHttp2StreamMock extends stream.Duplex implements
   aborted = false;
   closed = false;
   destroyed = false;
+  endAfterHeaders = false;
   pending = false;
   rstCode = 0;
   // tslint:disable:no-any


### PR DESCRIPTION
This should fix grpc/grpc#16692.