### PR TITLE
grpc-js Api changes for using statically generated code with grpc-js

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -36,6 +36,7 @@ import {
   loadPackageDefinition,
   makeClientConstructor,
   Serialize,
+  ServiceDefinition
 } from './make-client';
 import { Metadata } from './metadata';
 import {
@@ -46,6 +47,9 @@ import {
 import { KeyCertPair, ServerCredentials } from './server-credentials';
 import { StatusBuilder } from './status-builder';
 import {
+  handleBidiStreamingCall,
+  handleServerStreamingCall,
+  handleUnaryCall,
   ServerUnaryCall,
   ServerReadableStream,
   ServerWritableStream,
@@ -227,8 +231,17 @@ export {
   ServerReadableStream,
   ServerWritableStream,
   ServerDuplexStream,
+  ServiceDefinition,
   UntypedHandleCall,
   UntypedServiceImplementation,
+};
+
+/**** Server ****/
+
+export {
+  handleBidiStreamingCall,
+  handleServerStreamingCall,
+  handleUnaryCall,
 };
 
 /* tslint:disable:no-any */

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -39,7 +39,7 @@ export interface MethodDefinition<RequestType, ResponseType> {
 }
 
 export interface ServiceDefinition {
-  [index: string]: MethodDefinition<object, object>;
+  [index: string]: MethodDefinition<any, any>;
 }
 
 export interface ProtobufTypeDefinition {


### PR DESCRIPTION
Export `handleBidiStreamingCall`, `handleServerStreamingCall`, `handleUnaryCall`, and `ServiceDefinition` to match exports in regular grpc.

Also changed `MethodDefinition<object, object>` to `MethodDefinition<any, any>` in `ServiceDefinition` to emulate the `UntypedServiceImplementation` from the regular grpc code as `ServiceDefinition` is not generic in grpc-js.

This removes some of the barriers preventing using grpc-js in statically generated code as noted in https://github.com/grpc/grpc-node/issues/931