### PR TITLE
grpc-js: pick-first: fix bad state transition when reconnecting connected LB

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -312,10 +312,6 @@ export class PickFirstLoadBalancer implements LoadBalancer {
       subchannel.addConnectivityStateListener(this.subchannelStateListener);
       if (subchannel.getConnectivityState() === ConnectivityState.READY) {
         this.pickSubchannel(subchannel);
-        this.updateState(
-          ConnectivityState.READY,
-          new PickFirstPicker(subchannel)
-        );
         this.resetSubchannelList();
         return;
       }
@@ -327,15 +323,19 @@ export class PickFirstLoadBalancer implements LoadBalancer {
         subchannelState === ConnectivityState.CONNECTING
       ) {
         this.startConnecting(index);
-        this.updateState(ConnectivityState.CONNECTING, new QueuePicker(this));
+        if (this.currentPick === null) {
+          this.updateState(ConnectivityState.CONNECTING, new QueuePicker(this));
+        }
         return;
       }
     }
     // If the code reaches this point, every subchannel must be in TRANSIENT_FAILURE
-    this.updateState(
-      ConnectivityState.TRANSIENT_FAILURE,
-      new UnavailablePicker()
-    );
+    if (this.currentPick === null) {
+      this.updateState(
+        ConnectivityState.TRANSIENT_FAILURE,
+        new UnavailablePicker()
+      );
+    }
   }
 
   updateAddressList(


### PR DESCRIPTION
`connectToAddressList` can be called while there is a current pick, and it should not update the state to override that current pick. I think this is what is causing the remaining reports of the problem in #1064 after the partial fix in 0.6.6.