### PR TITLE
Fix a TypeError loading a non-existent proto file.

### DIFF
--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -121,7 +121,7 @@ function getAllHandledReflectionObjects(
   if (isHandledReflectionObject(obj)) {
     return [[objName, obj]];
   } else {
-    if (isNamespaceBase(obj) && typeof obj.nested !== undefined) {
+    if (isNamespaceBase(obj) && typeof obj.nested !== 'undefined') {
       return Object.keys(obj.nested!)
           .map((name) => {
             return getAllHandledReflectionObjects(obj.nested![name], objName);


### PR DESCRIPTION
The issue: https://github.com/grpc/grpc-node/issues/876

This is an obvious typo; `typeof` has to return a string `'undefined'`, not a literal `undefined.`

The fix is so minor and trivial that I don't mind anyone to please create a different PR and fix it there, instead of waiting for me to sign the Linux Foundation license, etc.