### PR TITLE
Add missing sendTrailers method in ClientHttp2StreamMock

### DIFF
--- a/packages/grpc-js/test/test-call-stream.ts
+++ b/packages/grpc-js/test/test-call-stream.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import {OutgoingHttpHeaders} from 'http';
 import * as http2 from 'http2';
 import {range} from 'lodash';
 import * as stream from 'stream';
@@ -46,6 +47,9 @@ class ClientHttp2StreamMock extends stream.Duplex implements
   endAfterHeaders = false;
   pending = false;
   rstCode = 0;
+  readonly sentHeaders: OutgoingHttpHeaders = {};
+  readonly sentInfoHeaders?: OutgoingHttpHeaders[] = [];
+  readonly sentTrailers?: OutgoingHttpHeaders = undefined;
   // tslint:disable:no-any
   session: http2.Http2Session = {} as any;
   state: http2.StreamState = {} as any;
@@ -75,6 +79,9 @@ class ClientHttp2StreamMock extends stream.Duplex implements
   _write(chunk: Buffer, encoding: string, cb: Function) {
     this.emit('write', chunk);
     cb();
+  }
+  sendTrailers(headers: OutgoingHttpHeaders) {
+    return this;
   }
 }
 


### PR DESCRIPTION
This should fix grpc/grpc#17218. This change is needed now as a result of the changes made in DefinitelyTyped/DefinitelyTyped#30425, which reflects changes made to the http2 module itself in Node 10.