### PR TITLE
Target grpc-js build at a higher ES standard

### DIFF
--- a/packages/grpc-js/tsconfig.json
+++ b/packages/grpc-js/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
+    "lib": ["es2017"],
     "rootDir": ".",
     "outDir": "build",
-    "target": "es6"
+    "target": "es2017",
+    "module": "commonjs"
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
According to [this StackOverflow post](https://stackoverflow.com/a/50466512/159388), the ES2017 target should work for Node 8.10 and above, which is our compatibility boundary anyway.