### PR TITLE
grpc-js: update typescript and enable incremental builds

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -22,7 +22,7 @@
     "clang-format": "^1.0.55",
     "gts": "^1.0.0",
     "lodash": "^4.17.4",
-    "typescript": "~3.4.5"
+    "typescript": "~3.5.1"
   },
   "contributors": [
     {

--- a/packages/grpc-js/tsconfig.json
+++ b/packages/grpc-js/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": ".",
     "outDir": "build",
     "target": "es2017",
-    "module": "commonjs"
+    "module": "commonjs",
+    "incremental": true
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
This PR updates [TypeScript to 3.5](https://devblogs.microsoft.com/typescript/announcing-typescript-3-5/), which is supposed to be faster. It also enables incremental builds to speed up compilation. On my machine I'm seeing the compile times drop from about ~4-5 seconds every time to  ~1.5-4 seconds depending on what is changed.