### PR TITLE
refactor: drop dependency on google-auth-library

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -39,7 +39,6 @@
     "body-parser": "^1.15.2",
     "electron-mocha": "^3.1.1",
     "express": "^4.14.0",
-    "google-auth-library": "^0.9.2",
     "google-protobuf": "^3.0.0",
     "istanbul": "^0.4.4",
     "lodash": "^4.17.4",

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -41,7 +41,6 @@
       "body-parser": "^1.15.2",
       "electron-mocha": "^3.1.1",
       "express": "^4.14.0",
-      "google-auth-library": "^0.9.2",
       "google-protobuf": "^3.0.0",
       "istanbul": "^0.4.4",
       "lodash": "^4.17.4",


### PR DESCRIPTION
Best I can tell, it isn't used, and we were installing a very, very old version.