### PR TITLE
refactor: use individual lodash packages for health check

### DIFF
--- a/packages/grpc-health-check/health.js
+++ b/packages/grpc-health-check/health.js
@@ -20,13 +20,14 @@
 
 var grpc = require('grpc');
 
-var _ = require('lodash');
+var _get = require('lodash.get');
+var _clone = require('lodash.clone')
 
 var health_messages = require('./v1/health_pb');
 var health_service = require('./v1/health_grpc_pb');
 
 function HealthImplementation(statusMap) {
-  this.statusMap = _.clone(statusMap);
+  this.statusMap = _clone(statusMap);
 }
 
 HealthImplementation.prototype.setStatus = function(service, status) {
@@ -35,7 +36,7 @@ HealthImplementation.prototype.setStatus = function(service, status) {
 
 HealthImplementation.prototype.check = function(call, callback){
   var service = call.request.getService();
-  var status = _.get(this.statusMap, service, null);
+  var status = _get(this.statusMap, service, null);
   if (status === null) {
     // TODO(murgatroid99): Do this without an explicit reference to grpc.
     callback({code:grpc.status.NOT_FOUND});

--- a/packages/grpc-health-check/package.json
+++ b/packages/grpc-health-check/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "google-protobuf": "^3.4.0",
     "grpc": "^1.6.0",
-    "lodash": "^4.17.5"
+    "lodash.clone": "^4.5.0",
+    "lodash.get": "^4.4.2"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
This swaps out `lodash` for `lodash.clone` and `lodash.get` packages. 