### PR TITLE
refactor: stop using _.identity

### DIFF
--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -895,8 +895,8 @@ var deprecated_request_wrap = {
                                           opt_args.options, callback);
     };
   },
-  [methodTypes.SERVER_STREAMING]: _.identity,
-  [methodTypes.BIDI_STREAMING]: _.identity
+  [methodTypes.SERVER_STREAMING]: x => x,
+  [methodTypes.BIDI_STREAMING]: x => x
 };
 
 /**

--- a/packages/grpc-native-core/src/common.js
+++ b/packages/grpc-native-core/src/common.js
@@ -30,7 +30,7 @@ var constants = require('./constants');
  */
 exports.wrapIgnoreNull = function wrapIgnoreNull(func) {
   if (!func) {
-    return _.identity;
+    return x => x;
   }
   return function(arg) {
     if (arg === null || arg === undefined) {

--- a/packages/grpc-native-core/test/surface_test.js
+++ b/packages/grpc-native-core/test/surface_test.js
@@ -204,10 +204,10 @@ describe('Client constructor building', function() {
       path: '/illegal/$method',
       requestStream: false,
       responseStream: false,
-      requestSerialize: _.identity,
-      requestDeserialize: _.identity,
-      responseSerialize: _.identity,
-      responseDeserialize: _.identity
+      requestSerialize: x => x,
+      requestDeserialize: x => x,
+      responseSerialize: x => x,
+      responseDeserialize: x => x
     }
   };
   it('Should reject method names starting with $', function() {
@@ -628,29 +628,29 @@ describe('Client malformed response handling', function() {
         path: '/TestService/Unary',
         requestStream: false,
         responseStream: false,
-        requestDeserialize: _.identity,
-        responseSerialize: _.identity
+        requestDeserialize: x => x,
+        responseSerialize: x => x
       },
       clientStream: {
         path: '/TestService/ClientStream',
         requestStream: true,
         responseStream: false,
-        requestDeserialize: _.identity,
-        responseSerialize: _.identity
+        requestDeserialize: x => x,
+        responseSerialize: x => x
       },
       serverStream: {
         path: '/TestService/ServerStream',
         requestStream: false,
         responseStream: true,
-        requestDeserialize: _.identity,
-        responseSerialize: _.identity
+        requestDeserialize: x => x,
+        responseSerialize: x => x
       },
       bidiStream: {
         path: '/TestService/BidiStream',
         requestStream: true,
         responseStream: true,
-        requestDeserialize: _.identity,
-        responseSerialize: _.identity
+        requestDeserialize: x => x,
+        responseSerialize: x => x
       }
     };
     server = new grpc.Server();
@@ -729,28 +729,28 @@ describe('Server serialization failure handling', function() {
         path: '/TestService/Unary',
         requestStream: false,
         responseStream: false,
-        requestDeserialize: _.identity,
+        requestDeserialize: x => x,
         responseSerialize: serializeFail
       },
       clientStream: {
         path: '/TestService/ClientStream',
         requestStream: true,
         responseStream: false,
-        requestDeserialize: _.identity,
+        requestDeserialize: x => x,
         responseSerialize: serializeFail
       },
       serverStream: {
         path: '/TestService/ServerStream',
         requestStream: false,
         responseStream: true,
-        requestDeserialize: _.identity,
+        requestDeserialize: x => x,
         responseSerialize: serializeFail
       },
       bidiStream: {
         path: '/TestService/BidiStream',
         requestStream: true,
         responseStream: true,
-        requestDeserialize: _.identity,
+        requestDeserialize: x => x,
         responseSerialize: serializeFail
       }
     };
@@ -943,29 +943,29 @@ describe('Other conditions', function() {
           path: '/TestService/Unary',
           requestStream: false,
           responseStream: false,
-          requestSerialize: _.identity,
-          responseDeserialize: _.identity
+          requestSerialize: x => x,
+          responseDeserialize: x => x
         },
         clientStream: {
           path: '/TestService/ClientStream',
           requestStream: true,
           responseStream: false,
-          requestSerialize: _.identity,
-          responseDeserialize: _.identity
+          requestSerialize: x => x,
+          responseDeserialize: x => x
         },
         serverStream: {
           path: '/TestService/ServerStream',
           requestStream: false,
           responseStream: true,
-          requestSerialize: _.identity,
-          responseDeserialize: _.identity
+          requestSerialize: x => x,
+          responseDeserialize: x => x
         },
         bidiStream: {
           path: '/TestService/BidiStream',
           requestStream: true,
           responseStream: true,
-          requestSerialize: _.identity,
-          responseDeserialize: _.identity
+          requestSerialize: x => x,
+          responseDeserialize: x => x
         }
       };
       var Client = grpc.makeGenericClientConstructor(test_service_attrs,


### PR DESCRIPTION
This just replaces the usage of `_.identity` with `x => x`