### PR TITLE
grpc-js-core: update compression flag byte offset

### DIFF
--- a/packages/grpc-js-core/src/compression-filter.ts
+++ b/packages/grpc-js-core/src/compression-filter.ts
@@ -29,7 +29,7 @@ abstract class CompressionHandler {
    * @return Uncompressed message
    */
   async readMessage(data: Buffer): Promise<Buffer> {
-    const compressed = data.readUInt8(1) === 1;
+    const compressed = data.readUInt8(0) === 1;
     let messageBuffer = data.slice(5);
     if (compressed) {
       messageBuffer = await this.decompressMessage(messageBuffer);


### PR DESCRIPTION
The compression flag is written to the first byte, but read from the second byte. Update the read offset to match.