### PR TITLE
refactor: use Array.isArray instead of _.isArray

### DIFF
--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -371,7 +371,7 @@ function Client(address, credentials, options) {
   }
 
   // Resolve interceptor options and assign interceptors to each method
-  if (_.isArray(options.interceptor_providers) && _.isArray(options.interceptors)) {
+  if (Array.isArray(options.interceptor_providers) && Array.isArray(options.interceptors)) {
     throw new client_interceptors.InterceptorConfigurationError(
       'Both interceptors and interceptor_providers were passed as options ' +
       'to the client constructor. Only one of these is allowed.');
@@ -409,12 +409,12 @@ function Client(address, credentials, options) {
 exports.Client = Client;
 
 Client.prototype.resolveCallInterceptors = function(method_definition, interceptors, interceptor_providers) {
-  if (_.isArray(interceptors) && _.isArray(interceptor_providers)) {
+  if (Array.isArray(interceptors) && Array.isArray(interceptor_providers)) {
     throw new client_interceptors.InterceptorConfigurationError(
       'Both interceptors and interceptor_providers were passed as call ' +
       'options. Only one of these is allowed.');
   }
-  if (_.isArray(interceptors) || _.isArray(interceptor_providers)) {
+  if (Array.isArray(interceptors) || Array.isArray(interceptor_providers)) {
     interceptors = interceptors || [];
     interceptor_providers = interceptor_providers || [];
     return client_interceptors.resolveInterceptorProviders(interceptor_providers, method_definition).concat(interceptors);

--- a/packages/grpc-native-core/src/client_interceptors.js
+++ b/packages/grpc-native-core/src/client_interceptors.js
@@ -353,7 +353,7 @@ RequesterBuilder.prototype.build = function() {
  * @return {null|Interceptor[]}
  */
 var resolveInterceptorProviders = function(providers, method_definition) {
-  if (!_.isArray(providers)) {
+  if (!Array.isArray(providers)) {
     return null;
   }
   var interceptors = [];

--- a/packages/grpc-native-core/src/protobuf_js_5_common.js
+++ b/packages/grpc-native-core/src/protobuf_js_5_common.js
@@ -167,5 +167,5 @@ exports.loadObject = function loadObject(value, options) {
  *   ReflectionObject
  */
 exports.isProbablyProtobufJs5 = function isProbablyProtobufJs5(obj) {
-  return _.isArray(obj.children) && (typeof obj.build === 'function');
+  return Array.isArray(obj.children) && (typeof obj.build === 'function');
 };

--- a/packages/grpc-native-core/test/client_interceptors_test.js
+++ b/packages/grpc-native-core/test/client_interceptors_test.js
@@ -39,7 +39,7 @@ var CallRegistry = function(done, expectation, is_ordered, is_verbose) {
   this.call_array = [];
   this.done = done;
   this.expectation = expectation;
-  this.expectation_is_array = _.isArray(this.expectation);
+  this.expectation_is_array = Array.isArray(this.expectation);
   this.is_ordered = is_ordered;
   this.is_verbose = is_verbose;
   if (is_verbose) {


### PR DESCRIPTION
This uses the native `Array.isArray` instead of lodash. 