### PR TITLE
Remove check in grpc-js that doesn't appear in grpc

### DIFF
--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -139,11 +139,6 @@ export class Client {
         );
       }
     });
-    call.on('end', () => {
-      if (responseMessage == null) {
-        call.cancelWithStatus(Status.INTERNAL, 'Not enough responses received');
-      }
-    });
     call.on('status', (status: StatusObject) => {
       /* We assume that call emits status after it emits end, and that it
        * accounts for any cancelWithStatus calls up until it emits status.


### PR DESCRIPTION
This is a follow-up to #943, fixing part of the problem reported in #941. I'm pretty sure that the current grpc library just outputs a `null` message if no message arrives for a unary call. This check here is overriding more useful errors, so it's best to just remove it.