### PR TITLE
proto loader: Fall back to default path resolution

### DIFF
--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -118,6 +118,7 @@ function createPackageDefinition(root: Protobuf.Root, options: Options): Package
 }
 
 function addIncludePathResolver(root: Protobuf.Root, includePaths: string[]) {
+  const originalResolvePath = root.resolvePath;
   root.resolvePath = (origin: string, target: string) => {
     if (path.isAbsolute(target)) {
       return target;
@@ -131,7 +132,7 @@ function addIncludePathResolver(root: Protobuf.Root, includePaths: string[]) {
         continue;
       }
     }
-    throw new Error(`Could not find file ${target}`);
+    return originalResolvePath(origin, target);
   };
 }
 


### PR DESCRIPTION
Fixes the bug described in #668. When handling "common" proto files, the Protobuf.js internals assume that the resolver outputs paths in a particular format, so we use its own resolver when the file cannot be found using the include paths.