### PR TITLE
Set grpc-health-check version to 1.7.0

### DIFF
--- a/packages/grpc-health-check/package.json
+++ b/packages/grpc-health-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/health-check",
-  "version": "1.8.0-dev",
+  "version": "1.7.0",
   "author": "Google Inc.",
   "description": "Health check service for use with gRPC",
   "repository": {


### PR DESCRIPTION
The last version we published was 1.6.6 and apparently there is some stuff since that that we haven't published.