### PR TITLE
refactor: drop dependency on async

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -35,7 +35,6 @@
     "protobufjs": "^5.0.3"
   },
   "devDependencies": {
-    "async": "^2.0.1",
     "body-parser": "^1.15.2",
     "electron-mocha": "^3.1.1",
     "express": "^4.14.0",

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -37,7 +37,6 @@
       "protobufjs": "^5.0.3"
     },
     "devDependencies": {
-      "async": "^2.0.1",
       "body-parser": "^1.15.2",
       "electron-mocha": "^3.1.1",
       "express": "^4.14.0",


### PR DESCRIPTION
Best I can tell, it's never used.