### PR TITLE
grpc-js-core: make semver a prod dependency

### DIFF
--- a/packages/grpc-js-core/package.json
+++ b/packages/grpc-js-core/package.json
@@ -20,7 +20,6 @@
     "@types/node": "^10.5.4",
     "clang-format": "^1.0.55",
     "gts": "^0.5.1",
-    "semver": "^5.5.0",
     "typescript": "~2.7.0"
   },
   "contributors": [
@@ -42,7 +41,8 @@
     "posttest": "npm run check"
   },
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "semver": "^5.5.0"
   },
   "files": [
     "build/src/*.{js,d.ts}"


### PR DESCRIPTION
`semver` is now used in `index.ts`, meaning that it needs to be included in the `"dependencies"` section of the `package.json`, otherwise deployments that use `npm i --production` will fail.