### PR TITLE
grpc native: Fix handling of non-service objects in package definitions

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -260,10 +260,19 @@ declare module "grpc" {
   }
 
   /**
+   * An object that defines a protobuf type
+   */
+  export interface ProtobufTypeDefinition {
+    format: string;
+    type: object;
+    fileDescriptorProtos: Buffer[];
+  }
+
+  /**
    * An object that defines a package containing multiple services
    */
   export type PackageDefinition = {
-    readonly [fullyQualifiedName: string]: ServiceDefinition<any>;
+    readonly [fullyQualifiedName: string]: ServiceDefinition<any> | ProtobufTypeDefinition;
   }
 
   /**

--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -169,7 +169,11 @@ exports.loadPackageDefinition = function loadPackageDefintion(packageDef) {
       }
       current = current[packageName];
     }
-    current[serviceName] = client.makeClientConstructor(service, serviceName, {});
+    if (service.hasOwnProperty('format')) {
+      current[serviceName] = service;
+    } else {
+      current[serviceName] = client.makeClientConstructor(service, serviceName, {});
+    }
   }
   return result;
 };

--- a/packages/grpc-native-core/src/common.js
+++ b/packages/grpc-native-core/src/common.js
@@ -317,9 +317,18 @@ exports.zipObject = function(props, values) {
  * @typedef {Object.<string, grpc~MethodDefinition>} grpc~ServiceDefinition
  */
 
+ /**
+  * An object that defines a protobuf type
+  * @typedef {object} grpc~ProtobufTypeDefinition
+  * @param {string} format The format of the type definition object
+  * @param {*} type The type definition object
+  * @param {Buffer[]} fileDescriptorProtos Binary protobuf file
+  *     descriptors for all files loaded to construct this type
+  */
+
 /**
  * An object that defines a package hierarchy with multiple services
- * @typedef {Object.<string, grpc~ServiceDefinition>} grpc~PackageDefinition
+ * @typedef {Object.<string, grpc~ServiceDefinition|grpc~ProtobufTypeDefinition>} grpc~PackageDefinition
  */
 
 /**


### PR DESCRIPTION
This is necessary for the proto-loader library to work with the native grpc library after #703 is merged. This also needs to be upmerged into master before the tests in that PR will pass.