### PR TITLE
refactor: drop usage of _.zipObject

### DIFF
--- a/packages/grpc-native-core/src/common.js
+++ b/packages/grpc-native-core/src/common.js
@@ -112,6 +112,20 @@ exports.getMethodType = function(method_definition) {
   }
 };
 
+/**
+ * Given an array of property names and an array of values,
+ * combine the two into an object map.
+ * Equivalent to _.zipObject.
+ * @param props {Array<String>} Array of property names
+ * @param values {Array} Array of property values
+ * @return {Object} An object with the combined values
+ */
+exports.zipObject = function(props, values) {
+  return props.reduce((acc, curr, idx) => {
+    return Object.assign(acc, { [curr]: values[idx] });
+  }, {});
+}
+
 // JSDoc definitions that are used in multiple other modules
 
 /**

--- a/packages/grpc-native-core/src/protobuf_js_5_common.js
+++ b/packages/grpc-native-core/src/protobuf_js_5_common.js
@@ -25,6 +25,7 @@
 
 var _ = require('lodash');
 var client = require('./client');
+var common = require('./common');
 
 /**
  * Get a function that deserializes a specific type of protobuf.
@@ -106,7 +107,7 @@ exports.getProtobufServiceAttrs = function getProtobufServiceAttrs(service,
      lodash@3.10.1-compatible functions. A previous version used
      _.fromPairs, which would be cleaner, but was introduced in lodash
      version 4 */
-  return _.zipObject(service.children.map(function(method) {
+  return common.zipObject(service.children.map(function(method) {
     return _.camelCase(method.name);
   }), service.children.map(function(method) {
     return {

--- a/packages/grpc-native-core/src/protobuf_js_6_common.js
+++ b/packages/grpc-native-core/src/protobuf_js_6_common.js
@@ -25,6 +25,7 @@
 
 var _ = require('lodash');
 var client = require('./client');
+var common = require('./common');
 
 /**
  * Get a function that deserializes a specific type of protobuf.
@@ -103,7 +104,7 @@ exports.getProtobufServiceAttrs = function getProtobufServiceAttrs(service,
                                                                    options) {
   var prefix = '/' + fullyQualifiedName(service) + '/';
   service.resolveAll();
-  return _.zipObject(service.methods.map(function(method) {
+  return common.zipObject(service.methods.map(function(method) {
     return _.camelCase(method.name);
   }), service.methods.map(function(method) {
     return {


### PR DESCRIPTION
Replaces `_.zipObject` with a reduce function.