### PR TITLE
Support for protobufjs's bundled definitions

### DIFF
--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -119,9 +119,15 @@ function createPackageDefinition(root: Protobuf.Root, options: Options): Package
 
 function addIncludePathResolver(root: Protobuf.Root, includePaths: string[]) {
   root.resolvePath = (origin: string, target: string) => {
+    const idx = target.lastIndexOf("google/protobuf/");
+    if (idx > -1 && target.substring(idx) in Protobuf.common) {
+      return target;
+    } 	
+
     if (path.isAbsolute(target)) {
       return target;
     }
+
     for (const directory of includePaths) {
       const fullPath: string = path.join(directory, target);
       try {
@@ -131,6 +137,7 @@ function addIncludePathResolver(root: Protobuf.Root, includePaths: string[]) {
         continue;
       }
     }
+
     throw new Error(`Could not find file ${target}`);
   };
 }


### PR DESCRIPTION
The `protobufjs` library in the` common.js` module contains definitions for standard types such as `google.protobuf.Empty`,` google.protobuf.Timestamp`, etc. This fix allows you to use them in a loadable proto-file without providing files containing them.