### PR TITLE
Fix grpc-tools install script

### DIFF
--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -20,7 +20,7 @@
     "grpc_tools_node_protoc_plugin": "./bin/protoc_plugin.js"
   },
   "scripts": {
-    "install": "./node_modules/.bin/node-pre-gyp install",
+    "install": "node-pre-gyp install",
     "prepublishOnly": "git submodule update --init --recursive && node copy_well_known_protos.js"
   },
   "bundledDependencies": ["node-pre-gyp"],


### PR DESCRIPTION
Fixes #746.

This allows npm to determine the path to `node-pre-gyp` for the install script from `grpc-tools` rather than specifying the path. This also brings the install script in line with the one used for the `grpc` package.