### PR TITLE
gitignore Node's bash completion file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ package-lock.json
 
 # Test generated files
 coverage
+
+# Node's bash completion file
+.node_bash_completion


### PR DESCRIPTION
This file is generated by newer versions of Node, and can show up in multiple locations.