### PR TITLE
refactor: use individual lodash package for proto loader

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -38,12 +38,12 @@
     "build/src/*.js"
   ],
   "dependencies": {
-    "@types/lodash": "^4.14.104",
-    "@types/node": "^9.4.6",
-    "lodash": "^4.17.5",
+    "lodash.camelcase": "^4.3.0",
     "protobufjs": "^6.8.6"
   },
   "devDependencies": {
+    "@types/lodash.camelcase": "^4.3.4",
+    "@types/node": "^10.12.5",
     "clang-format": "^1.2.2",
     "gts": "^0.5.3",
     "typescript": "~2.7.2"

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -18,7 +18,7 @@
 import * as Protobuf from 'protobufjs';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as _ from 'lodash';
+import camelCase = require('lodash.camelcase');
 
 export interface Serialize<T> {
   (value: T): Buffer;
@@ -97,7 +97,7 @@ function createMethodDefinition(method: Protobuf.Method, serviceName: string, op
     responseSerialize: createSerializer(method.resolvedResponseType as Protobuf.Type),
     responseDeserialize: createDeserializer(method.resolvedResponseType as Protobuf.Type, options),
     // TODO(murgatroid99): Find a better way to handle this
-    originalName: _.camelCase(method.name)
+    originalName: camelCase(method.name)
   };
 }
 

--- a/packages/proto-loader/tsconfig.json
+++ b/packages/proto-loader/tsconfig.json
@@ -5,10 +5,6 @@
     "outDir": "build"
   },
   "include": [
-    "src/*.ts",
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
+    "src/*.ts"
   ]
 }


### PR DESCRIPTION
This drops the `lodash` package in favor of `lodash.camelcase`