### PR TITLE
grpc-js: exitIdle asynchronously in QueuePicker, only act in exitIdle if IDLE

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/picker.ts
+++ b/packages/grpc-js/src/picker.ts
@@ -113,7 +113,9 @@ export class QueuePicker {
 
   pick(pickArgs: PickArgs): QueuePickResult {
     if (!this.calledExitIdle) {
-      this.loadBalancer.exitIdle();
+      process.nextTick(() => {
+        this.loadBalancer.exitIdle();
+      });
       this.calledExitIdle = true;
     }
     return {

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -331,14 +331,16 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   }
 
   exitIdle() {
-    this.innerResolver.updateResolution();
     if (this.innerLoadBalancer !== null) {
       this.innerLoadBalancer.exitIdle();
     }
-    this.channelControlHelper.updateState(
-      ConnectivityState.CONNECTING,
-      new QueuePicker(this)
-    );
+    if (this.currentState === ConnectivityState.IDLE) {
+      this.innerResolver.updateResolution();
+      this.updateState(
+        ConnectivityState.CONNECTING,
+        new QueuePicker(this)
+      );
+    }
   }
 
   updateAddressList(


### PR DESCRIPTION
This should fix #1061. Previously the `updateState` call in `exitIdle` could cause infinite recursion if there was a pending call, because the `QueuePicker` there would call `exitIdle` again. The change to `exitIdle` should stop the loop, and the change to the `QueuePicker` would make the loop non-recursive. It's probably just a good idea in general not to change the load balancer state while checking the picks of pending calls as a result of changing the load balancer state.