### PR TITLE
grpc-tools: Add option to generate package definition

### DIFF
--- a/packages/grpc-tools/src/node_generator.h
+++ b/packages/grpc-tools/src/node_generator.h
@@ -23,7 +23,13 @@
 
 namespace grpc_node_generator {
 
-grpc::string GenerateFile(const grpc::protobuf::FileDescriptor* file);
+struct Parameters {
+  // Generate a package definition object instead of Client classes
+  bool generate_package_definition;
+};
+
+grpc::string GenerateFile(const grpc::protobuf::FileDescriptor* file,
+                          const Parameters& params);
 
 }  // namespace grpc_node_generator
 

--- a/packages/grpc-tools/src/node_plugin.cc
+++ b/packages/grpc-tools/src/node_plugin.cc
@@ -36,8 +36,20 @@ class NodeGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
                 const grpc::string& parameter,
                 grpc::protobuf::compiler::GeneratorContext* context,
                 grpc::string* error) const {
-
-    grpc::string code = GenerateFile(file);
+    grpc_node_generator::Parameters generator_parameters;
+    generator_parameters.generate_package_definition = false;
+    if (!parameter.empty()) {
+      std::vector<grpc::string> parameters_list =	
+          grpc_generator::tokenize(parameter, ",");	
+      for (auto parameter_string = parameters_list.begin();	
+           parameter_string != parameters_list.end(); parameter_string++) {
+        printf("%s", parameter_string);
+        if (*parameter_string == "generate_package_definition") {
+          generator_parameters.generate_package_definition = true;
+        }
+      }
+    }
+    grpc::string code = GenerateFile(file, generator_parameters);
     if (code.size() == 0) {
       return true;
     }


### PR DESCRIPTION
This adds a `generate_package_definition` option to the code generation plugin we distribute with grpc-tools. If that option is set the output is a file that returns a `PackageDefintion` object (defined [here](https://github.com/grpc/proposal/blob/master/L23-node-protobufjs-library.md)), which can be loaded by either grpc implementation library's `loadPackageDefinition` function.

I tested this by building the plugin, generating a file from our examples' `helloworld.proto` and loading it with grpc-js.

I used the option handling code from the last time someone added an option to this package.