### PR TITLE
 grpc-js: destroy connections when session begins

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -329,8 +329,8 @@ export class Http2Channel extends EventEmitter implements Channel {
     stream: Http2CallStream,
     metadata: Metadata
   ) {
-    const connectMetadata: Promise<Metadata> = this.connect().then(
-      () => metadata.clone()
+    const connectMetadata: Promise<Metadata> = this.connect().then(() =>
+      metadata.clone()
     );
     const finalMetadata: Promise<Metadata> = stream.filterStack.sendMetadata(
       connectMetadata

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -284,11 +284,6 @@ export class Server {
     this.http2Server.on(
       'stream',
       (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => {
-        if (!this.started) {
-          stream.end();
-          return;
-        }
-
         const contentType = headers[http2.constants.HTTP2_HEADER_CONTENT_TYPE];
 
         if (
@@ -351,6 +346,13 @@ export class Server {
         }
       }
     );
+
+    this.http2Server.on('session', session => {
+      if (!this.started) {
+        session.destroy();
+        return;
+      }
+    });
   }
 }
 

--- a/packages/grpc-js/src/stream-decoder.ts
+++ b/packages/grpc-js/src/stream-decoder.ts
@@ -33,7 +33,7 @@ export class StreamDecoder {
   write(data: Buffer): Buffer[] {
     let readHead = 0;
     let toRead: number;
-    let result: Buffer[] = [];
+    const result: Buffer[] = [];
 
     while (readHead < data.length) {
       switch (this.readState) {


### PR DESCRIPTION
When the gRPC server has not been started, incoming connections can be destroyed on session establishment, which happens before a stream is created.