### PR TITLE
Handle parse failures when merging test logs

### DIFF
--- a/merge_kokoro_logs.js
+++ b/merge_kokoro_logs.js
@@ -25,6 +25,30 @@ const readDir = util.promisify(fs.readdir);
 
 const rootDir = __dirname;
 
+// Fake test suite log with a failure if log parsing failed
+const parseFailureLog = [
+  {
+    $: {
+      name: 'Unknown Test Suite',
+      tests: '1',
+      failures: '1',
+    },
+    testcase: [
+      {
+        $: {
+          classname: 'Test Log Parsing',
+          name: 'Test Log Parsing',
+          failure: {
+            $: {
+              message: "Log parsing failed"
+            }
+          }
+        }
+      }
+    ]
+  }
+];
+
 readDir(rootDir + '/reports')
     .then((dirNames) =>
           Promise.all(dirNames.map((dirName) =>
@@ -41,7 +65,12 @@ readDir(rootDir + '/reports')
                                         )
                                    .then((objects) => {
                                      let merged = objects[0];
-                                     merged.testsuites.testsuite = Array.prototype.concat.apply([], objects.map((obj) => obj.testsuites.testsuite));
+                                     merged.testsuites.testsuite = Array.prototype.concat.apply([], objects.map((obj) => {
+                                                                                                                if (obj) {
+                                                                                                                  return obj.testsuites.testsuite;
+                                                                                                                } else {
+                                                                                                                  return parseFailureLog;
+                                                                                                                }}));
                                      let builder = new xml2js.Builder();
                                      let xml = builder.buildObject(merged);
                                      let resultName = path.resolve(rootDir, 'reports', dirName, 'sponge_log.xml');


### PR DESCRIPTION
This should fix the problem we see in the test logs in #864 where some parsed logs were `null` and that stopped it from combining other logs for the same Node version.