### PR TITLE
Install npm 6.10 on Windows

### DIFF
--- a/tools/release/kokoro-electron.bat
+++ b/tools/release/kokoro-electron.bat
@@ -20,7 +20,7 @@ SET PATH=%APPDATA%\nvm-ps;%APPDATA%\nvm-ps\nodejs;%PATH%
 call nvm install 10
 call nvm use 10
 
-call npm install -g npm
+call npm install -g npm@6.10.x
 @rem https://github.com/mapbox/node-pre-gyp/issues/362
 call npm install -g node-gyp@3
 

--- a/tools/release/kokoro-nodejs.bat
+++ b/tools/release/kokoro-nodejs.bat
@@ -20,7 +20,7 @@ SET PATH=%APPDATA%\nvm-ps;%APPDATA%\nvm-ps\nodejs;%PATH%
 call nvm install 10
 call nvm use 10
 
-call npm install -g npm
+call npm install -g npm@6.10.x
 @rem https://github.com/mapbox/node-pre-gyp/issues/362
 call npm install -g node-gyp@3
 


### PR DESCRIPTION
Our build is currently failing because of [a bug in npm 6.11 on Windows](https://npm.community/t/6-11-0-npm-looking-for-executable-packages-in-root-c/9574).