### PR TITLE
Add specific call error for TCP disconnection

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -342,6 +342,14 @@ export class Http2CallStream extends Duplex implements Call {
          * from bubbling up. However, errors here should all correspond to
          * "close" events, where we will handle the error more granularly */
       });
+      /* If the underlying TLS or TCP connection closes, we want to end the
+       * call with an UNAVAILABLE status to match the behavior of the other
+       * library. In this handler we don't wait for trailers before ending the
+       * call. This should ensure that this endCall happens sooner than the one
+       * in the stream.on('close', ...) handler. */
+      stream.session.socket.on('close', () => {
+        this.endCall({code: Status.UNAVAILABLE, details: 'Connection dropped', metadata: new Metadata()});
+      });
       if (!this.pendingRead) {
         stream.pause();
       }

--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -342,20 +342,14 @@ export class Http2CallStream extends Duplex implements Call {
          * from bubbling up. However, errors here should all correspond to
          * "close" events, where we will handle the error more granularly */
       });
-      /* For some reason, stream.session.socket can sometimes be undefined.
-       * When that happens trying to add this event handler throws an error.
-       * This check is a stopgap measure to get this working sometimes until
-       * we understand/eliminate those cases. */
-      if (stream.session.socket) {
-        /* If the underlying TLS or TCP connection closes, we want to end the
-        * call with an UNAVAILABLE status to match the behavior of the other
-        * library. In this handler we don't wait for trailers before ending the
-        * call. This should ensure that this endCall happens sooner than the one
-        * in the stream.on('close', ...) handler. */
-        stream.session.socket.on('close', () => {
-          this.endCall({code: Status.UNAVAILABLE, details: 'Connection dropped', metadata: new Metadata()});
-        });
-      }
+      /* If the underlying TLS or TCP connection closes, we want to end the
+      * call with an UNAVAILABLE status to match the behavior of the other
+      * library. In this handler we don't wait for trailers before ending the
+      * call. This should ensure that this endCall happens sooner than the one
+      * in the stream.on('close', ...) handler. */
+      stream.session.socket.on('close', () => {
+        this.endCall({code: Status.UNAVAILABLE, details: 'Connection dropped', metadata: new Metadata()});
+      });
       if (!this.pendingRead) {
         stream.pause();
       }

--- a/packages/grpc-js/test/test-call-stream.ts
+++ b/packages/grpc-js/test/test-call-stream.ts
@@ -30,6 +30,7 @@ import { FilterStackFactory } from '../src/filter-stack';
 import { Metadata } from '../src/metadata';
 
 import { assert2, mockFunction } from './common';
+import { EventEmitter } from 'events';
 
 interface DataFrames {
   payload: Buffer;
@@ -69,7 +70,7 @@ class ClientHttp2StreamMock extends stream.Duplex
   readonly sentInfoHeaders?: OutgoingHttpHeaders[] = [];
   readonly sentTrailers?: OutgoingHttpHeaders = undefined;
   // tslint:disable:no-any
-  session: http2.Http2Session = {} as any;
+  session: http2.Http2Session = {socket: new EventEmitter()} as any;
   state: http2.StreamState = {} as any;
   // tslint:enable:no-any
   close = mockFunction;


### PR DESCRIPTION
I think this will fix the problem of reporting a status of INTERNAL instead of UNAVAILABLE when the network drops, originally reported in firebase/firebase-functions#536.