### PR TITLE
grpc-js-core: remove simple uses of lodash

### DIFF
--- a/packages/grpc-js-core/package.json
+++ b/packages/grpc-js-core/package.json
@@ -20,6 +20,7 @@
     "@types/node": "^10.5.4",
     "clang-format": "^1.0.55",
     "gts": "^0.5.1",
+    "lodash": "^4.17.4",
     "typescript": "~2.7.0"
   },
   "contributors": [
@@ -41,7 +42,6 @@
     "posttest": "npm run check"
   },
   "dependencies": {
-    "lodash": "^4.17.4",
     "semver": "^5.5.0"
   },
   "files": [

--- a/packages/grpc-js-core/src/call-credentials.ts
+++ b/packages/grpc-js-core/src/call-credentials.ts
@@ -1,5 +1,3 @@
-import {map} from 'lodash';
-
 import {Metadata} from './metadata';
 
 export type CallMetadataOptions = {
@@ -53,7 +51,7 @@ class ComposedCallCredentials extends CallCredentials {
   async generateMetadata(options: CallMetadataOptions): Promise<Metadata> {
     const base: Metadata = new Metadata();
     const generated: Metadata[] = await Promise.all(
-        map(this.creds, (cred) => cred.generateMetadata(options)));
+        this.creds.map((cred) => cred.generateMetadata(options)));
     for (const gen of generated) {
       base.merge(gen);
     }

--- a/packages/grpc-js-core/src/filter-stack.ts
+++ b/packages/grpc-js-core/src/filter-stack.ts
@@ -1,5 +1,3 @@
-import {map} from 'lodash';
-
 import {Call, StatusObject, WriteObject} from './call-stream';
 import {Filter, FilterFactory} from './filter';
 import {Metadata} from './metadata';
@@ -63,6 +61,6 @@ export class FilterStackFactory implements FilterFactory<FilterStack> {
 
   createFilter(callStream: Call): FilterStack {
     return new FilterStack(
-        map(this.factories, (factory) => factory.createFilter(callStream)));
+        this.factories.map((factory) => factory.createFilter(callStream)));
   }
 }


### PR DESCRIPTION
This commit removes lodash as a production dependency. It remains as a devDependency because it's used in tests, but the uses in the `src/` directory were easily replaced with vanilla JavaScript.