### PR TITLE
Add tracing functionality and a few connectivity state tracers

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -28,7 +28,7 @@ import { SubchannelPool, getSubchannelPool } from './subchannel-pool';
 import { ChannelControlHelper } from './load-balancer';
 import { UnavailablePicker, Picker, PickResultType } from './picker';
 import { Metadata } from './metadata';
-import { Status } from './constants';
+import { Status, LogVerbosity } from './constants';
 import { FilterStackFactory } from './filter-stack';
 import { CallCredentialsFilterFactory } from './call-credentials-filter';
 import { DeadlineFilterFactory } from './deadline-filter';
@@ -37,6 +37,7 @@ import { CompressionFilterFactory } from './compression-filter';
 import { getDefaultAuthority } from './resolver';
 import { LoadBalancingConfig } from './load-balancing-config';
 import { ServiceConfig } from './service-config';
+import { trace } from './logging';
 
 export enum ConnectivityState {
   CONNECTING,
@@ -265,6 +266,7 @@ export class ChannelImplementation implements Channel {
   }
 
   private updateState(newState: ConnectivityState): void {
+    trace(LogVerbosity.DEBUG, 'connectivity_state', this.target + ' ' + ConnectivityState[this.connectivityState] + ' -> ' + ConnectivityState[newState]);
     this.connectivityState = newState;
     const watchersCopy = this.connectivityStateWatchers.slice();
     for (const watcherObject of watchersCopy) {

--- a/packages/grpc-js/src/logging.ts
+++ b/packages/grpc-js/src/logging.ts
@@ -18,7 +18,23 @@
 import { LogVerbosity } from './constants';
 
 let _logger: Partial<Console> = console;
-let _logVerbosity: LogVerbosity = LogVerbosity.DEBUG;
+let _logVerbosity: LogVerbosity = LogVerbosity.ERROR;
+
+if (process.env.GRPC_VERBOSITY) {
+  switch (process.env.GRPC_VERBOSITY) {
+    case 'DEBUG':
+      _logVerbosity = LogVerbosity.DEBUG;
+      break;
+    case 'INFO':
+      _logVerbosity = LogVerbosity.INFO;
+      break;
+    case 'ERROR':
+      _logVerbosity = LogVerbosity.ERROR;
+      break;
+    default:
+      // Ignore any other values
+  }
+}
 
 export const getLogger = (): Partial<Console> => {
   return _logger;
@@ -38,3 +54,12 @@ export const log = (severity: LogVerbosity, ...args: any[]): void => {
     _logger.error(...args);
   }
 };
+
+const enabledTracers = process.env.GRPC_TRACE ? process.env.GRPC_TRACE.split(',') : [];
+const allEnabled = enabledTracers.includes('all');
+
+export function trace(severity: LogVerbosity, tracer: string, text: string): void {
+  if (allEnabled || enabledTracers.includes(tracer)) {
+    log(severity, (new Date().toISOString() + ' | ' + tracer + ' | ' + text));
+  }
+}

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -32,6 +32,14 @@ import { BackoffTimeout } from './backoff-timeout';
 import { Status } from './constants';
 import { StatusObject } from './call-stream';
 import { Metadata } from './metadata';
+import * as logging from './logging';
+import { LogVerbosity } from './constants';
+
+const TRACER_NAME = 'resolving_load_balancer';
+
+function trace(text: string): void {
+  logging.trace(LogVerbosity.DEBUG, TRACER_NAME, text);
+}
 
 const DEFAULT_LOAD_BALANCER_NAME = 'pick_first';
 
@@ -297,6 +305,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   }
 
   private updateState(connectivitystate: ConnectivityState, picker: Picker) {
+    trace(this.target + ' ' + ConnectivityState[this.currentState] + ' -> ' + ConnectivityState[connectivitystate]);
     this.currentState = connectivitystate;
     this.channelControlHelper.updateState(connectivitystate, picker);
   }

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -24,8 +24,16 @@ import { PeerCertificate, checkServerIdentity } from 'tls';
 import { ConnectivityState } from './channel';
 import { BackoffTimeout } from './backoff-timeout';
 import { getDefaultAuthority } from './resolver';
+import * as logging from './logging';
+import { LogVerbosity } from './constants';
 
 const { version: clientVersion } = require('../../package.json');
+
+const TRACER_NAME = 'subchannel';
+
+function trace(text: string): void {
+  logging.trace(LogVerbosity.DEBUG, TRACER_NAME, text);
+}
 
 const MIN_CONNECT_TIMEOUT_MS = 20000;
 const INITIAL_BACKOFF_MS = 1000;
@@ -277,6 +285,7 @@ export class Subchannel {
     if (oldStates.indexOf(this.connectivityState) === -1) {
       return false;
     }
+    trace(this.subchannelAddress + ' ' + ConnectivityState[this.connectivityState] + ' -> ' + ConnectivityState[newState]);
     const previousState = this.connectivityState;
     this.connectivityState = newState;
     switch (newState) {
@@ -463,5 +472,9 @@ export class Subchannel {
       [ConnectivityState.TRANSIENT_FAILURE],
       ConnectivityState.CONNECTING
     );
+  }
+
+  getAddress(): string {
+    return this.subchannelAddress;
   }
 }


### PR DESCRIPTION
This adds support for the `GRPC_TRACE` and `GRPC_VERBOSITY` environment variables, with the following tracers:

 - `connectivity_state`
 - `pick_first`
 - `dns_resolver`
 - `resolving_load_balancer`
 - `subchannel`

It also adds support for the `all` tracer option to enable all of them. The `-` tracer prefix to disable tracers is currently not supported.