### PR TITLE
Stop testing on node 4 and 5.

### DIFF
--- a/run-tests.bat
+++ b/run-tests.bat
@@ -38,7 +38,7 @@ call npm install || goto :error
 SET JUNIT_REPORT_STACK=1
 SET FAILED=0
 
-for %%v in (4 6 7 8 9 10 11) do (
+for %%v in (6 7 8 9 10 11) do (
   call nvm install %%v
   call nvm use %%v
   if "%%v"=="4" (

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -26,7 +26,7 @@ set -ex
 cd $ROOT
 
 if [ ! -n "$node_versions" ] ; then
-  node_versions="4 5 6 7 8 9 10 11"
+  node_versions="6 7 8 9 10 11"
 fi
 
 set +ex


### PR DESCRIPTION
We will still build binaries for node 4 and 5, but support is now going to be provided as a best effort.