### PR TITLE
Generate JS file even if no services are defined in proto file; fix #574

### DIFF
--- a/packages/grpc-tools/src/node_generator.cc
+++ b/packages/grpc-tools/src/node_generator.cc
@@ -252,6 +252,7 @@ grpc::string GenerateFile(const FileDescriptor* file,
     Printer out(&output_stream, '$');
 
     if (file->service_count() == 0) {
+      output = "// GENERATED CODE -- NO SERVICES IN PROTO";
       return output;
     }
     out.Print("// GENERATED CODE -- DO NOT EDIT!\n\n");


### PR DESCRIPTION
Reposting from https://github.com/grpc/grpc/pull/16874