### PR TITLE
Hopefully fix memory leak with socket close listener

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -112,8 +112,7 @@ export class Http2CallStream extends Duplex implements Call {
   // This is populated (non-null) if and only if the call has ended
   private finalStatus: StatusObject | null = null;
 
-  private socketCloseCallback: () => void = 
-    this.socketCloseCallback = () => {
+  private socketCloseCallback: () => void = () => {
       this.endCall({
         code: Status.UNAVAILABLE,
         details: 'Connection dropped',


### PR DESCRIPTION
This problem was reported in issue #1027. I think that was the issue, that the callback was never getting cleaned up.

Note: this only tries to fix the memory leak, not the warning. Further changes will be needed to fix the warning but those changes will conflict with #1015 so I want to get that PR merged first.