### PR TITLE
grpc-js: Add @types/semver as devDependency

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -19,6 +19,7 @@
     "@types/lodash": "^4.14.108",
     "@types/mocha": "^5.2.6",
     "@types/node": "^12.0.2",
+    "@types/semver": "^6.0.1",
     "clang-format": "^1.0.55",
     "gts": "^1.0.0",
     "lodash": "^4.17.4",
@@ -43,7 +44,7 @@
     "posttest": "npm run check"
   },
   "dependencies": {
-    "semver": "^6.0.0"
+    "semver": "^6.2.0"
   },
   "files": [
     "build/src/*.{js,d.ts}",


### PR DESCRIPTION
Currently when you `npm i` you get a failure to compile because there are no type definitions for `semver`
