### PR TITLE
Array.isArray instead of instanceof for consistent checking

### DIFF
--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -285,7 +285,7 @@ export function loadSync(filename: string, options?: Options): PackageDefinition
   options = options || {};
   if (!!options.includeDirs) {
     if (!(Array.isArray(options.includeDirs))) {
-      throw new Error('The include option must be an array');
+      throw new Error('The includeDirs option must be an array');
     }
     addIncludePathResolver(root, options.includeDirs as string[]);
   }

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -269,7 +269,7 @@ export function load(filename: string, options?: Options): Promise<PackageDefini
   const root: Protobuf.Root = new Protobuf.Root();
   options = options || {};
   if (!!options.includeDirs) {
-    if (!(options.includeDirs instanceof Array)) {
+    if (!(Array.isArray(options.includeDirs))) {
       return Promise.reject(new Error('The includeDirs option must be an array'));
     }
     addIncludePathResolver(root, options.includeDirs as string[]);
@@ -284,7 +284,7 @@ export function loadSync(filename: string, options?: Options): PackageDefinition
   const root: Protobuf.Root = new Protobuf.Root();
   options = options || {};
   if (!!options.includeDirs) {
-    if (!(options.includeDirs instanceof Array)) {
+    if (!(Array.isArray(options.includeDirs))) {
       throw new Error('The include option must be an array');
     }
     addIncludePathResolver(root, options.includeDirs as string[]);


### PR DESCRIPTION
I'm running proto-loader from inside a [haraka](https://github.com/haraka/Haraka/) plugin.
When I send `includeDirs` as Array, `instanceof` fails. 
When I do `Array.isArray` it works correctly. 
Turns out `instanceof` does not work correctly for arrays in different contexts!