### PR TITLE
Pin nan to non-buggy recent version

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "lodash.camelcase": "^4.3.0",
     "lodash.clone": "^4.5.0",
-    "nan": "^2.0.0",
+    "nan": "2.11.1",
     "node-pre-gyp": "^0.12.0",
     "protobufjs": "^5.0.3"
   },

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -33,7 +33,7 @@
     "dependencies": {
       "lodash.camelcase": "^4.3.0",
       "lodash.clone": "^4.5.0",
-      "nan": "^2.0.0",
+      "nan": "2.11.1",
       "node-pre-gyp": "^0.12.0",
       "protobufjs": "^5.0.3"
     },


### PR DESCRIPTION
Nan version 2.12.0 is buggy; we are specifically having a problem with nodejs/nan#83, so we pin to 2.11.1. We should undo this once nodejs/nan#833 is merged and published.