### PR TITLE
unary request and client stream promise support

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -1089,8 +1089,8 @@ declare module "grpc" {
       argument: RequestType | null,
       metadata: Metadata | null,
       options: CallOptions | null,
-      callback: requestCallback<ResponseType>,
-    ): ClientUnaryCall;
+      callback?: requestCallback<ResponseType>,
+    ): ClientUnaryCall & PromiseLike<ResponseType>;
 
     /**
      * Make a client stream request to the given method, using the given serialize
@@ -1109,8 +1109,8 @@ declare module "grpc" {
       deserialize: deserialize<ResponseType>,
       metadata: Metadata | null,
       options: CallOptions | null,
-      callback: requestCallback<ResponseType>,
-    ): ClientWritableStream<RequestType>;
+      callback?: requestCallback<ResponseType>,
+    ): ClientWritableStream<RequestType> & PromiseLike<ResponseType>;
 
     /**
      * Make a server stream request to the given method, with the given serialize

--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -559,8 +559,10 @@ Client.prototype.makeUnaryRequest = function(path, serialize, deserialize,
     intercepting_call.halfClose();
   });
 
-  // avoid UnhandledPromiseRejectionWarning
-  promise.catch(() => {});
+  if (typeof callProperties.callback === 'function') {
+    // avoid UnhandledPromiseRejectionWarning
+    promise.catch(() => {});
+  }
 
   emitter.then = promise.then.bind(promise);
 
@@ -685,8 +687,10 @@ Client.prototype.makeClientStreamRequest = function(path, serialize,
     intercepting_call.start(callProperties.metadata, last_listener);
   });
 
-  // avoid UnhandledPromiseRejectionWarning
-  promise.catch(() => {});
+  if (typeof callProperties.callback === 'function') {
+    // avoid UnhandledPromiseRejectionWarning
+    promise.catch(() => {});
+  }
 
   emitter.then = promise.then.bind(promise);
 

--- a/packages/grpc-native-core/test/client_interceptors_test.js
+++ b/packages/grpc-native-core/test/client_interceptors_test.js
@@ -193,6 +193,21 @@ describe('Client interceptors', function() {
         echoBidiStream: []
       }));
     });
+    it('with unary call and promise', function(done) {
+      var expected_value = 'foo';
+      var message = {value: expected_value};
+      client.echo(message)
+        .then(function(response) {
+          assert.strictEqual(response.value, expected_value);
+          done();
+        });
+      assert(_.isEqual(grpc_client.getClientInterceptors(client), {
+        echo: [],
+        echoClientStream: [],
+        echoServerStream: [],
+        echoBidiStream: []
+      }));
+    });
   });
 
   describe('execute downstream interceptors when a new call is made outbound',
@@ -287,6 +302,16 @@ describe('Client interceptors', function() {
         });
         stream.write(message);
         stream.end();
+      });
+      it('with client streaming call with promise', function(done) {
+        registry = new CallRegistry(done, expected_calls, false);
+        var message = { value: 'foo' };
+        var stream = client.echoClientStream(options);
+        stream.write(message);
+        stream.end().then(function (res) {
+          assert.strictEqual(res.value, message.value);
+          registry.addCall('response');
+        });
       });
       it('with server streaming call', function(done) {
         registry = new CallRegistry(done, expected_calls, true);


### PR DESCRIPTION
Support `then()` when unary request or client stream, essentially both APIs are the ones that already exposes a callback, so I just removed the need for a callback and make the return of both thenable.

No breaking change, every test pass(and two new ones), the API only became more open, now allow to avoid a callback.

Usage example:
```javascript
// with callback
it('with unary call', function(done) {
  registry = new CallRegistry(done, expected_calls, true);
  var message = { value: 'foo' };
  client.echo(message, options, function(err) {
    if (!err) { // do what if error happen? yeah nothing
      registry.addCall('response');
    }
  });
});

// async await version
it('with unary call', async function(done) {
  registry = new CallRegistry(done, expected_calls, true);
  var message = { value: 'foo' };
  await client.echo(message, options); // will throw if fail
  registry.addCall('response'); 
});
```