### PR TITLE
fixed: when node-pre-gyp download tar.gz use needle module, it will i…

### DIFF
--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -23,9 +23,12 @@
     "install": "node-pre-gyp install",
     "prepublishOnly": "git submodule update --init --recursive && node copy_well_known_protos.js"
   },
-  "bundledDependencies": ["node-pre-gyp"],
+  "bundledDependencies": [
+    "node-pre-gyp"
+  ],
   "dependencies": {
-    "node-pre-gyp": "^0.12.0"
+    "node-pre-gyp": "^0.12.0",
+    "request": "^2.88.0"
   },
   "binary": {
     "module_name": "grpc_tools",


### PR DESCRIPTION
…nstall error. error message is `There was a fatal problem while downloading/extracting the tarball`