### PR TITLE
refactor: use Object.keys

### DIFF
--- a/packages/grpc-native-core/src/client_interceptors.js
+++ b/packages/grpc-native-core/src/client_interceptors.js
@@ -746,14 +746,14 @@ function _areBatchRequirementsMet(batch_ops, completed_ops) {
 function _startBatchIfReady(call, batch, batch_state, callback) {
   var completed_ops = batch_state.completed_ops;
   var deferred_batches = batch_state.deferred_batches;
-  var batch_ops = _.keys(batch).map(Number);
+  var batch_ops = Object.keys(batch).map(Number);
   if (_areBatchRequirementsMet(batch_ops, completed_ops)) {
     // Dependencies are met, start the batch and any deferred batches whose
     // dependencies are met as a result.
     call.startBatch(batch, callback);
     completed_ops = _.union(completed_ops, batch_ops);
     deferred_batches = _.flatMap(deferred_batches, function(deferred_batch) {
-      var deferred_batch_ops = _.keys(deferred_batch).map(Number);
+      var deferred_batch_ops = Object.keys(deferred_batch).map(Number);
       if (_areBatchRequirementsMet(deferred_batch_ops, completed_ops)) {
         call.startBatch(deferred_batch.batch, deferred_batch.callback);
         return [];

--- a/packages/grpc-native-core/src/server.js
+++ b/packages/grpc-native-core/src/server.js
@@ -871,7 +871,7 @@ Server.prototype.addService = function(service, implementation) {
   if (!_.isObject(service) || !_.isObject(implementation)) {
     throw new Error('addService requires two objects as arguments');
   }
-  if (_.keys(service).length === 0) {
+  if (Object.keys(service).length === 0) {
     throw new Error('Cannot add an empty service to a server');
   }
   if (this.started) {


### PR DESCRIPTION
Uses `Object.keys` instead of `_.keys`