### PR TITLE
Add function for creating errors from statuses

### DIFF
--- a/packages/grpc-js/src/call.ts
+++ b/packages/grpc-js/src/call.ts
@@ -68,6 +68,19 @@ export type ClientDuplexStream<
   ResponseType
 > = ClientWritableStream<RequestType> & ClientReadableStream<ResponseType>;
 
+/**
+ * Construct a ServiceError from a StatusObject. This function exists primarily
+ * as an attempt to make the error stack trace clearly communicate that the
+ * error is not necessarily a problem in gRPC itself.
+ * @param status 
+ */
+export function callErrorFromStatus(status: StatusObject): ServiceError {
+  return Object.assign(
+    new Error(status.details),
+    status
+  );
+}
+
 export class ClientUnaryCallImpl extends EventEmitter
   implements ClientUnaryCall {
   constructor(private readonly call: Call) {
@@ -118,11 +131,7 @@ function setUpReadableStream<ResponseType>(
   });
   call.on('status', (status: StatusObject) => {
     if (status.code !== Status.OK) {
-      const error: ServiceError = Object.assign(
-        new Error(status.details),
-        status
-      );
-      stream.emit('error', error);
+      stream.emit('error', callErrorFromStatus(status));
     }
     stream.emit('status', status);
     statusEmitted = true;

--- a/packages/grpc-js/src/call.ts
+++ b/packages/grpc-js/src/call.ts
@@ -75,8 +75,9 @@ export type ClientDuplexStream<
  * @param status 
  */
 export function callErrorFromStatus(status: StatusObject): ServiceError {
+  const message = `${status.code} ${Status[status.code]}: ${status.details}`;
   return Object.assign(
-    new Error(status.details),
+    new Error(message),
     status
   );
 }

--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -25,6 +25,7 @@ import {
   ClientWritableStream,
   ClientWritableStreamImpl,
   ServiceError,
+  callErrorFromStatus,
 } from './call';
 import { CallCredentials } from './call-credentials';
 import { Call, Deadline, StatusObject, WriteObject } from './call-stream';
@@ -147,11 +148,7 @@ export class Client {
       if (status.code === Status.OK) {
         callback(null, responseMessage as ResponseType);
       } else {
-        const error: ServiceError = Object.assign(
-          new Error(status.details),
-          status
-        );
-        callback(error);
+        callback(callErrorFromStatus(status));
       }
     });
   }

--- a/packages/grpc-js/test/test-server-deadlines.ts
+++ b/packages/grpc-js/test/test-server-deadlines.ts
@@ -85,7 +85,6 @@ describe('Server deadlines', () => {
       (error: any, response: any) => {
         assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
         assert.strictEqual(error.details, 'Deadline exceeded');
-        assert.strictEqual(error.message, 'Deadline exceeded');
         done();
       }
     );
@@ -110,7 +109,6 @@ describe('Server deadlines', () => {
       (error: any, response: any) => {
         assert.strictEqual(error.code, grpc.status.OUT_OF_RANGE);
         assert.strictEqual(error.details, 'Invalid deadline');
-        assert.strictEqual(error.message, 'Invalid deadline');
         done();
       }
     );
@@ -160,7 +158,6 @@ describe('Cancellation', () => {
     call.on('error', (error: ServiceError) => {
       assert.strictEqual(error.code, grpc.status.CANCELLED);
       assert.strictEqual(error.details, 'Cancelled on client');
-      assert.strictEqual(error.message, 'Cancelled on client');
       waitForServerCancel();
     });
 


### PR DESCRIPTION
The idea here is to communicate in the stack trace that this error just comes from the status. Honestly, I don't know if this will actually improve anything. But in the worst case it still consolidates duplicated code from two files into one function.

This also makes the error message format match the other library (https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/src/common.js#L83).