### PR TITLE
Deadline exceeded

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -365,6 +365,12 @@ export class Http2CallStream extends Duplex implements Call {
       metadata
     );
   }
+  
+  private closeChannel() {
+    if (this.channel) {
+      this.channel.close();
+    }
+  }
 
   private destroyHttp2Stream() {
     // The http2 stream could already have been destroyed if cancelWithStatus
@@ -377,6 +383,7 @@ export class Http2CallStream extends Duplex implements Call {
   }
 
   cancelWithStatus(status: Status, details: string): void {
+    this.closeChannel();
     this.destroyHttp2Stream();
     (async () => {
       // If trailers are currently being processed, the call should be ended

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -196,8 +196,8 @@ export class Http2Channel extends EventEmitter implements Channel {
           this.subChannel.removeListener('close', this.subChannelCloseCallback);
           this.subChannel = null;
           this.emit('shutdown');
-          clearTimeout(this.backoffTimerId);
         }
+        clearTimeout(this.backoffTimerId);
         break;
       default:
         throw new Error('This should never happen');


### PR DESCRIPTION
When timeout for connection is exceeded a new connection is started. I think if timeout is exceeded there is should not more tries.