### PR TITLE
grpc-js: Change how filters access connectivity information

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -330,7 +330,7 @@ export class Http2Channel extends EventEmitter implements Channel {
     metadata: Metadata
   ) {
     const connectMetadata: Promise<Metadata> = this.connect().then(
-      () => new Metadata()
+      () => metadata
     );
     const finalMetadata: Promise<Metadata> = stream.filterStack.sendMetadata(
       connectMetadata

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -329,11 +329,14 @@ export class Http2Channel extends EventEmitter implements Channel {
     stream: Http2CallStream,
     metadata: Metadata
   ) {
-    const finalMetadata: Promise<Metadata> = stream.filterStack.sendMetadata(
-      Promise.resolve(metadata.clone())
+    const connectMetadata: Promise<Metadata> = this.connect().then(
+      () => new Metadata()
     );
-    Promise.all([finalMetadata, this.connect()])
-      .then(([metadataValue]) => {
+    const finalMetadata: Promise<Metadata> = stream.filterStack.sendMetadata(
+      connectMetadata
+    );
+    finalMetadata
+      .then(metadataValue => {
         const headers = metadataValue.toHttp2Headers();
         headers[HTTP2_HEADER_AUTHORITY] = authority;
         headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;


### PR DESCRIPTION
Instead of having filters explicitly use the channel's `connectivityStateChanged` listener to track connectivity state, make the filter stack's initial metadata promise only resolve when the channel becomes connected. Then any filter can just await that promise to wait for the channel to connect. This should fix the warning reported in https://github.com/grpc/grpc-node/issues/694#issuecomment-496566860.