### PR TITLE
grpc-js: Fix TLS server name handling

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -329,9 +329,11 @@ export class Http2CallStream extends Duplex implements Call {
         switch (stream.rstCode) {
           case http2.constants.NGHTTP2_REFUSED_STREAM:
             code = Status.UNAVAILABLE;
+            details = 'Stream refused by server';
             break;
           case http2.constants.NGHTTP2_CANCEL:
             code = Status.CANCELLED;
+            details = 'Call cancelled';
             break;
           case http2.constants.NGHTTP2_ENHANCE_YOUR_CALM:
             code = Status.RESOURCE_EXHAUSTED;

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -23,6 +23,7 @@ import { ChannelOptions } from './channel-options';
 import { PeerCertificate, checkServerIdentity } from 'tls';
 import { ConnectivityState } from './channel';
 import { BackoffTimeout } from './backoff-timeout';
+import { getDefaultAuthority } from './resolver';
 
 const { version: clientVersion } = require('../../package.json');
 
@@ -230,7 +231,7 @@ export class Subchannel {
         };
         connectionOptions.servername = sslTargetNameOverride;
       } else {
-        connectionOptions.servername = this.channelTarget;
+        connectionOptions.servername = getDefaultAuthority(this.channelTarget);
       }
     }
     this.session = http2.connect(

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -121,5 +121,37 @@ describe('Name Resolver', () => {
       const resolver = resolverManager.createResolver(target, listener);
       resolver.updateResolution();
     });
+    it('Should resolve gRPC interop servers', done => {
+      let completeCount = 0;
+      function done2(error?: Error) {
+        if (error) {
+          done(error);
+        } else {
+          completeCount += 1;
+          if (completeCount === 2) {
+            done();
+          }
+        }
+      }
+      const target1 = 'grpc-test.sandbox.googleapis.com';
+      const target2 = 'grpc-test4.sandbox.googleapis.com';
+      const listener: resolverManager.ResolverListener = {
+        onSuccessfulResolution: (
+          addressList: string[],
+          serviceConfig: ServiceConfig | null,
+          serviceConfigError: StatusObject | null
+        ) => {
+          assert(addressList.length > 0);
+          done2();
+        },
+        onError: (error: StatusObject) => {
+          done2(new Error(`Failed with status ${error.details}`));
+        },
+      };
+      const resolver1 = resolverManager.createResolver(target1, listener);
+      resolver1.updateResolution();
+      const resolver2 = resolverManager.createResolver(target1, listener);
+      resolver2.updateResolution();
+    })
   });
 });

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -22,12 +22,14 @@ import * as resolverManager from '../src/resolver';
 import { ServiceConfig } from '../src/service-config';
 import { StatusObject } from '../src/call-stream';
 
-describe('Name Resolver', () => {
-  describe('DNS Names', () => {
-    before(() => {
+describe('Name Resolver', function() {
+  describe('DNS Names', function() {
+    // For some reason DNS queries sometimes take a long time on Windows
+    this.timeout(4000);
+    before(function() {
       resolverManager.registerAll();
     });
-    it('Should resolve localhost properly', done => {
+    it('Should resolve localhost properly', function(done) {
       const target = 'localhost:50051';
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
@@ -46,7 +48,7 @@ describe('Name Resolver', () => {
       const resolver = resolverManager.createResolver(target, listener);
       resolver.updateResolution();
     });
-    it('Should default to port 443', done => {
+    it('Should default to port 443', function(done) {
       const target = 'localhost';
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
@@ -65,7 +67,7 @@ describe('Name Resolver', () => {
       const resolver = resolverManager.createResolver(target, listener);
       resolver.updateResolution();
     });
-    it('Should resolve a public address', done => {
+    it('Should resolve a public address', function(done) {
       const target = 'example.com';
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
@@ -83,7 +85,7 @@ describe('Name Resolver', () => {
       const resolver = resolverManager.createResolver(target, listener);
       resolver.updateResolution();
     });
-    it('Should resolve a name with multiple dots', done => {
+    it('Should resolve a name with multiple dots', function(done) {
       const target = 'loopback4.unittest.grpc.io';
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
@@ -101,7 +103,7 @@ describe('Name Resolver', () => {
       const resolver = resolverManager.createResolver(target, listener);
       resolver.updateResolution();
     });
-    it('Should resolve a name with a hyphen', done => {
+    it('Should resolve a name with a hyphen', function(done) {
       /* TODO(murgatroid99): Find or create a better domain name to test this with.
        * This is just the first one I found with a hyphen. */
       const target = 'network-tools.com';
@@ -121,7 +123,7 @@ describe('Name Resolver', () => {
       const resolver = resolverManager.createResolver(target, listener);
       resolver.updateResolution();
     });
-    it('Should resolve gRPC interop servers', done => {
+    it('Should resolve gRPC interop servers', function(done) {
       let completeCount = 0;
       function done2(error?: Error) {
         if (error) {


### PR DESCRIPTION
This fixes grpc/grpc#20383. The part of the change that actually fixes the problem is the change to `subchannel.ts`; the rest was for debugging the problem. The problem was that the channel target could include the port number, which would cause the server name/certificate matching to fail.