### PR TITLE
Native: Protobuf.js 6 loadObject: switch to nestedArray

### DIFF
--- a/packages/grpc-native-core/src/protobuf_js_6_common.js
+++ b/packages/grpc-native-core/src/protobuf_js_6_common.js
@@ -135,11 +135,10 @@ exports.loadObject = function loadObject(value, options) {
     return client.makeClientConstructor(service_attrs);
   }
 
-  if (value.hasOwnProperty('nested')) {
+  if (value.hasOwnProperty('nestedArray')) {
     // It's a namespace or root object
-    Object.keys(value.nested).forEach(name => {
-      const nested = value.nested[name];
-      result[name] = loadObject(nested, options);
+    value.nestedArray.forEach(nested => {
+      result[nested.name] = loadObject(nested, options);
     });
     return result;
   }


### PR DESCRIPTION
This fixes an error reported in https://github.com/grpc/grpc-node/issues/556#issuecomment-445176480. The documentation for those two members is [here](http://dcode.io/protobuf.js/NamespaceBase.html). Importantly, `nested` can be `undefined`, but `nestedArray` is always an array.