### PR TITLE
proto-loader: Pass file descriptors around instead of caching them separately

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": "Google Inc.",
   "contributors": [
     {


### PR DESCRIPTION
I think there's a good chance that this fixes the memory leak reported in #1085.