### PR TITLE
Omit a build warning that v8 headers violate

### DIFF
--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -963,7 +963,8 @@
       ],
       'cflags': [
         '-pthread',
-        '-Wno-error=deprecated-declarations'
+        '-Wno-error=deprecated-declarations',
+        '-Wno-cast-function-type'
       ],
       "conditions": [
         ['OS=="win" or runtime=="electron"', {

--- a/packages/grpc-native-core/templates/binding.gyp.template
+++ b/packages/grpc-native-core/templates/binding.gyp.template
@@ -312,7 +312,8 @@
         ],
         'cflags': [
           '-pthread',
-          '-Wno-error=deprecated-declarations'
+          '-Wno-error=deprecated-declarations',
+          '-Wno-cast-function-type'
         ],
         "conditions": [
           ['OS=="win" or runtime=="electron"', {


### PR DESCRIPTION
This should be another step toward fixing our Alpine build failures.