### PR TITLE
grpc-js: reject invalid Content-Type requests

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -288,6 +288,22 @@ export class Server {
           return;
         }
 
+        const contentType = headers[http2.constants.HTTP2_HEADER_CONTENT_TYPE];
+
+        if (
+          typeof contentType !== 'string' ||
+          !contentType.startsWith('application/grpc')
+        ) {
+          stream.respond(
+            {
+              [http2.constants.HTTP2_HEADER_STATUS]:
+                http2.constants.HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE,
+            },
+            { endStream: true }
+          );
+          return;
+        }
+
         try {
           const path = headers[http2.constants.HTTP2_HEADER_PATH] as string;
           const handler = this.handlers.get(path);


### PR DESCRIPTION
This commit implements the following portion of the spec:

If Content-Type does not begin with "application/grpc", gRPC servers SHOULD respond with HTTP status of 415 (Unsupported Media Type). This will prevent other HTTP/2 clients from interpreting a gRPC error response, which uses status 200 (OK), as successful.