### PR TITLE
Native: fix Node 12 compilation errors

### DIFF
--- a/packages/grpc-native-core/ext/channel.cc
+++ b/packages/grpc-native-core/ext/channel.cc
@@ -289,7 +289,7 @@ NAN_METHOD(Channel::GetConnectivityState) {
     return Nan::ThrowError(
         "Cannot call getConnectivityState on a closed Channel");
   }
-  int try_to_connect = (int)info[0]->Equals(Nan::True());
+  int try_to_connect = (int)info[0]->StrictEquals(Nan::True());
   info.GetReturnValue().Set(grpc_channel_check_connectivity_state(
       channel->wrapped_channel, try_to_connect));
 }

--- a/packages/grpc-native-core/ext/channel_credentials.cc
+++ b/packages/grpc-native-core/ext/channel_credentials.cc
@@ -194,7 +194,7 @@ NAN_METHOD(ChannelCredentials::CreateSsl) {
     if (!info[3]->IsObject()) {
       return Nan::ThrowTypeError("createSsl's fourth argument must be an object");
     }
-    Local<Object> object = info[3]->ToObject();
+    Local<Object> object = Nan::To<Object>(info[3]).ToLocalChecked();
 
     Local<Value> checkServerIdentityValue = Nan::Get(object,
         Nan::New("checkServerIdentity").ToLocalChecked()).ToLocalChecked();

--- a/packages/grpc-native-core/ext/server_credentials.cc
+++ b/packages/grpc-native-core/ext/server_credentials.cc
@@ -66,7 +66,7 @@ void ServerCredentials::Init(Local<Object> exports) {
   Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
   tpl->SetClassName(Nan::New("ServerCredentials").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
-  Local<Function> ctr = tpl->GetFunction();
+  Local<Function> ctr = Nan::GetFunction(tpl).ToLocalChecked();
   Nan::Set(
       ctr, Nan::New("createSsl").ToLocalChecked(),
       Nan::GetFunction(Nan::New<FunctionTemplate>(CreateSsl)).ToLocalChecked());

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "lodash.camelcase": "^4.3.0",
     "lodash.clone": "^4.5.0",
-    "nan": "^2.0.0",
+    "nan": "^2.13.2",
     "node-pre-gyp": "^0.12.0",
     "protobufjs": "^5.0.3"
   },

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -33,7 +33,7 @@
     "dependencies": {
       "lodash.camelcase": "^4.3.0",
       "lodash.clone": "^4.5.0",
-      "nan": "^2.0.0",
+      "nan": "^2.13.2",
       "node-pre-gyp": "^0.12.0",
       "protobufjs": "^5.0.3"
     },


### PR DESCRIPTION
Fixes #834, and lets us get out the Node 12 packages.