### PR TITLE
Bump grpc-js to 0.6.10

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
I have been convinced that it's worth publishing #1088 now rather than waiting and folding it into a bigger release. This release will also include the round robin load balancer implementation in #1063. The only API change there is a newly supported key in the channel options object.