### PR TITLE
grpc-js: Update gts and apply fixes

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -26,7 +26,7 @@
     "@types/semver": "^6.0.1",
     "clang-format": "^1.0.55",
     "execa": "^2.0.3",
-    "gts": "^1.0.0",
+    "gts": "^1.1.0",
     "gulp": "^4.0.2",
     "gulp-mocha": "^6.0.0",
     "lodash": "^4.17.4",

--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -343,12 +343,16 @@ export class Http2CallStream extends Duplex implements Call {
          * "close" events, where we will handle the error more granularly */
       });
       /* If the underlying TLS or TCP connection closes, we want to end the
-      * call with an UNAVAILABLE status to match the behavior of the other
-      * library. In this handler we don't wait for trailers before ending the
-      * call. This should ensure that this endCall happens sooner than the one
-      * in the stream.on('close', ...) handler. */
+       * call with an UNAVAILABLE status to match the behavior of the other
+       * library. In this handler we don't wait for trailers before ending the
+       * call. This should ensure that this endCall happens sooner than the one
+       * in the stream.on('close', ...) handler. */
       stream.session.socket.on('close', () => {
-        this.endCall({code: Status.UNAVAILABLE, details: 'Connection dropped', metadata: new Metadata()});
+        this.endCall({
+          code: Status.UNAVAILABLE,
+          details: 'Connection dropped',
+          metadata: new Metadata(),
+        });
       });
       if (!this.pendingRead) {
         stream.pause();

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -38,10 +38,19 @@ import {
   Serialize,
 } from './make-client';
 import { Metadata } from './metadata';
-import { Server, UntypedHandleCall, UntypedServiceImplementation } from './server';
+import {
+  Server,
+  UntypedHandleCall,
+  UntypedServiceImplementation,
+} from './server';
 import { KeyCertPair, ServerCredentials } from './server-credentials';
 import { StatusBuilder } from './status-builder';
-import { ServerUnaryCall, ServerReadableStream, ServerWritableStream, ServerDuplexStream } from './server-call';
+import {
+  ServerUnaryCall,
+  ServerReadableStream,
+  ServerWritableStream,
+  ServerDuplexStream,
+} from './server-call';
 
 const supportedNodeVersions = require('../../package.json').engines.node;
 if (!semver.satisfies(process.version, supportedNodeVersions)) {
@@ -219,7 +228,7 @@ export {
   ServerWritableStream,
   ServerDuplexStream,
   UntypedHandleCall,
-  UntypedServiceImplementation
+  UntypedServiceImplementation,
 };
 
 /* tslint:disable:no-any */

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -76,9 +76,11 @@ export type ServerReadableStream<
 export type ServerWritableStream<
   RequestType,
   ResponseType
-> = ServerSurfaceCall & ObjectWritable<ResponseType> & { request: RequestType | null };
+> = ServerSurfaceCall &
+  ObjectWritable<ResponseType> & { request: RequestType | null };
 export type ServerDuplexStream<RequestType, ResponseType> = ServerSurfaceCall &
-  ObjectReadable<RequestType> & ObjectWritable<ResponseType>;
+  ObjectReadable<RequestType> &
+  ObjectWritable<ResponseType>;
 
 export class ServerUnaryCallImpl<RequestType, ResponseType> extends EventEmitter
   implements ServerUnaryCall<RequestType, ResponseType> {
@@ -497,15 +499,18 @@ export class Http2ServerCallStream<
   sendError(error: ServerErrorResponse | ServerStatusResponse) {
     const status: StatusObject = {
       code: Status.UNKNOWN,
-      details: ('message' in error)
-        ? error.message
-        : 'Unknown Error',
-      metadata: ('metadata' in error && error.metadata !== undefined)
-        ? error.metadata
-        : new Metadata(),
+      details: 'message' in error ? error.message : 'Unknown Error',
+      metadata:
+        'metadata' in error && error.metadata !== undefined
+          ? error.metadata
+          : new Metadata(),
     };
 
-    if ('code' in error && typeof error.code === 'number' && Number.isInteger(error.code)) {
+    if (
+      'code' in error &&
+      typeof error.code === 'number' &&
+      Number.isInteger(error.code)
+    ) {
       status.code = error.code;
 
       if ('details' in error && typeof error.details === 'string') {

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -102,7 +102,10 @@ export class Server {
     throw new Error('Not implemented. Use addService() instead');
   }
 
-  addService(service: ServiceDefinition, implementation: UntypedServiceImplementation): void {
+  addService(
+    service: ServiceDefinition,
+    implementation: UntypedServiceImplementation
+  ): void {
     if (this.started === true) {
       throw new Error("Can't add a service to a started server.");
     }

--- a/packages/grpc-js/test/test-call-stream.ts
+++ b/packages/grpc-js/test/test-call-stream.ts
@@ -70,7 +70,7 @@ class ClientHttp2StreamMock extends stream.Duplex
   readonly sentInfoHeaders?: OutgoingHttpHeaders[] = [];
   readonly sentTrailers?: OutgoingHttpHeaders = undefined;
   // tslint:disable:no-any
-  session: http2.Http2Session = {socket: new EventEmitter()} as any;
+  session: http2.Http2Session = { socket: new EventEmitter() } as any;
   state: http2.StreamState = {} as any;
   // tslint:enable:no-any
   close = mockFunction;


### PR DESCRIPTION
My goal was to run:
```
git clone git@github.com:grpc/grpc-node.git
cd grpc-node/packages/grpc-js
npm i
npm run test
```

The tests would fail on the `gts check` portion:

```
> @grpc/grpc-js@0.5.3 posttest /Users/bjornstar/grpc-node/packages/grpc-js
> npm run check


> @grpc/grpc-js@0.5.3 check /Users/bjornstar/grpc-node/packages/grpc-js
> gts check

Index: /Users/bjornstar/grpc-node/packages/grpc-js/src/call-stream.ts
===================================================================
--- /Users/bjornstar/grpc-node/packages/grpc-js/src/call-stream.ts
+++ /Users/bjornstar/grpc-node/packages/grpc-js/src/call-stream.ts
@@ -342,14 +342,18 @@
          * from bubbling up. However, errors here should all correspond to
          * "close" events, where we will handle the error more granularly */
       });
       /* If the underlying TLS or TCP connection closes, we want to end the
-      * call with an UNAVAILABLE status to match the behavior of the other
-      * library. In this handler we don't wait for trailers before ending the
-      * call. This should ensure that this endCall happens sooner than the one
-      * in the stream.on('close', ...) handler. */
+       * call with an UNAVAILABLE status to match the behavior of the other
+       * library. In this handler we don't wait for trailers before ending the
+       * call. This should ensure that this endCall happens sooner than the one
+       * in the stream.on('close', ...) handler. */
       stream.session.socket.on('close', () => {
-        this.endCall({code: Status.UNAVAILABLE, details: 'Connection dropped', metadata: new Metadata()});
+        this.endCall({
+          code: Status.UNAVAILABLE,
+          details: 'Connection dropped',
+          metadata: new Metadata(),
+        });
       });
       if (!this.pendingRead) {
         stream.pause();
       }

Index: /Users/bjornstar/grpc-node/packages/grpc-js/src/index.ts
===================================================================
--- /Users/bjornstar/grpc-node/packages/grpc-js/src/index.ts
+++ /Users/bjornstar/grpc-node/packages/grpc-js/src/index.ts
@@ -37,12 +37,21 @@
   makeClientConstructor,
   Serialize,
 } from './make-client';
 import { Metadata } from './metadata';
-import { Server, UntypedHandleCall, UntypedServiceImplementation } from './server';
+import {
+  Server,
+  UntypedHandleCall,
+  UntypedServiceImplementation,
+} from './server';
 import { KeyCertPair, ServerCredentials } from './server-credentials';
 import { StatusBuilder } from './status-builder';
-import { ServerUnaryCall, ServerReadableStream, ServerWritableStream, ServerDuplexStream } from './server-call';
+import {
+  ServerUnaryCall,
+  ServerReadableStream,
+  ServerWritableStream,
+  ServerDuplexStream,
+} from './server-call';
 
 const supportedNodeVersions = require('../../package.json').engines.node;
 if (!semver.satisfies(process.version, supportedNodeVersions)) {
   throw new Error(`@grpc/grpc-js only works on Node ${supportedNodeVersions}`);
@@ -218,9 +227,9 @@
   ServerReadableStream,
   ServerWritableStream,
   ServerDuplexStream,
   UntypedHandleCall,
-  UntypedServiceImplementation
+  UntypedServiceImplementation,
 };
 
 /* tslint:disable:no-any */
 export type Call =

Index: /Users/bjornstar/grpc-node/packages/grpc-js/src/server-call.ts
===================================================================
--- /Users/bjornstar/grpc-node/packages/grpc-js/src/server-call.ts
+++ /Users/bjornstar/grpc-node/packages/grpc-js/src/server-call.ts
@@ -75,11 +75,13 @@
 > = ServerSurfaceCall & ObjectReadable<RequestType>;
 export type ServerWritableStream<
   RequestType,
   ResponseType
-> = ServerSurfaceCall & ObjectWritable<ResponseType> & { request: RequestType | null };
+> = ServerSurfaceCall &
+  ObjectWritable<ResponseType> & { request: RequestType | null };
 export type ServerDuplexStream<RequestType, ResponseType> = ServerSurfaceCall &
-  ObjectReadable<RequestType> & ObjectWritable<ResponseType>;
+  ObjectReadable<RequestType> &
+  ObjectWritable<ResponseType>;
 
 export class ServerUnaryCallImpl<RequestType, ResponseType> extends EventEmitter
   implements ServerUnaryCall<RequestType, ResponseType> {
   cancelled: boolean;
@@ -496,17 +498,20 @@
 
   sendError(error: ServerErrorResponse | ServerStatusResponse) {
     const status: StatusObject = {
       code: Status.UNKNOWN,
-      details: ('message' in error)
-        ? error.message
-        : 'Unknown Error',
-      metadata: ('metadata' in error && error.metadata !== undefined)
-        ? error.metadata
-        : new Metadata(),
+      details: 'message' in error ? error.message : 'Unknown Error',
+      metadata:
+        'metadata' in error && error.metadata !== undefined
+          ? error.metadata
+          : new Metadata(),
     };
 
-    if ('code' in error && typeof error.code === 'number' && Number.isInteger(error.code)) {
+    if (
+      'code' in error &&
+      typeof error.code === 'number' &&
+      Number.isInteger(error.code)
+    ) {
       status.code = error.code;
 
       if ('details' in error && typeof error.details === 'string') {
         status.details = error.details!;

Index: /Users/bjornstar/grpc-node/packages/grpc-js/src/server.ts
===================================================================
--- /Users/bjornstar/grpc-node/packages/grpc-js/src/server.ts
+++ /Users/bjornstar/grpc-node/packages/grpc-js/src/server.ts
@@ -101,9 +101,12 @@
   addProtoService(): void {
     throw new Error('Not implemented. Use addService() instead');
   }
 
-  addService(service: ServiceDefinition, implementation: UntypedServiceImplementation): void {
+  addService(
+    service: ServiceDefinition,
+    implementation: UntypedServiceImplementation
+  ): void {
     if (this.started === true) {
       throw new Error("Can't add a service to a started server.");
     }
 

Index: /Users/bjornstar/grpc-node/packages/grpc-js/test/test-call-stream.ts
===================================================================
--- /Users/bjornstar/grpc-node/packages/grpc-js/test/test-call-stream.ts
+++ /Users/bjornstar/grpc-node/packages/grpc-js/test/test-call-stream.ts
@@ -69,9 +69,9 @@
   readonly sentHeaders: OutgoingHttpHeaders = {};
   readonly sentInfoHeaders?: OutgoingHttpHeaders[] = [];
   readonly sentTrailers?: OutgoingHttpHeaders = undefined;
   // tslint:disable:no-any
-  session: http2.Http2Session = {socket: new EventEmitter()} as any;
+  session: http2.Http2Session = { socket: new EventEmitter() } as any;
   state: http2.StreamState = {} as any;
   // tslint:enable:no-any
   close = mockFunction;
   priority = mockFunction;

prettier reported errors... run `gts fix` to address.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @grpc/grpc-js@0.5.3 check: `gts check`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @grpc/grpc-js@0.5.3 check script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

I ran `gts fix` and now the tests can successfully run to completion.
