### PR TITLE
grpc-js: load semver range from package.json

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -41,7 +41,7 @@ import { Metadata } from './metadata';
 import { KeyCertPair, ServerCredentials } from './server-credentials';
 import { StatusBuilder } from './status-builder';
 
-const supportedNodeVersions = '^8.13.0 || >=10.10.0';
+const supportedNodeVersions = require('../../package.json').engines.node;
 if (!semver.satisfies(process.version, supportedNodeVersions)) {
   throw new Error(`@grpc/grpc-js only works on Node ${supportedNodeVersions}`);
 }


### PR DESCRIPTION
This commit loads the required semver range from the `package.json` file, instead of hard-coding the string in `index.ts`.

This should make it a bit easier to update the required version in the future. After this change, the version string will exist in:

- This module's `package.json` file. Ideally, this would be the only non-docs location.
- The top level `PACKAGE-COMPARISON.md` file.
- The top level's `test/gulpfile.js`. I'm happy to update that as well if it's OK.