### PR TITLE
grpc-js: misc small cleanup

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -15,14 +15,14 @@
   "types": "build/src/index.d.ts",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grpc/proto-loader": "^0.4.0",
+    "@grpc/proto-loader": "^0.5.0",
     "@types/lodash": "^4.14.108",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^11.13.2",
+    "@types/node": "^12.0.2",
     "clang-format": "^1.0.55",
     "gts": "^0.9.0",
     "lodash": "^4.17.4",
-    "typescript": "~3.3.3333"
+    "typescript": "~3.4.5"
   },
   "contributors": [
     {

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -26,10 +26,6 @@ import {Deserialize, Serialize} from './make-client';
 import {Metadata} from './metadata';
 import {StreamDecoder} from './stream-decoder';
 
-function noop(): void {}
-
-export type PartialServiceError = Partial<ServiceError>;
-
 type DeadlineUnitIndexSignature = {
   [name: string]: number
 };

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -104,8 +104,7 @@ export class ServerReadableStreamImpl<RequestType, ResponseType> extends
 
   constructor(
       private call: Http2ServerCallStream<RequestType, ResponseType>,
-      public metadata: Metadata,
-      private _deserialize: Deserialize<RequestType>) {
+      public metadata: Metadata, public deserialize: Deserialize<RequestType>) {
     super({objectMode: true});
     this.cancelled = false;
     this.call.setupReadable(this);
@@ -113,10 +112,6 @@ export class ServerReadableStreamImpl<RequestType, ResponseType> extends
 
   _read(size: number) {
     this.call.resume();
-  }
-
-  deserialize(input: Buffer): RequestType {
-    return this._deserialize(input);
   }
 
   getPeer(): string {
@@ -137,7 +132,7 @@ export class ServerWritableStreamImpl<RequestType, ResponseType> extends
 
   constructor(
       private call: Http2ServerCallStream<RequestType, ResponseType>,
-      public metadata: Metadata, private _serialize: Serialize<ResponseType>) {
+      public metadata: Metadata, public serialize: Serialize<ResponseType>) {
     super({objectMode: true});
     this.cancelled = false;
     this.request = null;
@@ -189,14 +184,6 @@ export class ServerWritableStreamImpl<RequestType, ResponseType> extends
     }
 
     super.end();
-  }
-
-  serialize(input: ResponseType): Buffer|null {
-    if (input === null || input === undefined) {
-      return null;
-    }
-
-    return this._serialize(input);
   }
 }
 

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -20,18 +20,18 @@ import {AddressInfo, ListenOptions} from 'net';
 import {URL} from 'url';
 
 import {ServiceError} from './call';
-import {StatusObject} from './call-stream';
 import {Status} from './constants';
 import {Deserialize, Serialize, ServiceDefinition} from './make-client';
 import {Metadata} from './metadata';
-import {BidiStreamingHandler, ClientStreamingHandler, HandleCall, Handler, HandlerType, Http2ServerCallStream, PartialServiceError, sendUnaryData, ServerDuplexStream, ServerDuplexStreamImpl, ServerReadableStream, ServerReadableStreamImpl, ServerStreamingHandler, ServerUnaryCall, ServerUnaryCallImpl, ServerWritableStream, ServerWritableStreamImpl, UnaryHandler} from './server-call';
+import {BidiStreamingHandler, ClientStreamingHandler, HandleCall, Handler, HandlerType, Http2ServerCallStream, sendUnaryData, ServerDuplexStream, ServerDuplexStreamImpl, ServerReadableStream, ServerReadableStreamImpl, ServerStreamingHandler, ServerUnaryCall, ServerUnaryCallImpl, ServerWritableStream, ServerWritableStreamImpl, UnaryHandler} from './server-call';
 import {ServerCredentials} from './server-credentials';
 
 function noop(): void {}
 
-const unimplementedStatusResponse: PartialServiceError = {
+const unimplementedStatusResponse: Partial<ServiceError> = {
   code: Status.UNIMPLEMENTED,
   details: 'The server does not implement this method',
+  metadata: new Metadata()
 };
 
 // tslint:disable:no-any

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -26,7 +26,7 @@ import {ServerCredentials} from '../src';
 import {ServiceError} from '../src/call';
 import {ServiceClient, ServiceClientConstructor} from '../src/make-client';
 import {Server} from '../src/server';
-import {sendUnaryData, ServerDuplexStream, ServerReadableStream, ServerUnaryCall, ServerWritableStream} from '../src/server-call';
+import {sendUnaryData, ServerUnaryCall} from '../src/server-call';
 
 import {loadProtoFile} from './common';
 


### PR DESCRIPTION
Now that all four server handler types have landed, this is just some small follow up cleanup:

**First commit:**
During initial implementation, the `serialize` and `deserialize` APIs of `ServerReadableStream`, `ServerWritableStream`, and `ServerDuplexStream` became inconsistent. This commit brings back consistency.

**Second commit:**
This commit removes some unnecessary imports and exports from the server code.

**Third commit:**
This commit resolves issues from `npm outdated`. The `gts` dependency will be updated to 1.x.x in a separate follow up PR, as it comes with significant churn.