### PR TITLE
refactor: drop usage of _.isFinite

### DIFF
--- a/packages/grpc-native-core/src/client_interceptors.js
+++ b/packages/grpc-native-core/src/client_interceptors.js
@@ -944,7 +944,7 @@ function _getClientStreamingInterceptor(method_definition, channel, emitter,
         callback(e);
         return;
       }
-      if (_.isFinite(encoding)) {
+      if (Number.isFinite(encoding)) {
         /* Attach the encoding if it is a finite number. This is the closest we
          * can get to checking that it is valid flags */
         message.grpcWriteFlags = encoding;
@@ -1145,7 +1145,7 @@ function _getBidiStreamingInterceptor(method_definition, channel, emitter) {
         callback(e);
         return;
       }
-      if (_.isFinite(encoding)) {
+      if (Number.isFinite(encoding)) {
         /* Attach the encoding if it is a finite number. This is the closest we
          * can get to checking that it is valid flags */
         message.grpcWriteFlags = encoding;

--- a/packages/grpc-native-core/src/credentials.js
+++ b/packages/grpc-native-core/src/credentials.js
@@ -170,7 +170,7 @@ exports.createFromMetadataGenerator = function(metadata_generator) {
       var message = '';
       if (error) {
         message = error.message;
-        if (error.hasOwnProperty('code') && _.isFinite(error.code)) {
+        if (error.hasOwnProperty('code') && Number.isFinite(error.code)) {
           code = error.code;
         } else {
           code = constants.status.UNAUTHENTICATED;

--- a/packages/grpc-native-core/src/server.js
+++ b/packages/grpc-native-core/src/server.js
@@ -318,7 +318,7 @@ function _write(chunk, encoding, callback) {
         (new Metadata())._getCoreRepresentation();
     this.call.metadataSent = true;
   }
-  if (_.isFinite(encoding)) {
+  if (Number.isFinite(encoding)) {
     /* Attach the encoding if it is a finite number. This is the closest we
      * can get to checking that it is valid flags */
     message.grpcWriteFlags = encoding;


### PR DESCRIPTION
This drops the usage of `_.isFinite` in favor of `Number.isFinite`