### PR TITLE
Revert "Add specific call error for TCP disconnection"

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -342,18 +342,6 @@ export class Http2CallStream extends Duplex implements Call {
          * from bubbling up. However, errors here should all correspond to
          * "close" events, where we will handle the error more granularly */
       });
-      /* If the underlying TLS or TCP connection closes, we want to end the
-       * call with an UNAVAILABLE status to match the behavior of the other
-       * library. In this handler we don't wait for trailers before ending the
-       * call. This should ensure that this endCall happens sooner than the one
-       * in the stream.on('close', ...) handler. */
-      stream.session.socket.on('close', () => {
-        this.endCall({
-          code: Status.UNAVAILABLE,
-          details: 'Connection dropped',
-          metadata: new Metadata(),
-        });
-      });
       if (!this.pendingRead) {
         stream.pause();
       }


### PR DESCRIPTION
Revert #1021 as an alternative to #1034 for fixing #1027. That PR caused a warning and a memory leak that are both causing significant issues, so it's probably best to just revert until we can do it properly after #1015 is merged.