### PR TITLE
Resolve new Buffer deprecation

### DIFF
--- a/packages/grpc-health-check/v1/health_grpc_pb.js
+++ b/packages/grpc-health-check/v1/health_grpc_pb.js
@@ -23,7 +23,7 @@ function serialize_HealthCheckRequest(arg) {
   if (!(arg instanceof v1_health_pb.HealthCheckRequest)) {
     throw new Error('Expected argument of type HealthCheckRequest');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_HealthCheckRequest(buffer_arg) {
@@ -34,7 +34,7 @@ function serialize_HealthCheckResponse(arg) {
   if (!(arg instanceof v1_health_pb.HealthCheckResponse)) {
     throw new Error('Expected argument of type HealthCheckResponse');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_HealthCheckResponse(buffer_arg) {

--- a/packages/grpc-native-core/src/credentials.js
+++ b/packages/grpc-native-core/src/credentials.js
@@ -93,7 +93,7 @@ function wrapCheckServerIdentityCallback(callback) {
       return new Error("Unable to parse certificate PEM.");
     }
     cert = cert.substring(PEM_CERT_HEADER.length, pemFooterIndex);
-    var rawBuffer = new Buffer(cert.replace("\n", "").replace(" ", ""), "base64");
+    var rawBuffer = Buffer.from(cert.replace("\n", "").replace(" ", ""), "base64");
 
     return callback(hostname, { raw: rawBuffer });
   }

--- a/packages/grpc-native-core/src/protobuf_js_5_common.js
+++ b/packages/grpc-native-core/src/protobuf_js_5_common.js
@@ -64,7 +64,7 @@ exports.serializeCls = function serializeCls(Cls) {
    * @return {Buffer} The serialized object
    */
   return function serialize(arg) {
-    return new Buffer(new Cls(arg).encode().toBuffer());
+    return Buffer.from(new Cls(arg).encode().toBuffer());
   };
 };
 

--- a/packages/grpc-native-core/test/call_test.js
+++ b/packages/grpc-native-core/test/call_test.js
@@ -142,8 +142,8 @@ describe('call', function() {
       assert.doesNotThrow(function() {
         var batch = {};
         batch[grpc.opType.SEND_INITIAL_METADATA] = {
-          'key1-bin': [new Buffer('value1')],
-          'key2-bin': [new Buffer('value2')]
+          'key1-bin': [Buffer.from('value1')],
+          'key2-bin': [Buffer.from('value2')]
         };
         call.startBatch(batch, function(err, resp) {
           assert.ifError(err);

--- a/packages/grpc-native-core/test/common_test.js
+++ b/packages/grpc-native-core/test/common_test.js
@@ -122,7 +122,7 @@ describe('Proto message bytes serialize and deserialize', function() {
   // This tests a bug that was fixed in Protobuf.js 6
   it.skip('should deserialize packed or unpacked repeated', function() {
     var expectedDeserialize = {
-      bytes_field: Buffer.from(''),
+      bytes_field: Buffer.alloc(''),
       repeated_field: [10]
     };
     var packedSerialized = Buffer.from([0x12, 0x01, 0x0a]);

--- a/packages/grpc-native-core/test/common_test.js
+++ b/packages/grpc-native-core/test/common_test.js
@@ -97,7 +97,7 @@ describe('Proto message bytes serialize and deserialize', function() {
   var b64_options = Object.assign({}, default_options, {binaryAsBase64: true});
   var sequenceBase64Deserialize = deserializeCls(
       messages_proto.SequenceValues, b64_options);
-  var buffer_val = new Buffer([0x69, 0xb7]);
+  var buffer_val = Buffer.from([0x69, 0xb7]);
   var base64_val = 'abc=';
   it('should preserve a buffer', function() {
     var serialized = sequenceSerialize({bytes_field: buffer_val});
@@ -115,18 +115,18 @@ describe('Proto message bytes serialize and deserialize', function() {
     assert.strictEqual(deserialized.bytes_field, base64_val);
   });
   it('should serialize a repeated field as packed by default', function() {
-    var expected_serialize = new Buffer([0x12, 0x01, 0x0a]);
+    var expected_serialize = Buffer.from([0x12, 0x01, 0x0a]);
     var serialized = sequenceSerialize({repeated_field: [10]});
     assert.strictEqual(expected_serialize.compare(serialized), 0);
   });
   // This tests a bug that was fixed in Protobuf.js 6
   it.skip('should deserialize packed or unpacked repeated', function() {
     var expectedDeserialize = {
-      bytes_field: new Buffer(''),
+      bytes_field: Buffer.from(''),
       repeated_field: [10]
     };
-    var packedSerialized = new Buffer([0x12, 0x01, 0x0a]);
-    var unpackedSerialized = new Buffer([0x10, 0x0a]);
+    var packedSerialized = Buffer.from([0x12, 0x01, 0x0a]);
+    var unpackedSerialized = Buffer.from([0x10, 0x0a]);
     var packedDeserialized;
     var unpackedDeserialized;
     assert.doesNotThrow(function() {

--- a/packages/grpc-native-core/test/credentials_test.js
+++ b/packages/grpc-native-core/test/credentials_test.js
@@ -295,7 +295,7 @@ describe('client credentials', function() {
       assert.equal(callback_host, 'foo.test.google.fr');
 
       // The roundabout forge APIs for converting PEM to a node DER Buffer
-      var expected_der = new Buffer(forge.asn1.toDer(
+      var expected_der = Buffer.from(forge.asn1.toDer(
           forge.pki.certificateToAsn1(forge.pki.certificateFromPem(pem_data)))
           .getBytes(), 'binary');
 

--- a/packages/grpc-native-core/test/end_to_end_test.js
+++ b/packages/grpc-native-core/test/end_to_end_test.js
@@ -172,7 +172,7 @@ describe('end-to-end', function() {
                              Infinity);
     var client_batch = {};
     client_batch[grpc.opType.SEND_INITIAL_METADATA] = {};
-    client_batch[grpc.opType.SEND_MESSAGE] = new Buffer(req_text);
+    client_batch[grpc.opType.SEND_MESSAGE] = Buffer.from(req_text);
     client_batch[grpc.opType.SEND_CLOSE_FROM_CLIENT] = true;
     client_batch[grpc.opType.RECV_INITIAL_METADATA] = true;
     client_batch[grpc.opType.RECV_MESSAGE] = true;
@@ -203,7 +203,7 @@ describe('end-to-end', function() {
         assert(response.send_metadata);
         assert.strictEqual(response.read.toString(), req_text);
         var response_batch = {};
-        response_batch[grpc.opType.SEND_MESSAGE] = new Buffer(reply_text);
+        response_batch[grpc.opType.SEND_MESSAGE] = Buffer.from(reply_text);
         response_batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
           metadata: {},
           code: constants.status.OK,
@@ -227,7 +227,7 @@ describe('end-to-end', function() {
                              Infinity);
     var client_batch = {};
     client_batch[grpc.opType.SEND_INITIAL_METADATA] = {};
-    client_batch[grpc.opType.SEND_MESSAGE] = new Buffer(requests[0]);
+    client_batch[grpc.opType.SEND_MESSAGE] = Buffer.from(requests[0]);
     client_batch[grpc.opType.RECV_INITIAL_METADATA] = true;
     call.startBatch(client_batch, function(err, response) {
       assert.ifError(err);
@@ -237,7 +237,7 @@ describe('end-to-end', function() {
         metadata: {}
       });
       var req2_batch = {};
-      req2_batch[grpc.opType.SEND_MESSAGE] = new Buffer(requests[1]);
+      req2_batch[grpc.opType.SEND_MESSAGE] = Buffer.from(requests[1]);
       req2_batch[grpc.opType.SEND_CLOSE_FROM_CLIENT] = true;
       req2_batch[grpc.opType.RECV_STATUS_ON_CLIENT] = true;
       call.startBatch(req2_batch, function(err, resp) {

--- a/packages/grpc-native-core/test/math/math_grpc_pb.js
+++ b/packages/grpc-native-core/test/math/math_grpc_pb.js
@@ -23,7 +23,7 @@ function serialize_DivArgs(arg) {
   if (!(arg instanceof math_math_pb.DivArgs)) {
     throw new Error('Expected argument of type DivArgs');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_DivArgs(buffer_arg) {
@@ -34,7 +34,7 @@ function serialize_DivReply(arg) {
   if (!(arg instanceof math_math_pb.DivReply)) {
     throw new Error('Expected argument of type DivReply');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_DivReply(buffer_arg) {
@@ -45,7 +45,7 @@ function serialize_FibArgs(arg) {
   if (!(arg instanceof math_math_pb.FibArgs)) {
     throw new Error('Expected argument of type FibArgs');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_FibArgs(buffer_arg) {
@@ -56,7 +56,7 @@ function serialize_Num(arg) {
   if (!(arg instanceof math_math_pb.Num)) {
     throw new Error('Expected argument of type Num');
   }
-  return new Buffer(arg.serializeBinary());
+  return Buffer.from(arg.serializeBinary());
 }
 
 function deserialize_Num(buffer_arg) {

--- a/packages/grpc-native-core/test/metadata_test.js
+++ b/packages/grpc-native-core/test/metadata_test.js
@@ -30,7 +30,7 @@ describe('Metadata', function() {
   describe('#set', function() {
     it('Only accepts string values for non "-bin" keys', function() {
       assert.throws(function() {
-        metadata.set('key', new Buffer('value'));
+        metadata.set('key', Buffer.from('value'));
       });
       assert.doesNotThrow(function() {
         metadata.set('key', 'value');
@@ -41,7 +41,7 @@ describe('Metadata', function() {
         metadata.set('key-bin', 'value');
       });
       assert.doesNotThrow(function() {
-        metadata.set('key-bin', new Buffer('value'));
+        metadata.set('key-bin', Buffer.from('value'));
       });
     });
     it('Rejects invalid keys', function() {
@@ -76,7 +76,7 @@ describe('Metadata', function() {
   describe('#add', function() {
     it('Only accepts string values for non "-bin" keys', function() {
       assert.throws(function() {
-        metadata.add('key', new Buffer('value'));
+        metadata.add('key', Buffer.from('value'));
       });
       assert.doesNotThrow(function() {
         metadata.add('key', 'value');
@@ -87,7 +87,7 @@ describe('Metadata', function() {
         metadata.add('key-bin', 'value');
       });
       assert.doesNotThrow(function() {
-        metadata.add('key-bin', new Buffer('value'));
+        metadata.add('key-bin', Buffer.from('value'));
       });
     });
     it('Rejects invalid keys', function() {
@@ -130,7 +130,7 @@ describe('Metadata', function() {
     beforeEach(function() {
       metadata.add('key', 'value1');
       metadata.add('key', 'value2');
-      metadata.add('key-bin', new Buffer('value'));
+      metadata.add('key-bin', Buffer.from('value'));
     });
     it('gets all values associated with a key', function() {
       assert.deepEqual(metadata.get('key'), ['value1', 'value2']);

--- a/packages/grpc-native-core/test/surface_test.js
+++ b/packages/grpc-native-core/test/surface_test.js
@@ -319,7 +319,7 @@ describe('Generic client and server', function() {
     return val.toString();
   }
   function toBuffer(str) {
-    return new Buffer(str);
+    return Buffer.from(str);
   }
   var string_service_attrs = {
     'capitalize' : {
@@ -365,7 +365,7 @@ describe('Server-side getPeer', function() {
     return val.toString();
   }
   function toBuffer(str) {
-    return new Buffer(str);
+    return Buffer.from(str);
   }
   var string_service_attrs = {
     'getPeer' : {
@@ -620,7 +620,7 @@ describe('Echo metadata', function() {
 describe('Client malformed response handling', function() {
   var server;
   var client;
-  var badArg = new Buffer([0xFF]);
+  var badArg = Buffer.from([0xFF]);
   before(function() {
     var Client = grpc.load(__dirname + '/test_service.proto').TestService;
     var malformed_test_service = {
@@ -936,7 +936,7 @@ describe('Other conditions', function() {
   });
   describe('Server recieving bad input', function() {
     var misbehavingClient;
-    var badArg = new Buffer([0xFF]);
+    var badArg = Buffer.from([0xFF]);
     before(function() {
       var test_service_attrs = {
         unary: {

--- a/packages/grpc-tools/src/node_generator.cc
+++ b/packages/grpc-tools/src/node_generator.cc
@@ -136,12 +136,7 @@ void PrintMessageTransformer(const Descriptor* descriptor, Printer* out,
              "throw new Error('Expected argument of type $name$');\n");
   out->Outdent();
   out->Print("}\n");
-  if (params.minimum_node_version > 5) {
-    // Node version is > 5, we should use Buffer.from
-    out->Print("return Buffer.from(arg.serializeBinary());\n");
-  } else {
-    out->Print("return new Buffer(arg.serializeBinary());\n");
-  }
+  out->Print("return Buffer.from(arg.serializeBinary());\n");
   out->Outdent();
   out->Print("}\n\n");
 

--- a/packages/grpc-tools/src/node_plugin.cc
+++ b/packages/grpc-tools/src/node_plugin.cc
@@ -37,7 +37,7 @@ class NodeGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
                 grpc::protobuf::compiler::GeneratorContext* context,
                 grpc::string* error) const {
     grpc_node_generator::Parameters generator_parameters;
-    generator_parameters.minimum_node_version = 4;
+    generator_parameters.minimum_node_version = 6;
 
     if (!parameter.empty()) {
       std::vector<grpc::string> parameters_list =

--- a/test/api/error_test.js
+++ b/test/api/error_test.js
@@ -315,7 +315,7 @@ describe('Client malformed response handling', function() {
     });
     describe('Server recieving bad input', function() {
       var misbehavingClient;
-      var badArg = new Buffer([0xFF]);
+      var badArg = Buffer.from([0xFF]);
       before(function() {
         var test_service_attrs = {
           unary: {

--- a/test/interop/interop_client.js
+++ b/test/interop/interop_client.js
@@ -49,10 +49,10 @@ var ECHO_TRAILING_KEY = 'x-grpc-test-echo-trailing-bin';
 /**
  * Create a buffer filled with size zeroes
  * @param {number} size The length of the buffer
- * @return {Buffer} The Buffer.from
+ * @return {Buffer} The New Buffer
  */
 function zeroBuffer(size) {
-  var zeros = Buffer.from(size);
+  var zeros = Buffer.alloc(size);
   zeros.fill(0);
   return zeros;
 }

--- a/test/interop/interop_client.js
+++ b/test/interop/interop_client.js
@@ -49,10 +49,10 @@ var ECHO_TRAILING_KEY = 'x-grpc-test-echo-trailing-bin';
 /**
  * Create a buffer filled with size zeroes
  * @param {number} size The length of the buffer
- * @return {Buffer} The new buffer
+ * @return {Buffer} The Buffer.from
  */
 function zeroBuffer(size) {
-  var zeros = new Buffer(size);
+  var zeros = Buffer.from(size);
   zeros.fill(0);
   return zeros;
 }
@@ -294,7 +294,7 @@ function customMetadata(client, done) {
   done = multiDone(done, 5);
   var metadata = new grpc.Metadata();
   metadata.set(ECHO_INITIAL_KEY, 'test_initial_metadata_value');
-  metadata.set(ECHO_TRAILING_KEY, new Buffer('ababab', 'hex'));
+  metadata.set(ECHO_TRAILING_KEY, Buffer.from('ababab', 'hex'));
   var arg = {
     response_type: 'COMPRESSABLE',
     response_size: 314159,

--- a/test/interop/interop_server.js
+++ b/test/interop/interop_server.js
@@ -39,10 +39,10 @@ var ECHO_TRAILING_KEY = 'x-grpc-test-echo-trailing-bin';
 /**
  * Create a buffer filled with size zeroes
  * @param {number} size The length of the buffer
- * @return {Buffer} The new buffer
+ * @return {Buffer} The Buffer.from
  */
 function zeroBuffer(size) {
-  var zeros = new Buffer(size);
+  var zeros = Buffer.from(size);
   zeros.fill(0);
   return zeros;
 }

--- a/test/interop/interop_server.js
+++ b/test/interop/interop_server.js
@@ -39,10 +39,10 @@ var ECHO_TRAILING_KEY = 'x-grpc-test-echo-trailing-bin';
 /**
  * Create a buffer filled with size zeroes
  * @param {number} size The length of the buffer
- * @return {Buffer} The Buffer.from
+ * @return {Buffer} The New Buffer
  */
 function zeroBuffer(size) {
-  var zeros = Buffer.from(size);
+  var zeros = Buffer.alloc(size);
   zeros.fill(0);
   return zeros;
 }

--- a/test/performance/benchmark_client.js
+++ b/test/performance/benchmark_client.js
@@ -50,10 +50,10 @@ var serviceProto = grpc.loadPackageDefinition(protoPackage).grpc.testing;
 /**
  * Create a buffer filled with size zeroes
  * @param {number} size The length of the buffer
- * @return {Buffer} The Buffer.from
+ * @return {Buffer} The New Buffer
  */
 function zeroBuffer(size) {
-  var zeros = Buffer.from(size);
+  var zeros = Buffer.alloc(size);
   zeros.fill(0);
   return zeros;
 }

--- a/test/performance/benchmark_client.js
+++ b/test/performance/benchmark_client.js
@@ -50,10 +50,10 @@ var serviceProto = grpc.loadPackageDefinition(protoPackage).grpc.testing;
 /**
  * Create a buffer filled with size zeroes
  * @param {number} size The length of the buffer
- * @return {Buffer} The new buffer
+ * @return {Buffer} The Buffer.from
  */
 function zeroBuffer(size) {
-  var zeros = new Buffer(size);
+  var zeros = Buffer.from(size);
   zeros.fill(0);
   return zeros;
 }

--- a/test/performance/benchmark_server.js
+++ b/test/performance/benchmark_server.js
@@ -44,10 +44,10 @@ var serviceProto = grpc.loadPackageDefinition(protoPackage).grpc.testing;
 /**
  * Create a buffer filled with size zeroes
  * @param {number} size The length of the buffer
- * @return {Buffer} The Buffer.from
+ * @return {Buffer} The New Buffer
  */
 function zeroBuffer(size) {
-  var zeros = Buffer.from(size);
+  var zeros = Buffer.alloc(size);
   zeros.fill(0);
   return zeros;
 }

--- a/test/performance/benchmark_server.js
+++ b/test/performance/benchmark_server.js
@@ -44,10 +44,10 @@ var serviceProto = grpc.loadPackageDefinition(protoPackage).grpc.testing;
 /**
  * Create a buffer filled with size zeroes
  * @param {number} size The length of the buffer
- * @return {Buffer} The new buffer
+ * @return {Buffer} The Buffer.from
  */
 function zeroBuffer(size) {
-  var zeros = new Buffer(size);
+  var zeros = Buffer.from(size);
   zeros.fill(0);
   return zeros;
 }


### PR DESCRIPTION
this PR comes to resolve #670 .

by doing so, I have done the following things:

- replaced all usages of `new Buffer` with `Buffer.from`
- changed default minimum node version to 6 to to EOL of older node versions