### PR TITLE
refactor: drop usage of _.map

### DIFF
--- a/packages/grpc-native-core/src/client_interceptors.js
+++ b/packages/grpc-native-core/src/client_interceptors.js
@@ -746,14 +746,14 @@ function _areBatchRequirementsMet(batch_ops, completed_ops) {
 function _startBatchIfReady(call, batch, batch_state, callback) {
   var completed_ops = batch_state.completed_ops;
   var deferred_batches = batch_state.deferred_batches;
-  var batch_ops = _.map(_.keys(batch), Number);
+  var batch_ops = _.keys(batch).map(Number);
   if (_areBatchRequirementsMet(batch_ops, completed_ops)) {
     // Dependencies are met, start the batch and any deferred batches whose
     // dependencies are met as a result.
     call.startBatch(batch, callback);
     completed_ops = _.union(completed_ops, batch_ops);
     deferred_batches = _.flatMap(deferred_batches, function(deferred_batch) {
-      var deferred_batch_ops = _.map(_.keys(deferred_batch), Number);
+      var deferred_batch_ops = _.keys(deferred_batch).map(Number);
       if (_areBatchRequirementsMet(deferred_batch_ops, completed_ops)) {
         call.startBatch(deferred_batch.batch, deferred_batch.callback);
         return [];

--- a/packages/grpc-native-core/src/protobuf_js_5_common.js
+++ b/packages/grpc-native-core/src/protobuf_js_5_common.js
@@ -106,9 +106,9 @@ exports.getProtobufServiceAttrs = function getProtobufServiceAttrs(service,
      lodash@3.10.1-compatible functions. A previous version used
      _.fromPairs, which would be cleaner, but was introduced in lodash
      version 4 */
-  return _.zipObject(_.map(service.children, function(method) {
+  return _.zipObject(service.children.map(function(method) {
     return _.camelCase(method.name);
-  }), _.map(service.children, function(method) {
+  }), service.children.map(function(method) {
     return {
       originalName: method.name,
       path: prefix + method.name,

--- a/packages/grpc-native-core/src/protobuf_js_6_common.js
+++ b/packages/grpc-native-core/src/protobuf_js_6_common.js
@@ -103,9 +103,9 @@ exports.getProtobufServiceAttrs = function getProtobufServiceAttrs(service,
                                                                    options) {
   var prefix = '/' + fullyQualifiedName(service) + '/';
   service.resolveAll();
-  return _.zipObject(_.map(service.methods, function(method) {
+  return _.zipObject(service.methods.map(function(method) {
     return _.camelCase(method.name);
-  }), _.map(service.methods, function(method) {
+  }), service.methods.map(function(method) {
     return {
       originalName: method.name,
       path: prefix + method.name,


### PR DESCRIPTION
This drops `_.map` in favor of the native `Array.prototype.map` implementation.