### PR TITLE
Make node-pre-gyp a regular dependency

### DIFF
--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -23,7 +23,9 @@
     "install": "node-pre-gyp install",
     "prepublishOnly": "git submodule update --init --recursive && node copy_well_known_protos.js"
   },
-  "bundledDependencies": ["node-pre-gyp"],
+  "dependencies": {
+    "node-pre-gyp": "^0.12.0"
+  },
   "binary": {
     "module_name": "grpc_tools",
     "host": "https://node-precompiled-binaries.grpc.io/",

--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -23,6 +23,7 @@
     "install": "node-pre-gyp install",
     "prepublishOnly": "git submodule update --init --recursive && node copy_well_known_protos.js"
   },
+  "bundledDependencies": ["node-pre-gyp"],
   "dependencies": {
     "node-pre-gyp": "^0.12.0"
   },


### PR DESCRIPTION
I investigated further why I'm having the problem I first described [here](https://github.com/grpc/grpc-node/issues/748#issuecomment-466409893) and subsequently led us to think it was [an issue in yarn](https://github.com/yarnpkg/yarn/issues/7063).

As it turns out yarn tried to install `grpc-tools` before `node-pre-gyp`. If there is a reason for having `node-pre-gyp` in `bundledDependencies` then feel free to close this PR.

You can verify that the issues disappear with following `package.json` (having this project cloned in a sibling directory):
```json
{
  "dependencies": {
    "grpc-tools": "^1.7.1"
  },
  "resolutions": {
    "grpc-tools": "file:../grpc-node/packages/grpc-tools"
  }
}
```