### PR TITLE
Clean up nanopb

### DIFF
--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -82,12 +82,10 @@
       'deps/grpc/third_party/address_sorting/include',
       'deps/grpc/third_party/cares',
       'deps/grpc/third_party/cares/cares',
-      'deps/grpc/third_party/nanopb',
       'deps/grpc/third_party/upb',
       'deps/grpc/third_party/upb/generated_for_cmake',
     ],
     'defines': [
-      'PB_FIELD_32BIT',
       'GPR_BACKWARDS_COMPATIBILITY_MODE',
       'GRPC_ARES=1',
       'GRPC_UV',

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -72,7 +72,6 @@
     "deps/grpc/third_party/boringssl/include/**/*.{c,cc,h}",
     "deps/grpc/third_party/boringssl/ssl/**/*.{c,cc,h}",
     "deps/grpc/third_party/boringssl/third_party/**/*.{c,h}",
-    "deps/grpc/third_party/nanopb/*.{c,cc,h}",
     "deps/grpc/third_party/upb/**/*.{c,h}",
     "deps/grpc/third_party/zlib/**/*.{c,cc,h}",
     "binding.gyp"

--- a/packages/grpc-native-core/templates/binding.gyp.template
+++ b/packages/grpc-native-core/templates/binding.gyp.template
@@ -78,12 +78,10 @@
         'deps/grpc/third_party/address_sorting/include',
         'deps/grpc/third_party/cares',
         'deps/grpc/third_party/cares/cares',
-        'deps/grpc/third_party/nanopb',
         'deps/grpc/third_party/upb',
         'deps/grpc/third_party/upb/generated_for_cmake',
       ],
       'defines': [
-        'PB_FIELD_32BIT',
         'GPR_BACKWARDS_COMPATIBILITY_MODE',
         'GRPC_ARES=1',
         'GRPC_UV',

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -74,7 +74,6 @@
       "deps/grpc/third_party/boringssl/include/**/*.{c,cc,h}",
       "deps/grpc/third_party/boringssl/ssl/**/*.{c,cc,h}",
       "deps/grpc/third_party/boringssl/third_party/**/*.{c,h}",
-      "deps/grpc/third_party/nanopb/*.{c,cc,h}",
       "deps/grpc/third_party/upb/**/*.{c,h}",
       "deps/grpc/third_party/zlib/**/*.{c,cc,h}",
       "binding.gyp"


### PR DESCRIPTION
Remove nanopb from node project. This should be merged after `packages/grpc-native-core/deps/grpc` is updated to the latest.