### PR TITLE
Fix #502 - Make all properties of CallOptions optional

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -1198,11 +1198,11 @@ declare module "grpc" {
      * Indicates which properties of a parent call should propagate to this
      * call. Bitwise combination of flags in `grpc.propagate`.
      */
-    propagate_flags: number;
+    propagate_flags?: number;
     /**
      * The credentials that should be used to make this particular call.
      */
-    credentials: CallCredentials;
+    credentials?: CallCredentials;
     /**
      * Additional custom call options. These can be used to pass additional
      * data per-call to client interceptors


### PR DESCRIPTION
More context —

1. https://github.com/grpc/grpc-node/issues/502#issue-351407366
2. https://github.com/grpc/grpc-node/issues/502#issuecomment-530293049