### PR TITLE
grpc-js: Fix handling of non-service objects in package definitions

### DIFF
--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -21,7 +21,13 @@ export interface ServiceDefinition {
   [index: string]: MethodDefinition<object, object>;
 }
 
-export interface PackageDefinition { [index: string]: ServiceDefinition; }
+export interface ProtobufTypeDefinition {
+  format: string;
+  type: object;
+  fileDescriptorProtos: Buffer[];
+}
+
+export interface PackageDefinition { [index: string]: ServiceDefinition | ProtobufTypeDefinition; }
 
 /**
  * Map with short names for each of the requester maker functions. Used in
@@ -119,8 +125,12 @@ function partial(
 }
 
 export type GrpcObject = {
-  [index: string]: GrpcObject|ServiceClientConstructor;
+  [index: string]: GrpcObject|ServiceClientConstructor|ProtobufTypeDefinition;
 };
+
+function isProtobufTypeDefinition(obj: ServiceDefinition | ProtobufTypeDefinition): obj is ProtobufTypeDefinition {
+  return 'format' in obj;
+}
 
 /**
  * Load a gRPC package definition as a gRPC object hierarchy.
@@ -142,7 +152,11 @@ export function loadPackageDefinition(packageDef: PackageDefinition):
         }
         current = current[packageName] as GrpcObject;
       }
-      current[serviceName] = makeClientConstructor(service, serviceName, {});
+      if (isProtobufTypeDefinition(service)) {
+        current[serviceName] = service;
+      } else {
+        current[serviceName] = makeClientConstructor(service, serviceName, {});
+      }
     }
   }
   return result;


### PR DESCRIPTION
This is necessary for the proto-loader library to work with grpc-js after #703 is merged.