### PR TITLE
Improve server-related types exported by grpc-js

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -38,9 +38,10 @@ import {
   Serialize,
 } from './make-client';
 import { Metadata } from './metadata';
-import { Server } from './server';
+import { Server, UntypedHandleCall, UntypedServiceImplementation } from './server';
 import { KeyCertPair, ServerCredentials } from './server-credentials';
 import { StatusBuilder } from './status-builder';
+import { ServerUnaryCall, ServerReadableStream, ServerWritableStream, ServerDuplexStream } from './server-call';
 
 const supportedNodeVersions = require('../../package.json').engines.node;
 if (!semver.satisfies(process.version, supportedNodeVersions)) {
@@ -213,6 +214,12 @@ export {
   CallOptions,
   StatusObject,
   ServiceError,
+  ServerUnaryCall,
+  ServerReadableStream,
+  ServerWritableStream,
+  ServerDuplexStream,
+  UntypedHandleCall,
+  UntypedServiceImplementation
 };
 
 /* tslint:disable:no-any */

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -18,7 +18,6 @@
 import { EventEmitter } from 'events';
 import * as http2 from 'http2';
 import { Duplex, Readable, Writable } from 'stream';
-import * as util from 'util';
 
 import { StatusObject } from './call-stream';
 import { Status } from './constants';
@@ -506,11 +505,11 @@ export class Http2ServerCallStream<
         : new Metadata(),
     };
 
-    if ('code' in error && util.isNumber(error.code) && Number.isInteger(error.code)) {
+    if ('code' in error && typeof error.code === 'number' && Number.isInteger(error.code)) {
       status.code = error.code;
 
-      if ('details' in error && util.isString(error.details)) {
-        status.details = error.details;
+      if ('details' in error && typeof error.details === 'string') {
+        status.details = error.details!;
       }
     }
 

--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -412,13 +412,13 @@ declare module "grpc" {
    * User provided method to handle server streaming methods on the server.
    */
   type handleServerStreamingCall<RequestType, ResponseType> =
-    (call: ServerWriteableStream<RequestType>) => void;
+    (call: ServerWritableStream<RequestType>) => void;
 
   /**
    * A stream that the server can write to. Used for calls that are streaming
    * from the server side.
    */
-  export class ServerWriteableStream<RequestType> extends Writable {
+  export class ServerWritableStream<RequestType> extends Writable {
     /**
      * Indicates if the call has been cancelled
      */
@@ -448,6 +448,10 @@ declare module "grpc" {
      */
     sendMetadata(responseMetadata: Metadata): void;
   }
+
+  /* This typo existed in previous versions of this file, so we provide this
+   * type alias for backwards compatibility. */
+  export type ServerWriteableStream<RequestType> = ServerWritableStream<RequestType>;
 
   /**
    * User provided method to handle bidirectional streaming calls on the server.


### PR DESCRIPTION
This mainly makes the server call types and `Server#registerService` function signature more specific, the server error types more permissive, and exports some more types needed for writing service implementations.

Also, this fixes a typo in the native library's `index.d.ts` that got brought up in #965. That class is essentially internal, so code written using the typo works. I have added an alias to avoid breaking that.