### PR TITLE
grpc-js: Some fixes for how idleness and reresolution are handled

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -77,6 +77,8 @@ export class ResolvingLoadBalancer implements LoadBalancer {
    */
   private innerBalancerState: ConnectivityState = ConnectivityState.IDLE;
 
+  private innerBalancerPicker: Picker = new UnavailablePicker();
+
   /**
    * The most recent reported state of the pendingReplacementLoadBalancer.
    * Starts at IDLE for type simplicity. This should get updated as soon as the
@@ -103,6 +105,12 @@ export class ResolvingLoadBalancer implements LoadBalancer {
    * The backoff timer for handling name resolution failures.
    */
   private readonly backoffTimeout: BackoffTimeout;
+
+  /**
+   * Indicates whether we should attempt to resolve again after the backoff
+   * timer runs out.
+   */
+  private continueResolving = false;
 
   /**
    * Wrapper class that behaves like a `LoadBalancer` and also handles name
@@ -245,12 +253,22 @@ export class ResolvingLoadBalancer implements LoadBalancer {
       },
       updateState: (connectivityState: ConnectivityState, picker: Picker) => {
         this.innerBalancerState = connectivityState;
+        if (connectivityState === ConnectivityState.IDLE) {
+          picker = new QueuePicker(this);
+        }
+        this.innerBalancerPicker = picker;
         if (
           connectivityState !== ConnectivityState.READY &&
           this.pendingReplacementLoadBalancer !== null
         ) {
           this.switchOverReplacementBalancer();
         } else {
+          if (connectivityState === ConnectivityState.IDLE) {
+            if (this.innerLoadBalancer) {
+              this.innerLoadBalancer.destroy();
+              this.innerLoadBalancer = null;
+            }
+          }
           this.updateState(connectivityState, picker);
         }
       },
@@ -260,8 +278,10 @@ export class ResolvingLoadBalancer implements LoadBalancer {
            * making resolve requests, so we shouldn't make another one here.
            * In that case, the backoff timer callback will call
            * updateResolution */
-          if (!this.backoffTimeout.isRunning()) {
-            this.innerResolver.updateResolution();
+          if (this.backoffTimeout.isRunning()) {
+            this.continueResolving = true;
+          } else {
+            this.updateResolution();
           }
         }
       },
@@ -278,30 +298,52 @@ export class ResolvingLoadBalancer implements LoadBalancer {
         );
       },
       updateState: (connectivityState: ConnectivityState, picker: Picker) => {
+        if (connectivityState === ConnectivityState.IDLE) {
+          picker = new QueuePicker(this);
+        }
         this.replacementBalancerState = connectivityState;
         this.replacementBalancerPicker = picker;
         if (connectivityState === ConnectivityState.READY) {
           this.switchOverReplacementBalancer();
+        } else if (connectivityState === ConnectivityState.IDLE) {
+          if (this.pendingReplacementLoadBalancer) {
+            this.pendingReplacementLoadBalancer.destroy();
+            this.pendingReplacementLoadBalancer = null;
+          }
         }
       },
       requestReresolution: () => {
-        if (!this.backoffTimeout.isRunning()) {
-          /* If the backoffTimeout is running, we're still backing off from
-           * making resolve requests, so we shouldn't make another one here.
-           * In that case, the backoff timer callback will call
-           * updateResolution */
-          this.innerResolver.updateResolution();
+        /* If the backoffTimeout is running, we're still backing off from
+         * making resolve requests, so we shouldn't make another one here.
+         * In that case, the backoff timer callback will call
+         * updateResolution */
+        if (this.backoffTimeout.isRunning()) {
+          this.continueResolving = true;
+        } else {
+          this.updateResolution();
         }
       },
     };
 
     this.backoffTimeout = new BackoffTimeout(() => {
-      if (this.innerLoadBalancer === null) {
-        this.updateState(ConnectivityState.IDLE, new QueuePicker(this));
+      if (this.continueResolving) {
+        this.updateResolution();
+        this.continueResolving = false;
       } else {
-        this.innerResolver.updateResolution();
+        if (this.innerLoadBalancer === null) {
+          this.updateState(ConnectivityState.IDLE, new QueuePicker(this));
+        } else {
+          this.updateState(this.innerBalancerState, this.innerBalancerPicker);
+        }
       }
     });
+  }
+
+  private updateResolution() {
+    this.innerResolver.updateResolution();
+    if (this.innerLoadBalancer === null || this.innerBalancerState === ConnectivityState.IDLE) {
+      this.updateState(ConnectivityState.CONNECTING, new QueuePicker(this));
+    }
   }
 
   private updateState(connectivitystate: ConnectivityState, picker: Picker) {
@@ -323,6 +365,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
     );
     this.pendingReplacementLoadBalancer = null;
     this.innerBalancerState = this.replacementBalancerState;
+    this.innerBalancerPicker = this.replacementBalancerPicker;
     this.updateState(
       this.replacementBalancerState,
       this.replacementBalancerPicker
@@ -330,7 +373,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   }
 
   private handleResolutionFailure(error: StatusObject) {
-    if (this.innerLoadBalancer === null) {
+    if (this.innerLoadBalancer === null || this.innerBalancerState === ConnectivityState.IDLE) {
       this.updateState(
         ConnectivityState.TRANSIENT_FAILURE,
         new UnavailablePicker(error)
@@ -344,7 +387,11 @@ export class ResolvingLoadBalancer implements LoadBalancer {
       this.innerLoadBalancer.exitIdle();
     }
     if (this.currentState === ConnectivityState.IDLE) {
-      this.innerResolver.updateResolution();
+      if (this.backoffTimeout.isRunning()) {
+        this.continueResolving = true;
+      } else {
+        this.updateResolution();
+      }
       this.updateState(
         ConnectivityState.CONNECTING,
         new QueuePicker(this)


### PR DESCRIPTION
This change does the following:

 - If all of the subchannels in the pick first load balancer subchannel list go IDLE, the list is removed.

 - If a load balancer goes IDLE, the resolving load balancer removes it (redundant with previous item, but good for defense in depth)

 - After backing off from failed name resolution, only resolve again if something has requested it in the intervening time. Otherwise just go IDLE.

 - Always change to CONNECTING when starting name resolution if the underlying load balancer is IDLE.