### PR TITLE
grpc-js: pick first: remove reference and go idle after disconnect

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
Also move the `requestReresolution` call to `exitIdle` to ensure that resolution will always be attempted if the connection fails because the backend addresses changed.