### PR TITLE
fix: properly handle http error status codes

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -243,24 +243,24 @@ export class Http2CallStream extends Duplex implements Call {
     } else {
       this.http2Stream = stream;
       stream.on('response', (headers, flags) => {
-        switch (headers[HTTP2_HEADER_STATUS]) {
+        switch (headers[':status']) {
           // TODO(murgatroid99): handle 100 and 101
-          case '400':
+          case 400:
             this.mappedStatusCode = Status.INTERNAL;
             break;
-          case '401':
+          case 401:
             this.mappedStatusCode = Status.UNAUTHENTICATED;
             break;
-          case '403':
+          case 403:
             this.mappedStatusCode = Status.PERMISSION_DENIED;
             break;
-          case '404':
+          case 404:
             this.mappedStatusCode = Status.UNIMPLEMENTED;
             break;
-          case '429':
-          case '502':
-          case '503':
-          case '504':
+          case 429:
+          case 502:
+          case 503:
+          case 504:
             this.mappedStatusCode = Status.UNAVAILABLE;
             break;
           default:


### PR DESCRIPTION
This is an attempt to get a fix for #941

There are 2 things here:

1) Correctly check http error status codes as number rather than string. This is probably correct.

2) Trigger `handleTrailers` in the case of an http error. This is probably not the right thing to do, but I'm not very familiar with the codebase or protocol and I'm literally just hacking away trying to get the result I'm looking for. This does fix the error I'm experiencing, although probably not the right way to go about it.

