### PR TITLE
node-pre-gyp refers to Windows as 'win32'

### DIFF
--- a/packages/grpc-tools/build_binaries.ps1
+++ b/packages/grpc-tools/build_binaries.ps1
@@ -46,7 +46,7 @@ foreach ($Arch in $ArchList) {
   Copy-Item ($Base + "/Debug/grpc_node_plugin.exe") -Destination ($Base + "/build/bin/grpc_node_plugin.exe")
 
   Compress-7Zip -Path ($Base + "/build") -Format Tar -ArchiveFileName ($Base + "/Archive.tar")
-  Compress-7Zip -Path ($Base + "/Archive.tar") -Format GZip -ArchiveFileName ($OutDir + "/windows-" + $Arch + ".tar.gz")
+  Compress-7Zip -Path ($Base + "/Archive.tar") -Format GZip -ArchiveFileName ($OutDir + "/win32-" + $Arch + ".tar.gz")
 
   Remove-Item ($Base + "/build/bin/protoc.exe")
   Remove-Item ($Base + "/build/bin/grpc_node_plugin.exe")


### PR DESCRIPTION
Fixing an issue pointed out in #499.