### PR TITLE
refactor: drop usage of _.bind

### DIFF
--- a/packages/grpc-native-core/src/server.js
+++ b/packages/grpc-native-core/src/server.js
@@ -871,15 +871,14 @@ Server.prototype.addService = function(service, implementation) {
   if (!_.isObject(service) || !_.isObject(implementation)) {
     throw new Error('addService requires two objects as arguments');
   }
-  if (Object.keys(service).length === 0) {
+  if (_.keys(service).length === 0) {
     throw new Error('Cannot add an empty service to a server');
   }
   if (this.started) {
     throw new Error('Can\'t add a service to a started server.');
   }
   var self = this;
-  Object.keys(service).forEach(key => {
-    const attrs = service[key];
+  _.forOwn(service, function(attrs, name) {
     var method_type;
     if (attrs.requestStream) {
       if (attrs.responseStream) {

--- a/packages/grpc-native-core/src/server.js
+++ b/packages/grpc-native-core/src/server.js
@@ -871,14 +871,15 @@ Server.prototype.addService = function(service, implementation) {
   if (!_.isObject(service) || !_.isObject(implementation)) {
     throw new Error('addService requires two objects as arguments');
   }
-  if (_.keys(service).length === 0) {
+  if (Object.keys(service).length === 0) {
     throw new Error('Cannot add an empty service to a server');
   }
   if (this.started) {
     throw new Error('Can\'t add a service to a started server.');
   }
   var self = this;
-  _.forOwn(service, function(attrs, name) {
+  Object.keys(service).forEach(key => {
+    const attrs = service[key];
     var method_type;
     if (attrs.requestStream) {
       if (attrs.responseStream) {
@@ -903,10 +904,10 @@ Server.prototype.addService = function(service, implementation) {
             ' for ' + attrs.path + ' expected but not provided');
         impl = defaultHandler[method_type];
       } else {
-        impl = _.bind(implementation[attrs.originalName], implementation);
+        impl = implementation[attrs.originalName].bind(implementation);
       }
     } else {
-      impl = _.bind(implementation[name], implementation);
+      impl = implementation[name].bind(implementation);
     }
     var serialize = attrs.responseSerialize;
     var deserialize = attrs.requestDeserialize;


### PR DESCRIPTION
Replaces `_.bind` with the native `Function.prototype.bind`.