### PR TITLE
Require @types/protobuf.js at version 5.x as a dependency

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -29,6 +29,7 @@
     "node-pre-gyp"
   ],
   "dependencies": {
+    "@types/protobufjs": "^5.0.31",
     "lodash.camelcase": "^4.3.0",
     "lodash.clone": "^4.5.0",
     "nan": "^2.0.0",


### PR DESCRIPTION
Fixes #572 