### PR TITLE
Pure JS: Fixed two bugs with goaway handling

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -130,7 +130,16 @@ export class Http2CallStream extends Duplex implements Call {
   private endCall(status: StatusObject): void {
     if (this.finalStatus === null) {
       this.finalStatus = status;
-      this.emit('status', status);
+      /* We do this asynchronously to ensure that no async function is in the
+       * call stack when we return control to the application. If an async
+       * function is in the call stack, any exception thrown by the application
+       * (or our tests) will bubble up and turn into promise rejection, which
+       * will result in an UnhandledPromiseRejectionWarning. Because that is
+       * a warning, the error will be effectively swallowed and execution will
+       * continue */
+      process.nextTick(() => {
+        this.emit('status', status);
+      });
     }
   }
 

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -78,6 +78,10 @@ export class Http2SubChannel extends EventEmitter implements SubChannel {
       this.stopKeepalivePings();
       this.emit('close');
     });
+    this.session.on('goaway', () => {
+      this.stopKeepalivePings();
+      this.emit('close');
+    });
     this.userAgent = userAgent;
 
     if (channelArgs['grpc.keepalive_time_ms']) {

--- a/packages/grpc-js/test/test-call-stream.ts
+++ b/packages/grpc-js/test/test-call-stream.ts
@@ -196,7 +196,8 @@ describe('CallStream', () => {
               reject(e);
             }
           });
-          http2Stream.emit('close', Number(key));
+          http2Stream.rstCode = Number(key);
+          http2Stream.emit('close');
         });
       });
     });

--- a/test/api/connectivity_test.js
+++ b/test/api/connectivity_test.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+const options = {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
+};
+const path = require('path');
+const fs = require('fs');
+const assert = require('assert');
+const _ = require('lodash');
+const anyGrpc = require('../any_grpc');
+const clientGrpc = anyGrpc.client;
+const serverGrpc = anyGrpc.server;
+const protoLoader = require('../../packages/proto-loader', options);
+const testServiceDef = protoLoader.loadSync(__dirname + '/../proto/test_service.proto');
+const TestService = serverGrpc.loadPackageDefinition(testServiceDef).TestService.service;
+const TestServiceClient = clientGrpc.loadPackageDefinition(testServiceDef).TestService;
+
+const clientCreds = clientGrpc.credentials.createInsecure();
+const serverCreds = serverGrpc.ServerCredentials.createInsecure();
+
+const serviceImpl = {
+  unary: function(call, cb) {
+    cb(null, {});
+  },
+  clientStream: function(stream, cb){
+    stream.on('data', function(data) {});
+    stream.on('end', function() {
+      cb(null, {});
+    });
+  },
+  serverStream: function(stream) {
+    stream.end();
+  },
+  bidiStream: function(stream) {
+    stream.on('data', function(data) {});
+    stream.on('end', function() {
+      stream.end();
+    });
+  }
+};
+
+describe('Reconnection', function() {
+  let server1;
+  let server2;
+  let port;
+  before(function() {
+    server1 = new serverGrpc.Server();
+    server1.addService(TestService, serviceImpl);
+    server2 = new serverGrpc.Server();
+    server2.addService(TestService, serviceImpl);
+    port = server1.bind('localhost:0', serverCreds);
+    server1.start();
+    client = new TestServiceClient(`localhost:${port}`, clientCreds);
+  });
+  after(function() {
+    server1.forceShutdown();
+    server2.forceShutdown();
+  });
+  it('Should end with either OK or UNAVAILABLE when querying a server that is shutting down', function(done) {
+    client.unary({}, (err, data) => {
+      assert.ifError(err);
+      server1.tryShutdown(() => {
+        server2.bind(`localhost:${port}`, serverCreds);
+        server2.start();
+        client.unary({}, (err, data) => {
+          assert.ifError(err);
+          clearInterval(callInterval);
+          done();
+        });
+      });
+      let callInterval = setInterval(() => {
+        client.unary({}, (err, data) => {
+          if (err) {
+            assert.strictEqual(err.code, clientGrpc.status.UNAVAILABLE);
+          }
+        });
+      }, 0);
+    });
+  });
+});


### PR DESCRIPTION
First, I think this fixes #734. When a Node http2 client session receives a GOAWAY from the server, it sets its closed flag and emits a `'goaway'` event immediately, and then emits the `'close'` and `'error'` (if needed) events a tick or two later. We listen for the `'close'` event to know when a session should be considered unusable, and if the channel tries to start a stream in between the `'goaway'` event and the `'close'` event, it ends with an error. The fix is to simply stop using the subchannel as soon is the `'goaway'` event comes in.

Second, RST_STREAM error codes were not getting handled correctly in the stream code, including artificial RST_STREAM errors created by the Node http2 code when a GOAWAY is received.