### PR TITLE
refactor: use Object.assign

### DIFF
--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -72,8 +72,8 @@ grpc.setDefaultRootsPem(fs.readFileSync(SSL_ROOTS_PATH, 'ascii'));
  * @return {Object<string, *>} The resulting gRPC object.
  */
 exports.loadObject = function loadObject(value, options) {
-  options = _.defaults(options, common.defaultGrpcOptions);
-  options = _.defaults(options, {'protobufjsVersion': 'detect'});
+  options = Object.assign(common.defaultGrpcOptions, options);
+  options = Object.assign({'protobufjsVersion': 'detect'}, options);
   var protobufjsVersion;
   if (options.protobufjsVersion === 'detect') {
     if (protobuf_js_6_common.isProbablyProtobufJs6(value)) {
@@ -122,7 +122,7 @@ var loadObject = exports.loadObject;
  * @return {Object<string, *>} The resulting gRPC object
  */
 exports.load = util.deprecate(function load(filename, format, options) {
-  options = _.defaults(options, common.defaultGrpcOptions);
+  options = Object.assign(common.defaultGrpcOptions, options);
   options.protobufjsVersion = 5;
   if (!format) {
     format = 'proto';

--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -72,8 +72,8 @@ grpc.setDefaultRootsPem(fs.readFileSync(SSL_ROOTS_PATH, 'ascii'));
  * @return {Object<string, *>} The resulting gRPC object.
  */
 exports.loadObject = function loadObject(value, options) {
-  options = Object.assign(common.defaultGrpcOptions, options);
-  options = Object.assign({'protobufjsVersion': 'detect'}, options);
+  options = Object.assign({}, common.defaultGrpcOptions, options);
+  options = Object.assign({}, {'protobufjsVersion': 'detect'}, options);
   var protobufjsVersion;
   if (options.protobufjsVersion === 'detect') {
     if (protobuf_js_6_common.isProbablyProtobufJs6(value)) {
@@ -122,7 +122,7 @@ var loadObject = exports.loadObject;
  * @return {Object<string, *>} The resulting gRPC object
  */
 exports.load = util.deprecate(function load(filename, format, options) {
-  options = Object.assign(common.defaultGrpcOptions, options);
+  options = Object.assign({}, common.defaultGrpcOptions, options);
   options.protobufjsVersion = 5;
   if (!format) {
     format = 'proto';

--- a/packages/grpc-native-core/src/server.js
+++ b/packages/grpc-native-core/src/server.js
@@ -932,12 +932,12 @@ Server.prototype.addProtoService = util.deprecate(function(service,
   var protobuf_js_5_common = require('./protobuf_js_5_common');
   var protobuf_js_6_common = require('./protobuf_js_6_common');
   if (protobuf_js_5_common.isProbablyProtobufJs5(service)) {
-    options = Object.assign(common.defaultGrpcOptions, service.grpc_options);
+    options = Object.assign({}, common.defaultGrpcOptions, service.grpc_options);
     this.addService(
         protobuf_js_5_common.getProtobufServiceAttrs(service, options),
         implementation);
   } else if (protobuf_js_6_common.isProbablyProtobufJs6(service)) {
-    options = Object.assign(common.defaultGrpcOptions, service.grpc_options);
+    options = Object.assign({}, common.defaultGrpcOptions, service.grpc_options);
     this.addService(
         protobuf_js_6_common.getProtobufServiceAttrs(service, options),
         implementation);

--- a/packages/grpc-native-core/src/server.js
+++ b/packages/grpc-native-core/src/server.js
@@ -932,12 +932,12 @@ Server.prototype.addProtoService = util.deprecate(function(service,
   var protobuf_js_5_common = require('./protobuf_js_5_common');
   var protobuf_js_6_common = require('./protobuf_js_6_common');
   if (protobuf_js_5_common.isProbablyProtobufJs5(service)) {
-    options = _.defaults(service.grpc_options, common.defaultGrpcOptions);
+    options = Object.assign(common.defaultGrpcOptions, service.grpc_options);
     this.addService(
         protobuf_js_5_common.getProtobufServiceAttrs(service, options),
         implementation);
   } else if (protobuf_js_6_common.isProbablyProtobufJs6(service)) {
-    options = _.defaults(service.grpc_options, common.defaultGrpcOptions);
+    options = Object.assign(common.defaultGrpcOptions, service.grpc_options);
     this.addService(
         protobuf_js_6_common.getProtobufServiceAttrs(service, options),
         implementation);

--- a/packages/grpc-native-core/test/common_test.js
+++ b/packages/grpc-native-core/test/common_test.js
@@ -81,7 +81,7 @@ describe('Proto message long int serialize and deserialize', function() {
                        neg_value);
   });
   it('should deserialize as a number with the right option set', function() {
-    var num_options = Object.assign(default_options, {longsAsStrings: false});
+    var num_options = Object.assign({}, default_options, {longsAsStrings: false});
     var longNumDeserialize = deserializeCls(messages_proto.LongValues,
                                             num_options);
     var serialized = longSerialize({int_64: pos_value});
@@ -95,7 +95,7 @@ describe('Proto message bytes serialize and deserialize', function() {
   var sequenceSerialize = serializeCls(messages_proto.SequenceValues);
   var sequenceDeserialize = deserializeCls(
       messages_proto.SequenceValues, default_options);
-  var b64_options = Object.assign(default_options, {binaryAsBase64: true});
+  var b64_options = Object.assign({}, default_options, {binaryAsBase64: true});
   var sequenceBase64Deserialize = deserializeCls(
       messages_proto.SequenceValues, b64_options);
   var buffer_val = new Buffer([0x69, 0xb7]);
@@ -169,7 +169,7 @@ describe('Proto message enum serialize and deserialize', function() {
   var enumSerialize = serializeCls(messages_proto.EnumValues);
   var enumDeserialize = deserializeCls(
       messages_proto.EnumValues, default_options);
-  var enumIntOptions = Object.assign(default_options, {enumsAsStrings: false});
+  var enumIntOptions = Object.assign({}, default_options, {enumsAsStrings: false});
   var enumIntDeserialize = deserializeCls(
       messages_proto.EnumValues, enumIntOptions);
   it('Should accept both names and numbers', function() {

--- a/packages/grpc-native-core/test/common_test.js
+++ b/packages/grpc-native-core/test/common_test.js
@@ -81,7 +81,7 @@ describe('Proto message long int serialize and deserialize', function() {
                        neg_value);
   });
   it('should deserialize as a number with the right option set', function() {
-    var num_options = _.defaults({longsAsStrings: false}, default_options);
+    var num_options = Object.assign(default_options, {longsAsStrings: false});
     var longNumDeserialize = deserializeCls(messages_proto.LongValues,
                                             num_options);
     var serialized = longSerialize({int_64: pos_value});
@@ -95,7 +95,7 @@ describe('Proto message bytes serialize and deserialize', function() {
   var sequenceSerialize = serializeCls(messages_proto.SequenceValues);
   var sequenceDeserialize = deserializeCls(
       messages_proto.SequenceValues, default_options);
-  var b64_options = _.defaults({binaryAsBase64: true}, default_options);
+  var b64_options = Object.assign(default_options, {binaryAsBase64: true});
   var sequenceBase64Deserialize = deserializeCls(
       messages_proto.SequenceValues, b64_options);
   var buffer_val = new Buffer([0x69, 0xb7]);
@@ -169,7 +169,7 @@ describe('Proto message enum serialize and deserialize', function() {
   var enumSerialize = serializeCls(messages_proto.EnumValues);
   var enumDeserialize = deserializeCls(
       messages_proto.EnumValues, default_options);
-  var enumIntOptions = _.defaults({enumsAsStrings: false}, default_options);
+  var enumIntOptions = Object.assign(default_options, {enumsAsStrings: false});
   var enumIntDeserialize = deserializeCls(
       messages_proto.EnumValues, enumIntOptions);
   it('Should accept both names and numbers', function() {


### PR DESCRIPTION
This replaces the usage of `_.defaults` with `Object.assign`.  Note that the order of assignment with this change is reversed.