### PR TITLE
Add metadata options

### DIFF
--- a/PACKAGE-COMPARISON.md
+++ b/PACKAGE-COMPARISON.md
@@ -18,6 +18,7 @@ HTTP Connect Support | :heavy_check_mark: | :x:
 Retries | :heavy_check_mark: | :x:
 Stats/tracing/monitoring | :heavy_check_mark: | :x:
 Load Balancing | :heavy_check_mark: | :x:
+Initial Metadata Options | :heavy_check_mark: | :x:
 
 Other Properties | `grpc` | `@grpc/grpc-js`
 -----------------|--------|----------------

--- a/packages/grpc-js/src/metadata.ts
+++ b/packages/grpc-js/src/metadata.ts
@@ -44,11 +44,26 @@ function validate(key: string, value?: MetadataValue): void {
   }
 }
 
+interface MetadataOptions {
+  /* Signal that the request is idempotent. Defaults to false */
+  idempotentRequest?: boolean;
+  /* Signal that the call should not return UNAVAILABLE before it has
+   * started. Defaults to true. */
+  waitForReady?: boolean;
+  /* Signal that the call is cacheable. GRPC is free to use GET verb.
+   * Defaults to false */
+  cacheableRequest?: boolean;
+  /* Signal that the initial metadata should be corked. Defaults to false. */
+  corked?: boolean;
+}
+
 /**
  * A class for storing metadata. Keys are normalized to lowercase ASCII.
  */
 export class Metadata {
   protected internalRepr: MetadataObject = new Map<string, MetadataValue[]>();
+
+  constructor(private options?: MetadataOptions) {}
 
   /**
    * Sets the given value for the given key by replacing any other values
@@ -158,6 +173,10 @@ export class Metadata {
 
       this.internalRepr.set(key, mergedValue);
     });
+  }
+
+  setOptions(options: MetadataOptions) {
+    this.options = options;
   }
 
   /**

--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -489,10 +489,29 @@ declare module "grpc" {
   type sendUnaryData<ResponseType> =
     (error: ServiceError | null, value: ResponseType | null, trailer?: Metadata, flags?: number) => void;
 
+  interface MetadataOptions {
+    /* Signal that the request is idempotent. Defaults to false */
+    idempotentRequest?: boolean;
+    /* Signal that the call should not return UNAVAILABLE before it has
+     * started. Defaults to true. */
+    waitForReady?: boolean;
+    /* Signal that the call is cacheable. GRPC is free to use GET verb.
+     * Defaults to false */
+    cacheableRequest?: boolean;
+    /* Signal that the initial metadata should be corked. Defaults to false. */
+    corked?: boolean;
+  }
+
   /**
    * A class for storing metadata. Keys are normalized to lowercase ASCII.
    */
   export class Metadata {
+    /**
+     * @param options Boolean options for the beginning of the call.
+     *   These options only have any effect when passed at the beginning of
+     *   a client request.
+     */
+    constructor(options?: MetadataOptions);
     /**
      * Sets the given value for the given key by replacing any other values
      * associated with that key. Normalizes the key.
@@ -536,6 +555,14 @@ declare module "grpc" {
      * @return The newly cloned object.
      */
     clone(): Metadata;
+
+    /**
+     * Set options on the metadata object
+     * @param options Boolean options for the beginning of the call.
+     *   These options only have any effect when passed at the beginning of
+     *   a client request.
+     */
+    setOptions(options: MetadataOptions);
   }
 
   export type MetadataValue = string | Buffer;

--- a/packages/grpc-native-core/src/server.js
+++ b/packages/grpc-native-core/src/server.js
@@ -772,7 +772,7 @@ Server.prototype.start = function() {
       batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
         code: constants.status.UNIMPLEMENTED,
         details: 'RPC method not implemented ' + method,
-        metadata: {}
+        metadata: (new Metadata())._getCoreRepresentation()
       };
       batch[grpc.opType.RECV_CLOSE_ON_SERVER] = true;
       call.startBatch(batch, function() {});

--- a/packages/grpc-native-core/test/call_test.js
+++ b/packages/grpc-native-core/test/call_test.js
@@ -128,8 +128,9 @@ describe('call', function() {
       var call = channel.createCall('method', getDeadline(1));
       assert.doesNotThrow(function() {
         var batch = {};
-        batch[grpc.opType.SEND_INITIAL_METADATA] = {'key1': ['value1'],
-                                                    'key2': ['value2']};
+        batch[grpc.opType.SEND_INITIAL_METADATA] = {
+          metadata: {'key1': ['value1'], 'key2': ['value2']}
+        };
         call.startBatch(batch, function(err, resp) {
           assert.ifError(err);
           assert.deepEqual(resp, {'send_metadata': true});
@@ -142,8 +143,10 @@ describe('call', function() {
       assert.doesNotThrow(function() {
         var batch = {};
         batch[grpc.opType.SEND_INITIAL_METADATA] = {
-          'key1-bin': [Buffer.from('value1')],
-          'key2-bin': [Buffer.from('value2')]
+          metadata: {
+            'key1-bin': [Buffer.from('value1')],
+            'key2-bin': [Buffer.from('value2')]
+          }
         };
         call.startBatch(batch, function(err, resp) {
           assert.ifError(err);
@@ -172,6 +175,11 @@ describe('call', function() {
       assert.throws(function() {
         var batch = {};
         batch[grpc.opType.SEND_INITIAL_METADATA] = 5;
+        call.startBatch(batch, function(){});
+      }, TypeError);
+      assert.throws(function() {
+        var batch = {};
+        batch[grpc.opType.SEND_INITIAL_METADATA] = {};
         call.startBatch(batch, function(){});
       }, TypeError);
     });

--- a/packages/grpc-native-core/test/end_to_end_test.js
+++ b/packages/grpc-native-core/test/end_to_end_test.js
@@ -65,7 +65,7 @@ describe('end-to-end', function() {
                              'dummy_method',
                              Infinity);
     var client_batch = {};
-    client_batch[grpc.opType.SEND_INITIAL_METADATA] = {};
+    client_batch[grpc.opType.SEND_INITIAL_METADATA] = {metadata: {}};
     client_batch[grpc.opType.SEND_CLOSE_FROM_CLIENT] = true;
     client_batch[grpc.opType.RECV_INITIAL_METADATA] = true;
     client_batch[grpc.opType.RECV_STATUS_ON_CLIENT] = true;
@@ -74,11 +74,17 @@ describe('end-to-end', function() {
       assert.deepEqual(response, {
         send_metadata: true,
         client_close: true,
-        metadata: {},
+        metadata: {
+          metadata: {},
+          flags: 0
+        },
         status: {
           code: constants.status.OK,
           details: status_text,
-          metadata: {}
+          metadata: {
+            metadata: {},
+            flags: 0
+          }
         }
       });
       done();
@@ -90,9 +96,9 @@ describe('end-to-end', function() {
       var server_call = new_call.call;
       assert.notEqual(server_call, null);
       var server_batch = {};
-      server_batch[grpc.opType.SEND_INITIAL_METADATA] = {};
+      server_batch[grpc.opType.SEND_INITIAL_METADATA] = {metadata: {}};
       server_batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
-        metadata: {},
+        metadata: {metadata: {}},
         code: constants.status.OK,
         details: status_text
       };
@@ -116,7 +122,9 @@ describe('end-to-end', function() {
                              Infinity);
     var client_batch = {};
     client_batch[grpc.opType.SEND_INITIAL_METADATA] = {
-      client_key: ['client_value']
+      metadata: {
+        client_key: ['client_value']
+      }
     };
     client_batch[grpc.opType.SEND_CLOSE_FROM_CLIENT] = true;
     client_batch[grpc.opType.RECV_INITIAL_METADATA] = true;
@@ -126,10 +134,13 @@ describe('end-to-end', function() {
       assert.deepEqual(response,{
         send_metadata: true,
         client_close: true,
-        metadata: {server_key: ['server_value']},
+        metadata: {metadata: {
+          server_key: ['server_value']}, 
+          flags: 0
+        },
         status: {code: constants.status.OK,
                  details: status_text,
-                 metadata: {}}
+                 metadata: {metadata: {}, flags: 0}}
       });
       done();
     });
@@ -137,16 +148,18 @@ describe('end-to-end', function() {
     server.requestCall(function(err, call_details) {
       var new_call = call_details.new_call;
       assert.notEqual(new_call, null);
-      assert.strictEqual(new_call.metadata.client_key[0],
+      assert.strictEqual(new_call.metadata.metadata.client_key[0],
                          'client_value');
       var server_call = new_call.call;
       assert.notEqual(server_call, null);
       var server_batch = {};
       server_batch[grpc.opType.SEND_INITIAL_METADATA] = {
-        server_key: ['server_value']
+        metadata: {
+          server_key: ['server_value']
+        }
       };
       server_batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
-        metadata: {},
+        metadata: {metadata: {}},
         code: constants.status.OK,
         details: status_text
       };
@@ -171,7 +184,7 @@ describe('end-to-end', function() {
                              'dummy_method',
                              Infinity);
     var client_batch = {};
-    client_batch[grpc.opType.SEND_INITIAL_METADATA] = {};
+    client_batch[grpc.opType.SEND_INITIAL_METADATA] = {metadata: {}};
     client_batch[grpc.opType.SEND_MESSAGE] = Buffer.from(req_text);
     client_batch[grpc.opType.SEND_CLOSE_FROM_CLIENT] = true;
     client_batch[grpc.opType.RECV_INITIAL_METADATA] = true;
@@ -181,12 +194,12 @@ describe('end-to-end', function() {
       assert.ifError(err);
       assert(response.send_metadata);
       assert(response.client_close);
-      assert.deepEqual(response.metadata, {});
+      assert.deepEqual(response.metadata, {metadata: {}, flags: 0});
       assert(response.send_message);
       assert.strictEqual(response.read.toString(), reply_text);
       assert.deepEqual(response.status, {code: constants.status.OK,
                                          details: status_text,
-                                         metadata: {}});
+                                         metadata: {metadata: {}, flags: 0}});
       done();
     });
 
@@ -196,7 +209,7 @@ describe('end-to-end', function() {
       var server_call = new_call.call;
       assert.notEqual(server_call, null);
       var server_batch = {};
-      server_batch[grpc.opType.SEND_INITIAL_METADATA] = {};
+      server_batch[grpc.opType.SEND_INITIAL_METADATA] = {metadata: {}};
       server_batch[grpc.opType.RECV_MESSAGE] = true;
       server_call.startBatch(server_batch, function(err, response) {
         assert.ifError(err);
@@ -205,7 +218,7 @@ describe('end-to-end', function() {
         var response_batch = {};
         response_batch[grpc.opType.SEND_MESSAGE] = Buffer.from(reply_text);
         response_batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
-          metadata: {},
+          metadata: {metadata: {}},
           code: constants.status.OK,
           details: status_text
         };
@@ -226,7 +239,7 @@ describe('end-to-end', function() {
                              'dummy_method',
                              Infinity);
     var client_batch = {};
-    client_batch[grpc.opType.SEND_INITIAL_METADATA] = {};
+    client_batch[grpc.opType.SEND_INITIAL_METADATA] = {metadata: {}};
     client_batch[grpc.opType.SEND_MESSAGE] = Buffer.from(requests[0]);
     client_batch[grpc.opType.RECV_INITIAL_METADATA] = true;
     call.startBatch(client_batch, function(err, response) {
@@ -234,7 +247,7 @@ describe('end-to-end', function() {
       assert.deepEqual(response, {
         send_metadata: true,
         send_message: true,
-        metadata: {}
+        metadata: {metadata: {}, flags: 0}
       });
       var req2_batch = {};
       req2_batch[grpc.opType.SEND_MESSAGE] = Buffer.from(requests[1]);
@@ -248,7 +261,7 @@ describe('end-to-end', function() {
           status: {
             code: constants.status.OK,
             details: status_text,
-            metadata: {}
+            metadata: {metadata: {}, flags: 0}
           }
         });
         done();
@@ -261,7 +274,7 @@ describe('end-to-end', function() {
       var server_call = new_call.call;
       assert.notEqual(server_call, null);
       var server_batch = {};
-      server_batch[grpc.opType.SEND_INITIAL_METADATA] = {};
+      server_batch[grpc.opType.SEND_INITIAL_METADATA] = {metadata: {}};
       server_batch[grpc.opType.RECV_MESSAGE] = true;
       server_call.startBatch(server_batch, function(err, response) {
         assert.ifError(err);
@@ -275,7 +288,7 @@ describe('end-to-end', function() {
           var end_batch = {};
           end_batch[grpc.opType.RECV_CLOSE_ON_SERVER] = true;
           end_batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
-            metadata: {},
+            metadata: {metadata: {}},
             code: constants.status.OK,
             details: status_text
           };

--- a/packages/grpc-native-core/test/surface_test.js
+++ b/packages/grpc-native-core/test/surface_test.js
@@ -934,6 +934,19 @@ describe('Other conditions', function() {
     call.write({});
     call.end();
   });
+  it('client should drop a call if not connected with waitForReady off', function(done) {
+    /* We have to wait for the client to reach the first connection timeout
+     * and go to TRANSIENT_FAILURE to confirm that the waitForReady option
+     * makes it end the call instead of continuing to try. A DNS resolution
+     * failure makes that transition very fast. */
+    const disconnectedClient = new Client('nothing.invalid:50051', grpc.credentials.createInsecure());
+    const metadata = new grpc.Metadata({waitForReady: false});
+    disconnectedClient.unary({}, metadata, (error, value) =>{
+      assert(error);
+      assert.strictEqual(error.code, grpc.status.UNAVAILABLE);
+      done();
+    });
+  });
   describe('Server recieving bad input', function() {
     var misbehavingClient;
     var badArg = Buffer.from([0xFF]);

--- a/packages/grpc-native-core/test/surface_test.js
+++ b/packages/grpc-native-core/test/surface_test.js
@@ -939,10 +939,11 @@ describe('Other conditions', function() {
      * and go to TRANSIENT_FAILURE to confirm that the waitForReady option
      * makes it end the call instead of continuing to try. A DNS resolution
      * failure makes that transition very fast. */
+    this.timeout(15000);
     const disconnectedClient = new Client('foo.test.google.com:50051', grpc.credentials.createInsecure());
     const metadata = new grpc.Metadata({waitForReady: false});
     const deadline = new Date();
-    deadline.setSeconds(deadline.getSeconds() + 1);
+    deadline.setSeconds(deadline.getSeconds() + 10);
     disconnectedClient.unary({}, metadata, {deadline: deadline}, (error, value) =>{
       assert(error);
       assert.strictEqual(error.code, grpc.status.UNAVAILABLE);

--- a/packages/grpc-native-core/test/surface_test.js
+++ b/packages/grpc-native-core/test/surface_test.js
@@ -934,24 +934,7 @@ describe('Other conditions', function() {
     call.write({});
     call.end();
   });
-  it('client should wait for ready by default', function(done) {
-    this.timeout(15000);
-    const disconnectedClient = new Client('foo.test.google.com:50051', grpc.credentials.createInsecure());
-    const metadata = new grpc.Metadata({waitForReady: false});
-    const deadline = new Date();
-    deadline.setSeconds(deadline.getSeconds() + 10);
-    disconnectedClient.unary({}, metadata, {deadline: deadline}, (error, value) =>{
-      assert(error);
-      assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
-      done();
-    });
-
-  });
-  it('client should drop a call if not connected with waitForReady off', function(done) {
-    /* We have to wait for the client to reach the first connection timeout
-     * and go to TRANSIENT_FAILURE to confirm that the waitForReady option
-     * makes it end the call instead of continuing to try. A DNS resolution
-     * failure makes that transition very fast. */
+  it('client should not wait for ready by default', function(done) {
     this.timeout(15000);
     const disconnectedClient = new Client('foo.test.google.com:50051', grpc.credentials.createInsecure());
     const metadata = new grpc.Metadata({waitForReady: false});
@@ -960,6 +943,23 @@ describe('Other conditions', function() {
     disconnectedClient.unary({}, metadata, {deadline: deadline}, (error, value) =>{
       assert(error);
       assert.strictEqual(error.code, grpc.status.UNAVAILABLE);
+      done();
+    });
+
+  });
+  it('client should wait for a connection with waitForReady on', function(done) {
+    /* We have to wait for the client to reach the first connection timeout
+     * and go to TRANSIENT_FAILURE to confirm that the waitForReady option
+     * makes it end the call instead of continuing to try. A DNS resolution
+     * failure makes that transition very fast. */
+    this.timeout(15000);
+    const disconnectedClient = new Client('foo.test.google.com:50051', grpc.credentials.createInsecure());
+    const metadata = new grpc.Metadata({waitForReady: true});
+    const deadline = new Date();
+    deadline.setSeconds(deadline.getSeconds() + 10);
+    disconnectedClient.unary({}, metadata, {deadline: deadline}, (error, value) =>{
+      assert(error);
+      assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
       done();
     });
   });

--- a/packages/grpc-native-core/test/surface_test.js
+++ b/packages/grpc-native-core/test/surface_test.js
@@ -934,6 +934,19 @@ describe('Other conditions', function() {
     call.write({});
     call.end();
   });
+  it('client should wait for ready by default', function(done) {
+    this.timeout(15000);
+    const disconnectedClient = new Client('foo.test.google.com:50051', grpc.credentials.createInsecure());
+    const metadata = new grpc.Metadata({waitForReady: false});
+    const deadline = new Date();
+    deadline.setSeconds(deadline.getSeconds() + 10);
+    disconnectedClient.unary({}, metadata, {deadline: deadline}, (error, value) =>{
+      assert(error);
+      assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
+      done();
+    });
+
+  });
   it('client should drop a call if not connected with waitForReady off', function(done) {
     /* We have to wait for the client to reach the first connection timeout
      * and go to TRANSIENT_FAILURE to confirm that the waitForReady option

--- a/packages/grpc-native-core/test/surface_test.js
+++ b/packages/grpc-native-core/test/surface_test.js
@@ -934,19 +934,6 @@ describe('Other conditions', function() {
     call.write({});
     call.end();
   });
-  it('client should not wait for ready by default', function(done) {
-    this.timeout(15000);
-    const disconnectedClient = new Client('foo.test.google.com:50051', grpc.credentials.createInsecure());
-    const metadata = new grpc.Metadata({waitForReady: false});
-    const deadline = new Date();
-    deadline.setSeconds(deadline.getSeconds() + 10);
-    disconnectedClient.unary({}, metadata, {deadline: deadline}, (error, value) =>{
-      assert(error);
-      assert.strictEqual(error.code, grpc.status.UNAVAILABLE);
-      done();
-    });
-
-  });
   it('client should wait for a connection with waitForReady on', function(done) {
     /* We have to wait for the client to reach the first connection timeout
      * and go to TRANSIENT_FAILURE to confirm that the waitForReady option

--- a/packages/grpc-native-core/test/surface_test.js
+++ b/packages/grpc-native-core/test/surface_test.js
@@ -941,7 +941,9 @@ describe('Other conditions', function() {
      * failure makes that transition very fast. */
     const disconnectedClient = new Client('nothing.invalid:50051', grpc.credentials.createInsecure());
     const metadata = new grpc.Metadata({waitForReady: false});
-    disconnectedClient.unary({}, metadata, (error, value) =>{
+    const deadline = new Date();
+    deadline.setSeconds(deadline.getSeconds() + 1);
+    disconnectedClient.unary({}, metadata, {deadline: deadline}, (error, value) =>{
       assert(error);
       assert.strictEqual(error.code, grpc.status.UNAVAILABLE);
       done();

--- a/packages/grpc-native-core/test/surface_test.js
+++ b/packages/grpc-native-core/test/surface_test.js
@@ -939,7 +939,7 @@ describe('Other conditions', function() {
      * and go to TRANSIENT_FAILURE to confirm that the waitForReady option
      * makes it end the call instead of continuing to try. A DNS resolution
      * failure makes that transition very fast. */
-    const disconnectedClient = new Client('nothing.invalid:50051', grpc.credentials.createInsecure());
+    const disconnectedClient = new Client('foo.test.google.com:50051', grpc.credentials.createInsecure());
     const metadata = new grpc.Metadata({waitForReady: false});
     const deadline = new Date();
     deadline.setSeconds(deadline.getSeconds() + 1);


### PR DESCRIPTION
This is an implementation of [proposal L48](https://github.com/grpc/proposal/blob/master/L48-node-metadata-options.md). For grpc-js this just adds the API to pass the options in. They currently have no effect, but this is required to make it a working drop-in TypeScript replacement.