### PR TITLE
grpc-js: pick first: resolve address again after trying all addresses

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -343,15 +343,20 @@ export class PickFirstLoadBalancer implements LoadBalancer {
     lbConfig: LoadBalancingConfig | null
   ): void {
     // lbConfig has no useful information for pick first load balancing
-    this.latestAddressList = addressList;
-    this.connectToAddressList();
+    /* To avoid unnecessary churn, we only do something with this address list
+     * if we're not currently trying to establish a connection, or if the new
+     * address list is different from the existing one */
+    if (this.subchannels.length === 0 || !this.latestAddressList.every((value, index) => addressList[index] === value)) {
+      this.latestAddressList = addressList;
+      this.connectToAddressList();
+    }
   }
 
   exitIdle() {
     for (const subchannel of this.subchannels) {
       subchannel.startConnecting();
     }
-    if (this.currentState === ConnectivityState.IDLE) {
+    if (this.currentState === ConnectivityState.IDLE || this.triedAllSubchannels) {
       this.channelControlHelper.requestReresolution();
       if (this.latestAddressList.length > 0) {
         this.connectToAddressList();

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -356,11 +356,13 @@ export class PickFirstLoadBalancer implements LoadBalancer {
     for (const subchannel of this.subchannels) {
       subchannel.startConnecting();
     }
-    if (this.currentState === ConnectivityState.IDLE || this.triedAllSubchannels) {
-      this.channelControlHelper.requestReresolution();
+    if (this.currentState === ConnectivityState.IDLE) {
       if (this.latestAddressList.length > 0) {
         this.connectToAddressList();
       }
+    }
+    if (this.currentState === ConnectivityState.IDLE || this.triedAllSubchannels) {
+      this.channelControlHelper.requestReresolution();
     }
   }
 


### PR DESCRIPTION
This addresses a failure in a situation where none of the backends in the current address list is available and a DNS query would return new addresses. With the previous code, as long as there were active calls on a channel, `exitIdle` would keep getting called, causing all subchannels in TRANSIENT_FAILURE to switch to CONNECTING after the backoff timer ended, and causing all subchannels in IDLE to switch to CONNECTING immediately. The result is that if there are at least two subchannels that are failing to connect, the load balancer would never enter the IDLE state, so it would never call `requestReresolution` and it would never get the new good address list.

This change can increase churn because it requests reresolution once all subchannels have started connecting, not when they have failed. This is mitigated by the backoff timer on resolution in the resolving load balancer, and by not restarting the connection attempt when the new result from the resolver matches the current one we are already connecting to.