### PR TITLE
Update protobufjs module

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -33,7 +33,7 @@
     "lodash.clone": "^4.5.0",
     "nan": "^2.0.0",
     "node-pre-gyp": "^0.12.0",
-    "protobufjs": "^5.0.3"
+    "protobufjs": "^6.8.6"
   },
   "devDependencies": {
     "body-parser": "^1.15.2",


### PR DESCRIPTION
Match version to that in @grpc/proto-loader

Will now include type definitions from `protobufjs` module

Fixes #572