### PR TITLE
Revert grpc-health-check name to original name

### DIFF
--- a/packages/grpc-health-check/package.json
+++ b/packages/grpc-health-check/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@grpc/health-check",
+  "name": "grpc-health-check",
   "version": "1.7.0",
   "author": "Google Inc.",
   "description": "Health check service for use with gRPC",


### PR DESCRIPTION
The package name we currently have there was never actually published, and I think we want continuity for now.