### PR TITLE
Properly use filtered metadata when starting requests

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -211,7 +211,7 @@ export class ChannelImplementation implements Channel {
                   ConnectivityState.READY
                 ) {
                   pickResult.subchannel!.startCallStream(
-                    callMetadata,
+                    finalMetadata,
                     callStream
                   );
                 } else {

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -203,7 +203,7 @@ export class ChannelImplementation implements Channel {
           /* If the subchannel disconnects between calling pick and getting
            * the filter stack metadata, the call will end with an error. */
           callStream.filterStack
-            .sendMetadata(Promise.resolve(new Metadata()))
+            .sendMetadata(Promise.resolve(callMetadata))
             .then(
               finalMetadata => {
                 if (

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -277,7 +277,7 @@ export class ChannelImplementation implements Channel {
   }
 
   _startCallStream(stream: Http2CallStream, metadata: Metadata) {
-    this.tryPick(stream, metadata);
+    this.tryPick(stream, metadata.clone());
   }
 
   close() {

--- a/packages/grpc-js/test/test-server-deadlines.ts
+++ b/packages/grpc-js/test/test-server-deadlines.ts
@@ -83,9 +83,9 @@ describe('Server deadlines', () => {
       metadata,
       {},
       (error: any, response: any) => {
+        assert(error);
         assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
         assert.strictEqual(error.details, 'Deadline exceeded');
-        assert.strictEqual(error.message, 'Deadline exceeded');
         done();
       }
     );
@@ -108,9 +108,9 @@ describe('Server deadlines', () => {
       metadata,
       {},
       (error: any, response: any) => {
+        assert(error);
         assert.strictEqual(error.code, grpc.status.OUT_OF_RANGE);
         assert.strictEqual(error.details, 'Invalid deadline');
-        assert.strictEqual(error.message, 'Invalid deadline');
         done();
       }
     );


### PR DESCRIPTION
This should fix metadata elements from `CallCredentials` (plus a couple of other sources) not being sent to the server. This should have been caught by metadata credentials interop tests; I will need to figure out why we missed this.