### PR TITLE
refactor: drop usage of _.isString

### DIFF
--- a/packages/grpc-native-core/src/metadata.js
+++ b/packages/grpc-native-core/src/metadata.js
@@ -51,7 +51,7 @@ function validate(key, value) {
       throw new Error('keys that end with \'-bin\' must have Buffer values');
     }
   } else {
-    if (!_.isString(value)) {
+    if (typeof value !== 'string') {
       throw new Error(
           'keys that don\'t end with \'-bin\' must have String values');
     }


### PR DESCRIPTION
This drops the usage of `_.isString` in favor of `typeof foo === 'string'`