### PR TITLE
Remove dependency on @types/protobufjs again

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -29,7 +29,6 @@
     "node-pre-gyp"
   ],
   "dependencies": {
-    "@types/protobufjs": "^5.0.31",
     "lodash.camelcase": "^4.3.0",
     "lodash.clone": "^4.5.0",
     "nan": "^2.13.2",

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -31,7 +31,6 @@
       "node-pre-gyp"
     ],
     "dependencies": {
-      "@types/protobufjs": "^5.0.31",
       "lodash.camelcase": "^4.3.0",
       "lodash.clone": "^4.5.0",
       "nan": "^2.13.2",


### PR DESCRIPTION
I definitely already did this, but I guess there's some git weirdness with backporting a change from master, reverting the backport in the branch, and then merging the branch into master.