### PR TITLE
Remove @types/protobufjs and bump to 1.23.1

### DIFF
--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -97,7 +97,7 @@
       'GPR_BACKWARDS_COMPATIBILITY_MODE',
       'GRPC_ARES=1',
       'GRPC_UV',
-      'GRPC_NODE_VERSION="1.23.0"',
+      'GRPC_NODE_VERSION="1.23.1"',
       'CARES_STATICLIB',
       'CARES_SYMBOL_HIDING'
     ],

--- a/packages/grpc-native-core/build.yaml
+++ b/packages/grpc-native-core/build.yaml
@@ -1,2 +1,3 @@
 settings:
   '#': It's possible to have node_version here as a key to override the core's version.
+  node_version: 1.23.1

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "author": "Google Inc.",
   "description": "gRPC Library for Node",
   "homepage": "https://grpc.io/",
@@ -29,7 +29,6 @@
     "node-pre-gyp"
   ],
   "dependencies": {
-    "@types/protobufjs": "^5.0.31",
     "lodash.camelcase": "^4.3.0",
     "lodash.clone": "^4.5.0",
     "nan": "^2.13.2",

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -31,7 +31,6 @@
       "node-pre-gyp"
     ],
     "dependencies": {
-      "@types/protobufjs": "^5.0.31",
       "lodash.camelcase": "^4.3.0",
       "lodash.clone": "^4.5.0",
       "nan": "^2.13.2",


### PR DESCRIPTION
Somehow the last removal of that dependency didn't make it into the 1.23.x branch.