### PR TITLE
refactor: use lodash subpackages

### DIFF
--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -24,8 +24,6 @@ var util = require('util');
 
 var SSL_ROOTS_PATH = path.resolve(__dirname, 'deps', 'grpc', 'etc', 'roots.pem');
 
-var _ = require('lodash');
-
 var ProtoBuf = require('protobufjs');
 
 var client = require('./src/client.js');

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -29,7 +29,8 @@
     "node-pre-gyp"
   ],
   "dependencies": {
-    "lodash": "^4.17.5",
+    "lodash.camelcase": "^4.3.0",
+    "lodash.clone": "^4.5.0",
     "nan": "^2.0.0",
     "node-pre-gyp": "^0.12.0",
     "protobufjs": "^5.0.3"

--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -32,8 +32,6 @@
 
 'use strict';
 
-var _ = require('lodash');
-
 var client_interceptors = require('./client_interceptors');
 var grpc = require('./grpc_extension');
 
@@ -949,7 +947,7 @@ exports.makeClientConstructor = function(methods, serviceName,
     }
     var method_type = common.getMethodType(attrs);
     var method_func = function() {
-      return requester_funcs[method_type].apply(this, 
+      return requester_funcs[method_type].apply(this,
         [ attrs.path, attrs.requestSerialize, attrs.responseDeserialize ]
         .concat([].slice.call(arguments))
       );

--- a/packages/grpc-native-core/src/client_interceptors.js
+++ b/packages/grpc-native-core/src/client_interceptors.js
@@ -141,7 +141,6 @@
 
 'use strict';
 
-var _ = require('lodash');
 var grpc = require('./grpc_extension');
 var Metadata = require('./metadata');
 var constants = require('./constants');

--- a/packages/grpc-native-core/src/common.js
+++ b/packages/grpc-native-core/src/common.js
@@ -18,7 +18,6 @@
 
 'use strict';
 
-var _ = require('lodash');
 var constants = require('./constants');
 
 /**

--- a/packages/grpc-native-core/src/credentials.js
+++ b/packages/grpc-native-core/src/credentials.js
@@ -69,8 +69,6 @@ var common = require('./common.js');
 
 var constants = require('./constants');
 
-var _ = require('lodash');
-
 /**
  * @external GoogleCredential
  * @see https://github.com/google/google-auth-library-nodejs

--- a/packages/grpc-native-core/src/metadata.js
+++ b/packages/grpc-native-core/src/metadata.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-var _ = require('lodash');
+var clone = require('lodash.clone');
 
 var grpc = require('./grpc_extension');
 
@@ -139,7 +139,7 @@ Metadata.prototype.clone = function() {
   var copy = new Metadata();
   Object.keys(this._internal_repr).forEach(key => {
     const value = this._internal_repr[key];
-    copy._internal_repr[key] = _.clone(value);
+    copy._internal_repr[key] = clone(value);
   });
   return copy;
 };
@@ -166,7 +166,7 @@ Metadata._fromCoreRepresentation = function(metadata) {
   if (metadata) {
     Object.keys(metadata).forEach(key => {
       const value = metadata[key];
-      newMetadata._internal_repr[key] = _.clone(value);
+      newMetadata._internal_repr[key] = clone(value);
     });
   }
   return newMetadata;

--- a/packages/grpc-native-core/src/protobuf_js_5_common.js
+++ b/packages/grpc-native-core/src/protobuf_js_5_common.js
@@ -23,7 +23,7 @@
 
 'use strict';
 
-var _ = require('lodash');
+var camelCase = require('lodash.camelcase');
 var client = require('./client');
 var common = require('./common');
 
@@ -108,7 +108,7 @@ exports.getProtobufServiceAttrs = function getProtobufServiceAttrs(service,
      _.fromPairs, which would be cleaner, but was introduced in lodash
      version 4 */
   return common.zipObject(service.children.map(function(method) {
-    return _.camelCase(method.name);
+    return camelCase(method.name);
   }), service.children.map(function(method) {
     return {
       originalName: method.name,

--- a/packages/grpc-native-core/src/protobuf_js_6_common.js
+++ b/packages/grpc-native-core/src/protobuf_js_6_common.js
@@ -23,7 +23,7 @@
 
 'use strict';
 
-var _ = require('lodash');
+var camelCase = require('lodash.camelcase');
 var client = require('./client');
 var common = require('./common');
 
@@ -105,7 +105,7 @@ exports.getProtobufServiceAttrs = function getProtobufServiceAttrs(service,
   var prefix = '/' + fullyQualifiedName(service) + '/';
   service.resolveAll();
   return common.zipObject(service.methods.map(function(method) {
-    return _.camelCase(method.name);
+    return camelCase(method.name);
   }), service.methods.map(function(method) {
     return {
       originalName: method.name,

--- a/packages/grpc-native-core/src/server.js
+++ b/packages/grpc-native-core/src/server.js
@@ -18,8 +18,6 @@
 
 'use strict';
 
-var _ = require('lodash');
-
 var grpc = require('./grpc_extension');
 
 var common = require('./common');

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -31,7 +31,8 @@
       "node-pre-gyp"
     ],
     "dependencies": {
-      "lodash": "^4.17.5",
+      "lodash.camelcase": "^4.3.0",
+      "lodash.clone": "^4.5.0",
       "nan": "^2.0.0",
       "node-pre-gyp": "^0.12.0",
       "protobufjs": "^5.0.3"

--- a/packages/grpc-native-core/test/common_test.js
+++ b/packages/grpc-native-core/test/common_test.js
@@ -19,7 +19,6 @@
 'use strict';
 
 var assert = require('assert');
-var _ = require('lodash');
 
 var common = require('../src/common');
 var protobuf_js_5_common = require('../src/protobuf_js_5_common');


### PR DESCRIPTION
This is the final PR for dropping `lodash` 🍻