### PR TITLE
Re-add typescript dependency on packages that use it

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -20,7 +20,8 @@
     "@types/node": "^10.5.4",
     "clang-format": "^1.0.55",
     "gts": "^0.5.1",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "typescript": "~3.3.3333"
   },
   "contributors": [
     {

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -46,7 +46,8 @@
     "@types/lodash.camelcase": "^4.3.4",
     "@types/node": "^10.12.5",
     "clang-format": "^1.2.2",
-    "gts": "^0.5.3"
+    "gts": "^0.5.3",
+    "typescript": "~3.3.3333"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
It turns out that the `prepare` scripts need a direct dependency on Typescript.