### PR TITLE
Use cross docker only for artifacts

### DIFF
--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -205,6 +205,11 @@
             '-Wno-error=deprecated-declarations'
           ],
         },
+      }],
+      ['OS == "linux"', {
+        'defines': [
+          '_GLIBCXX_USE_CXX11_ABI=0'
+        ]
       }]
     ]
   },

--- a/packages/grpc-native-core/templates/binding.gyp.template
+++ b/packages/grpc-native-core/templates/binding.gyp.template
@@ -187,6 +187,11 @@
             ],
             % endif
           },
+        }],
+        ['OS == "linux"', {
+          'defines': [
+            '_GLIBCXX_USE_CXX11_ABI=0'
+          ]
         }]
       ]
     },

--- a/tools/release/cross/Dockerfile
+++ b/tools/release/cross/Dockerfile
@@ -1,8 +1,7 @@
 FROM debian:stretch
 
 RUN dpkg --add-architecture i386
-RUN apt-get update
-RUN apt-get install -y curl build-essential g++-aarch64-linux-gnu g++-arm-linux-gnueabihf python libc6-dev:i386 lib32stdc++-6-dev
+RUN apt-get update && apt-get install -y curl build-essential g++-aarch64-linux-gnu g++-arm-linux-gnueabihf python libc6-dev:i386 lib32stdc++-6-dev jq cmake
 RUN curl -fsSL get.docker.com | bash
 
 RUN mkdir /usr/local/nvm

--- a/tools/release/kokoro-electron.sh
+++ b/tools/release/kokoro-electron.sh
@@ -38,7 +38,7 @@ OS=`uname`
 
 case $OS in
 Linux)
-    docker build -t kokoro-native-image tools/release/native
+    docker build -t kokoro-native-image tools/release/cross
     docker run -v /var/run/docker.sock:/var/run/docker.sock -v $base_dir:$base_dir kokoro-native-image $base_dir/packages/grpc-native-core/tools/run_tests/artifacts/build_all_linux_artifacts.sh --native-only --electron-only
     cp -rv packages/grpc-native-core/artifacts .
     ;;

--- a/tools/release/kokoro-grpc-tools.sh
+++ b/tools/release/kokoro-grpc-tools.sh
@@ -25,7 +25,7 @@ uname -a
 
 case $OS in
 Linux)
-  docker build -t kokoro-native-image tools/release/native
+  docker build -t kokoro-native-image tools/release/cross
   docker run -v /var/run/docker.sock:/var/run/docker.sock -v $base_dir:$base_dir -e ARTIFACTS_OUT=$base_dir/artifacts kokoro-native-image $base_dir/packages/grpc-tools/build_binaries.sh
   ;;
 Darwin)

--- a/tools/release/kokoro-nodejs.sh
+++ b/tools/release/kokoro-nodejs.sh
@@ -38,11 +38,8 @@ OS=`uname`
 
 case $OS in
 Linux)
-    docker build -t kokoro-native-image tools/release/native
     docker build -t kokoro-cross-image tools/release/cross
-    docker run -v /var/run/docker.sock:/var/run/docker.sock -v $base_dir:$base_dir kokoro-native-image $base_dir/packages/grpc-native-core/tools/run_tests/artifacts/build_all_linux_artifacts.sh --native-only --nodejs-only
-    cp -rv packages/grpc-native-core/artifacts .
-    docker run -v /var/run/docker.sock:/var/run/docker.sock -v $base_dir:$base_dir kokoro-cross-image $base_dir/packages/grpc-native-core/tools/run_tests/artifacts/build_all_linux_artifacts.sh --cross-only --nodejs-only
+    docker run -v /var/run/docker.sock:/var/run/docker.sock -v $base_dir:$base_dir kokoro-cross-image $base_dir/packages/grpc-native-core/tools/run_tests/artifacts/build_all_linux_artifacts.sh --nodejs-only
     cp -rv packages/grpc-native-core/artifacts .
     ;;
 Darwin)


### PR DESCRIPTION
Instead of having two docker images, only one latest docker image is used. From node.js 12, GCC 6.3 or later is required ([ref](https://medium.com/@nodejs/introducing-node-js-12-76c41a1b3f3f)) and only cross docker based on `debian:stretch` has it.

To address the problem where generated artifacts from GCC 6.x have a dependency against newer version of libstdc++, `_GLIBCXX_USE_CXX11_ABI=0` is defined for linux to use the old version of API explicitly. ([ref](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html))