### PR TITLE
Connectivity test: ensure all calls end before ending the test

### DIFF
--- a/test/api/connectivity_test.js
+++ b/test/api/connectivity_test.js
@@ -79,7 +79,7 @@ describe('Reconnection', function() {
     let pendingCalls = 0;
     let testDone = false;
     function maybeDone() {
-      if (testDone && pendingCalls == 0) {
+      if (testDone && pendingCalls === 0) {
         done();
       }
     };


### PR DESCRIPTION
Avoid potential timing issues with making the final calls and calling `forceShutdown` on the server in the `after` hook.