### PR TITLE
grpc-js: remove experimental text for http2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Directory: [`packages/grpc-js`](https://github.com/grpc/grpc-node/tree/master/pa
 
 npm package: [@grpc/grpc-js](https://www.npmjs.com/package/@grpc/grpc-js)
 
-**This library is currently incomplete and experimental, built on the [experimental http2 Node module](https://nodejs.org/api/http2.html).**
+**This library is currently incomplete and experimental. It is built on the [http2 Node module](https://nodejs.org/api/http2.html).**
 
 This library implements the core functionality of gRPC purely in JavaScript, without a C++ addon. It works on the latest version of Node.js on all platforms that Node.js runs on.
 


### PR DESCRIPTION
The `http2` module is no longer considered experimental.

Fixes: https://github.com/grpc/grpc-node/issues/808