### PR TITLE
Add dev-dependencies and fix tests so they exit after running

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "through2": "^2.0.3",
     "ts-node": "^8.1.0",
     "tslint": "^5.5.0",
-    "typescript": "~3.3.3333",
+    "typescript": "^3.5.3",
     "xml2js": "^0.4.19"
   },
   "contributors": [

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -16,14 +16,25 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@grpc/proto-loader": "^0.5.0",
+    "@types/gulp": "^4.0.6",
+    "@types/gulp-mocha": "0.0.32",
     "@types/lodash": "^4.14.108",
     "@types/mocha": "^5.2.6",
+    "@types/ncp": "^2.0.1",
     "@types/node": "^12.0.2",
+    "@types/pify": "^3.0.2",
     "@types/semver": "^6.0.1",
     "clang-format": "^1.0.55",
+    "execa": "^2.0.3",
     "gts": "^1.0.0",
+    "gulp": "^4.0.2",
+    "gulp-mocha": "^6.0.0",
     "lodash": "^4.17.4",
-    "typescript": "~3.5.1"
+    "mocha-jenkins-reporter": "^0.4.1",
+    "ncp": "^2.0.0",
+    "pify": "^4.0.1",
+    "ts-node": "^8.3.0",
+    "typescript": "^3.5.3"
   },
   "contributors": [
     {

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -86,7 +86,7 @@ describe('Server', () => {
       });
     });
 
-    it('throws if bind is called after the server is started', () => {
+    it('throws if bind is called after the server is started', done => {
       const server = new Server();
 
       server.bindAsync(
@@ -102,6 +102,7 @@ describe('Server', () => {
               noop
             );
           }, /server is already started/);
+          server.tryShutdown(done);
         }
       );
     });
@@ -243,7 +244,7 @@ describe('Server', () => {
     const mathClient = (loadProtoFile(mathProtoFile).math as any).Math;
     const mathServiceAttrs = mathClient.service;
 
-    beforeEach(done => {
+    before(done => {
       server = new Server();
       server.addService(mathServiceAttrs, {});
       server.bindAsync(
@@ -259,6 +260,11 @@ describe('Server', () => {
           done();
         }
       );
+    });
+
+    after(done => {
+      client.close();
+      server.tryShutdown(done);
     });
 
     it('should respond to a unary call with UNIMPLEMENTED', done => {


### PR DESCRIPTION
My goal was to be able to successfully:

```
git clone git@github.com:grpc/grpc-node.git
cd grpc-node/packages/grpc-js
npm i
npm run test
```

What I did:

1. Specify all of the dependencies required to run the tests in `package.json` as `devDependencies`
2. Add teardown steps to two tests that prevented the process from exiting when the tests completed.

