### PR TITLE
grpc-tools cleanup and packaging update

### DIFF
--- a/packages/grpc-tools/build_binaries.ps1
+++ b/packages/grpc-tools/build_binaries.ps1
@@ -9,22 +9,16 @@ function MkDir-p($Path) {
     }
 }
 
-$WellKnownProtos = "any","api","compiler/plugin","descriptor","duration","empty","field_mask","source_context","struct","timestamp","type","wrappers"
-
 $Base = $PSScriptRoot
 cd $Base
 $ProtobufBase = $Base + "/deps/protobuf"
-MkDir-p ($Base + "/build/bin/google/protobuf/compiler")
+MkDir-p ($Base + "/build/bin")
 
 $PackageFile = $Base + "/package.json"
 $ToolsVersion = (Get-Content $PackageFile) -join "`n" | ConvertFrom-Json | Get-Member -Name version
 
 $OutDir = $Env:ARTIFACTS_OUT + "/grpc-tools/v" + $ToolsVersion
 Mkdir-p $OutDir
-
-foreach ($Proto in $WellKnownProtos) {
-  Copy-Item ($ProtobufBase + "/src/google/protobuf/" + $Proto + ".proto") -Destination ($Base + "/build/bin/google/protobuf/" + $Proto + ".proto")
-}
 
 $ArchList = "ia32","x64"
 

--- a/packages/grpc-tools/build_binaries.sh
+++ b/packages/grpc-tools/build_binaries.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-well_known_protos=( any api compiler/plugin descriptor duration empty field_mask source_context struct timestamp type wrappers )
-
 cd $(dirname $0)
 base=$(pwd)
 protobuf_base=$base/deps/protobuf
@@ -13,10 +11,7 @@ tools_version=$(jq '.version' < package.json | tr -d '"')
 out_dir=$ARTIFACTS_OUT/grpc-tools/v$tools_version
 mkdir -p "$out_dir"
 
-mkdir -p "$base/build/bin/google/protobuf/compiler"
-for proto in "${well_known_protos[@]}"; do
-  cp "$protobuf_base/src/google/protobuf/$proto.proto" "$base/build/bin/google/protobuf/$proto.proto"
-done
+mkdir -p "$base/build/bin"
 
 case $(uname -s) in
   Linux)

--- a/packages/grpc-tools/copy_well_known_protos.js
+++ b/packages/grpc-tools/copy_well_known_protos.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const sourceDir = path.join(__dirname, 'deps/protobuf/src/google/protobuf');
+const destDir = path.join(__dirname, 'bin/google/protobuf');
+
+fs.mkdirSync(path.join(destDir, 'compiler'), {recursive: true});
+
+const wellKnownProtos=['any', 'api', 'compiler/plugin', 'descriptor', 'duration', 'empty',
+                       'field_mask', 'source_context', 'struct', 'timestamp', 'type', 'wrappers'];
+for (const proto of wellKnownProtos) {
+  fs.copyFileSync(path.join(sourceDir, proto + '.proto'), path.join(destDir, proto + '.proto'));
+}

--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-tools",
-  "version": "1.7.0-pre1",
+  "version": "1.7.0",
   "author": "Google Inc.",
   "description": "Tools for developing with gRPC on Node.js",
   "homepage": "https://grpc.io/",
@@ -20,13 +20,14 @@
     "grpc_tools_node_protoc_plugin": "./bin/protoc_plugin.js"
   },
   "scripts": {
-    "install": "./node_modules/.bin/node-pre-gyp install"
+    "install": "./node_modules/.bin/node-pre-gyp install",
+    "prepublishOnly": "git submodule update --init --recursive && node copy_well_known_protos.js"
   },
   "bundledDependencies": ["node-pre-gyp"],
   "binary": {
     "module_name": "grpc_tools",
-    "host": "https://storage.googleapis.com/",
-    "remote_path": "grpc-precompiled-binaries/node/{name}/v{version}",
+    "host": "https://node-precompiled-binaries.grpc.io/",
+    "remote_path": "{name}/v{version}",
     "package_name": "{platform}-{arch}.tar.gz",
     "module_path": "bin"
   },

--- a/packages/grpc-tools/src/node_generator.cc
+++ b/packages/grpc-tools/src/node_generator.cc
@@ -120,8 +120,7 @@ grpc::string NodeObjectPath(const Descriptor* descriptor) {
 }
 
 // Prints out the message serializer and deserializer functions
-void PrintMessageTransformer(const Descriptor* descriptor, Printer* out,
-                             const Parameters& params) {
+void PrintMessageTransformer(const Descriptor* descriptor, Printer* out) {
   map<grpc::string, grpc::string> template_vars;
   grpc::string full_name = descriptor->full_name();
   template_vars["identifier_name"] = MessageIdentifierName(full_name);
@@ -221,13 +220,12 @@ void PrintImports(const FileDescriptor* file, Printer* out) {
   out->Print("\n");
 }
 
-void PrintTransformers(const FileDescriptor* file, Printer* out,
-                       const Parameters& params) {
+void PrintTransformers(const FileDescriptor* file, Printer* out) {
   map<grpc::string, const Descriptor*> messages = GetAllMessages(file);
   for (std::map<grpc::string, const Descriptor*>::iterator it =
            messages.begin();
        it != messages.end(); it++) {
-    PrintMessageTransformer(it->second, out, params);
+    PrintMessageTransformer(it->second, out);
   }
   out->Print("\n");
 }
@@ -239,8 +237,7 @@ void PrintServices(const FileDescriptor* file, Printer* out) {
 }
 }  // namespace
 
-grpc::string GenerateFile(const FileDescriptor* file,
-                          const Parameters& params) {
+grpc::string GenerateFile(const FileDescriptor* file) {
   grpc::string output;
   {
     StringOutputStream output_stream(&output);
@@ -262,7 +259,7 @@ grpc::string GenerateFile(const FileDescriptor* file,
 
     PrintImports(file, &out);
 
-    PrintTransformers(file, &out, params);
+    PrintTransformers(file, &out);
 
     PrintServices(file, &out);
 

--- a/packages/grpc-tools/src/node_generator.h
+++ b/packages/grpc-tools/src/node_generator.h
@@ -23,14 +23,7 @@
 
 namespace grpc_node_generator {
 
-// Contains all the parameters that are parsed from the command line.
-struct Parameters {
-  // Sets the earliest version of nodejs that needs to be supported.
-  int minimum_node_version;
-};
-
-grpc::string GenerateFile(const grpc::protobuf::FileDescriptor* file,
-                          const Parameters& params);
+grpc::string GenerateFile(const grpc::protobuf::FileDescriptor* file);
 
 }  // namespace grpc_node_generator
 

--- a/packages/grpc-tools/src/node_plugin.cc
+++ b/packages/grpc-tools/src/node_plugin.cc
@@ -36,27 +36,8 @@ class NodeGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
                 const grpc::string& parameter,
                 grpc::protobuf::compiler::GeneratorContext* context,
                 grpc::string* error) const {
-    grpc_node_generator::Parameters generator_parameters;
-    generator_parameters.minimum_node_version = 6;
 
-    if (!parameter.empty()) {
-      std::vector<grpc::string> parameters_list =
-          grpc_generator::tokenize(parameter, ",");
-      for (auto parameter_string = parameters_list.begin();
-           parameter_string != parameters_list.end(); parameter_string++) {
-        std::vector<grpc::string> param =
-            grpc_generator::tokenize(*parameter_string, "=");
-        if (param[0] == "minimum_node_version") {
-          sscanf(param[1].c_str(), "%d",
-                 &generator_parameters.minimum_node_version);
-        } else {
-          *error = grpc::string("Unknown parameter: ") + *parameter_string;
-          return false;
-        }
-      }
-    }
-
-    grpc::string code = GenerateFile(file, generator_parameters);
+    grpc::string code = GenerateFile(file);
     if (code.size() == 0) {
       return true;
     }

--- a/tools/release/kokoro/macos-grpc-tools.cfg
+++ b/tools/release/kokoro/macos-grpc-tools.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-node/tools/release/kokoro-grpc-tools.sh"
-timeout_mins: 120
+timeout_mins: 60
 action {
   define_artifacts {
     regex: "github/grpc-node/artifacts/**",


### PR DESCRIPTION
This has a few different cleanup changes that we need before publishing the next release:

 - Move the well-known protos copying logic to a prepublish hook instead of putting them in the binary tarball. This more closely matches what we did before.
 - Move the binaries to the new GCS bucket.
 - Bump the version number.
 - Remove the "minimum_node_version" argument that was made unnecessary in a previous change. We never published a version with that argument so we're not breaking anything by removing it.