### PR TITLE
Stop testing EOL versions of node

### DIFF
--- a/run-tests.bat
+++ b/run-tests.bat
@@ -38,7 +38,7 @@ call npm install || goto :error
 SET JUNIT_REPORT_STACK=1
 SET FAILED=0
 
-for %%v in (6 7 8 9 10 11 12) do (
+for %%v in (8 10 12) do (
   call nvm install %%v
   call nvm use %%v
   if "%%v"=="4" (

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -26,7 +26,7 @@ set -ex
 cd $ROOT
 
 if [ ! -n "$node_versions" ] ; then
-  node_versions="6 7 8 9 10 11 12"
+  node_versions="8 10 12"
 fi
 
 set +ex


### PR DESCRIPTION
Resolves #1038 

In order to use modern javascript syntax and libraries using that syntax we need to stop supporting node v6. At the same time, we can also stop testing other versions of node that are officially EOL.

This PR removes testing against node v6, 7, 9, and 11 while moving the initial node version from v8 to v10.

I also added `node-gyp` as a devDependency since it is required to build.
