### PR TITLE
Add message and enum type information to package definition output.

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -99,7 +99,7 @@ gulp.task('native.test', 'Run tests of native code', (callback) => {
 });
 
 gulp.task('test.only', 'Run tests without rebuilding anything',
-          ['js.core.test', 'native.test.only']);
+          ['js.core.test', 'native.test.only', 'protobuf.test']);
 
 gulp.task('test', 'Run all tests', (callback) => {
   runSequence('build', 'test.only', 'internal.test.test', callback);

--- a/packages/proto-loader/gulpfile.ts
+++ b/packages/proto-loader/gulpfile.ts
@@ -54,7 +54,16 @@ gulp.task('clean', 'Deletes transpiled code.', ['install'],
 gulp.task('clean.all', 'Deletes all files added by targets', ['clean']);
 
 /**
- * Transpiles TypeScript files in src/ to JavaScript according to the settings
+ * Transpiles TypeScript files in src/ and test/ to JavaScript according to the settings
  * found in tsconfig.json.
  */
-gulp.task('compile', 'Transpiles src/.', () => execNpmCommand('compile'));
+gulp.task('compile', 'Transpiles src/ and test/.', () => execNpmCommand('compile'));
+
+/**
+ * Transpiles src/ and test/, and then runs all tests.
+ */
+gulp.task('test', 'Runs all tests.', () => {
+  return gulp.src(`${outDir}/test/**/*.js`)
+    .pipe(mocha({reporter: 'mocha-jenkins-reporter',
+                  require: ['ts-node/register']}));
+});

--- a/packages/proto-loader/gulpfile.ts
+++ b/packages/proto-loader/gulpfile.ts
@@ -22,6 +22,7 @@ import * as fs from 'fs';
 import * as mocha from 'gulp-mocha';
 import * as path from 'path';
 import * as execa from 'execa';
+import * as semver from 'semver';
 
 // gulp-help monkeypatches tasks to have an additional description parameter
 const gulp = help(_gulp);
@@ -63,7 +64,12 @@ gulp.task('compile', 'Transpiles src/ and test/.', () => execNpmCommand('compile
  * Transpiles src/ and test/, and then runs all tests.
  */
 gulp.task('test', 'Runs all tests.', () => {
-  return gulp.src(`${outDir}/test/**/*.js`)
-    .pipe(mocha({reporter: 'mocha-jenkins-reporter',
-                  require: ['ts-node/register']}));
+  if (semver.satisfies(process.version, ">=6")) {
+    return gulp.src(`${outDir}/test/**/*.js`)
+      .pipe(mocha({reporter: 'mocha-jenkins-reporter',
+                    require: ['ts-node/register']}));
+  } else {
+    console.log(`Skipping proto-loader tests for Node ${process.version}`);
+    return Promise.resolve(null);
+  }
 });

--- a/packages/proto-loader/test/descriptor_type_test.ts
+++ b/packages/proto-loader/test/descriptor_type_test.ts
@@ -1,0 +1,53 @@
+import * as assert from 'assert';
+
+import * as proto_loader from '../src/index';
+
+// Relative path from build output directory to test_protos directory
+const TEST_PROTO_DIR = `${__dirname}/../../test_protos/`;
+
+type TypeDefinition = proto_loader.EnumTypeDefinition | proto_loader.MessageTypeDefinition;
+
+function isTypeObject(obj: proto_loader.AnyDefinition): obj is TypeDefinition {
+  return 'format' in obj;
+}
+
+describe('Descriptor types', () => {
+  it('Should be output for each enum', (done) => {
+    proto_loader.load(`${TEST_PROTO_DIR}/enums.proto`).then((packageDefinition) => {
+      assert('Enum1' in packageDefinition);
+      assert(isTypeObject(packageDefinition.Enum1));
+      // Need additional check because compiler doesn't understand asserts
+      if(isTypeObject(packageDefinition.Enum1)) {
+        const enum1Def: TypeDefinition = packageDefinition.Enum1;
+        assert.strictEqual(enum1Def.format, 'Protocol Buffer 3 EnumDescriptorProto');
+      }
+
+      assert('Enum2' in packageDefinition);
+      assert(isTypeObject(packageDefinition.Enum2));
+      // Need additional check because compiler doesn't understand asserts
+      if(isTypeObject(packageDefinition.Enum2)) {
+        const enum2Def: TypeDefinition = packageDefinition.Enum2;
+        assert.strictEqual(enum2Def.format, 'Protocol Buffer 3 EnumDescriptorProto');
+      }
+      done();
+    }, (error) => {done(error);});
+  });
+  it('Should be output for each message', (done) => {
+    proto_loader.load(`${TEST_PROTO_DIR}/messages.proto`).then((packageDefinition) => {
+      assert('LongValues' in packageDefinition);
+      assert(isTypeObject(packageDefinition.LongValues));
+      if(isTypeObject(packageDefinition.LongValues)) {
+        const longValuesDef: TypeDefinition = packageDefinition.LongValues;
+        assert.strictEqual(longValuesDef.format, 'Protocol Buffer 3 DescriptorProto');
+      }
+
+      assert('SequenceValues' in packageDefinition);
+      assert(isTypeObject(packageDefinition.SequenceValues));
+      if(isTypeObject(packageDefinition.SequenceValues)) {
+        const sequenceValuesDef: TypeDefinition = packageDefinition.SequenceValues;
+        assert.strictEqual(sequenceValuesDef.format, 'Protocol Buffer 3 DescriptorProto');
+      }
+      done();
+    }, (error) => {done(error);});
+  });
+});

--- a/packages/proto-loader/test_protos/enums.proto
+++ b/packages/proto-loader/test_protos/enums.proto
@@ -1,0 +1,27 @@
+// Copyright 2019 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+enum Enum1 {
+  DEFAULT = 0;
+  VALUE1 = 1;
+  VALUE2 = 2;
+}
+
+enum Enum2 {
+  DEFAULT = 0;
+  ABC = 5;
+  DEF = 10;
+}

--- a/packages/proto-loader/test_protos/messages.proto
+++ b/packages/proto-loader/test_protos/messages.proto
@@ -1,0 +1,28 @@
+// Copyright 2019 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+message LongValues {
+  int64 int_64 = 1;
+  uint64 uint_64 = 2;
+  sint64 sint_64 = 3;
+  fixed64 fixed_64 = 4;
+  sfixed64 sfixed_64 = 5;
+}
+
+message SequenceValues {
+  bytes bytes_field = 1;
+  repeated int32 repeated_field = 2;
+}

--- a/packages/proto-loader/tsconfig.json
+++ b/packages/proto-loader/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "build"
   },
   "include": [
-    "src/*.ts"
+    "src/*.ts",
+    "test/*.ts"
   ]
 }


### PR DESCRIPTION
This is an implementation of [gRFC proposal L43](https://github.com/grpc/proposal/blob/master/L43-node-type-info.md), adding message and enum type information to the output of the `load` and `loadSync` functions. When loaded into a gRPC implementation using `loadPackageDefinition` those objects will appear in the expected place in the object tree. They will also be included in the `requestType` and `responseType` message properties.

This supersedes PRs #408 and #448, and fixes #407.