### PR TITLE
feat: export package version

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -250,3 +250,7 @@ export const InterceptingCall = () => {
 };
 
 export {GrpcObject} from './make-client';
+
+const packageJson = require('../../package.json');
+export const version =
+    `${packageJson.name.replace(/.*\//, '')}/${packageJson.version}`;

--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -947,6 +947,11 @@ declare module "grpc" {
   };
 
   /**
+   * Package version.
+   */
+  export const version: string;
+
+  /**
    * Metadata generator function.
    */
   export type metadataGenerator = (params: { service_url: string }, callback: (error: Error | null, metadata?: Metadata) => void) => void;

--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -243,6 +243,10 @@ exports.connectivityState = constants.connectivityState;
 
 exports.credentials = require('./src/credentials.js');
 
+const packageJson = require('./package.json');
+exports.version =
+    `${packageJson.name.replace(/.*\//, '')}/${packageJson.version}`;
+
 /**
  * ServerCredentials factories
  * @constructor ServerCredentials


### PR DESCRIPTION
Since we are entering a phase when different client libraries will use different gRPC implementations (most will be migrated to `@grpc/grpc-js` but some will still stay with `grpc`), we'd like to have an easy way for the client library to set the gRPC version in the headers without actually knowing if the `grpc` instance they work with is a C-core or JS implementation.

Can we have this `grpc.version` added to both implementations to make this tracking easier? (or feel free to suggest another options!)