### PR TITLE
grpc-js: require non-experimental http2

### DIFF
--- a/PACKAGE-COMPARISON.md
+++ b/PACKAGE-COMPARISON.md
@@ -22,7 +22,7 @@ Load Balancing | :heavy_check_mark: | :x:
 Other Properties | `grpc` | `@grpc/grpc-js`
 -----------------|--------|----------------
 Pure JavaScript Code | :x: | :heavy_check_mark:
-Supported Node Versions | >= 4 | ^8.11.2 or >=9.4
+Supported Node Versions | >= 4 | ^8.13.0 or >=10.10.0
 Supported Electron Versions | All | >= 3
 Supported Platforms | Linux, Windows, MacOS | All
 Supported Architectures | x86, x86-64, ARM7+ | All

--- a/packages/grpc-js/gulpfile.ts
+++ b/packages/grpc-js/gulpfile.ts
@@ -72,7 +72,7 @@ gulp.task('copy-test-fixtures', 'Copy test fixtures.', () => {
  * Transpiles src/ and test/, and then runs all tests.
  */
 gulp.task('test', 'Runs all tests.', ['lint', 'copy-test-fixtures'], () => {
-  if (semver.satisfies(process.version, '^8.11.2 || >=9.4')) {
+  if (semver.satisfies(process.version, '^8.13.0 || >=10.10.0')) {
     return gulp.src(`${outDir}/test/**/*.js`)
       .pipe(mocha({reporter: 'mocha-jenkins-reporter',
                    require: ['ts-node/register']}));

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",
   "main": "build/src/index.js",
   "engines": {
-    "node": "^8.11.2 || >=9.4"
+    "node": "^8.13.0 || >=10.10.0"
   },
   "keywords": [],
   "author": {

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -30,7 +30,7 @@ import {Metadata} from './metadata';
 import {KeyCertPair, ServerCredentials} from './server-credentials';
 import {StatusBuilder} from './status-builder';
 
-const supportedNodeVersions = '^8.11.2 || >=9.4';
+const supportedNodeVersions = '^8.13.0 || >=10.10.0';
 if (!semver.satisfies(process.version, supportedNodeVersions)) {
   throw new Error(`@grpc/grpc-js only works on Node ${supportedNodeVersions}`);
 }

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('clean.all', 'Delete all files created by tasks', () => {});
 gulp.task('test', 'Run API-level tests', () => {
   // run mocha tests matching a glob with a pre-required fixture,
   // returning the associated gulp stream
-  if (!semver.satisfies(process.version, '>=9.4')) {
+  if (!semver.satisfies(process.version, '>=10.10.0')) {
     console.log(`Skipping cross-implementation tests for Node ${process.version}`);
     return;
   }
@@ -57,7 +57,7 @@ gulp.task('test', 'Run API-level tests', () => {
       .on('error', reject);
   });
   var runTestsArgPairs;
-  if (semver.satisfies(process.version, '^ 8.11.2 || >=9.4')) {
+  if (semver.satisfies(process.version, '^8.13.0 || >=10.10.0')) {
     runTestsArgPairs = [
       ['native', 'native'],
       ['native', 'js'],


### PR DESCRIPTION
This commit bumps the required semver range to versions of Node that include a non-experimental http2 module.