### PR TITLE
grpc-js: adding GrpcObject

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -249,5 +249,4 @@ export const InterceptingCall = () => {
   throw new Error('Not yet implemented');
 };
 
-export { ChannelCredentials } from './channel-credentials';
-export { GrpcObject } from './make-client';
+export {GrpcObject} from './make-client';

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -248,3 +248,6 @@ export const InterceptorBuilder = () => {
 export const InterceptingCall = () => {
   throw new Error('Not yet implemented');
 };
+
+export { ChannelCredentials } from './channel-credentials';
+export { GrpcObject } from './make-client';


### PR DESCRIPTION
We (`google-gax`) need these two types exported to switch from C-core gRPC.