### PR TITLE
fix: require package.json directly

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -15,7 +15,7 @@ import {Metadata} from './metadata';
 import {MetadataStatusFilterFactory} from './metadata-status-filter';
 import {Http2SubChannel} from './subchannel';
 
-const {version: clientVersion} = require('../../package');
+const {version: clientVersion} = require('../../package.json');
 
 const MIN_CONNECT_TIMEOUT_MS = 20000;
 const INITIAL_BACKOFF_MS = 1000;


### PR DESCRIPTION
# Problem

When running jest tests against a project that includes `grpc-js` I'm getting the following module resolve related error from jest:

```
 FAIL  test/unit/lnd/util.spec.js
 Test suite failed to run

    Cannot find module '../../package' from 'channel.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@grpc/grpc-js/build/src/channel.js:16:36)
```

This is caused by the following code:

```javascript
require('../../package')
```

The problem is that grpc-js is relying on the node module resolver to load in package.json when there is really no need for it to do this.

This is the only place in the code where `package.json` is required in this way. All other places it is required as a file (`require('../../package.json')`

# Solution

Require package.json as a file rather than relying on the node module resolver:

change:
```javascript
require('../../package')
```

to:
```javascript
require('../../package.json')
```