### PR TITLE
Bump submodule and version to 1.16.0-pre1

### DIFF
--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -91,7 +91,7 @@
       'GPR_BACKWARDS_COMPATIBILITY_MODE',
       'GRPC_ARES=0',
       'GRPC_UV',
-      'GRPC_NODE_VERSION="1.15.0-dev"'
+      'GRPC_NODE_VERSION="1.16.0-pre1"'
     ],
     'conditions': [
       ['grpc_gcov=="true"', {
@@ -648,6 +648,7 @@
         'deps/grpc/src/core/lib/http/format_request.cc',
         'deps/grpc/src/core/lib/http/httpcli.cc',
         'deps/grpc/src/core/lib/http/parser.cc',
+        'deps/grpc/src/core/lib/iomgr/buffer_list.cc',
         'deps/grpc/src/core/lib/iomgr/call_combiner.cc',
         'deps/grpc/src/core/lib/iomgr/combiner.cc',
         'deps/grpc/src/core/lib/iomgr/endpoint.cc',
@@ -657,7 +658,6 @@
         'deps/grpc/src/core/lib/iomgr/error.cc',
         'deps/grpc/src/core/lib/iomgr/ev_epoll1_linux.cc',
         'deps/grpc/src/core/lib/iomgr/ev_epollex_linux.cc',
-        'deps/grpc/src/core/lib/iomgr/ev_epollsig_linux.cc',
         'deps/grpc/src/core/lib/iomgr/ev_poll_posix.cc',
         'deps/grpc/src/core/lib/iomgr/ev_posix.cc',
         'deps/grpc/src/core/lib/iomgr/ev_windows.cc',
@@ -668,6 +668,7 @@
         'deps/grpc/src/core/lib/iomgr/gethostname_fallback.cc',
         'deps/grpc/src/core/lib/iomgr/gethostname_host_name_max.cc',
         'deps/grpc/src/core/lib/iomgr/gethostname_sysconf.cc',
+        'deps/grpc/src/core/lib/iomgr/internal_errqueue.cc',
         'deps/grpc/src/core/lib/iomgr/iocp_windows.cc',
         'deps/grpc/src/core/lib/iomgr/iomgr.cc',
         'deps/grpc/src/core/lib/iomgr/iomgr_custom.cc',
@@ -929,7 +930,7 @@
         'deps/grpc/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_windows.cc',
         'deps/grpc/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc',
         'deps/grpc/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc',
-        'deps/grpc/src/cpp/ext/filters/census/grpc_context.cc',
+        'deps/grpc/src/core/ext/filters/census/grpc_context.cc',
         'deps/grpc/src/core/ext/filters/max_age/max_age_filter.cc',
         'deps/grpc/src/core/ext/filters/message_size/message_size_filter.cc',
         'deps/grpc/src/core/ext/filters/http/client_authority_filter.cc',

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc",
-  "version": "1.15.0-dev",
+  "version": "1.16.0-pre1",
   "author": "Google Inc.",
   "description": "gRPC Library for Node",
   "homepage": "https://grpc.io/",
@@ -68,7 +68,6 @@
     "deps/grpc/include/grpc/**/*.h",
     "deps/grpc/src/core/**/*.{c,cc,h}",
     "deps/grpc/src/boringssl/err_data.c",
-    "deps/grpc/src/cpp/ext/filters/census/grpc_context.cc",
     "deps/grpc/third_party/nanopb/*.{c,cc,h}",
     "deps/grpc/third_party/zlib/**/*.{c,cc,h}",
     "deps/grpc/third_party/boringssl/crypto/**/*.{c,cc,h}",

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -70,7 +70,6 @@
       "deps/grpc/include/grpc/**/*.h",
       "deps/grpc/src/core/**/*.{c,cc,h}",
       "deps/grpc/src/boringssl/err_data.c",
-      "deps/grpc/src/cpp/ext/filters/census/grpc_context.cc",
       "deps/grpc/third_party/nanopb/*.{c,cc,h}",
       "deps/grpc/third_party/zlib/**/*.{c,cc,h}",
       "deps/grpc/third_party/boringssl/crypto/**/*.{c,cc,h}",


### PR DESCRIPTION
Also remove an included file in `package.json` because it was a workaround for an issue in core that was fixed.