### PR TITLE
Native: Protobuf.js 6 loadObject: switch to mappable methodsArray

### DIFF
--- a/packages/grpc-native-core/src/protobuf_js_6_common.js
+++ b/packages/grpc-native-core/src/protobuf_js_6_common.js
@@ -104,9 +104,9 @@ exports.getProtobufServiceAttrs = function getProtobufServiceAttrs(service,
                                                                    options) {
   var prefix = '/' + fullyQualifiedName(service) + '/';
   service.resolveAll();
-  return common.zipObject(service.methods.map(function(method) {
+  return common.zipObject(service.methodsArray.map(function(method) {
     return camelCase(method.name);
-  }), service.methods.map(function(method) {
+  }), service.methodsArray.map(function(method) {
     return {
       originalName: method.name,
       path: prefix + method.name,


### PR DESCRIPTION
This fixes an error when using `loadObject` with Protobuf.js 6 exposed by a change introduced in #618. See [these docs](http://dcode.io/protobuf.js/Service.html) for the definition of the new variable.