### PR TITLE
refactor: drop usage of _.startsWith

### DIFF
--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -935,7 +935,7 @@ exports.makeClientConstructor = function(methods, serviceName,
   ServiceClient.prototype.$method_names = {};
 
   _.each(methods, function(attrs, name) {
-    if (_.startsWith(name, '$')) {
+    if (name.indexOf('$') === 0) {
       throw new Error('Method names cannot start with $');
     }
     var method_type = common.getMethodType(attrs);

--- a/packages/grpc-native-core/test/surface_test.js
+++ b/packages/grpc-native-core/test/surface_test.js
@@ -489,8 +489,8 @@ describe('Echo metadata', function() {
     var call = client.unary({}, metadata,
                             function(err, data) { assert.ifError(err); });
     call.on('metadata', function(metadata) {
-      assert(_.startsWith(metadata.get('user-agent')[0],
-                          'grpc-node/' + version));
+      assert.strictEqual(0,
+        metadata.get('user-agent')[0].indexOf('grpc-node/' + version));
       done();
     });
   });


### PR DESCRIPTION
This replaces `_.startsWith` with the native `String.prototype.indexOf`.