### PR TITLE
@grpc/proto-loader: Fix absolute path handling and improve reporting of loading failures

### DIFF
--- a/packages/grpc-protobufjs/src/index.ts
+++ b/packages/grpc-protobufjs/src/index.ts
@@ -119,6 +119,9 @@ function createPackageDefinition(root: Protobuf.Root, options: Options): Package
 
 function addIncludePathResolver(root: Protobuf.Root, includePaths: string[]) {
   root.resolvePath = (origin: string, target: string) => {
+    if (path.isAbsolute(target)) {
+      return target;
+    }
     for (const directory of includePaths) {
       const fullPath: string = path.join(directory, target);
       try {
@@ -128,7 +131,7 @@ function addIncludePathResolver(root: Protobuf.Root, includePaths: string[]) {
         continue;
       }
     }
-    return null;
+    throw new Error(`Could not find file ${target}`);
   };
 }
 


### PR DESCRIPTION
This now allows users to load `.proto` files using absolute paths, and failures to resolve any files should now result in errors instead of empty return values.

A couple of notes:

 - For efficiency, we don't check anything for absolute paths. We just return them directly and let Protobuf.js check them itself when it tries to read the file.

 - Throwing an error is OK here even when loading asynchronously because Protobuf.js catches errors thrown by `resolvePath`.