### PR TITLE
Bump submodule to 1.23.1 and library version to 1.23.4

### DIFF
--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -97,7 +97,7 @@
       'GPR_BACKWARDS_COMPATIBILITY_MODE',
       'GRPC_ARES=1',
       'GRPC_UV',
-      'GRPC_NODE_VERSION="1.23.3"',
+      'GRPC_NODE_VERSION="1.23.4"',
       'CARES_STATICLIB',
       'CARES_SYMBOL_HIDING'
     ],

--- a/packages/grpc-native-core/build.yaml
+++ b/packages/grpc-native-core/build.yaml
@@ -1,3 +1,3 @@
 settings:
   '#': It's possible to have node_version here as a key to override the core's version.
-  node_version: 1.23.3
+  node_version: 1.23.4

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "author": "Google Inc.",
   "description": "gRPC Library for Node",
   "homepage": "https://grpc.io/",


### PR DESCRIPTION
Apparently there's a fix in core that needs to be backported to 1.23