### PR TITLE
Remove deprecated @types/protobufjs module

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -29,7 +29,6 @@
     "node-pre-gyp"
   ],
   "dependencies": {
-    "@types/protobufjs": "^5.0.31",
     "lodash.camelcase": "^4.3.0",
     "lodash.clone": "^4.5.0",
     "nan": "^2.13.2",

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -31,7 +31,6 @@
       "node-pre-gyp"
     ],
     "dependencies": {
-      "@types/protobufjs": "^5.0.31",
       "lodash.camelcase": "^4.3.0",
       "lodash.clone": "^4.5.0",
       "nan": "^2.13.2",


### PR DESCRIPTION
From the [description of `@types/protobufjs`](https://www.npmjs.com/package/@types/protobufjs):

> This is a stub types definition for protobufjs (https://github.com/dcodeIO/ProtoBuf.js). protobufjs provides its own type definitions, so you don't need @types/protobufjs installed!

Introducing this module caused a bunch of build failures for me on a project that depends on `grpc`.