### PR TITLE
grpc-js: deadline filter: reject promise if call ends

### DIFF
--- a/packages/grpc-js/src/deadline-filter.ts
+++ b/packages/grpc-js/src/deadline-filter.ts
@@ -60,6 +60,7 @@ export class DeadlineFilter extends BaseFilter implements Filter {
                    resolve(metadata);
                    this.channel.removeListener(
                        'connectivityStateChanged', handleStateChange);
+                   this.callStream.removeListener('status', handleStatus);
                  }
                };
                const handleStatus = () => {

--- a/packages/grpc-js/src/deadline-filter.ts
+++ b/packages/grpc-js/src/deadline-filter.ts
@@ -62,7 +62,13 @@ export class DeadlineFilter extends BaseFilter implements Filter {
                        'connectivityStateChanged', handleStateChange);
                  }
                };
+               const handleStatus = () => {
+                 reject(new Error('Call ended'));
+                 this.channel.removeListener(
+                     'connectivityStateChanged', handleStateChange);
+               };
                this.channel.on('connectivityStateChanged', handleStateChange);
+               this.callStream.once('status', handleStatus);
              }
            })
         .then((finalMetadata: Metadata) => {

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -46,6 +46,7 @@ export class Http2SubChannel extends EventEmitter implements SubChannel {
       userAgent: string, channelArgs: Partial<ChannelOptions>) {
     super();
     this.session = http2.connect(target, connectionOptions);
+    this.session.unref();
     this.session.on('connect', () => {
       this.emit('connect');
     });


### PR DESCRIPTION
This fixes a problem I encountered while trying to reproduce #694. Currently if the channel never connects the promise sticks around forever.

Edit: The original test that exposed this problem no longer shows it with these changes.