### PR TITLE
Move EventEmitter inside declare module "grpc"

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -17,6 +17,7 @@
  */
 
 declare module "grpc" {
+  // add imports here, inside the "grpc" module, to keep it as an ambient module
   import { Message, Service as ProtobufService } from "protobufjs";
   import { EventEmitter } from "events";
   import { Duplex, Readable, Writable } from "stream";

--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from "events";
 
 /*
  * Copyright 2019 gRPC authors.
@@ -19,6 +18,7 @@ import { EventEmitter } from "events";
 
 declare module "grpc" {
   import { Message, Service as ProtobufService } from "protobufjs";
+  import { EventEmitter } from "events";
   import { Duplex, Readable, Writable } from "stream";
   import { SecureContext } from "tls";
 


### PR DESCRIPTION
Fixes #1006 

For sad historical reasons, Typescript's syntax for ambient modules, which is what grpc-native-core's index.d.ts tries to declare, is the same as module augmentations. The way to tell the difference between the two is whether the file has imports or exports outside the declaration. #1002 adds such a declaration, turning the ambient module into a module augmentation. Not only is there no grpc module to augment, module augmentations are subject to a bunch of restrictions since they are only supposed to augment the contents of an existing module. That's the cause of the new errors.

I'm not sure if merging into the grpc@1.23.x branch is correct. That's what I targetted with this change.