### PR TITLE
grpc-js: update to gts@1.x.x

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.6",
     "@types/node": "^12.0.2",
     "clang-format": "^1.0.55",
-    "gts": "^0.9.0",
+    "gts": "^1.0.0",
     "lodash": "^4.17.4",
     "typescript": "~3.4.5"
   },

--- a/packages/grpc-js/src/call-credentials-filter.ts
+++ b/packages/grpc-js/src/call-credentials-filter.ts
@@ -15,16 +15,18 @@
  *
  */
 
-import {CallCredentials} from './call-credentials';
-import {Call} from './call-stream';
-import {Http2Channel} from './channel';
-import {BaseFilter, Filter, FilterFactory} from './filter';
-import {Metadata} from './metadata';
+import { CallCredentials } from './call-credentials';
+import { Call } from './call-stream';
+import { Http2Channel } from './channel';
+import { BaseFilter, Filter, FilterFactory } from './filter';
+import { Metadata } from './metadata';
 
 export class CallCredentialsFilter extends BaseFilter implements Filter {
   private serviceUrl: string;
   constructor(
-      private readonly channel: Http2Channel, private readonly stream: Call) {
+    private readonly channel: Http2Channel,
+    private readonly stream: Call
+  ) {
     super();
     this.channel = channel;
     this.stream = stream;
@@ -45,16 +47,17 @@ export class CallCredentialsFilter extends BaseFilter implements Filter {
     const channelCredentials = this.channel.credentials._getCallCredentials();
     const streamCredentials = this.stream.getCredentials();
     const credentials = channelCredentials.compose(streamCredentials);
-    const credsMetadata =
-        credentials.generateMetadata({service_url: this.serviceUrl});
+    const credsMetadata = credentials.generateMetadata({
+      service_url: this.serviceUrl,
+    });
     const resultMetadata = await metadata;
     resultMetadata.merge(await credsMetadata);
     return resultMetadata;
   }
 }
 
-export class CallCredentialsFilterFactory implements
-    FilterFactory<CallCredentialsFilter> {
+export class CallCredentialsFilterFactory
+  implements FilterFactory<CallCredentialsFilter> {
   private readonly channel: Http2Channel;
   constructor(channel: Http2Channel) {
     this.channel = channel;

--- a/packages/grpc-js/src/call-credentials.ts
+++ b/packages/grpc-js/src/call-credentials.ts
@@ -15,15 +15,16 @@
  *
  */
 
-import {Metadata} from './metadata';
+import { Metadata } from './metadata';
 
-export type CallMetadataOptions = {
+export interface CallMetadataOptions {
   service_url: string;
-};
+}
 
-export type CallMetadataGenerator =
-    (options: CallMetadataOptions,
-     cb: (err: Error|null, metadata?: Metadata) => void) => void;
+export type CallMetadataGenerator = (
+  options: CallMetadataOptions,
+  cb: (err: Error | null, metadata?: Metadata) => void
+) => void;
 
 /**
  * A class that represents a generic method of adding authentication-related
@@ -50,8 +51,9 @@ export abstract class CallCredentials {
    * generates a Metadata object based on these options, which is passed back
    * to the caller via a supplied (err, metadata) callback.
    */
-  static createFromMetadataGenerator(metadataGenerator: CallMetadataGenerator):
-      CallCredentials {
+  static createFromMetadataGenerator(
+    metadataGenerator: CallMetadataGenerator
+  ): CallCredentials {
     return new SingleCallCredentials(metadataGenerator);
   }
 
@@ -68,7 +70,8 @@ class ComposedCallCredentials extends CallCredentials {
   async generateMetadata(options: CallMetadataOptions): Promise<Metadata> {
     const base: Metadata = new Metadata();
     const generated: Metadata[] = await Promise.all(
-        this.creds.map((cred) => cred.generateMetadata(options)));
+      this.creds.map(cred => cred.generateMetadata(options))
+    );
     for (const gen of generated) {
       base.merge(gen);
     }

--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -15,9 +15,9 @@
  *
  */
 
-import {ConnectionOptions, createSecureContext, PeerCertificate} from 'tls';
+import { ConnectionOptions, createSecureContext, PeerCertificate } from 'tls';
 
-import {CallCredentials} from './call-credentials';
+import { CallCredentials } from './call-credentials';
 
 // tslint:disable-next-line:no-any
 function verifyIsBufferOrNull(obj: any, friendlyName: string): void {
@@ -42,8 +42,10 @@ export interface Certificate {
  * indicate that the presented certificate is considered invalid and
  * otherwise returned undefined.
  */
-export type CheckServerIdentityCallback =
-    (hostname: string, cert: Certificate) => Error|undefined;
+export type CheckServerIdentityCallback = (
+  hostname: string,
+  cert: Certificate
+) => Error | undefined;
 
 /**
  * Additional peer verification options that can be set when creating
@@ -88,7 +90,7 @@ export abstract class ChannelCredentials {
    * instance was created with createSsl, or null if this instance was created
    * with createInsecure.
    */
-  abstract _getConnectionOptions(): ConnectionOptions|null;
+  abstract _getConnectionOptions(): ConnectionOptions | null;
 
   /**
    * Indicates whether this credentials object creates a secure channel.
@@ -104,31 +106,37 @@ export abstract class ChannelCredentials {
    * @param certChain The client certificate key chain, if available.
    */
   static createSsl(
-      rootCerts?: Buffer|null, privateKey?: Buffer|null,
-      certChain?: Buffer|null,
-      verifyOptions?: VerifyOptions): ChannelCredentials {
+    rootCerts?: Buffer | null,
+    privateKey?: Buffer | null,
+    certChain?: Buffer | null,
+    verifyOptions?: VerifyOptions
+  ): ChannelCredentials {
     verifyIsBufferOrNull(rootCerts, 'Root certificate');
     verifyIsBufferOrNull(privateKey, 'Private key');
     verifyIsBufferOrNull(certChain, 'Certificate chain');
     if (privateKey && !certChain) {
       throw new Error(
-          'Private key must be given with accompanying certificate chain');
+        'Private key must be given with accompanying certificate chain'
+      );
     }
     if (!privateKey && certChain) {
       throw new Error(
-          'Certificate chain must be given with accompanying private key');
+        'Certificate chain must be given with accompanying private key'
+      );
     }
     const secureContext = createSecureContext({
       ca: rootCerts || undefined,
       key: privateKey || undefined,
-      cert: certChain || undefined
+      cert: certChain || undefined,
     });
-    const connectionOptions: ConnectionOptions = {secureContext};
+    const connectionOptions: ConnectionOptions = { secureContext };
     if (verifyOptions && verifyOptions.checkServerIdentity) {
-      connectionOptions.checkServerIdentity =
-          (host: string, cert: PeerCertificate) => {
-            return verifyOptions.checkServerIdentity!(host, {raw: cert.raw});
-          };
+      connectionOptions.checkServerIdentity = (
+        host: string,
+        cert: PeerCertificate
+      ) => {
+        return verifyOptions.checkServerIdentity!(host, { raw: cert.raw });
+      };
     }
     return new SecureChannelCredentialsImpl(connectionOptions);
   }
@@ -150,7 +158,7 @@ class InsecureChannelCredentialsImpl extends ChannelCredentials {
     throw new Error('Cannot compose insecure credentials');
   }
 
-  _getConnectionOptions(): ConnectionOptions|null {
+  _getConnectionOptions(): ConnectionOptions | null {
     return null;
   }
   _isSecure(): boolean {
@@ -162,19 +170,24 @@ class SecureChannelCredentialsImpl extends ChannelCredentials {
   connectionOptions: ConnectionOptions;
 
   constructor(
-      connectionOptions: ConnectionOptions, callCredentials?: CallCredentials) {
+    connectionOptions: ConnectionOptions,
+    callCredentials?: CallCredentials
+  ) {
     super(callCredentials);
     this.connectionOptions = connectionOptions;
   }
 
   compose(callCredentials: CallCredentials): ChannelCredentials {
-    const combinedCallCredentials =
-        this.callCredentials.compose(callCredentials);
+    const combinedCallCredentials = this.callCredentials.compose(
+      callCredentials
+    );
     return new SecureChannelCredentialsImpl(
-        this.connectionOptions, combinedCallCredentials);
+      this.connectionOptions,
+      combinedCallCredentials
+    );
   }
 
-  _getConnectionOptions(): ConnectionOptions|null {
+  _getConnectionOptions(): ConnectionOptions | null {
     return this.connectionOptions;
   }
   _isSecure(): boolean {

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -25,7 +25,7 @@ export interface ChannelOptions {
   'grpc.default_authority': string;
   'grpc.keepalive_time_ms': number;
   'grpc.keepalive_timeout_ms': number;
-  [key: string]: string|number;
+  [key: string]: string | number;
 }
 
 /**
@@ -38,5 +38,5 @@ export const recognizedOptions = {
   'grpc.secondary_user_agent': true,
   'grpc.default_authority': true,
   'grpc.keepalive_time_ms': true,
-  'grpc.keepalive_timeout_ms': true
+  'grpc.keepalive_timeout_ms': true,
 };

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -15,24 +15,29 @@
  *
  */
 
-import {EventEmitter} from 'events';
+import { EventEmitter } from 'events';
 import * as http2 from 'http2';
-import {checkServerIdentity, PeerCertificate} from 'tls';
+import { checkServerIdentity, PeerCertificate } from 'tls';
 import * as url from 'url';
 
-import {CallCredentialsFilterFactory} from './call-credentials-filter';
-import {Call, CallStreamOptions, Deadline, Http2CallStream} from './call-stream';
-import {ChannelCredentials} from './channel-credentials';
-import {ChannelOptions, recognizedOptions} from './channel-options';
-import {CompressionFilterFactory} from './compression-filter';
-import {Status} from './constants';
-import {DeadlineFilterFactory} from './deadline-filter';
-import {FilterStackFactory} from './filter-stack';
-import {Metadata} from './metadata';
-import {MetadataStatusFilterFactory} from './metadata-status-filter';
-import {Http2SubChannel} from './subchannel';
+import { CallCredentialsFilterFactory } from './call-credentials-filter';
+import {
+  Call,
+  CallStreamOptions,
+  Deadline,
+  Http2CallStream,
+} from './call-stream';
+import { ChannelCredentials } from './channel-credentials';
+import { ChannelOptions, recognizedOptions } from './channel-options';
+import { CompressionFilterFactory } from './compression-filter';
+import { Status } from './constants';
+import { DeadlineFilterFactory } from './deadline-filter';
+import { FilterStackFactory } from './filter-stack';
+import { Metadata } from './metadata';
+import { MetadataStatusFilterFactory } from './metadata-status-filter';
+import { Http2SubChannel } from './subchannel';
 
-const {version: clientVersion} = require('../../package.json');
+const { version: clientVersion } = require('../../package.json');
 
 const MIN_CONNECT_TIMEOUT_MS = 20000;
 const INITIAL_BACKOFF_MS = 1000;
@@ -46,7 +51,7 @@ const {
   HTTP2_HEADER_METHOD,
   HTTP2_HEADER_PATH,
   HTTP2_HEADER_TE,
-  HTTP2_HEADER_USER_AGENT
+  HTTP2_HEADER_USER_AGENT,
 } = http2.constants;
 
 export enum ConnectivityState {
@@ -54,7 +59,7 @@ export enum ConnectivityState {
   READY,
   TRANSIENT_FAILURE,
   IDLE,
-  SHUTDOWN
+  SHUTDOWN,
 }
 
 function uniformRandom(min: number, max: number) {
@@ -98,8 +103,10 @@ export interface Channel {
    *     error if the deadline passes without a state change.
    */
   watchConnectivityState(
-      currentState: ConnectivityState, deadline: Date|number,
-      callback: (error?: Error) => void): void;
+    currentState: ConnectivityState,
+    deadline: Date | number,
+    callback: (error?: Error) => void
+  ): void;
   /**
    * Create a call object. Call is an opaque type that is used by the Client
    * class. This function is called by the gRPC library when starting a
@@ -113,9 +120,12 @@ export interface Channel {
    *     that indicates what information to propagate from parentCall.
    */
   createCall(
-      method: string, deadline: Deadline|null|undefined,
-      host: string|null|undefined, parentCall: Call|null|undefined,
-      propagateFlags: number|null|undefined): Call;
+    method: string,
+    deadline: Deadline | null | undefined,
+    host: string | null | undefined,
+    parentCall: Call | null | undefined,
+    propagateFlags: number | null | undefined
+  ): Call;
 }
 
 export class Http2Channel extends EventEmitter implements Channel {
@@ -124,10 +134,10 @@ export class Http2Channel extends EventEmitter implements Channel {
   private readonly defaultAuthority: string;
   private connectivityState: ConnectivityState = ConnectivityState.IDLE;
   // Helper Promise object only used in the implementation of connect().
-  private connecting: Promise<void>|null = null;
+  private connecting: Promise<void> | null = null;
   /* For now, we have up to one subchannel, which will exist as long as we are
    * connecting or trying to connect */
-  private subChannel: Http2SubChannel|null = null;
+  private subChannel: Http2SubChannel | null = null;
   private filterStackFactory: FilterStackFactory;
 
   private subChannelConnectCallback: () => void = () => {};
@@ -138,21 +148,28 @@ export class Http2Channel extends EventEmitter implements Channel {
   private currentBackoffDeadline: Date;
 
   private handleStateChange(
-      oldState: ConnectivityState, newState: ConnectivityState): void {
+    oldState: ConnectivityState,
+    newState: ConnectivityState
+  ): void {
     const now: Date = new Date();
     switch (newState) {
       case ConnectivityState.CONNECTING:
         if (oldState === ConnectivityState.IDLE) {
           this.currentBackoff = INITIAL_BACKOFF_MS;
-          this.currentBackoffDeadline =
-              new Date(now.getTime() + INITIAL_BACKOFF_MS);
+          this.currentBackoffDeadline = new Date(
+            now.getTime() + INITIAL_BACKOFF_MS
+          );
         } else if (oldState === ConnectivityState.TRANSIENT_FAILURE) {
           this.currentBackoff = Math.min(
-              this.currentBackoff * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
+            this.currentBackoff * BACKOFF_MULTIPLIER,
+            MAX_BACKOFF_MS
+          );
           const jitterMagnitude: number = BACKOFF_JITTER * this.currentBackoff;
           this.currentBackoffDeadline = new Date(
-              now.getTime() + this.currentBackoff +
-              uniformRandom(-jitterMagnitude, jitterMagnitude));
+            now.getTime() +
+              this.currentBackoff +
+              uniformRandom(-jitterMagnitude, jitterMagnitude)
+          );
         }
         this.startConnecting();
         break;
@@ -163,8 +180,9 @@ export class Http2Channel extends EventEmitter implements Channel {
         this.subChannel = null;
         this.backoffTimerId = setTimeout(() => {
           this.transitionToState(
-              [ConnectivityState.TRANSIENT_FAILURE],
-              ConnectivityState.CONNECTING);
+            [ConnectivityState.TRANSIENT_FAILURE],
+            ConnectivityState.CONNECTING
+          );
         }, this.currentBackoffDeadline.getTime() - now.getTime());
         break;
       case ConnectivityState.IDLE:
@@ -172,7 +190,9 @@ export class Http2Channel extends EventEmitter implements Channel {
         if (this.subChannel) {
           this.subChannel.close();
           this.subChannel.removeListener(
-              'connect', this.subChannelConnectCallback);
+            'connect',
+            this.subChannelConnectCallback
+          );
           this.subChannel.removeListener('close', this.subChannelCloseCallback);
           this.subChannel = null;
           this.emit('shutdown');
@@ -186,7 +206,9 @@ export class Http2Channel extends EventEmitter implements Channel {
 
   // Transition from any of a set of oldStates to a specific newState
   private transitionToState(
-      oldStates: ConnectivityState[], newState: ConnectivityState): void {
+    oldStates: ConnectivityState[],
+    newState: ConnectivityState
+  ): void {
     if (oldStates.indexOf(this.connectivityState) > -1) {
       const oldState: ConnectivityState = this.connectivityState;
       this.connectivityState = newState;
@@ -197,28 +219,36 @@ export class Http2Channel extends EventEmitter implements Channel {
 
   private startConnecting(): void {
     const connectionOptions: http2.SecureClientSessionOptions =
-        this.credentials._getConnectionOptions() || {};
+      this.credentials._getConnectionOptions() || {};
     if (connectionOptions.secureContext !== null) {
       // If provided, the value of grpc.ssl_target_name_override should be used
       // to override the target hostname when checking server identity.
       // This option is used for testing only.
       if (this.options['grpc.ssl_target_name_override']) {
-        const sslTargetNameOverride =
-            this.options['grpc.ssl_target_name_override']!;
-        connectionOptions.checkServerIdentity =
-            (host: string, cert: PeerCertificate): Error|undefined => {
-              return checkServerIdentity(sslTargetNameOverride, cert);
-            };
+        const sslTargetNameOverride = this.options[
+          'grpc.ssl_target_name_override'
+        ]!;
+        connectionOptions.checkServerIdentity = (
+          host: string,
+          cert: PeerCertificate
+        ): Error | undefined => {
+          return checkServerIdentity(sslTargetNameOverride, cert);
+        };
         connectionOptions.servername = sslTargetNameOverride;
       }
     }
     const subChannel: Http2SubChannel = new Http2SubChannel(
-        this.target, connectionOptions, this.userAgent, this.options);
+      this.target,
+      connectionOptions,
+      this.userAgent,
+      this.options
+    );
     this.subChannel = subChannel;
     const now = new Date();
     const connectionTimeout: number = Math.max(
-        this.currentBackoffDeadline.getTime() - now.getTime(),
-        MIN_CONNECT_TIMEOUT_MS);
+      this.currentBackoffDeadline.getTime() - now.getTime(),
+      MIN_CONNECT_TIMEOUT_MS
+    );
     const connectionTimerId: NodeJS.Timer = setTimeout(() => {
       // This should trigger the 'close' event, which will send us back to
       // TRANSIENT_FAILURE
@@ -228,7 +258,9 @@ export class Http2Channel extends EventEmitter implements Channel {
       // Connection succeeded
       clearTimeout(connectionTimerId);
       this.transitionToState(
-          [ConnectivityState.CONNECTING], ConnectivityState.READY);
+        [ConnectivityState.CONNECTING],
+        ConnectivityState.READY
+      );
     };
     subChannel.once('connect', this.subChannelConnectCallback);
     this.subChannelCloseCallback = () => {
@@ -237,21 +269,25 @@ export class Http2Channel extends EventEmitter implements Channel {
       /* TODO(murgatroid99): verify that this works for
        * CONNECTING->TRANSITIVE_FAILURE see nodejs/node#16645 */
       this.transitionToState(
-          [ConnectivityState.CONNECTING, ConnectivityState.READY],
-          ConnectivityState.TRANSIENT_FAILURE);
+        [ConnectivityState.CONNECTING, ConnectivityState.READY],
+        ConnectivityState.TRANSIENT_FAILURE
+      );
     };
     subChannel.once('close', this.subChannelCloseCallback);
   }
 
   constructor(
-      address: string, readonly credentials: ChannelCredentials,
-      private readonly options: Partial<ChannelOptions>) {
+    address: string,
+    readonly credentials: ChannelCredentials,
+    private readonly options: Partial<ChannelOptions>
+  ) {
     super();
     for (const option in options) {
       if (options.hasOwnProperty(option)) {
         if (!recognizedOptions.hasOwnProperty(option)) {
           console.warn(
-              `Unrecognized channel argument '${option}' will be ignored.`);
+            `Unrecognized channel argument '${option}' will be ignored.`
+          );
         }
       }
     }
@@ -267,8 +303,10 @@ export class Http2Channel extends EventEmitter implements Channel {
       this.defaultAuthority = this.target.host;
     }
     this.filterStackFactory = new FilterStackFactory([
-      new CallCredentialsFilterFactory(this), new DeadlineFilterFactory(this),
-      new MetadataStatusFilterFactory(this), new CompressionFilterFactory(this)
+      new CallCredentialsFilterFactory(this),
+      new DeadlineFilterFactory(this),
+      new MetadataStatusFilterFactory(this),
+      new CompressionFilterFactory(this),
     ]);
     this.currentBackoffDeadline = new Date();
     /* The only purpose of these lines is to ensure that this.backoffTimerId has
@@ -277,61 +315,75 @@ export class Http2Channel extends EventEmitter implements Channel {
 
     // Build user-agent string.
     this.userAgent = [
-      options['grpc.primary_user_agent'], `grpc-node-js/${clientVersion}`,
-      options['grpc.secondary_user_agent']
-    ].filter(e => e).join(' ');  // remove falsey values first
+      options['grpc.primary_user_agent'],
+      `grpc-node-js/${clientVersion}`,
+      options['grpc.secondary_user_agent'],
+    ]
+      .filter(e => e)
+      .join(' '); // remove falsey values first
   }
 
   _startHttp2Stream(
-      authority: string, methodName: string, stream: Http2CallStream,
-      metadata: Metadata) {
-    const finalMetadata: Promise<Metadata> =
-        stream.filterStack.sendMetadata(Promise.resolve(metadata.clone()));
+    authority: string,
+    methodName: string,
+    stream: Http2CallStream,
+    metadata: Metadata
+  ) {
+    const finalMetadata: Promise<Metadata> = stream.filterStack.sendMetadata(
+      Promise.resolve(metadata.clone())
+    );
     Promise.all([finalMetadata, this.connect()])
-        .then(([metadataValue]) => {
-          const headers = metadataValue.toHttp2Headers();
-          headers[HTTP2_HEADER_AUTHORITY] = authority;
-          headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;
-          headers[HTTP2_HEADER_CONTENT_TYPE] = 'application/grpc';
-          headers[HTTP2_HEADER_METHOD] = 'POST';
-          headers[HTTP2_HEADER_PATH] = methodName;
-          headers[HTTP2_HEADER_TE] = 'trailers';
-          if (this.connectivityState === ConnectivityState.READY) {
-            const subChannel: Http2SubChannel = this.subChannel!;
-            subChannel.startCallStream(metadataValue, stream);
-          } else {
-            /* In this case, we lost the connection while finalizing
-             * metadata. That should be very unusual */
-            setImmediate(() => {
-              this._startHttp2Stream(authority, methodName, stream, metadata);
-            });
-          }
-        })
-        .catch((error: Error&{code: number}) => {
-          // We assume the error code isn't 0 (Status.OK)
-          stream.cancelWithStatus(
-              error.code || Status.UNKNOWN,
-              `Getting metadata from plugin failed with error: ${
-                  error.message}`);
-        });
+      .then(([metadataValue]) => {
+        const headers = metadataValue.toHttp2Headers();
+        headers[HTTP2_HEADER_AUTHORITY] = authority;
+        headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;
+        headers[HTTP2_HEADER_CONTENT_TYPE] = 'application/grpc';
+        headers[HTTP2_HEADER_METHOD] = 'POST';
+        headers[HTTP2_HEADER_PATH] = methodName;
+        headers[HTTP2_HEADER_TE] = 'trailers';
+        if (this.connectivityState === ConnectivityState.READY) {
+          const subChannel: Http2SubChannel = this.subChannel!;
+          subChannel.startCallStream(metadataValue, stream);
+        } else {
+          /* In this case, we lost the connection while finalizing
+           * metadata. That should be very unusual */
+          setImmediate(() => {
+            this._startHttp2Stream(authority, methodName, stream, metadata);
+          });
+        }
+      })
+      .catch((error: Error & { code: number }) => {
+        // We assume the error code isn't 0 (Status.OK)
+        stream.cancelWithStatus(
+          error.code || Status.UNKNOWN,
+          `Getting metadata from plugin failed with error: ${error.message}`
+        );
+      });
   }
 
   createCall(
-      method: string, deadline: Deadline|null|undefined,
-      host: string|null|undefined, parentCall: Call|null|undefined,
-      propagateFlags: number|null|undefined): Call {
+    method: string,
+    deadline: Deadline | null | undefined,
+    host: string | null | undefined,
+    parentCall: Call | null | undefined,
+    propagateFlags: number | null | undefined
+  ): Call {
     if (this.connectivityState === ConnectivityState.SHUTDOWN) {
       throw new Error('Channel has been shut down');
     }
     const finalOptions: CallStreamOptions = {
-      deadline: (deadline === null || deadline === undefined) ? Infinity :
-                                                                deadline,
+      deadline:
+        deadline === null || deadline === undefined ? Infinity : deadline,
       flags: propagateFlags || 0,
       host: host || this.defaultAuthority,
-      parentCall: parentCall || null
+      parentCall: parentCall || null,
     };
     const stream: Http2CallStream = new Http2CallStream(
-        method, this, finalOptions, this.filterStackFactory);
+      method,
+      this,
+      finalOptions,
+      this.filterStackFactory
+    );
     return stream;
   }
 
@@ -351,7 +403,9 @@ export class Http2Channel extends EventEmitter implements Channel {
       if (!this.connecting) {
         this.connecting = new Promise((resolve, reject) => {
           this.transitionToState(
-              [ConnectivityState.IDLE], ConnectivityState.CONNECTING);
+            [ConnectivityState.IDLE],
+            ConnectivityState.CONNECTING
+          );
           const onConnect = () => {
             this.connecting = null;
             this.removeListener('shutdown', onShutdown);
@@ -373,14 +427,18 @@ export class Http2Channel extends EventEmitter implements Channel {
   getConnectivityState(tryToConnect: boolean): ConnectivityState {
     if (tryToConnect) {
       this.transitionToState(
-          [ConnectivityState.IDLE], ConnectivityState.CONNECTING);
+        [ConnectivityState.IDLE],
+        ConnectivityState.CONNECTING
+      );
     }
     return this.connectivityState;
   }
 
   watchConnectivityState(
-      currentState: ConnectivityState, deadline: Date|number,
-      callback: (error?: Error) => void) {
+    currentState: ConnectivityState,
+    deadline: Date | number,
+    callback: (error?: Error) => void
+  ) {
     if (this.connectivityState !== currentState) {
       /* If the connectivity state is different from the provided currentState,
        * we assume that a state change has successfully occurred */
@@ -417,10 +475,13 @@ export class Http2Channel extends EventEmitter implements Channel {
       throw new Error('Channel has been shut down');
     }
     this.transitionToState(
-        [
-          ConnectivityState.CONNECTING, ConnectivityState.READY,
-          ConnectivityState.TRANSIENT_FAILURE, ConnectivityState.IDLE
-        ],
-        ConnectivityState.SHUTDOWN);
+      [
+        ConnectivityState.CONNECTING,
+        ConnectivityState.READY,
+        ConnectivityState.TRANSIENT_FAILURE,
+        ConnectivityState.IDLE,
+      ],
+      ConnectivityState.SHUTDOWN
+    );
   }
 }

--- a/packages/grpc-js/src/compression-filter.ts
+++ b/packages/grpc-js/src/compression-filter.ts
@@ -17,10 +17,10 @@
 
 import * as zlib from 'zlib';
 
-import {Call, WriteFlags, WriteObject} from './call-stream';
-import {Channel} from './channel';
-import {BaseFilter, Filter, FilterFactory} from './filter';
-import {Metadata, MetadataValue} from './metadata';
+import { Call, WriteFlags, WriteObject } from './call-stream';
+import { Channel } from './channel';
+import { BaseFilter, Filter, FilterFactory } from './filter';
+import { Metadata, MetadataValue } from './metadata';
 
 abstract class CompressionHandler {
   protected abstract compressMessage(message: Buffer): Promise<Buffer>;
@@ -71,8 +71,11 @@ class IdentityHandler extends CompressionHandler {
   }
 
   decompressMessage(message: Buffer): Promise<Buffer> {
-    return Promise.reject<Buffer>(new Error(
-        'Received compressed message but "grpc-encoding" header was identity'));
+    return Promise.reject<Buffer>(
+      new Error(
+        'Received compressed message but "grpc-encoding" header was identity'
+      )
+    );
   }
 }
 
@@ -133,15 +136,20 @@ class UnknownHandler extends CompressionHandler {
     super();
   }
   compressMessage(message: Buffer): Promise<Buffer> {
-    return Promise.reject<Buffer>(new Error(
+    return Promise.reject<Buffer>(
+      new Error(
         `Received message compressed wth unsupported compression method ${
-            this.compressionName}`));
+          this.compressionName
+        }`
+      )
+    );
   }
 
   decompressMessage(message: Buffer): Promise<Buffer> {
     // This should be unreachable
     return Promise.reject<Buffer>(
-        new Error(`Compression method not supported: ${this.compressionName}`));
+      new Error(`Compression method not supported: ${this.compressionName}`)
+    );
   }
 }
 
@@ -187,13 +195,16 @@ export class CompressionFilter extends BaseFilter implements Filter {
      * and the output is a framed and possibly compressed message. For this
      * reason, this filter should be at the bottom of the filter stack */
     const resolvedMessage: WriteObject = await message;
-    const compress = resolvedMessage.flags === undefined ?
-        false :
-        (resolvedMessage.flags & WriteFlags.NoCompress) === 0;
+    const compress =
+      resolvedMessage.flags === undefined
+        ? false
+        : (resolvedMessage.flags & WriteFlags.NoCompress) === 0;
     return {
       message: await this.sendCompression.writeMessage(
-          resolvedMessage.message, compress),
-      flags: resolvedMessage.flags
+        resolvedMessage.message,
+        compress
+      ),
+      flags: resolvedMessage.flags,
     };
   }
 
@@ -206,8 +217,8 @@ export class CompressionFilter extends BaseFilter implements Filter {
   }
 }
 
-export class CompressionFilterFactory implements
-    FilterFactory<CompressionFilter> {
+export class CompressionFilterFactory
+  implements FilterFactory<CompressionFilter> {
   constructor(private readonly channel: Channel) {}
   createFilter(callStream: Call): CompressionFilter {
     return new CompressionFilter();

--- a/packages/grpc-js/src/constants.ts
+++ b/packages/grpc-js/src/constants.ts
@@ -32,11 +32,11 @@ export enum Status {
   INTERNAL,
   UNAVAILABLE,
   DATA_LOSS,
-  UNAUTHENTICATED
+  UNAUTHENTICATED,
 }
 
 export enum LogVerbosity {
   DEBUG = 0,
   INFO,
-  ERROR
+  ERROR,
 }

--- a/packages/grpc-js/src/events.ts
+++ b/packages/grpc-js/src/events.ts
@@ -15,7 +15,7 @@
  *
  */
 
-export interface EmitterAugmentation1<Name extends string|symbol, Arg> {
+export interface EmitterAugmentation1<Name extends string | symbol, Arg> {
   addListener(event: Name, listener: (arg1: Arg) => void): this;
   emit(event: Name, arg1: Arg): boolean;
   on(event: Name, listener: (arg1: Arg) => void): this;

--- a/packages/grpc-js/src/filter-stack.ts
+++ b/packages/grpc-js/src/filter-stack.ts
@@ -15,9 +15,9 @@
  *
  */
 
-import {Call, StatusObject, WriteObject} from './call-stream';
-import {Filter, FilterFactory} from './filter';
-import {Metadata} from './metadata';
+import { Call, StatusObject, WriteObject } from './call-stream';
+import { Filter, FilterFactory } from './filter';
+import { Metadata } from './metadata';
 
 export class FilterStack implements Filter {
   constructor(private readonly filters: Filter[]) {}
@@ -78,6 +78,7 @@ export class FilterStackFactory implements FilterFactory<FilterStack> {
 
   createFilter(callStream: Call): FilterStack {
     return new FilterStack(
-        this.factories.map((factory) => factory.createFilter(callStream)));
+      this.factories.map(factory => factory.createFilter(callStream))
+    );
   }
 }

--- a/packages/grpc-js/src/filter.ts
+++ b/packages/grpc-js/src/filter.ts
@@ -15,8 +15,8 @@
  *
  */
 
-import {Call, StatusObject, WriteObject} from './call-stream';
-import {Metadata} from './metadata';
+import { Call, StatusObject, WriteObject } from './call-stream';
+import { Metadata } from './metadata';
 
 /**
  * Filter classes represent related per-call logic and state that is primarily

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -17,18 +17,29 @@
 
 import * as semver from 'semver';
 
-import {ClientDuplexStream, ClientReadableStream, ClientUnaryCall, ClientWritableStream, ServiceError} from './call';
-import {CallCredentials} from './call-credentials';
-import {Deadline, StatusObject} from './call-stream';
-import {Channel, ConnectivityState, Http2Channel} from './channel';
-import {ChannelCredentials} from './channel-credentials';
-import {CallOptions, Client} from './client';
-import {LogVerbosity, Status} from './constants';
+import {
+  ClientDuplexStream,
+  ClientReadableStream,
+  ClientUnaryCall,
+  ClientWritableStream,
+  ServiceError,
+} from './call';
+import { CallCredentials } from './call-credentials';
+import { Deadline, StatusObject } from './call-stream';
+import { Channel, ConnectivityState, Http2Channel } from './channel';
+import { ChannelCredentials } from './channel-credentials';
+import { CallOptions, Client } from './client';
+import { LogVerbosity, Status } from './constants';
 import * as logging from './logging';
-import {Deserialize, loadPackageDefinition, makeClientConstructor, Serialize} from './make-client';
-import {Metadata} from './metadata';
-import {KeyCertPair, ServerCredentials} from './server-credentials';
-import {StatusBuilder} from './status-builder';
+import {
+  Deserialize,
+  loadPackageDefinition,
+  makeClientConstructor,
+  Serialize,
+} from './make-client';
+import { Metadata } from './metadata';
+import { KeyCertPair, ServerCredentials } from './server-credentials';
+import { StatusBuilder } from './status-builder';
 
 const supportedNodeVersions = '^8.13.0 || >=10.10.0';
 if (!semver.satisfies(process.version, supportedNodeVersions)) {
@@ -36,15 +47,15 @@ if (!semver.satisfies(process.version, supportedNodeVersions)) {
 }
 
 interface IndexedObject {
-  [key: string]: any;  // tslint:disable-line no-any
-  [key: number]: any;  // tslint:disable-line no-any
+  [key: string]: any; // tslint:disable-line no-any
+  [key: number]: any; // tslint:disable-line no-any
 }
 
 function mixin(...sources: IndexedObject[]) {
-  const result: {[key: string]: Function} = {};
+  const result: { [key: string]: Function } = {};
   for (const source of sources) {
     for (const propName of Object.getOwnPropertyNames(source)) {
-      const property: any = source[propName];  // tslint:disable-line no-any
+      const property: any = source[propName]; // tslint:disable-line no-any
       if (typeof property === 'function') {
         result[propName] = property;
       }
@@ -54,95 +65,113 @@ function mixin(...sources: IndexedObject[]) {
 }
 
 export interface OAuth2Client {
-  getRequestMetadata: (url: string, callback: (err: Error|null, headers?: {
-                                      Authorization: string
-                                    }) => void) => void;
-  getRequestHeaders: (url?: string) => Promise<{Authorization: string}>;
+  getRequestMetadata: (
+    url: string,
+    callback: (
+      err: Error | null,
+      headers?: {
+        Authorization: string;
+      }
+    ) => void
+  ) => void;
+  getRequestHeaders: (url?: string) => Promise<{ Authorization: string }>;
 }
 
 /**** Client Credentials ****/
 
 // Using assign only copies enumerable properties, which is what we want
 export const credentials = mixin(
-    {
-      /**
-       * Create a gRPC credential from a Google credential object.
-       * @param googleCredentials The authentication client to use.
-       * @return The resulting CallCredentials object.
-       */
-      createFromGoogleCredential: (
-          googleCredentials: OAuth2Client): CallCredentials => {
-        return CallCredentials.createFromMetadataGenerator(
-            (options, callback) => {
-              // google-auth-library pre-v2.0.0 does not have getRequestHeaders
-              // but has getRequestMetadata, which is deprecated in v2.0.0
-              let getHeaders: Promise<{Authorization: string}>;
-              if (typeof googleCredentials.getRequestHeaders === 'function') {
-                getHeaders =
-                    googleCredentials.getRequestHeaders(options.service_url);
-              } else {
-                getHeaders = new Promise((resolve, reject) => {
-                  googleCredentials.getRequestMetadata(
-                      options.service_url, (err, headers) => {
-                        if (err) {
-                          reject(err);
-                          return;
-                        }
-                        resolve(headers);
-                      });
-                });
-              }
-              getHeaders.then(
-                  headers => {
-                    const metadata = new Metadata();
-                    metadata.add('authorization', headers.Authorization);
-                    callback(null, metadata);
-                  },
-                  err => {
-                    callback(err);
-                  });
+  {
+    /**
+     * Create a gRPC credential from a Google credential object.
+     * @param googleCredentials The authentication client to use.
+     * @return The resulting CallCredentials object.
+     */
+    createFromGoogleCredential: (
+      googleCredentials: OAuth2Client
+    ): CallCredentials => {
+      return CallCredentials.createFromMetadataGenerator(
+        (options, callback) => {
+          // google-auth-library pre-v2.0.0 does not have getRequestHeaders
+          // but has getRequestMetadata, which is deprecated in v2.0.0
+          let getHeaders: Promise<{ Authorization: string }>;
+          if (typeof googleCredentials.getRequestHeaders === 'function') {
+            getHeaders = googleCredentials.getRequestHeaders(
+              options.service_url
+            );
+          } else {
+            getHeaders = new Promise((resolve, reject) => {
+              googleCredentials.getRequestMetadata(
+                options.service_url,
+                (err, headers) => {
+                  if (err) {
+                    reject(err);
+                    return;
+                  }
+                  resolve(headers);
+                }
+              );
             });
-      },
-
-      /**
-       * Combine a ChannelCredentials with any number of CallCredentials into a
-       * single ChannelCredentials object.
-       * @param channelCredentials The ChannelCredentials object.
-       * @param callCredentials Any number of CallCredentials objects.
-       * @return The resulting ChannelCredentials object.
-       */
-      combineChannelCredentials:
-          (channelCredentials: ChannelCredentials,
-           ...callCredentials: CallCredentials[]): ChannelCredentials => {
-            return callCredentials.reduce(
-                (acc, other) => acc.compose(other), channelCredentials);
-          },
-
-      /**
-       * Combine any number of CallCredentials into a single CallCredentials
-       * object.
-       * @param first The first CallCredentials object.
-       * @param additional Any number of additional CallCredentials objects.
-       * @return The resulting CallCredentials object.
-       */
-      combineCallCredentials: (
-          first: CallCredentials, ...additional: CallCredentials[]):
-          CallCredentials => {
-            return additional.reduce((acc, other) => acc.compose(other), first);
           }
+          getHeaders.then(
+            headers => {
+              const metadata = new Metadata();
+              metadata.add('authorization', headers.Authorization);
+              callback(null, metadata);
+            },
+            err => {
+              callback(err);
+            }
+          );
+        }
+      );
     },
-    ChannelCredentials, CallCredentials);
+
+    /**
+     * Combine a ChannelCredentials with any number of CallCredentials into a
+     * single ChannelCredentials object.
+     * @param channelCredentials The ChannelCredentials object.
+     * @param callCredentials Any number of CallCredentials objects.
+     * @return The resulting ChannelCredentials object.
+     */
+    combineChannelCredentials: (
+      channelCredentials: ChannelCredentials,
+      ...callCredentials: CallCredentials[]
+    ): ChannelCredentials => {
+      return callCredentials.reduce(
+        (acc, other) => acc.compose(other),
+        channelCredentials
+      );
+    },
+
+    /**
+     * Combine any number of CallCredentials into a single CallCredentials
+     * object.
+     * @param first The first CallCredentials object.
+     * @param additional Any number of additional CallCredentials objects.
+     * @return The resulting CallCredentials object.
+     */
+    combineCallCredentials: (
+      first: CallCredentials,
+      ...additional: CallCredentials[]
+    ): CallCredentials => {
+      return additional.reduce((acc, other) => acc.compose(other), first);
+    },
+  },
+  ChannelCredentials,
+  CallCredentials
+);
 
 /**** Metadata ****/
 
-export {Metadata};
+export { Metadata };
 
 /**** Constants ****/
 
 export {
   LogVerbosity as logVerbosity,
   Status as status,
-  ConnectivityState as connectivityState
+  ConnectivityState as connectivityState,
   // TODO: Other constants as well
 };
 
@@ -153,7 +182,7 @@ export {
   loadPackageDefinition,
   makeClientConstructor,
   makeClientConstructor as makeGenericClientConstructor,
-  Http2Channel as Channel
+  Http2Channel as Channel,
 };
 
 /**
@@ -162,10 +191,11 @@ export {
  */
 export const closeClient = (client: Client) => client.close();
 
-export const waitForClientReady =
-    (client: Client, deadline: Date|number,
-     callback: (error?: Error) => void) =>
-        client.waitForReady(deadline, callback);
+export const waitForClientReady = (
+  client: Client,
+  deadline: Date | number,
+  callback: (error?: Error) => void
+) => client.waitForReady(deadline, callback);
 
 /* Interfaces */
 
@@ -181,12 +211,15 @@ export {
   ClientDuplexStream,
   CallOptions,
   StatusObject,
-  ServiceError
+  ServiceError,
 };
 
 /* tslint:disable:no-any */
-export type Call = ClientUnaryCall|ClientReadableStream<any>|
-    ClientWritableStream<any>|ClientDuplexStream<any, any>;
+export type Call =
+  | ClientUnaryCall
+  | ClientReadableStream<any>
+  | ClientWritableStream<any>
+  | ClientDuplexStream<any, any>;
 /* tslint:enable:no-any */
 
 export type MetadataListener = (metadata: Metadata, next: Function) => void;
@@ -208,12 +241,14 @@ export interface Listener {
 
 export const loadObject = (value: any, options: any) => {
   throw new Error(
-      'Not available in this library. Use @grpc/proto-loader and loadPackageDefinition instead');
+    'Not available in this library. Use @grpc/proto-loader and loadPackageDefinition instead'
+  );
 };
 
 export const load = (filename: any, format: any, options: any) => {
   throw new Error(
-      'Not available in this library. Use @grpc/proto-loader and loadPackageDefinition instead');
+    'Not available in this library. Use @grpc/proto-loader and loadPackageDefinition instead'
+  );
 };
 
 export const setLogger = (logger: Partial<Console>): void => {
@@ -228,15 +263,14 @@ export const Server = (options: any) => {
   throw new Error('Not yet implemented');
 };
 
-export {ServerCredentials};
-export {KeyCertPair};
-
+export { ServerCredentials };
+export { KeyCertPair };
 
 export const getClientChannel = (client: Client) => {
   return Client.prototype.getChannel.call(client);
 };
 
-export {StatusBuilder};
+export { StatusBuilder };
 
 export const ListenerBuilder = () => {
   throw new Error('Not yet implemented');
@@ -250,4 +284,4 @@ export const InterceptingCall = () => {
   throw new Error('Not yet implemented');
 };
 
-export {GrpcObject} from './make-client';
+export { GrpcObject } from './make-client';

--- a/packages/grpc-js/src/logging.ts
+++ b/packages/grpc-js/src/logging.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import {LogVerbosity} from './constants';
+import { LogVerbosity } from './constants';
 
 let _logger: Partial<Console> = console;
 let _logVerbosity: LogVerbosity = LogVerbosity.DEBUG;

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -15,9 +15,9 @@
  *
  */
 
-import {ChannelCredentials} from './channel-credentials';
-import {ChannelOptions} from './channel-options';
-import {Client} from './client';
+import { ChannelCredentials } from './channel-credentials';
+import { ChannelOptions } from './channel-options';
+import { Client } from './client';
 
 export interface Serialize<T> {
   (value: T): Buffer;
@@ -49,7 +49,7 @@ export interface ProtobufTypeDefinition {
 }
 
 export interface PackageDefinition {
-  [index: string]: ServiceDefinition|ProtobufTypeDefinition;
+  [index: string]: ServiceDefinition | ProtobufTypeDefinition;
 }
 
 /**
@@ -61,7 +61,7 @@ const requesterFuncs = {
   unary: Client.prototype.makeUnaryRequest,
   server_stream: Client.prototype.makeServerStreamRequest,
   client_stream: Client.prototype.makeClientStreamRequest,
-  bidi: Client.prototype.makeBidiStreamRequest
+  bidi: Client.prototype.makeBidiStreamRequest,
 };
 
 export interface ServiceClient extends Client {
@@ -69,8 +69,11 @@ export interface ServiceClient extends Client {
 }
 
 export interface ServiceClientConstructor {
-  new(address: string, credentials: ChannelCredentials,
-      options?: Partial<ChannelOptions>): ServiceClient;
+  new (
+    address: string,
+    credentials: ChannelCredentials,
+    options?: Partial<ChannelOptions>
+  ): ServiceClient;
   service: ServiceDefinition;
 }
 
@@ -89,8 +92,10 @@ export interface ServiceClientConstructor {
  *     {@link grpc.Client}, and has the same arguments as that constructor.
  */
 export function makeClientConstructor(
-    methods: ServiceDefinition, serviceName: string,
-    classOptions?: {}): ServiceClientConstructor {
+  methods: ServiceDefinition,
+  serviceName: string,
+  classOptions?: {}
+): ServiceClientConstructor {
   if (!classOptions) {
     classOptions = {};
   }
@@ -100,7 +105,7 @@ export function makeClientConstructor(
     [methodName: string]: Function;
   }
 
-  Object.keys(methods).forEach((name) => {
+  Object.keys(methods).forEach(name => {
     const attrs = methods[name];
     let methodType: keyof typeof requesterFuncs;
     // TODO(murgatroid99): Verify that we don't need this anymore
@@ -122,14 +127,18 @@ export function makeClientConstructor(
     }
     const serialize = attrs.requestSerialize;
     const deserialize = attrs.responseDeserialize;
-    const methodFunc =
-        partial(requesterFuncs[methodType], attrs.path, serialize, deserialize);
+    const methodFunc = partial(
+      requesterFuncs[methodType],
+      attrs.path,
+      serialize,
+      deserialize
+    );
     ServiceClientImpl.prototype[name] = methodFunc;
     // Associate all provided attributes with the method
     Object.assign(ServiceClientImpl.prototype[name], attrs);
     if (attrs.originalName) {
       ServiceClientImpl.prototype[attrs.originalName] =
-          ServiceClientImpl.prototype[name];
+        ServiceClientImpl.prototype[name];
     }
   });
 
@@ -139,21 +148,27 @@ export function makeClientConstructor(
 }
 
 function partial(
-    fn: Function, path: string, serialize: Function,
-    deserialize: Function): Function {
+  fn: Function,
+  path: string,
+  serialize: Function,
+  deserialize: Function
+): Function {
   // tslint:disable-next-line:no-any
   return function(this: any, ...args: any[]) {
     return fn.call(this, path, serialize, deserialize, ...args);
   };
 }
 
-export type GrpcObject = {
-  [index: string]: GrpcObject|ServiceClientConstructor|ProtobufTypeDefinition;
-};
+export interface GrpcObject {
+  [index: string]:
+    | GrpcObject
+    | ServiceClientConstructor
+    | ProtobufTypeDefinition;
+}
 
 function isProtobufTypeDefinition(
-    obj: ServiceDefinition|
-    ProtobufTypeDefinition): obj is ProtobufTypeDefinition {
+  obj: ServiceDefinition | ProtobufTypeDefinition
+): obj is ProtobufTypeDefinition {
   return 'format' in obj;
 }
 
@@ -162,8 +177,9 @@ function isProtobufTypeDefinition(
  * @param packageDef The package definition object.
  * @return The resulting gRPC object.
  */
-export function loadPackageDefinition(packageDef: PackageDefinition):
-    GrpcObject {
+export function loadPackageDefinition(
+  packageDef: PackageDefinition
+): GrpcObject {
   const result: GrpcObject = {};
   for (const serviceFqn in packageDef) {
     if (packageDef.hasOwnProperty(serviceFqn)) {

--- a/packages/grpc-js/src/metadata-status-filter.ts
+++ b/packages/grpc-js/src/metadata-status-filter.ts
@@ -15,19 +15,19 @@
  *
  */
 
-import {Call} from './call-stream';
-import {StatusObject} from './call-stream';
-import {Channel} from './channel';
-import {Status} from './constants';
-import {BaseFilter, Filter, FilterFactory} from './filter';
+import { Call } from './call-stream';
+import { StatusObject } from './call-stream';
+import { Channel } from './channel';
+import { Status } from './constants';
+import { BaseFilter, Filter, FilterFactory } from './filter';
 
 export class MetadataStatusFilter extends BaseFilter implements Filter {
   async receiveTrailers(status: Promise<StatusObject>): Promise<StatusObject> {
     // tslint:disable-next-line:prefer-const
-    let {code, details, metadata} = await status;
+    let { code, details, metadata } = await status;
     if (code !== Status.UNKNOWN) {
       // we already have a known status, so don't assign a new one.
-      return {code, details, metadata};
+      return { code, details, metadata };
     }
     const metadataMap = metadata.getMap();
     if (typeof metadataMap['grpc-status'] === 'string') {
@@ -41,12 +41,12 @@ export class MetadataStatusFilter extends BaseFilter implements Filter {
       details = decodeURI(metadataMap['grpc-message'] as string);
       metadata.remove('grpc-message');
     }
-    return {code, details, metadata};
+    return { code, details, metadata };
   }
 }
 
-export class MetadataStatusFilterFactory implements
-    FilterFactory<MetadataStatusFilter> {
+export class MetadataStatusFilterFactory
+  implements FilterFactory<MetadataStatusFilter> {
   constructor(private readonly channel: Channel) {}
   createFilter(callStream: Call): MetadataStatusFilter {
     return new MetadataStatusFilter();

--- a/packages/grpc-js/src/metadata.ts
+++ b/packages/grpc-js/src/metadata.ts
@@ -19,7 +19,7 @@ import * as http2 from 'http2';
 const LEGAL_KEY_REGEX = /^[0-9a-z_.-]+$/;
 const LEGAL_NON_BINARY_VALUE_REGEX = /^[ -~]*$/;
 
-export type MetadataValue = string|Buffer;
+export type MetadataValue = string | Buffer;
 export type MetadataObject = Map<string, MetadataValue[]>;
 
 function isLegalKey(key: string): boolean {
@@ -45,17 +45,18 @@ function validate(key: string, value?: MetadataValue): void {
   if (value != null) {
     if (isBinaryKey(key)) {
       if (!(value instanceof Buffer)) {
-        throw new Error('keys that end with \'-bin\' must have Buffer values');
+        throw new Error("keys that end with '-bin' must have Buffer values");
       }
     } else {
       if (value instanceof Buffer) {
         throw new Error(
-            'keys that don\'t end with \'-bin\' must have String values');
+          "keys that don't end with '-bin' must have String values"
+        );
       }
       if (!isLegalNonBinaryValue(value)) {
         throw new Error(
-            'Metadata string value "' + value +
-            '" contains illegal characters');
+          'Metadata string value "' + value + '" contains illegal characters'
+        );
       }
     }
   }
@@ -91,7 +92,9 @@ export class Metadata {
     key = normalizeKey(key);
     validate(key, value);
 
-    const existingValue: MetadataValue[]|undefined = this.internalRepr.get(key);
+    const existingValue: MetadataValue[] | undefined = this.internalRepr.get(
+      key
+    );
 
     if (existingValue === undefined) {
       this.internalRepr.set(key, [value]);
@@ -126,8 +129,8 @@ export class Metadata {
    * This reflects the most common way that people will want to see metadata.
    * @return A key/value mapping of the metadata.
    */
-  getMap(): {[key: string]: MetadataValue} {
-    const result: {[key: string]: MetadataValue} = {};
+  getMap(): { [key: string]: MetadataValue } {
+    const result: { [key: string]: MetadataValue } = {};
 
     this.internalRepr.forEach((values, key) => {
       if (values.length > 0) {
@@ -170,8 +173,9 @@ export class Metadata {
    */
   merge(other: Metadata): void {
     other.internalRepr.forEach((values, key) => {
-      const mergedValue: MetadataValue[] =
-          (this.internalRepr.get(key) || []).concat(values);
+      const mergedValue: MetadataValue[] = (
+        this.internalRepr.get(key) || []
+      ).concat(values);
 
       this.internalRepr.set(key, mergedValue);
     });
@@ -186,7 +190,7 @@ export class Metadata {
     this.internalRepr.forEach((values, key) => {
       // We assume that the user's interaction with this object is limited to
       // through its public API (i.e. keys and values are already validated).
-      result[key] = values.map((value) => {
+      result[key] = values.map(value => {
         if (value instanceof Buffer) {
           return value.toString('base64');
         } else {
@@ -209,7 +213,7 @@ export class Metadata {
    */
   static fromHttp2Headers(headers: http2.IncomingHttpHeaders): Metadata {
     const result = new Metadata();
-    Object.keys(headers).forEach((key) => {
+    Object.keys(headers).forEach(key => {
       // Reserved headers (beginning with `:`) are not valid keys.
       if (key.charAt(0) === ':') {
         return;
@@ -219,7 +223,7 @@ export class Metadata {
 
       if (isBinaryKey(key)) {
         if (Array.isArray(values)) {
-          values.forEach((value) => {
+          values.forEach(value => {
             result.add(key, Buffer.from(value, 'base64'));
           });
         } else if (values !== undefined) {
@@ -229,7 +233,7 @@ export class Metadata {
         }
       } else {
         if (Array.isArray(values)) {
-          values.forEach((value) => {
+          values.forEach(value => {
             result.add(key, value);
           });
         } else if (values !== undefined) {

--- a/packages/grpc-js/src/object-stream.ts
+++ b/packages/grpc-js/src/object-stream.ts
@@ -15,29 +15,30 @@
  *
  */
 
-import {Duplex, Readable, Writable} from 'stream';
-import {EmitterAugmentation1} from './events';
+import { Duplex, Readable, Writable } from 'stream';
+import { EmitterAugmentation1 } from './events';
 
 // tslint:disable:no-any
 
-export type WriteCallback = (error: Error|null|undefined) => void;
+export type WriteCallback = (error: Error | null | undefined) => void;
 
 export interface IntermediateObjectReadable<T> extends Readable {
-  read(size?: number): any&T;
+  read(size?: number): any & T;
 }
 
 export type ObjectReadable<T> = {
   read(size?: number): T;
-}&EmitterAugmentation1<'data', T>&IntermediateObjectReadable<T>;
+} & EmitterAugmentation1<'data', T> &
+  IntermediateObjectReadable<T>;
 
 export interface IntermediateObjectWritable<T> extends Writable {
-  _write(chunk: any&T, encoding: string, callback: Function): void;
-  write(chunk: any&T, cb?: WriteCallback): boolean;
-  write(chunk: any&T, encoding?: any, cb?: WriteCallback): boolean;
+  _write(chunk: any & T, encoding: string, callback: Function): void;
+  write(chunk: any & T, cb?: WriteCallback): boolean;
+  write(chunk: any & T, encoding?: any, cb?: WriteCallback): boolean;
   setDefaultEncoding(encoding: string): this;
   end(): void;
-  end(chunk: any&T, cb?: Function): void;
-  end(chunk: any&T, encoding?: any, cb?: Function): void;
+  end(chunk: any & T, cb?: Function): void;
+  end(chunk: any & T, encoding?: any, cb?: Function): void;
 }
 
 export interface ObjectWritable<T> extends IntermediateObjectWritable<T> {
@@ -59,4 +60,6 @@ export type ObjectDuplex<T, U> = {
   end(): void;
   end(chunk: T, cb?: Function): void;
   end(chunk: T, encoding?: any, cb?: Function): void;
-}&Duplex&ObjectWritable<T>&ObjectReadable<U>;
+} & Duplex &
+  ObjectWritable<T> &
+  ObjectReadable<U>;

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -15,20 +15,20 @@
  *
  */
 
-import {EventEmitter} from 'events';
+import { EventEmitter } from 'events';
 import * as http2 from 'http2';
-import {Duplex, Readable, Writable} from 'stream';
+import { Duplex, Readable, Writable } from 'stream';
 
-import {ServiceError} from './call';
-import {StatusObject} from './call-stream';
-import {Status} from './constants';
-import {Deserialize, Serialize} from './make-client';
-import {Metadata} from './metadata';
-import {StreamDecoder} from './stream-decoder';
+import { ServiceError } from './call';
+import { StatusObject } from './call-stream';
+import { Status } from './constants';
+import { Deserialize, Serialize } from './make-client';
+import { Metadata } from './metadata';
+import { StreamDecoder } from './stream-decoder';
 
-type DeadlineUnitIndexSignature = {
-  [name: string]: number
-};
+interface DeadlineUnitIndexSignature {
+  [name: string]: number;
+}
 
 const GRPC_ACCEPT_ENCODING_HEADER = 'grpc-accept-encoding';
 const GRPC_ENCODING_HEADER = 'grpc-encoding';
@@ -42,7 +42,7 @@ const deadlineUnitsToMs: DeadlineUnitIndexSignature = {
   S: 1000,
   m: 1,
   u: 0.001,
-  n: 0.000001
+  n: 0.000001,
 };
 const defaultResponseHeaders = {
   // TODO(cjihrig): Remove these encoding headers from the default response
@@ -50,35 +50,41 @@ const defaultResponseHeaders = {
   [GRPC_ACCEPT_ENCODING_HEADER]: 'identity',
   [GRPC_ENCODING_HEADER]: 'identity',
   [http2.constants.HTTP2_HEADER_STATUS]: http2.constants.HTTP_STATUS_OK,
-  [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: 'application/grpc+proto'
+  [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: 'application/grpc+proto',
 };
 const defaultResponseOptions = {
-  waitForTrailers: true
+  waitForTrailers: true,
 } as http2.ServerStreamResponseOptions;
 
+export interface ServerSurfaceCall {
+  cancelled: boolean;
+  getPeer(): string;
+  sendMetadata(responseMetadata: Metadata): void;
+}
 
-export type ServerSurfaceCall = {
-  cancelled: boolean; getPeer(): string;
-  sendMetadata(responseMetadata: Metadata): void
+export type ServerUnaryCall<RequestType, ResponseType> = ServerSurfaceCall & {
+  request: RequestType | null;
 };
-
-export type ServerUnaryCall<RequestType, ResponseType> =
-    ServerSurfaceCall&{request: RequestType | null};
-export type ServerReadableStream<RequestType, ResponseType> =
-    ServerSurfaceCall&Readable;
-export type ServerWritableStream<RequestType, ResponseType> =
-    ServerSurfaceCall&Writable&{request: RequestType | null};
-export type ServerDuplexStream<RequestType, ResponseType> =
-    ServerSurfaceCall&Duplex;
+export type ServerReadableStream<
+  RequestType,
+  ResponseType
+> = ServerSurfaceCall & Readable;
+export type ServerWritableStream<
+  RequestType,
+  ResponseType
+> = ServerSurfaceCall & Writable & { request: RequestType | null };
+export type ServerDuplexStream<RequestType, ResponseType> = ServerSurfaceCall &
+  Duplex;
 
 export class ServerUnaryCallImpl<RequestType, ResponseType> extends EventEmitter
-    implements ServerUnaryCall<RequestType, ResponseType> {
+  implements ServerUnaryCall<RequestType, ResponseType> {
   cancelled: boolean;
-  request: RequestType|null;
+  request: RequestType | null;
 
   constructor(
-      private call: Http2ServerCallStream<RequestType, ResponseType>,
-      public metadata: Metadata) {
+    private call: Http2ServerCallStream<RequestType, ResponseType>,
+    public metadata: Metadata
+  ) {
     super();
     this.cancelled = false;
     this.request = null;
@@ -93,15 +99,17 @@ export class ServerUnaryCallImpl<RequestType, ResponseType> extends EventEmitter
   }
 }
 
-
-export class ServerReadableStreamImpl<RequestType, ResponseType> extends
-    Readable implements ServerReadableStream<RequestType, ResponseType> {
+export class ServerReadableStreamImpl<RequestType, ResponseType>
+  extends Readable
+  implements ServerReadableStream<RequestType, ResponseType> {
   cancelled: boolean;
 
   constructor(
-      private call: Http2ServerCallStream<RequestType, ResponseType>,
-      public metadata: Metadata, public deserialize: Deserialize<RequestType>) {
-    super({objectMode: true});
+    private call: Http2ServerCallStream<RequestType, ResponseType>,
+    public metadata: Metadata,
+    public deserialize: Deserialize<RequestType>
+  ) {
+    super({ objectMode: true });
     this.cancelled = false;
     this.call.setupReadable(this);
   }
@@ -119,22 +127,24 @@ export class ServerReadableStreamImpl<RequestType, ResponseType> extends
   }
 }
 
-
-export class ServerWritableStreamImpl<RequestType, ResponseType> extends
-    Writable implements ServerWritableStream<RequestType, ResponseType> {
+export class ServerWritableStreamImpl<RequestType, ResponseType>
+  extends Writable
+  implements ServerWritableStream<RequestType, ResponseType> {
   cancelled: boolean;
-  request: RequestType|null;
+  request: RequestType | null;
   private trailingMetadata: Metadata;
 
   constructor(
-      private call: Http2ServerCallStream<RequestType, ResponseType>,
-      public metadata: Metadata, public serialize: Serialize<ResponseType>) {
-    super({objectMode: true});
+    private call: Http2ServerCallStream<RequestType, ResponseType>,
+    public metadata: Metadata,
+    public serialize: Serialize<ResponseType>
+  ) {
+    super({ objectMode: true });
     this.cancelled = false;
     this.request = null;
     this.trailingMetadata = new Metadata();
 
-    this.on('error', (err) => {
+    this.on('error', err => {
       this.call.sendError(err as ServiceError);
       this.end();
     });
@@ -149,9 +159,11 @@ export class ServerWritableStreamImpl<RequestType, ResponseType> extends
   }
 
   async _write(
-      chunk: ResponseType, encoding: string,
-      // tslint:disable-next-line:no-any
-      callback: (...args: any[]) => void) {
+    chunk: ResponseType,
+    encoding: string,
+    // tslint:disable-next-line:no-any
+    callback: (...args: any[]) => void
+  ) {
     try {
       const response = await this.call.serializeMessage(chunk);
 
@@ -168,8 +180,11 @@ export class ServerWritableStreamImpl<RequestType, ResponseType> extends
   }
 
   _final(callback: Function): void {
-    this.call.sendStatus(
-        {code: Status.OK, details: 'OK', metadata: this.trailingMetadata});
+    this.call.sendStatus({
+      code: Status.OK,
+      details: 'OK',
+      metadata: this.trailingMetadata,
+    });
     callback(null);
   }
 
@@ -183,22 +198,23 @@ export class ServerWritableStreamImpl<RequestType, ResponseType> extends
   }
 }
 
-
 export class ServerDuplexStreamImpl<RequestType, ResponseType> extends Duplex
-    implements ServerDuplexStream<RequestType, ResponseType> {
+  implements ServerDuplexStream<RequestType, ResponseType> {
   cancelled: boolean;
   private trailingMetadata: Metadata;
 
   constructor(
-      private call: Http2ServerCallStream<RequestType, ResponseType>,
-      public metadata: Metadata, public serialize: Serialize<ResponseType>,
-      public deserialize: Deserialize<RequestType>) {
-    super({objectMode: true});
+    private call: Http2ServerCallStream<RequestType, ResponseType>,
+    public metadata: Metadata,
+    public serialize: Serialize<ResponseType>,
+    public deserialize: Deserialize<RequestType>
+  ) {
+    super({ objectMode: true });
     this.cancelled = false;
     this.trailingMetadata = new Metadata();
     this.call.setupReadable(this);
 
-    this.on('error', (err) => {
+    this.on('error', err => {
       this.call.sendError(err as ServiceError);
       this.end();
     });
@@ -214,92 +230,101 @@ export class ServerDuplexStreamImpl<RequestType, ResponseType> extends Duplex
 }
 
 ServerDuplexStreamImpl.prototype._read =
-    ServerReadableStreamImpl.prototype._read;
+  ServerReadableStreamImpl.prototype._read;
 ServerDuplexStreamImpl.prototype._write =
-    ServerWritableStreamImpl.prototype._write;
+  ServerWritableStreamImpl.prototype._write;
 ServerDuplexStreamImpl.prototype._final =
-    ServerWritableStreamImpl.prototype._final;
+  ServerWritableStreamImpl.prototype._final;
 ServerDuplexStreamImpl.prototype.end = ServerWritableStreamImpl.prototype.end;
 
-
 // Unary response callback signature.
-export type sendUnaryData<ResponseType> =
-    (error: ServiceError|null, value: ResponseType|null, trailer?: Metadata,
-     flags?: number) => void;
+export type sendUnaryData<ResponseType> = (
+  error: ServiceError | null,
+  value: ResponseType | null,
+  trailer?: Metadata,
+  flags?: number
+) => void;
 
 // User provided handler for unary calls.
-export type handleUnaryCall<RequestType, ResponseType> =
-    (call: ServerUnaryCall<RequestType, ResponseType>,
-     callback: sendUnaryData<ResponseType>) => void;
+export type handleUnaryCall<RequestType, ResponseType> = (
+  call: ServerUnaryCall<RequestType, ResponseType>,
+  callback: sendUnaryData<ResponseType>
+) => void;
 
 // User provided handler for client streaming calls.
-export type handleClientStreamingCall<RequestType, ResponseType> =
-    (call: ServerReadableStream<RequestType, ResponseType>,
-     callback: sendUnaryData<ResponseType>) => void;
+export type handleClientStreamingCall<RequestType, ResponseType> = (
+  call: ServerReadableStream<RequestType, ResponseType>,
+  callback: sendUnaryData<ResponseType>
+) => void;
 
 // User provided handler for server streaming calls.
-export type handleServerStreamingCall<RequestType, ResponseType> =
-    (call: ServerWritableStream<RequestType, ResponseType>) => void;
+export type handleServerStreamingCall<RequestType, ResponseType> = (
+  call: ServerWritableStream<RequestType, ResponseType>
+) => void;
 
 // User provided handler for bidirectional streaming calls.
-export type handleBidiStreamingCall<RequestType, ResponseType> =
-    (call: ServerDuplexStream<RequestType, ResponseType>) => void;
+export type handleBidiStreamingCall<RequestType, ResponseType> = (
+  call: ServerDuplexStream<RequestType, ResponseType>
+) => void;
 
 export type HandleCall<RequestType, ResponseType> =
-    handleUnaryCall<RequestType, ResponseType>|
-    handleClientStreamingCall<RequestType, ResponseType>|
-    handleServerStreamingCall<RequestType, ResponseType>|
-    handleBidiStreamingCall<RequestType, ResponseType>;
+  | handleUnaryCall<RequestType, ResponseType>
+  | handleClientStreamingCall<RequestType, ResponseType>
+  | handleServerStreamingCall<RequestType, ResponseType>
+  | handleBidiStreamingCall<RequestType, ResponseType>;
 
-export type UnaryHandler<RequestType, ResponseType> = {
+export interface UnaryHandler<RequestType, ResponseType> {
   func: handleUnaryCall<RequestType, ResponseType>;
   serialize: Serialize<ResponseType>;
   deserialize: Deserialize<RequestType>;
   type: HandlerType;
-};
+}
 
-export type ClientStreamingHandler<RequestType, ResponseType> = {
+export interface ClientStreamingHandler<RequestType, ResponseType> {
   func: handleClientStreamingCall<RequestType, ResponseType>;
   serialize: Serialize<ResponseType>;
   deserialize: Deserialize<RequestType>;
   type: HandlerType;
-};
+}
 
-export type ServerStreamingHandler<RequestType, ResponseType> = {
+export interface ServerStreamingHandler<RequestType, ResponseType> {
   func: handleServerStreamingCall<RequestType, ResponseType>;
   serialize: Serialize<ResponseType>;
   deserialize: Deserialize<RequestType>;
   type: HandlerType;
-};
+}
 
-export type BidiStreamingHandler<RequestType, ResponseType> = {
+export interface BidiStreamingHandler<RequestType, ResponseType> {
   func: handleBidiStreamingCall<RequestType, ResponseType>;
   serialize: Serialize<ResponseType>;
   deserialize: Deserialize<RequestType>;
   type: HandlerType;
-};
+}
 
 export type Handler<RequestType, ResponseType> =
-    UnaryHandler<RequestType, ResponseType>|
-    ClientStreamingHandler<RequestType, ResponseType>|
-    ServerStreamingHandler<RequestType, ResponseType>|
-    BidiStreamingHandler<RequestType, ResponseType>;
+  | UnaryHandler<RequestType, ResponseType>
+  | ClientStreamingHandler<RequestType, ResponseType>
+  | ServerStreamingHandler<RequestType, ResponseType>
+  | BidiStreamingHandler<RequestType, ResponseType>;
 
-export type HandlerType = 'bidi'|'clientStream'|'serverStream'|'unary';
+export type HandlerType = 'bidi' | 'clientStream' | 'serverStream' | 'unary';
 
 const noopTimer: NodeJS.Timer = setTimeout(() => {}, 0);
 
 // Internal class that wraps the HTTP2 request.
-export class Http2ServerCallStream<RequestType, ResponseType> extends
-    EventEmitter {
+export class Http2ServerCallStream<
+  RequestType,
+  ResponseType
+> extends EventEmitter {
   cancelled = false;
   deadline: NodeJS.Timer = noopTimer;
   private wantTrailers = false;
   private metadataSent = false;
 
   constructor(
-      private stream: http2.ServerHttp2Stream,
-      private handler: Handler<RequestType, ResponseType>) {
+    private stream: http2.ServerHttp2Stream,
+    private handler: Handler<RequestType, ResponseType>
+  ) {
     super();
 
     this.stream.once('error', (err: ServiceError) => {
@@ -402,8 +427,11 @@ export class Http2ServerCallStream<RequestType, ResponseType> extends
   }
 
   async sendUnaryMessage(
-      err: ServiceError|null, value: ResponseType|null, metadata?: Metadata,
-      flags?: number) {
+    err: ServiceError | null,
+    value: ResponseType | null,
+    metadata?: Metadata,
+    flags?: number
+  ) {
     if (!metadata) {
       metadata = new Metadata();
     }
@@ -418,7 +446,7 @@ export class Http2ServerCallStream<RequestType, ResponseType> extends
       const response = await this.serializeMessage(value!);
 
       this.write(response);
-      this.sendStatus({code: Status.OK, details: 'OK', metadata});
+      this.sendStatus({ code: Status.OK, details: 'OK', metadata });
     } catch (err) {
       err.code = Status.INTERNAL;
       this.sendError(err);
@@ -436,11 +464,12 @@ export class Http2ServerCallStream<RequestType, ResponseType> extends
       this.wantTrailers = true;
       this.stream.once('wantTrailers', () => {
         const trailersToSend = Object.assign(
-            {
-              [GRPC_STATUS_HEADER]: statusObj.code,
-              [GRPC_MESSAGE_HEADER]: encodeURI(statusObj.details as string)
-            },
-            statusObj.metadata.toHttp2Headers());
+          {
+            [GRPC_STATUS_HEADER]: statusObj.code,
+            [GRPC_MESSAGE_HEADER]: encodeURI(statusObj.details as string),
+          },
+          statusObj.metadata.toHttp2Headers()
+        );
 
         this.stream.sendTrailers(trailersToSend);
       });
@@ -452,10 +481,12 @@ export class Http2ServerCallStream<RequestType, ResponseType> extends
   sendError(error: ServiceError) {
     const status: StatusObject = {
       code: Status.UNKNOWN,
-      details: error.hasOwnProperty('message') ? error.message :
-                                                 'Unknown Error',
-      metadata: error.hasOwnProperty('metadata') ? error.metadata :
-                                                   new Metadata()
+      details: error.hasOwnProperty('message')
+        ? error.message
+        : 'Unknown Error',
+      metadata: error.hasOwnProperty('metadata')
+        ? error.metadata
+        : new Metadata(),
     };
 
     if (error.hasOwnProperty('code') && Number.isInteger(error.code)) {
@@ -482,8 +513,11 @@ export class Http2ServerCallStream<RequestType, ResponseType> extends
     this.stream.resume();
   }
 
-  setupReadable(readable: ServerReadableStream<RequestType, ResponseType>|
-                ServerDuplexStream<RequestType, ResponseType>) {
+  setupReadable(
+    readable:
+      | ServerReadableStream<RequestType, ResponseType>
+      | ServerDuplexStream<RequestType, ResponseType>
+  ) {
     const decoder = new StreamDecoder();
 
     this.stream.on('data', async (data: Buffer) => {

--- a/packages/grpc-js/src/server-credentials.ts
+++ b/packages/grpc-js/src/server-credentials.ts
@@ -15,26 +15,26 @@
  *
  */
 
-import {SecureServerOptions} from 'http2';
+import { SecureServerOptions } from 'http2';
 
-
-export type KeyCertPair = {
-  private_key: Buffer,
-  cert_chain: Buffer
-};
-
+export interface KeyCertPair {
+  private_key: Buffer;
+  cert_chain: Buffer;
+}
 
 export abstract class ServerCredentials {
   abstract _isSecure(): boolean;
-  abstract _getSettings(): SecureServerOptions|null;
+  abstract _getSettings(): SecureServerOptions | null;
 
   static createInsecure(): ServerCredentials {
     return new InsecureServerCredentials();
   }
 
   static createSsl(
-      rootCerts: Buffer|null, keyCertPairs: KeyCertPair[],
-      checkClientCertificate = false): ServerCredentials {
+    rootCerts: Buffer | null,
+    keyCertPairs: KeyCertPair[],
+    checkClientCertificate = false
+  ): ServerCredentials {
     if (rootCerts !== null && !Buffer.isBuffer(rootCerts)) {
       throw new TypeError('rootCerts must be null or a Buffer');
     }
@@ -73,11 +73,10 @@ export abstract class ServerCredentials {
       ca: rootCerts || undefined,
       cert,
       key,
-      requestCert: checkClientCertificate
+      requestCert: checkClientCertificate,
     });
   }
 }
-
 
 class InsecureServerCredentials extends ServerCredentials {
   _isSecure(): boolean {
@@ -88,7 +87,6 @@ class InsecureServerCredentials extends ServerCredentials {
     return null;
   }
 }
-
 
 class SecureServerCredentials extends ServerCredentials {
   private options: SecureServerOptions;

--- a/packages/grpc-js/src/status-builder.ts
+++ b/packages/grpc-js/src/status-builder.ts
@@ -15,17 +15,17 @@
  *
  */
 
-import {StatusObject} from './call-stream';
-import {Status} from './constants';
-import {Metadata} from './metadata';
+import { StatusObject } from './call-stream';
+import { Status } from './constants';
+import { Metadata } from './metadata';
 
 /**
  * A builder for gRPC status objects.
  */
 export class StatusBuilder {
-  private code: Status|null;
-  private details: string|null;
-  private metadata: Metadata|null;
+  private code: Status | null;
+  private details: string | null;
+  private metadata: Metadata | null;
 
   constructor() {
     this.code = null;

--- a/packages/grpc-js/src/stream-decoder.ts
+++ b/packages/grpc-js/src/stream-decoder.ts
@@ -18,9 +18,8 @@
 enum ReadState {
   NO_DATA,
   READING_SIZE,
-  READING_MESSAGE
+  READING_MESSAGE,
 }
-
 
 export class StreamDecoder {
   private readState: ReadState = ReadState.NO_DATA;
@@ -31,8 +30,7 @@ export class StreamDecoder {
   private readPartialMessage: Buffer[] = [];
   private readMessageRemaining = 0;
 
-
-  write(data: Buffer): Buffer|null {
+  write(data: Buffer): Buffer | null {
     let readHead = 0;
     let toRead: number;
 
@@ -51,8 +49,11 @@ export class StreamDecoder {
         case ReadState.READING_SIZE:
           toRead = Math.min(data.length - readHead, this.readSizeRemaining);
           data.copy(
-              this.readPartialSize, 4 - this.readSizeRemaining, readHead,
-              readHead + toRead);
+            this.readPartialSize,
+            4 - this.readSizeRemaining,
+            readHead,
+            readHead + toRead
+          );
           this.readSizeRemaining -= toRead;
           readHead += toRead;
           // readSizeRemaining >=0 here
@@ -63,7 +64,9 @@ export class StreamDecoder {
               this.readState = ReadState.READING_MESSAGE;
             } else {
               const message = Buffer.concat(
-                  [this.readCompressFlag, this.readPartialSize], 5);
+                [this.readCompressFlag, this.readPartialSize],
+                5
+              );
 
               this.readState = ReadState.NO_DATA;
               return message;
@@ -79,10 +82,13 @@ export class StreamDecoder {
           if (this.readMessageRemaining === 0) {
             // At this point, we have read a full message
             const framedMessageBuffers = [
-              this.readCompressFlag, this.readPartialSize
+              this.readCompressFlag,
+              this.readPartialSize,
             ].concat(this.readPartialMessage);
-            const framedMessage =
-                Buffer.concat(framedMessageBuffers, this.readMessageSize + 5);
+            const framedMessage = Buffer.concat(
+              framedMessageBuffers,
+              this.readMessageSize + 5
+            );
 
             this.readState = ReadState.NO_DATA;
             return framedMessage;

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -15,13 +15,13 @@
  *
  */
 
-import {EventEmitter} from 'events';
+import { EventEmitter } from 'events';
 import * as http2 from 'http2';
 import * as url from 'url';
 
-import {Call, Http2CallStream} from './call-stream';
-import {ChannelOptions} from './channel-options';
-import {Metadata} from './metadata';
+import { Call, Http2CallStream } from './call-stream';
+import { ChannelOptions } from './channel-options';
+import { Metadata } from './metadata';
 
 const {
   HTTP2_HEADER_AUTHORITY,
@@ -29,7 +29,7 @@ const {
   HTTP2_HEADER_METHOD,
   HTTP2_HEADER_PATH,
   HTTP2_HEADER_TE,
-  HTTP2_HEADER_USER_AGENT
+  HTTP2_HEADER_USER_AGENT,
 } = http2.constants;
 
 /* setInterval and setTimeout only accept signed 32 bit integers. JS doesn't
@@ -59,8 +59,11 @@ export class Http2SubChannel extends EventEmitter implements SubChannel {
   private keepaliveTimeoutId: NodeJS.Timer;
 
   constructor(
-      target: url.URL, connectionOptions: http2.SecureClientSessionOptions,
-      userAgent: string, channelArgs: Partial<ChannelOptions>) {
+    target: url.URL,
+    connectionOptions: http2.SecureClientSessionOptions,
+    userAgent: string,
+    channelArgs: Partial<ChannelOptions>
+  ) {
     super();
     this.session = http2.connect(target, connectionOptions);
     this.session.unref();
@@ -109,9 +112,11 @@ export class Http2SubChannel extends EventEmitter implements SubChannel {
     this.keepaliveTimeoutId = setTimeout(() => {
       this.emit('close');
     }, this.keepaliveTimeoutMs);
-    this.session.ping((err: Error|null, duration: number, payload: Buffer) => {
-      clearTimeout(this.keepaliveTimeoutId);
-    });
+    this.session.ping(
+      (err: Error | null, duration: number, payload: Buffer) => {
+        clearTimeout(this.keepaliveTimeoutId);
+      }
+    );
   }
 
   /* TODO(murgatroid99): refactor subchannels so that keepalives can be handled

--- a/packages/grpc-js/test/common.ts
+++ b/packages/grpc-js/test/common.ts
@@ -18,14 +18,14 @@
 import * as loader from '@grpc/proto-loader';
 import * as assert from 'assert';
 
-import {GrpcObject, loadPackageDefinition} from '../src/make-client';
+import { GrpcObject, loadPackageDefinition } from '../src/make-client';
 
 const protoLoaderOptions = {
   keepCase: true,
   longs: String,
   enums: String,
   defaults: true,
-  oneofs: true
+  oneofs: true,
 };
 
 export function mockFunction(): never {
@@ -49,7 +49,7 @@ export namespace assert2 {
       assert.throws(() => {
         throw e;
       });
-      throw e;  // for type safety only
+      throw e; // for type safety only
     }
   }
 
@@ -59,7 +59,7 @@ export namespace assert2 {
    */
   function mustCallsSatisfied(): boolean {
     let result = true;
-    toCall.forEach((value) => {
+    toCall.forEach(value => {
       result = result && value === 0;
     });
     return result;
@@ -74,8 +74,9 @@ export namespace assert2 {
    * @param fn The function to wrap.
    */
   // tslint:disable:no-any
-  export function mustCall<T>(fn: (...args: any[]) => T):
-      (...args: any[]) => T {
+  export function mustCall<T>(
+    fn: (...args: any[]) => T
+  ): (...args: any[]) => T {
     const existingValue = toCall.get(fn);
     if (existingValue !== undefined) {
       toCall.set(fn, existingValue + 1);

--- a/packages/grpc-js/test/test-call-credentials.ts
+++ b/packages/grpc-js/test/test-call-credentials.ts
@@ -17,8 +17,11 @@
 
 import * as assert from 'assert';
 
-import {CallCredentials, CallMetadataGenerator} from '../src/call-credentials';
-import {Metadata} from '../src/metadata';
+import {
+  CallCredentials,
+  CallMetadataGenerator,
+} from '../src/call-credentials';
+import { Metadata } from '../src/metadata';
 
 // Metadata generators
 
@@ -36,107 +39,123 @@ const generateFromServiceURL: CallMetadataGenerator = (options, cb) => {
   cb(null, metadata);
 };
 const generateWithError: CallMetadataGenerator = (options, cb) =>
-    cb(new Error());
+  cb(new Error());
 
 // Tests
 
 describe('CallCredentials', () => {
   describe('createFromMetadataGenerator', () => {
     it('should accept a metadata generator', () => {
-      assert.doesNotThrow(
-          () => CallCredentials.createFromMetadataGenerator(
-              generateFromServiceURL));
+      assert.doesNotThrow(() =>
+        CallCredentials.createFromMetadataGenerator(generateFromServiceURL)
+      );
     });
   });
 
   describe('compose', () => {
     it('should accept a CallCredentials object and return a new object', () => {
-      const callCredentials1 =
-          CallCredentials.createFromMetadataGenerator(generateFromServiceURL);
-      const callCredentials2 =
-          CallCredentials.createFromMetadataGenerator(generateFromServiceURL);
+      const callCredentials1 = CallCredentials.createFromMetadataGenerator(
+        generateFromServiceURL
+      );
+      const callCredentials2 = CallCredentials.createFromMetadataGenerator(
+        generateFromServiceURL
+      );
       const combinedCredentials = callCredentials1.compose(callCredentials2);
-      assert.notEqual(combinedCredentials, callCredentials1);
-      assert.notEqual(combinedCredentials, callCredentials2);
+      assert.notStrictEqual(combinedCredentials, callCredentials1);
+      assert.notStrictEqual(combinedCredentials, callCredentials2);
     });
 
     it('should be chainable', () => {
-      const callCredentials1 =
-          CallCredentials.createFromMetadataGenerator(generateFromServiceURL);
-      const callCredentials2 =
-          CallCredentials.createFromMetadataGenerator(generateFromServiceURL);
+      const callCredentials1 = CallCredentials.createFromMetadataGenerator(
+        generateFromServiceURL
+      );
+      const callCredentials2 = CallCredentials.createFromMetadataGenerator(
+        generateFromServiceURL
+      );
       assert.doesNotThrow(() => {
-        callCredentials1.compose(callCredentials2)
-            .compose(callCredentials2)
-            .compose(callCredentials2);
+        callCredentials1
+          .compose(callCredentials2)
+          .compose(callCredentials2)
+          .compose(callCredentials2);
       });
     });
   });
 
   describe('generateMetadata', () => {
-    it('should call the function passed to createFromMetadataGenerator',
-       async () => {
-         const callCredentials = CallCredentials.createFromMetadataGenerator(
-             generateFromServiceURL);
-         let metadata: Metadata;
-         try {
-           metadata =
-               await callCredentials.generateMetadata({service_url: 'foo'});
-         } catch (err) {
-           throw err;
-         }
-         assert.deepEqual(metadata.get('service_url'), ['foo']);
-       });
+    it('should call the function passed to createFromMetadataGenerator', async () => {
+      const callCredentials = CallCredentials.createFromMetadataGenerator(
+        generateFromServiceURL
+      );
+      let metadata: Metadata;
+      try {
+        metadata = await callCredentials.generateMetadata({
+          service_url: 'foo',
+        });
+      } catch (err) {
+        throw err;
+      }
+      assert.deepStrictEqual(metadata.get('service_url'), ['foo']);
+    });
 
-    it('should emit an error if the associated metadataGenerator does',
-       async () => {
-         const callCredentials =
-             CallCredentials.createFromMetadataGenerator(generateWithError);
-         let metadata: Metadata|null = null;
-         try {
-           metadata = await callCredentials.generateMetadata({service_url: ''});
-         } catch (err) {
-           assert.ok(err instanceof Error);
-         }
-         assert.strictEqual(metadata, null);
-       });
+    it('should emit an error if the associated metadataGenerator does', async () => {
+      const callCredentials = CallCredentials.createFromMetadataGenerator(
+        generateWithError
+      );
+      let metadata: Metadata | null = null;
+      try {
+        metadata = await callCredentials.generateMetadata({ service_url: '' });
+      } catch (err) {
+        assert.ok(err instanceof Error);
+      }
+      assert.strictEqual(metadata, null);
+    });
 
     it('should combine metadata from multiple generators', async () => {
-      const [callCreds1, callCreds2, callCreds3, callCreds4] =
-          [50, 100, 150, 200].map((ms) => {
-            const generator: CallMetadataGenerator =
-                makeAfterMsElapsedGenerator(ms);
-            return CallCredentials.createFromMetadataGenerator(generator);
-          });
+      const [callCreds1, callCreds2, callCreds3, callCreds4] = [
+        50,
+        100,
+        150,
+        200,
+      ].map(ms => {
+        const generator: CallMetadataGenerator = makeAfterMsElapsedGenerator(
+          ms
+        );
+        return CallCredentials.createFromMetadataGenerator(generator);
+      });
       const testCases = [
         {
-          credentials: callCreds1.compose(callCreds2)
-                           .compose(callCreds3)
-                           .compose(callCreds4),
-          expected: ['50', '100', '150', '200']
+          credentials: callCreds1
+            .compose(callCreds2)
+            .compose(callCreds3)
+            .compose(callCreds4),
+          expected: ['50', '100', '150', '200'],
         },
         {
           credentials: callCreds4.compose(
-              callCreds3.compose(callCreds2.compose(callCreds1))),
-          expected: ['200', '150', '100', '50']
+            callCreds3.compose(callCreds2.compose(callCreds1))
+          ),
+          expected: ['200', '150', '100', '50'],
         },
         {
           credentials: callCreds3.compose(
-              callCreds4.compose(callCreds1).compose(callCreds2)),
-          expected: ['150', '200', '50', '100']
-        }
+            callCreds4.compose(callCreds1).compose(callCreds2)
+          ),
+          expected: ['150', '200', '50', '100'],
+        },
       ];
       // Try each test case and make sure the msElapsed field is as expected
-      await Promise.all(testCases.map(async (testCase) => {
-        const {credentials, expected} = testCase;
-        let metadata: Metadata;
-        try {
-          metadata = await credentials.generateMetadata({service_url: ''});
-        } catch (err) {
-          throw err;
-        }
-        assert.deepEqual(metadata.get('msElapsed'), expected);
-      }));
+      await Promise.all(
+        testCases.map(async testCase => {
+          const { credentials, expected } = testCase;
+          let metadata: Metadata;
+          try {
+            metadata = await credentials.generateMetadata({ service_url: '' });
+          } catch (err) {
+            throw err;
+          }
+          assert.deepStrictEqual(metadata.get('msElapsed'), expected);
+        })
+      );
     });
   });
 });

--- a/packages/grpc-js/test/test-call-stream.ts
+++ b/packages/grpc-js/test/test-call-stream.ts
@@ -16,44 +16,44 @@
  */
 
 import * as assert from 'assert';
-import {OutgoingHttpHeaders} from 'http';
+import { OutgoingHttpHeaders } from 'http';
 import * as http2 from 'http2';
-import {range} from 'lodash';
+import { range } from 'lodash';
 import * as stream from 'stream';
 
-import {CallCredentials} from '../src/call-credentials';
-import {Http2CallStream} from '../src/call-stream';
-import {Channel, Http2Channel} from '../src/channel';
-import {CompressionFilterFactory} from '../src/compression-filter';
-import {Status} from '../src/constants';
-import {FilterStackFactory} from '../src/filter-stack';
-import {Metadata} from '../src/metadata';
+import { CallCredentials } from '../src/call-credentials';
+import { Http2CallStream } from '../src/call-stream';
+import { Channel, Http2Channel } from '../src/channel';
+import { CompressionFilterFactory } from '../src/compression-filter';
+import { Status } from '../src/constants';
+import { FilterStackFactory } from '../src/filter-stack';
+import { Metadata } from '../src/metadata';
 
-import {assert2, mockFunction} from './common';
+import { assert2, mockFunction } from './common';
 
 interface DataFrames {
   payload: Buffer;
   frameLengths: number[];
 }
 
-const {HTTP2_HEADER_STATUS} = http2.constants;
+const { HTTP2_HEADER_STATUS } = http2.constants;
 
 function serialize(data: string): Buffer {
   const header: Buffer = Buffer.alloc(5);
-  header.writeUInt8(0, 0);  // TODO: Uncompressed only
+  header.writeUInt8(0, 0); // TODO: Uncompressed only
   header.writeInt32BE(data.length, 1);
   return Buffer.concat([header, Buffer.from(data, 'utf8')]);
 }
 
-class ClientHttp2StreamMock extends stream.Duplex implements
-    http2.ClientHttp2Stream {
+class ClientHttp2StreamMock extends stream.Duplex
+  implements http2.ClientHttp2Stream {
   constructor(private readonly dataFrames: DataFrames) {
     super();
   }
   emitResponse(responseCode: number, metadata?: Metadata) {
     this.emit('response', {
       [HTTP2_HEADER_STATUS]: responseCode,
-      ...metadata ? metadata.toHttp2Headers() : {}
+      ...(metadata ? metadata.toHttp2Headers() : {}),
     });
   }
   bytesRead = 0;
@@ -84,8 +84,12 @@ class ClientHttp2StreamMock extends stream.Duplex implements
   _read() {
     if (this.dataFrame === this.dataFrames.frameLengths.length) {
       if (this.bytesRead < this.dataFrames.payload.length) {
-        this.push(this.dataFrames.payload.slice(
-            this.bytesRead, this.dataFrames.payload.length));
+        this.push(
+          this.dataFrames.payload.slice(
+            this.bytesRead,
+            this.dataFrames.payload.length
+          )
+        );
       }
       this.push(null);
       return;
@@ -104,36 +108,49 @@ class ClientHttp2StreamMock extends stream.Duplex implements
 }
 
 describe('CallStream', () => {
-  const callStreamArgs =
-      {deadline: Infinity, flags: 0, host: '', parentCall: null};
+  const callStreamArgs = {
+    deadline: Infinity,
+    flags: 0,
+    host: '',
+    parentCall: null,
+  };
   /* A CompressionFilter is now necessary to frame and deframe messages.
    * Currently the channel is unused, so we can replace it with an empty object,
    * but this might break if we start checking channel arguments, in which case
    * we will need a more sophisticated fake */
-  const filterStackFactory =
-      new FilterStackFactory([new CompressionFilterFactory({} as Channel)]);
-  const message = 'eat this message';  // 16 bytes
+  const filterStackFactory = new FilterStackFactory([
+    new CompressionFilterFactory({} as Channel),
+  ]);
+  const message = 'eat this message'; // 16 bytes
 
   beforeEach(() => {
     assert2.clearMustCalls();
   });
 
-  it('should emit a metadata event when it receives a response event',
-     (done) => {
-       const responseMetadata = new Metadata();
-       responseMetadata.add('key', 'value');
-       const callStream = new Http2CallStream(
-           'foo', {} as Http2Channel, callStreamArgs, filterStackFactory);
+  it('should emit a metadata event when it receives a response event', done => {
+    const responseMetadata = new Metadata();
+    responseMetadata.add('key', 'value');
+    const callStream = new Http2CallStream(
+      'foo',
+      {} as Http2Channel,
+      callStreamArgs,
+      filterStackFactory
+    );
 
-       const http2Stream = new ClientHttp2StreamMock(
-           {payload: Buffer.alloc(0), frameLengths: []});
-       callStream.once('metadata', assert2.mustCall((metadata) => {
-         assert.deepStrictEqual(metadata.get('key'), ['value']);
-       }));
-       callStream.attachHttp2Stream(http2Stream);
-       http2Stream.emitResponse(200, responseMetadata);
-       assert2.afterMustCallsSatisfied(done);
-     });
+    const http2Stream = new ClientHttp2StreamMock({
+      payload: Buffer.alloc(0),
+      frameLengths: [],
+    });
+    callStream.once(
+      'metadata',
+      assert2.mustCall(metadata => {
+        assert.deepStrictEqual(metadata.get('key'), ['value']);
+      })
+    );
+    callStream.attachHttp2Stream(http2Stream);
+    http2Stream.emitResponse(200, responseMetadata);
+    assert2.afterMustCallsSatisfied(done);
+  });
 
   describe('should end a call with an error if a stream was closed', () => {
     const c = http2.constants;
@@ -151,21 +168,27 @@ describe('CallStream', () => {
       [c.NGHTTP2_COMPRESSION_ERROR]: s.INTERNAL,
       [c.NGHTTP2_CONNECT_ERROR]: s.INTERNAL,
       [c.NGHTTP2_ENHANCE_YOUR_CALM]: s.RESOURCE_EXHAUSTED,
-      [c.NGHTTP2_INADEQUATE_SECURITY]: s.PERMISSION_DENIED
+      [c.NGHTTP2_INADEQUATE_SECURITY]: s.PERMISSION_DENIED,
     };
     const keys = Object.keys(errorCodeMapping).map(key => Number(key));
-    keys.forEach((key) => {
+    keys.forEach(key => {
       const value = errorCodeMapping[key];
       // A null value indicates: behavior isn't specified, so skip this test.
-      const maybeSkip = (fn: typeof it) => value ? fn : fn.skip;
+      const maybeSkip = (fn: typeof it) => (value ? fn : fn.skip);
       maybeSkip(it)(`for error code ${key}`, () => {
         return new Promise((resolve, reject) => {
           const callStream = new Http2CallStream(
-              'foo', {} as Http2Channel, callStreamArgs, filterStackFactory);
-          const http2Stream = new ClientHttp2StreamMock(
-              {payload: Buffer.alloc(0), frameLengths: []});
+            'foo',
+            {} as Http2Channel,
+            callStreamArgs,
+            filterStackFactory
+          );
+          const http2Stream = new ClientHttp2StreamMock({
+            payload: Buffer.alloc(0),
+            frameLengths: [],
+          });
           callStream.attachHttp2Stream(http2Stream);
-          callStream.once('status', (status) => {
+          callStream.once('status', status => {
             try {
               assert.strictEqual(status.code, value);
               resolve();
@@ -179,151 +202,228 @@ describe('CallStream', () => {
     });
   });
 
-  it('should have functioning getters', (done) => {
+  it('should have functioning getters', done => {
     const callStream = new Http2CallStream(
-        'foo', {} as Http2Channel, callStreamArgs, filterStackFactory);
+      'foo',
+      {} as Http2Channel,
+      callStreamArgs,
+      filterStackFactory
+    );
     assert.strictEqual(callStream.getDeadline(), callStreamArgs.deadline);
     assert.strictEqual(callStream.getStatus(), null);
     const credentials = CallCredentials.createEmpty();
     callStream.setCredentials(credentials);
     assert.strictEqual(callStream.getCredentials(), credentials);
-    callStream.on('status', assert2.mustCall((status) => {
-      assert.strictEqual(status.code, Status.CANCELLED);
-      assert.strictEqual(status.details, ';)');
-      assert.strictEqual(callStream.getStatus(), status);
-    }));
+    callStream.on(
+      'status',
+      assert2.mustCall(status => {
+        assert.strictEqual(status.code, Status.CANCELLED);
+        assert.strictEqual(status.details, ';)');
+        assert.strictEqual(callStream.getStatus(), status);
+      })
+    );
     callStream.cancelWithStatus(Status.CANCELLED, ';)');
     // TODO: getPeer
     assert2.afterMustCallsSatisfied(done);
   });
 
   describe('attachHttp2Stream', () => {
-    it('should handle an empty message', (done) => {
+    it('should handle an empty message', done => {
       const callStream = new Http2CallStream(
-          'foo', {} as Http2Channel, callStreamArgs, filterStackFactory);
-      const http2Stream =
-          new ClientHttp2StreamMock({payload: serialize(''), frameLengths: []});
-      callStream.once('data', assert2.mustCall((buffer) => {
-        assert.strictEqual(buffer.toString('utf8'), '');
-      }));
+        'foo',
+        {} as Http2Channel,
+        callStreamArgs,
+        filterStackFactory
+      );
+      const http2Stream = new ClientHttp2StreamMock({
+        payload: serialize(''),
+        frameLengths: [],
+      });
+      callStream.once(
+        'data',
+        assert2.mustCall(buffer => {
+          assert.strictEqual(buffer.toString('utf8'), '');
+        })
+      );
       callStream.attachHttp2Stream(http2Stream);
       assert2.afterMustCallsSatisfied(done);
     });
 
-    [{description: 'all data is supplied in a single frame', frameLengths: []},
-     {
-       description: 'frames are split along header field delimiters',
-       frameLengths: [1, 4]
-     },
-     {
-       description:
-           'portions of header fields are split between different frames',
-       frameLengths: [2, 1, 1, 4]
-     },
-     {
-       description: 'frames are split into bytes',
-       frameLengths: range(0, 20).map(() => 1)
-     }].forEach((testCase: {description: string, frameLengths: number[]}) => {
-      it(`should handle a short message where ${testCase.description}`,
-         (done) => {
-           const callStream = new Http2CallStream(
-               'foo', {} as Http2Channel, callStreamArgs, filterStackFactory);
-           const http2Stream = new ClientHttp2StreamMock({
-             payload: serialize(message),  // 21 bytes
-             frameLengths: testCase.frameLengths
-           });
-           callStream.once('data', assert2.mustCall((buffer) => {
-             assert.strictEqual(buffer.toString('utf8'), message);
-           }));
-           callStream.once('end', assert2.mustCall(() => {}));
-           callStream.attachHttp2Stream(http2Stream);
-           assert2.afterMustCallsSatisfied(done);
-         });
-    });
-
-    [{description: 'all data is supplied in a single frame', frameLengths: []},
-     {
-       description: 'frames are split between delimited messages',
-       frameLengths: [21]
-     },
-     {description: 'frames are split within messages', frameLengths: [10, 22]},
-     {
-       description: 'part of 2nd message\'s header is in first frame',
-       frameLengths: [24]
-     },
-     {
-       description: 'frames are split into bytes',
-       frameLengths: range(0, 41).map(() => 1)
-     }].forEach((testCase: {description: string, frameLengths: number[]}) => {
-      it(`should handle two messages where ${testCase.description}`, (done) => {
+    [
+      {
+        description: 'all data is supplied in a single frame',
+        frameLengths: [],
+      },
+      {
+        description: 'frames are split along header field delimiters',
+        frameLengths: [1, 4],
+      },
+      {
+        description:
+          'portions of header fields are split between different frames',
+        frameLengths: [2, 1, 1, 4],
+      },
+      {
+        description: 'frames are split into bytes',
+        frameLengths: range(0, 20).map(() => 1),
+      },
+    ].forEach((testCase: { description: string; frameLengths: number[] }) => {
+      it(`should handle a short message where ${
+        testCase.description
+      }`, done => {
         const callStream = new Http2CallStream(
-            'foo', {} as Http2Channel, callStreamArgs, filterStackFactory);
+          'foo',
+          {} as Http2Channel,
+          callStreamArgs,
+          filterStackFactory
+        );
         const http2Stream = new ClientHttp2StreamMock({
-          payload: Buffer.concat(
-              [serialize(message), serialize(message)]),  // 42 bytes
-          frameLengths: testCase.frameLengths
+          payload: serialize(message), // 21 bytes
+          frameLengths: testCase.frameLengths,
         });
-        callStream.once('data', assert2.mustCall((buffer) => {
-          assert.strictEqual(buffer.toString('utf8'), message);
-        }));
-        callStream.once('data', assert2.mustCall((buffer) => {
-          assert.strictEqual(buffer.toString('utf8'), message);
-        }));
+        callStream.once(
+          'data',
+          assert2.mustCall(buffer => {
+            assert.strictEqual(buffer.toString('utf8'), message);
+          })
+        );
         callStream.once('end', assert2.mustCall(() => {}));
         callStream.attachHttp2Stream(http2Stream);
         assert2.afterMustCallsSatisfied(done);
       });
     });
 
-    it('should send buffered writes', (done) => {
+    [
+      {
+        description: 'all data is supplied in a single frame',
+        frameLengths: [],
+      },
+      {
+        description: 'frames are split between delimited messages',
+        frameLengths: [21],
+      },
+      {
+        description: 'frames are split within messages',
+        frameLengths: [10, 22],
+      },
+      {
+        description: "part of 2nd message's header is in first frame",
+        frameLengths: [24],
+      },
+      {
+        description: 'frames are split into bytes',
+        frameLengths: range(0, 41).map(() => 1),
+      },
+    ].forEach((testCase: { description: string; frameLengths: number[] }) => {
+      it(`should handle two messages where ${testCase.description}`, done => {
+        const callStream = new Http2CallStream(
+          'foo',
+          {} as Http2Channel,
+          callStreamArgs,
+          filterStackFactory
+        );
+        const http2Stream = new ClientHttp2StreamMock({
+          payload: Buffer.concat([serialize(message), serialize(message)]), // 42 bytes
+          frameLengths: testCase.frameLengths,
+        });
+        callStream.once(
+          'data',
+          assert2.mustCall(buffer => {
+            assert.strictEqual(buffer.toString('utf8'), message);
+          })
+        );
+        callStream.once(
+          'data',
+          assert2.mustCall(buffer => {
+            assert.strictEqual(buffer.toString('utf8'), message);
+          })
+        );
+        callStream.once('end', assert2.mustCall(() => {}));
+        callStream.attachHttp2Stream(http2Stream);
+        assert2.afterMustCallsSatisfied(done);
+      });
+    });
+
+    it('should send buffered writes', done => {
       const callStream = new Http2CallStream(
-          'foo', {} as Http2Channel, callStreamArgs, filterStackFactory);
-      const http2Stream = new ClientHttp2StreamMock(
-          {payload: Buffer.alloc(0), frameLengths: []});
+        'foo',
+        {} as Http2Channel,
+        callStreamArgs,
+        filterStackFactory
+      );
+      const http2Stream = new ClientHttp2StreamMock({
+        payload: Buffer.alloc(0),
+        frameLengths: [],
+      });
       let streamFlushed = false;
-      http2Stream.once('write', assert2.mustCall((chunk: Buffer) => {
-        const dataLength = chunk.readInt32BE(1);
-        const encodedMessage = chunk.slice(5).toString('utf8');
-        assert.strictEqual(dataLength, message.length);
-        assert.strictEqual(encodedMessage, message);
-        streamFlushed = true;
-      }));
-      callStream.write({message: Buffer.from(message)}, assert2.mustCall(() => {
-        // Ensure this is called only after contents are written to http2Stream
-        assert.ok(streamFlushed);
-      }));
+      http2Stream.once(
+        'write',
+        assert2.mustCall((chunk: Buffer) => {
+          const dataLength = chunk.readInt32BE(1);
+          const encodedMessage = chunk.slice(5).toString('utf8');
+          assert.strictEqual(dataLength, message.length);
+          assert.strictEqual(encodedMessage, message);
+          streamFlushed = true;
+        })
+      );
+      callStream.write(
+        { message: Buffer.from(message) },
+        assert2.mustCall(() => {
+          // Ensure this is called only after contents are written to http2Stream
+          assert.ok(streamFlushed);
+        })
+      );
       callStream.end(assert2.mustCall(() => {}));
       callStream.attachHttp2Stream(http2Stream);
       assert2.afterMustCallsSatisfied(done);
     });
 
-    it('should cause data chunks in write calls afterward to be written to the given stream',
-       (done) => {
-         const callStream = new Http2CallStream(
-             'foo', {} as Http2Channel, callStreamArgs, filterStackFactory);
-         const http2Stream = new ClientHttp2StreamMock(
-             {payload: Buffer.alloc(0), frameLengths: []});
-         http2Stream.once('write', assert2.mustCall((chunk: Buffer) => {
-           const dataLength = chunk.readInt32BE(1);
-           const encodedMessage = chunk.slice(5).toString('utf8');
-           assert.strictEqual(dataLength, message.length);
-           assert.strictEqual(encodedMessage, message);
-         }));
-         callStream.attachHttp2Stream(http2Stream);
-         callStream.write(
-             {message: Buffer.from(message)}, assert2.mustCall(() => {}));
-         callStream.end(assert2.mustCall(() => {}));
-         assert2.afterMustCallsSatisfied(done);
-       });
+    it('should cause data chunks in write calls afterward to be written to the given stream', done => {
+      const callStream = new Http2CallStream(
+        'foo',
+        {} as Http2Channel,
+        callStreamArgs,
+        filterStackFactory
+      );
+      const http2Stream = new ClientHttp2StreamMock({
+        payload: Buffer.alloc(0),
+        frameLengths: [],
+      });
+      http2Stream.once(
+        'write',
+        assert2.mustCall((chunk: Buffer) => {
+          const dataLength = chunk.readInt32BE(1);
+          const encodedMessage = chunk.slice(5).toString('utf8');
+          assert.strictEqual(dataLength, message.length);
+          assert.strictEqual(encodedMessage, message);
+        })
+      );
+      callStream.attachHttp2Stream(http2Stream);
+      callStream.write(
+        { message: Buffer.from(message) },
+        assert2.mustCall(() => {})
+      );
+      callStream.end(assert2.mustCall(() => {}));
+      assert2.afterMustCallsSatisfied(done);
+    });
 
     it('should handle underlying stream errors', () => {
       const callStream = new Http2CallStream(
-          'foo', {} as Http2Channel, callStreamArgs, filterStackFactory);
-      const http2Stream = new ClientHttp2StreamMock(
-          {payload: Buffer.alloc(0), frameLengths: []});
-      callStream.once('status', assert2.mustCall((status) => {
-        assert.strictEqual(status.code, Status.INTERNAL);
-      }));
+        'foo',
+        {} as Http2Channel,
+        callStreamArgs,
+        filterStackFactory
+      );
+      const http2Stream = new ClientHttp2StreamMock({
+        payload: Buffer.alloc(0),
+        frameLengths: [],
+      });
+      callStream.once(
+        'status',
+        assert2.mustCall(status => {
+          assert.strictEqual(status.code, Status.INTERNAL);
+        })
+      );
       callStream.attachHttp2Stream(http2Stream);
       http2Stream.emit('error');
     });

--- a/packages/grpc-js/test/test-channel-credentials.ts
+++ b/packages/grpc-js/test/test-channel-credentials.ts
@@ -17,15 +17,15 @@
 
 import * as assert from 'assert';
 import * as fs from 'fs';
-import {promisify} from 'util';
+import { promisify } from 'util';
 
-import {CallCredentials} from '../src/call-credentials';
-import {ChannelCredentials} from '../src/channel-credentials';
+import { CallCredentials } from '../src/call-credentials';
+import { ChannelCredentials } from '../src/channel-credentials';
 
-import {assert2, mockFunction} from './common';
+import { assert2, mockFunction } from './common';
 
 class CallCredentialsMock implements CallCredentials {
-  child: CallCredentialsMock|null = null;
+  child: CallCredentialsMock | null = null;
   constructor(child?: CallCredentialsMock) {
     if (child) {
       this.child = child;
@@ -52,61 +52,65 @@ class CallCredentialsMock implements CallCredentials {
 // tslint:disable-next-line:no-any
 const readFile: (...args: any[]) => Promise<Buffer> = promisify(fs.readFile);
 // A promise which resolves to loaded files in the form { ca, key, cert }
-const pFixtures = Promise
-                      .all(['ca.pem', 'server1.key', 'server1.pem'].map(
-                          (file) => readFile(`${__dirname}/fixtures/${file}`)))
-                      .then((result) => {
-                        return {ca: result[0], key: result[1], cert: result[2]};
-                      });
+const pFixtures = Promise.all(
+  ['ca.pem', 'server1.key', 'server1.pem'].map(file =>
+    readFile(`${__dirname}/fixtures/${file}`)
+  )
+).then(result => {
+  return { ca: result[0], key: result[1], cert: result[2] };
+});
 
 describe('ChannelCredentials Implementation', () => {
   describe('createInsecure', () => {
-    it('should return a ChannelCredentials object with no associated secure context',
-       () => {
-         const creds = assert2.noThrowAndReturn(
-             () => ChannelCredentials.createInsecure());
-         assert.ok(!creds._getConnectionOptions());
-       });
+    it('should return a ChannelCredentials object with no associated secure context', () => {
+      const creds = assert2.noThrowAndReturn(() =>
+        ChannelCredentials.createInsecure()
+      );
+      assert.ok(!creds._getConnectionOptions());
+    });
   });
 
   describe('createSsl', () => {
     it('should work when given no arguments', () => {
-      const creds: ChannelCredentials =
-          assert2.noThrowAndReturn(() => ChannelCredentials.createSsl());
+      const creds: ChannelCredentials = assert2.noThrowAndReturn(() =>
+        ChannelCredentials.createSsl()
+      );
       assert.ok(!!creds._getConnectionOptions());
     });
 
     it('should work with just a CA override', async () => {
-      const {ca} = await pFixtures;
-      const creds =
-          assert2.noThrowAndReturn(() => ChannelCredentials.createSsl(ca));
+      const { ca } = await pFixtures;
+      const creds = assert2.noThrowAndReturn(() =>
+        ChannelCredentials.createSsl(ca)
+      );
       assert.ok(!!creds._getConnectionOptions());
     });
 
     it('should work with just a private key and cert chain', async () => {
-      const {key, cert} = await pFixtures;
-      const creds = assert2.noThrowAndReturn(
-          () => ChannelCredentials.createSsl(null, key, cert));
+      const { key, cert } = await pFixtures;
+      const creds = assert2.noThrowAndReturn(() =>
+        ChannelCredentials.createSsl(null, key, cert)
+      );
       assert.ok(!!creds._getConnectionOptions());
     });
 
     it('should work with three parameters specified', async () => {
-      const {ca, key, cert} = await pFixtures;
-      const creds = assert2.noThrowAndReturn(
-          () => ChannelCredentials.createSsl(ca, key, cert));
+      const { ca, key, cert } = await pFixtures;
+      const creds = assert2.noThrowAndReturn(() =>
+        ChannelCredentials.createSsl(ca, key, cert)
+      );
       assert.ok(!!creds._getConnectionOptions());
     });
 
-    it('should throw if just one of private key and cert chain are missing',
-       async () => {
-         const {ca, key, cert} = await pFixtures;
-         assert.throws(() => ChannelCredentials.createSsl(ca, key));
-         assert.throws(() => ChannelCredentials.createSsl(ca, key, null));
-         assert.throws(() => ChannelCredentials.createSsl(ca, null, cert));
-         assert.throws(() => ChannelCredentials.createSsl(null, key));
-         assert.throws(() => ChannelCredentials.createSsl(null, key, null));
-         assert.throws(() => ChannelCredentials.createSsl(null, null, cert));
-       });
+    it('should throw if just one of private key and cert chain are missing', async () => {
+      const { ca, key, cert } = await pFixtures;
+      assert.throws(() => ChannelCredentials.createSsl(ca, key));
+      assert.throws(() => ChannelCredentials.createSsl(ca, key, null));
+      assert.throws(() => ChannelCredentials.createSsl(ca, null, cert));
+      assert.throws(() => ChannelCredentials.createSsl(null, key));
+      assert.throws(() => ChannelCredentials.createSsl(null, key, null));
+      assert.throws(() => ChannelCredentials.createSsl(null, null, cert));
+    });
   });
 
   describe('compose', () => {
@@ -122,12 +126,15 @@ describe('ChannelCredentials Implementation', () => {
       const callCreds2 = new CallCredentialsMock();
       // Associate both call credentials with channelCreds
       const composedChannelCreds = ChannelCredentials.createSsl()
-                                       .compose(callCreds1)
-                                       .compose(callCreds2);
+        .compose(callCreds1)
+        .compose(callCreds2);
       // Build a mock object that should be an identical copy
       const composedCallCreds = callCreds1.compose(callCreds2);
-      assert.ok(composedCallCreds.isEqual(
-          composedChannelCreds._getCallCredentials() as CallCredentialsMock));
+      assert.ok(
+        composedCallCreds.isEqual(
+          composedChannelCreds._getCallCredentials() as CallCredentialsMock
+        )
+      );
     });
   });
 });

--- a/packages/grpc-js/test/test-logging.ts
+++ b/packages/grpc-js/test/test-logging.ts
@@ -39,11 +39,11 @@ describe('Logging', () => {
   });
 
   it('gates logging based on severity', () => {
-    const output: Array<string|string[]> = [];
+    const output: Array<string | string[]> = [];
     const logger: Partial<Console> = {
       error(...args: string[]): void {
         output.push(args);
-      }
+      },
     };
 
     logging.setLogger(logger);
@@ -65,8 +65,13 @@ describe('Logging', () => {
     logging.log(grpc.logVerbosity.INFO, 7, 8);
     logging.log(grpc.logVerbosity.ERROR, 'j', 'k');
 
-    assert.deepStrictEqual(
-        output,
-        [['a', 'b', 'c'], ['d', 'e'], ['f'], ['g'], ['h', 'i'], ['j', 'k']]);
+    assert.deepStrictEqual(output, [
+      ['a', 'b', 'c'],
+      ['d', 'e'],
+      ['f'],
+      ['g'],
+      ['h', 'i'],
+      ['j', 'k'],
+    ]);
   });
 });

--- a/packages/grpc-js/test/test-metadata.ts
+++ b/packages/grpc-js/test/test-metadata.ts
@@ -17,8 +17,8 @@
 
 import * as assert from 'assert';
 import * as http2 from 'http2';
-import {range} from 'lodash';
-import {Metadata, MetadataObject, MetadataValue} from '../src/metadata';
+import { range } from 'lodash';
+import { Metadata, MetadataObject, MetadataValue } from '../src/metadata';
 
 class TestMetadata extends Metadata {
   getInternalRepresentation() {
@@ -28,14 +28,15 @@ class TestMetadata extends Metadata {
   static fromHttp2Headers(headers: http2.IncomingHttpHeaders): TestMetadata {
     const result = Metadata.fromHttp2Headers(headers) as TestMetadata;
     result.getInternalRepresentation =
-        TestMetadata.prototype.getInternalRepresentation;
+      TestMetadata.prototype.getInternalRepresentation;
     return result;
   }
 }
 
 const validKeyChars = '0123456789abcdefghijklmnopqrstuvwxyz_-.';
-const validNonBinValueChars =
-    range(0x20, 0x7f).map(code => String.fromCharCode(code)).join('');
+const validNonBinValueChars = range(0x20, 0x7f)
+  .map(code => String.fromCharCode(code))
+  .join('');
 
 describe('Metadata', () => {
   let metadata: TestMetadata;
@@ -86,20 +87,20 @@ describe('Metadata', () => {
 
     it('Saves values that can be retrieved', () => {
       metadata.set('key', 'value');
-      assert.deepEqual(metadata.get('key'), ['value']);
+      assert.deepStrictEqual(metadata.get('key'), ['value']);
     });
 
     it('Overwrites previous values', () => {
       metadata.set('key', 'value1');
       metadata.set('key', 'value2');
-      assert.deepEqual(metadata.get('key'), ['value2']);
+      assert.deepStrictEqual(metadata.get('key'), ['value2']);
     });
 
     it('Normalizes keys', () => {
       metadata.set('Key', 'value1');
-      assert.deepEqual(metadata.get('key'), ['value1']);
+      assert.deepStrictEqual(metadata.get('key'), ['value1']);
       metadata.set('KEY', 'value2');
-      assert.deepEqual(metadata.get('key'), ['value2']);
+      assert.deepStrictEqual(metadata.get('key'), ['value2']);
     });
   });
 
@@ -133,20 +134,20 @@ describe('Metadata', () => {
 
     it('Saves values that can be retrieved', () => {
       metadata.add('key', 'value');
-      assert.deepEqual(metadata.get('key'), ['value']);
+      assert.deepStrictEqual(metadata.get('key'), ['value']);
     });
 
     it('Combines with previous values', () => {
       metadata.add('key', 'value1');
       metadata.add('key', 'value2');
-      assert.deepEqual(metadata.get('key'), ['value1', 'value2']);
+      assert.deepStrictEqual(metadata.get('key'), ['value1', 'value2']);
     });
 
     it('Normalizes keys', () => {
       metadata.add('Key', 'value1');
-      assert.deepEqual(metadata.get('key'), ['value1']);
+      assert.deepStrictEqual(metadata.get('key'), ['value1']);
       metadata.add('KEY', 'value2');
-      assert.deepEqual(metadata.get('key'), ['value1', 'value2']);
+      assert.deepStrictEqual(metadata.get('key'), ['value1', 'value2']);
     });
   });
 
@@ -154,13 +155,13 @@ describe('Metadata', () => {
     it('clears values from a key', () => {
       metadata.add('key', 'value');
       metadata.remove('key');
-      assert.deepEqual(metadata.get('key'), []);
+      assert.deepStrictEqual(metadata.get('key'), []);
     });
 
     it('Normalizes keys', () => {
       metadata.add('key', 'value');
       metadata.remove('KEY');
-      assert.deepEqual(metadata.get('key'), []);
+      assert.deepStrictEqual(metadata.get('key'), []);
     });
   });
 
@@ -172,15 +173,15 @@ describe('Metadata', () => {
     });
 
     it('gets all values associated with a key', () => {
-      assert.deepEqual(metadata.get('key'), ['value1', 'value2']);
+      assert.deepStrictEqual(metadata.get('key'), ['value1', 'value2']);
     });
 
     it('Normalizes keys', () => {
-      assert.deepEqual(metadata.get('KEY'), ['value1', 'value2']);
+      assert.deepStrictEqual(metadata.get('KEY'), ['value1', 'value2']);
     });
 
     it('returns an empty list for non-existent keys', () => {
-      assert.deepEqual(metadata.get('non-existent-key'), []);
+      assert.deepStrictEqual(metadata.get('non-existent-key'), []);
     });
 
     it('returns Buffers for "-bin" keys', () => {
@@ -194,8 +195,11 @@ describe('Metadata', () => {
       metadata.add('Key2', 'value2');
       metadata.add('KEY3', 'value3a');
       metadata.add('KEY3', 'value3b');
-      assert.deepEqual(
-          metadata.getMap(), {key1: 'value1', key2: 'value2', key3: 'value3a'});
+      assert.deepStrictEqual(metadata.getMap(), {
+        key1: 'value1',
+        key2: 'value2',
+        key3: 'value3a',
+      });
     });
   });
 
@@ -203,21 +207,21 @@ describe('Metadata', () => {
     it('retains values from the original', () => {
       metadata.add('key', 'value');
       const copy = metadata.clone();
-      assert.deepEqual(copy.get('key'), ['value']);
+      assert.deepStrictEqual(copy.get('key'), ['value']);
     });
 
     it('Does not see newly added values', () => {
       metadata.add('key', 'value1');
       const copy = metadata.clone();
       metadata.add('key', 'value2');
-      assert.deepEqual(copy.get('key'), ['value1']);
+      assert.deepStrictEqual(copy.get('key'), ['value1']);
     });
 
     it('Does not add new values to the original', () => {
       metadata.add('key', 'value1');
       const copy = metadata.clone();
       copy.add('key', 'value2');
-      assert.deepEqual(metadata.get('key'), ['value1']);
+      assert.deepStrictEqual(metadata.get('key'), ['value1']);
     });
 
     it('Copy cannot modify binary values in the original', () => {
@@ -227,7 +231,7 @@ describe('Metadata', () => {
       const copyBuf = copy.get('key-bin')[0] as Buffer;
       assert.deepStrictEqual(copyBuf, buf);
       copyBuf.fill(0);
-      assert.notDeepEqual(copyBuf, buf);
+      assert.notDeepStrictEqual(copyBuf, buf);
     });
   });
 
@@ -246,12 +250,15 @@ describe('Metadata', () => {
       const metadata2IR = metadata2.getInternalRepresentation();
       metadata.merge(metadata2);
       // Ensure metadata2 didn't change
-      assert.deepEqual(metadata2.getInternalRepresentation(), metadata2IR);
-      assert.deepEqual(metadata.get('key1'), ['value1', 'value1']);
-      assert.deepEqual(metadata.get('key2'), ['value2a', 'value2b']);
-      assert.deepEqual(metadata.get('key3'), ['value3a', 'value3b']);
-      assert.deepEqual(metadata.get('key4'), ['value4']);
-      assert.deepEqual(metadata.get('key5'), ['value5a', 'value5b']);
+      assert.deepStrictEqual(
+        metadata2.getInternalRepresentation(),
+        metadata2IR
+      );
+      assert.deepStrictEqual(metadata.get('key1'), ['value1', 'value1']);
+      assert.deepStrictEqual(metadata.get('key2'), ['value2a', 'value2b']);
+      assert.deepStrictEqual(metadata.get('key3'), ['value3a', 'value3b']);
+      assert.deepStrictEqual(metadata.get('key4'), ['value4']);
+      assert.deepStrictEqual(metadata.get('key5'), ['value5a', 'value5b']);
     });
   });
 
@@ -265,19 +272,20 @@ describe('Metadata', () => {
       metadata.add('key-bin', Buffer.from(range(16, 32)));
       metadata.add('key-bin', Buffer.from(range(0, 32)));
       const headers = metadata.toHttp2Headers();
-      assert.deepEqual(headers, {
+      assert.deepStrictEqual(headers, {
         key1: ['value1'],
         key2: ['value2'],
         key3: ['value3a', 'value3b'],
         'key-bin': [
-          'AAECAwQFBgcICQoLDA0ODw==', 'EBESExQVFhcYGRobHB0eHw==',
-          'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8='
-        ]
+          'AAECAwQFBgcICQoLDA0ODw==',
+          'EBESExQVFhcYGRobHB0eHw==',
+          'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=',
+        ],
       });
     });
 
     it('creates an empty header object from empty Metadata', () => {
-      assert.deepEqual(metadata.toHttp2Headers(), {});
+      assert.deepStrictEqual(metadata.toHttp2Headers(), {});
     });
   });
 
@@ -288,30 +296,33 @@ describe('Metadata', () => {
         key2: ['value2'],
         key3: ['value3a', 'value3b'],
         'key-bin': [
-          'AAECAwQFBgcICQoLDA0ODw==', 'EBESExQVFhcYGRobHB0eHw==',
-          'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8='
-        ]
+          'AAECAwQFBgcICQoLDA0ODw==',
+          'EBESExQVFhcYGRobHB0eHw==',
+          'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=',
+        ],
       };
       const metadataFromHeaders = TestMetadata.fromHttp2Headers(headers);
       const internalRepr = metadataFromHeaders.getInternalRepresentation();
       const expected: MetadataObject = new Map<string, MetadataValue[]>([
-        ['key1', ['value1']], ['key2', ['value2']],
+        ['key1', ['value1']],
+        ['key2', ['value2']],
         ['key3', ['value3a', 'value3b']],
         [
           'key-bin',
           [
-            Buffer.from(range(0, 16)), Buffer.from(range(16, 32)),
-            Buffer.from(range(0, 32))
-          ]
-        ]
+            Buffer.from(range(0, 16)),
+            Buffer.from(range(16, 32)),
+            Buffer.from(range(0, 32)),
+          ],
+        ],
       ]);
-      assert.deepEqual(internalRepr, expected);
+      assert.deepStrictEqual(internalRepr, expected);
     });
 
     it('creates an empty Metadata object from empty headers', () => {
       const metadataFromHeaders = TestMetadata.fromHttp2Headers({});
       const internalRepr = metadataFromHeaders.getInternalRepresentation();
-      assert.deepEqual(internalRepr, new Map<string, MetadataValue[]>());
+      assert.deepStrictEqual(internalRepr, new Map<string, MetadataValue[]>());
     });
   });
 });

--- a/packages/grpc-js/test/test-server-credentials.ts
+++ b/packages/grpc-js/test/test-server-credentials.ts
@@ -18,9 +18,9 @@
 // Allow `any` data type for testing runtime type checking.
 // tslint:disable no-any
 import * as assert from 'assert';
-import {readFileSync} from 'fs';
-import {join} from 'path';
-import {ServerCredentials} from '../src';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { ServerCredentials } from '../src';
 
 const ca = readFileSync(join(__dirname, 'fixtures', 'ca.pem'));
 const key = readFileSync(join(__dirname, 'fixtures', 'server1.key'));
@@ -41,32 +41,43 @@ describe('Server Credentials', () => {
       const creds = ServerCredentials.createSsl(ca, []);
 
       assert.strictEqual(creds._isSecure(), true);
-      assert.deepStrictEqual(
-          creds._getSettings(), {ca, cert: [], key: [], requestCert: false});
+      assert.deepStrictEqual(creds._getSettings(), {
+        ca,
+        cert: [],
+        key: [],
+        requestCert: false,
+      });
     });
 
     it('accepts a boolean as the third argument', () => {
       const creds = ServerCredentials.createSsl(ca, [], true);
 
       assert.strictEqual(creds._isSecure(), true);
-      assert.deepStrictEqual(
-          creds._getSettings(), {ca, cert: [], key: [], requestCert: true});
+      assert.deepStrictEqual(creds._getSettings(), {
+        ca,
+        cert: [],
+        key: [],
+        requestCert: true,
+      });
     });
 
     it('accepts an object with two buffers in the second argument', () => {
-      const keyCertPairs = [{private_key: key, cert_chain: cert}];
+      const keyCertPairs = [{ private_key: key, cert_chain: cert }];
       const creds = ServerCredentials.createSsl(null, keyCertPairs);
 
       assert.strictEqual(creds._isSecure(), true);
-      assert.deepStrictEqual(
-          creds._getSettings(),
-          {ca: undefined, cert: [cert], key: [key], requestCert: false});
+      assert.deepStrictEqual(creds._getSettings(), {
+        ca: undefined,
+        cert: [cert],
+        key: [key],
+        requestCert: false,
+      });
     });
 
     it('accepts multiple objects in the second argument', () => {
       const keyCertPairs = [
-        {private_key: key, cert_chain: cert},
-        {private_key: key, cert_chain: cert}
+        { private_key: key, cert_chain: cert },
+        { private_key: key, cert_chain: cert },
       ];
       const creds = ServerCredentials.createSsl(null, keyCertPairs, false);
 
@@ -75,7 +86,7 @@ describe('Server Credentials', () => {
         ca: undefined,
         cert: [cert, cert],
         key: [key, key],
-        requestCert: false
+        requestCert: false,
       });
     });
 
@@ -108,7 +119,7 @@ describe('Server Credentials', () => {
     });
 
     it('fails if the object does not have a Buffer private key', () => {
-      const keyCertPairs: any = [{private_key: 'test', cert_chain: cert}];
+      const keyCertPairs: any = [{ private_key: 'test', cert_chain: cert }];
 
       assert.throws(() => {
         ServerCredentials.createSsl(null, keyCertPairs);
@@ -116,7 +127,7 @@ describe('Server Credentials', () => {
     });
 
     it('fails if the object does not have a Buffer cert chain', () => {
-      const keyCertPairs: any = [{private_key: key, cert_chain: 'test'}];
+      const keyCertPairs: any = [{ private_key: key, cert_chain: 'test' }];
 
       assert.throws(() => {
         ServerCredentials.createSsl(null, keyCertPairs);

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -22,31 +22,30 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import * as grpc from '../src';
-import {ServerCredentials} from '../src';
-import {ServiceError} from '../src/call';
-import {ServiceClient, ServiceClientConstructor} from '../src/make-client';
-import {Server} from '../src/server';
-import {sendUnaryData, ServerUnaryCall} from '../src/server-call';
+import { ServerCredentials } from '../src';
+import { ServiceError } from '../src/call';
+import { ServiceClient, ServiceClientConstructor } from '../src/make-client';
+import { Server } from '../src/server';
+import { sendUnaryData, ServerUnaryCall } from '../src/server-call';
 
-import {loadProtoFile} from './common';
+import { loadProtoFile } from './common';
 
 const ca = fs.readFileSync(path.join(__dirname, 'fixtures', 'ca.pem'));
 const key = fs.readFileSync(path.join(__dirname, 'fixtures', 'server1.key'));
 const cert = fs.readFileSync(path.join(__dirname, 'fixtures', 'server1.pem'));
 function noop(): void {}
 
-
 describe('Server', () => {
   describe('constructor', () => {
     it('should work with no arguments', () => {
       assert.doesNotThrow(() => {
-        new Server();  // tslint:disable-line:no-unused-expression
+        new Server(); // tslint:disable-line:no-unused-expression
       });
     });
 
     it('should work with an empty object argument', () => {
       assert.doesNotThrow(() => {
-        new Server({});  // tslint:disable-line:no-unused-expression
+        new Server({}); // tslint:disable-line:no-unused-expression
       });
     });
 
@@ -58,21 +57,27 @@ describe('Server', () => {
   });
 
   describe('bindAsync', () => {
-    it('binds with insecure credentials', (done) => {
+    it('binds with insecure credentials', done => {
       const server = new Server();
 
       server.bindAsync(
-          'localhost:0', ServerCredentials.createInsecure(), (err, port) => {
-            assert.ifError(err);
-            assert(typeof port === 'number' && port > 0);
-            server.tryShutdown(done);
-          });
+        'localhost:0',
+        ServerCredentials.createInsecure(),
+        (err, port) => {
+          assert.ifError(err);
+          assert(typeof port === 'number' && port > 0);
+          server.tryShutdown(done);
+        }
+      );
     });
 
-    it('binds with secure credentials', (done) => {
+    it('binds with secure credentials', done => {
       const server = new Server();
       const creds = ServerCredentials.createSsl(
-          ca, [{private_key: key, cert_chain: cert}], true);
+        ca,
+        [{ private_key: key, cert_chain: cert }],
+        true
+      );
 
       server.bindAsync('localhost:0', creds, (err, port) => {
         assert.ifError(err);
@@ -85,14 +90,20 @@ describe('Server', () => {
       const server = new Server();
 
       server.bindAsync(
-          'localhost:0', ServerCredentials.createInsecure(), (err, port) => {
-            assert.ifError(err);
-            server.start();
-            assert.throws(() => {
-              server.bindAsync(
-                  'localhost:0', ServerCredentials.createInsecure(), noop);
-            }, /server is already started/);
-          });
+        'localhost:0',
+        ServerCredentials.createInsecure(),
+        (err, port) => {
+          assert.ifError(err);
+          server.start();
+          assert.throws(() => {
+            server.bindAsync(
+              'localhost:0',
+              ServerCredentials.createInsecure(),
+              noop
+            );
+          }, /server is already started/);
+        }
+      );
     });
 
     it('throws on invalid inputs', () => {
@@ -108,16 +119,19 @@ describe('Server', () => {
 
       assert.throws(() => {
         server.bindAsync(
-            'localhost:0', ServerCredentials.createInsecure(), null as any);
+          'localhost:0',
+          ServerCredentials.createInsecure(),
+          null as any
+        );
       }, /callback must be a function/);
     });
   });
 
   describe('tryShutdown', () => {
-    it('calls back with an error if the server is not running', (done) => {
+    it('calls back with an error if the server is not running', done => {
       const server = new Server();
 
-      server.tryShutdown((err) => {
+      server.tryShutdown(err => {
         assert(err !== undefined && err.message === 'server is not running');
         done();
       });
@@ -127,12 +141,12 @@ describe('Server', () => {
   describe('start', () => {
     let server: Server;
 
-    beforeEach((done) => {
+    beforeEach(done => {
       server = new Server();
       server.bindAsync('localhost:0', ServerCredentials.createInsecure(), done);
     });
 
-    afterEach((done) => {
+    afterEach(done => {
       server.tryShutdown(done);
     });
 
@@ -162,8 +176,8 @@ describe('Server', () => {
     const mathProtoFile = path.join(__dirname, 'fixtures', 'math.proto');
     const mathClient = (loadProtoFile(mathProtoFile).math as any).Math;
     const mathServiceAttrs = mathClient.service;
-    const dummyImpls = {div() {}, divMany() {}, fib() {}, sum() {}};
-    const altDummyImpls = {Div() {}, DivMany() {}, Fib() {}, Sum() {}};
+    const dummyImpls = { div() {}, divMany() {}, fib() {}, sum() {} };
+    const altDummyImpls = { Div() {}, DivMany() {}, Fib() {}, Sum() {} };
 
     it('succeeds with a single service', () => {
       const server = new Server();
@@ -198,18 +212,21 @@ describe('Server', () => {
       });
     });
 
-    it('fails if the server has been started', (done) => {
+    it('fails if the server has been started', done => {
       const server = new Server();
 
       server.bindAsync(
-          'localhost:0', ServerCredentials.createInsecure(), (err, port) => {
-            assert.ifError(err);
-            server.start();
-            assert.throws(() => {
-              server.addService(mathServiceAttrs, dummyImpls);
-            }, /Can't add a service to a started server\./);
-            server.tryShutdown(done);
-          });
+        'localhost:0',
+        ServerCredentials.createInsecure(),
+        (err, port) => {
+          assert.ifError(err);
+          server.start();
+          assert.throws(() => {
+            server.addService(mathServiceAttrs, dummyImpls);
+          }, /Can't add a service to a started server\./);
+          server.tryShutdown(done);
+        }
+      );
     });
   });
 
@@ -241,29 +258,36 @@ describe('Server', () => {
     const mathClient = (loadProtoFile(mathProtoFile).math as any).Math;
     const mathServiceAttrs = mathClient.service;
 
-    beforeEach((done) => {
+    beforeEach(done => {
       server = new Server();
       server.addService(mathServiceAttrs, {});
       server.bindAsync(
-          'localhost:0', ServerCredentials.createInsecure(), (err, port) => {
-            assert.ifError(err);
-            client = new mathClient(
-                `localhost:${port}`, grpc.credentials.createInsecure());
-            server.start();
-            done();
-          });
+        'localhost:0',
+        ServerCredentials.createInsecure(),
+        (err, port) => {
+          assert.ifError(err);
+          client = new mathClient(
+            `localhost:${port}`,
+            grpc.credentials.createInsecure()
+          );
+          server.start();
+          done();
+        }
+      );
     });
 
-    it('should respond to a unary call with UNIMPLEMENTED', (done) => {
+    it('should respond to a unary call with UNIMPLEMENTED', done => {
       client.div(
-          {divisor: 4, dividend: 3}, (error: ServiceError, response: any) => {
-            assert(error);
-            assert.strictEqual(error.code, grpc.status.UNIMPLEMENTED);
-            done();
-          });
+        { divisor: 4, dividend: 3 },
+        (error: ServiceError, response: any) => {
+          assert(error);
+          assert.strictEqual(error.code, grpc.status.UNIMPLEMENTED);
+          done();
+        }
+      );
     });
 
-    it('should respond to a client stream with UNIMPLEMENTED', (done) => {
+    it('should respond to a client stream with UNIMPLEMENTED', done => {
       const call = client.sum((error: ServiceError, response: any) => {
         assert(error);
         assert.strictEqual(error.code, grpc.status.UNIMPLEMENTED);
@@ -273,8 +297,8 @@ describe('Server', () => {
       call.end();
     });
 
-    it('should respond to a server stream with UNIMPLEMENTED', (done) => {
-      const call = client.fib({limit: 5});
+    it('should respond to a server stream with UNIMPLEMENTED', done => {
+      const call = client.fib({ limit: 5 });
 
       call.on('data', (value: any) => {
         assert.fail('No messages expected');
@@ -287,7 +311,7 @@ describe('Server', () => {
       });
     });
 
-    it('should respond to a bidi call with UNIMPLEMENTED', (done) => {
+    it('should respond to a bidi call with UNIMPLEMENTED', done => {
       const call = client.divMany();
 
       call.on('data', (value: any) => {
@@ -309,41 +333,47 @@ describe('Echo service', () => {
   let server: Server;
   let client: ServiceClient;
 
-  before((done) => {
+  before(done => {
     const protoFile = path.join(__dirname, 'fixtures', 'echo_service.proto');
-    const echoService =
-        loadProtoFile(protoFile).EchoService as ServiceClientConstructor;
+    const echoService = loadProtoFile(protoFile)
+      .EchoService as ServiceClientConstructor;
 
     server = new Server();
     server.addService(echoService.service, {
       echo(call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) {
         callback(null, call.request);
-      }
+      },
     });
 
     server.bindAsync(
-        'localhost:0', ServerCredentials.createInsecure(), (err, port) => {
-          assert.ifError(err);
-          client = new echoService(
-              `localhost:${port}`, grpc.credentials.createInsecure());
-          server.start();
-          done();
-        });
+      'localhost:0',
+      ServerCredentials.createInsecure(),
+      (err, port) => {
+        assert.ifError(err);
+        client = new echoService(
+          `localhost:${port}`,
+          grpc.credentials.createInsecure()
+        );
+        server.start();
+        done();
+      }
+    );
   });
 
-  after((done) => {
+  after(done => {
     client.close();
     server.tryShutdown(done);
   });
 
-  it('should echo the recieved message directly', (done) => {
+  it('should echo the recieved message directly', done => {
     client.echo(
-        {value: 'test value', value2: 3},
-        (error: ServiceError, response: any) => {
-          assert.ifError(error);
-          assert.deepStrictEqual(response, {value: 'test value', value2: 3});
-          done();
-        });
+      { value: 'test value', value2: 3 },
+      (error: ServiceError, response: any) => {
+        assert.ifError(error);
+        assert.deepStrictEqual(response, { value: 'test value', value2: 3 });
+        done();
+      }
+    );
   });
 });
 
@@ -368,43 +398,51 @@ describe('Generic client and server', () => {
       requestSerialize: toBuffer,
       requestDeserialize: toString,
       responseSerialize: toBuffer,
-      responseDeserialize: toString
-    }
+      responseDeserialize: toString,
+    },
   };
 
   describe('String client and server', () => {
     let client: ServiceClient;
     let server: Server;
 
-    before((done) => {
+    before(done => {
       server = new Server();
 
       server.addService(stringServiceAttrs as any, {
         capitalize(
-            call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) {
+          call: ServerUnaryCall<any, any>,
+          callback: sendUnaryData<any>
+        ) {
           callback(null, capitalize(call.request));
-        }
+        },
       });
 
       server.bindAsync(
-          'localhost:0', ServerCredentials.createInsecure(), (err, port) => {
-            assert.ifError(err);
-            server.start();
-            const clientConstr = grpc.makeGenericClientConstructor(
-                stringServiceAttrs as any,
-                'unused_but_lets_appease_typescript_anyway');
-            client = new clientConstr(
-                `localhost:${port}`, grpc.credentials.createInsecure());
-            done();
-          });
+        'localhost:0',
+        ServerCredentials.createInsecure(),
+        (err, port) => {
+          assert.ifError(err);
+          server.start();
+          const clientConstr = grpc.makeGenericClientConstructor(
+            stringServiceAttrs as any,
+            'unused_but_lets_appease_typescript_anyway'
+          );
+          client = new clientConstr(
+            `localhost:${port}`,
+            grpc.credentials.createInsecure()
+          );
+          done();
+        }
+      );
     });
 
-    after((done) => {
+    after(done => {
       client.close();
       server.tryShutdown(done);
     });
 
-    it('Should respond with a capitalized string', (done) => {
+    it('Should respond with a capitalized string', done => {
       client.capitalize('abc', (err: ServiceError, response: string) => {
         assert.ifError(err);
         assert.strictEqual(response, 'Abc');

--- a/packages/grpc-js/test/test-status-builder.ts
+++ b/packages/grpc-js/test/test-status-builder.ts
@@ -18,7 +18,7 @@
 import * as assert from 'assert';
 
 import * as grpc from '../src';
-import {StatusBuilder} from '../src/status-builder';
+import { StatusBuilder } from '../src/status-builder';
 
 describe('StatusBuilder', () => {
   it('is exported by the module', () => {
@@ -33,14 +33,19 @@ describe('StatusBuilder', () => {
     assert.deepStrictEqual(builder.build(), {});
     result = builder.withCode(grpc.status.OK);
     assert.strictEqual(result, builder);
-    assert.deepStrictEqual(builder.build(), {code: grpc.status.OK});
+    assert.deepStrictEqual(builder.build(), { code: grpc.status.OK });
     result = builder.withDetails('foobar');
     assert.strictEqual(result, builder);
-    assert.deepStrictEqual(
-        builder.build(), {code: grpc.status.OK, details: 'foobar'});
+    assert.deepStrictEqual(builder.build(), {
+      code: grpc.status.OK,
+      details: 'foobar',
+    });
     result = builder.withMetadata(metadata);
     assert.strictEqual(result, builder);
-    assert.deepStrictEqual(
-        builder.build(), {code: grpc.status.OK, details: 'foobar', metadata});
+    assert.deepStrictEqual(builder.build(), {
+      code: grpc.status.OK,
+      details: 'foobar',
+      metadata,
+    });
   });
 });


### PR DESCRIPTION
This commit updates the `gts` dependency to 1.x.x. All of the changes come from running `npm run fix` and find+replace'ing a handful of `assert` methods, as instructed by the tool.