### PR TITLE
Make clients fail better with malformed responses

### DIFF
--- a/packages/grpc-native-core/test/surface_test.js
+++ b/packages/grpc-native-core/test/surface_test.js
@@ -666,15 +666,11 @@ describe('Client malformed response handling', function() {
       },
       serverStream: function(stream) {
         stream.write(badArg);
-        stream.end();
       },
       bidiStream: function(stream) {
         stream.on('data', function() {
           // Ignore requests
           stream.write(badArg);
-        });
-        stream.on('end', function() {
-          stream.end();
         });
       }
     });


### PR DESCRIPTION
This fixes #595. The tests now verify that clients report errors immediately when receiving malformed responses, no matter what the server does. The new error thrown in `InterceptingCall#_callNext` should prevent this particular kind of error from happening silently in the future.