### PR TITLE
Fix 'noImplicitAny' issue with declaration file.

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -579,7 +579,7 @@ declare module "grpc" {
      *   These options only have any effect when passed at the beginning of
      *   a client request.
      */
-    setOptions(options: MetadataOptions);
+    setOptions(options: MetadataOptions): void;
   }
 
   export type MetadataValue = string | Buffer;


### PR DESCRIPTION
Cherry-pick 26e30ab136d8ec00106fd8d67844e5df651a4df8

The latest release of grpc-node cannot be used in a typescript project that uses -noImplicitAny.  This is due to a signature being added without a specified return type.  This causes the return type to implicitly be 'any' which TS explicitly disallows.  For projects that use strict flags to catch lots of bugs, this prevents usage of this version of grpc entirely.