### PR TITLE
doc: Change the default value of waitForReady argument

### DIFF
--- a/packages/grpc-js/src/metadata.ts
+++ b/packages/grpc-js/src/metadata.ts
@@ -66,7 +66,7 @@ export interface MetadataOptions {
   /* Signal that the request is idempotent. Defaults to false */
   idempotentRequest?: boolean;
   /* Signal that the call should not return UNAVAILABLE before it has
-   * started. Defaults to true. */
+   * started. Defaults to false. */
   waitForReady?: boolean;
   /* Signal that the call is cacheable. GRPC is free to use GET verb.
    * Defaults to false */

--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -554,7 +554,7 @@ declare module "grpc" {
     /* Signal that the request is idempotent. Defaults to false */
     idempotentRequest?: boolean;
     /* Signal that the call should not return UNAVAILABLE before it has
-     * started. Defaults to true. */
+     * started. Defaults to false. */
     waitForReady?: boolean;
     /* Signal that the call is cacheable. GRPC is free to use GET verb.
      * Defaults to false */

--- a/packages/grpc-native-core/src/metadata.js
+++ b/packages/grpc-native-core/src/metadata.js
@@ -37,7 +37,7 @@ const CORKED_FLAG = 0x100;
  *     a client request.
  * @param {boolean=} [options.idempotentRequest=false] Signal that the request
  *     is idempotent
- * @param {boolean=} [options.waitForReady=true] Signal that the call should
+ * @param {boolean=} [options.waitForReady=false] Signal that the call should
  *     not return UNAVAILABLE before it has started.
  * @param {boolean=} [options.cacheableRequest=false] Signal that the call is
  *     cacheable. GRPC is free to use GET verb.
@@ -170,7 +170,7 @@ Metadata.prototype.clone = function() {
  *     a client request.
  * @param {boolean=} [options.idempotentRequest=false] Signal that the request
  *     is idempotent
- * @param {boolean=} [options.waitForReady=true] Signal that the call should
+ * @param {boolean=} [options.waitForReady=false] Signal that the call should
  *     not return UNAVAILABLE before it has started.
  * @param {boolean=} [options.cacheableRequest=false] Signal that the call is
  *     cacheable. GRPC is free to use GET verb.


### PR DESCRIPTION
I'm using the latest version of grpc-native-core client and in my use case, the default behavior of `waitForReady` for RPC is `false`, but the annotations tell us the default is `true`. After digging into the source codes, as well as https://github.com/grpc/grpc-node/pull/899 and https://github.com/grpc/grpc-node/issues/896 , the default value should probably be the `false`. This ps is going to change the relevant annotations, both in grpc-native-core and grpc-js packages.

Signed-off-by: imjoey <majunjiev@gmail.com>