### PR TITLE
Fix typo in makeServerStreamRequest return type (grpc-native-core)

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -1131,7 +1131,7 @@ declare module "grpc" {
       argument: RequestType,
       metadata?: Metadata | null,
       options?: CallOptions | null,
-    ): ClientReadableStream<RequestType>;
+    ): ClientReadableStream<ResponseType>;
 
     /**
      * Make a bidirectional stream request with this method on the given channel.


### PR DESCRIPTION
The `makeServerStreamRequest` return type in grpc-native-core is currently `ClientReadableStream<RequestType>`; this PR updates it to `ClientReadableStream<ResponseType>`.