### PR TITLE
(doc): add compression documentation part of #402

### DIFF
--- a/Documentation/compression.md
+++ b/Documentation/compression.md
@@ -1,0 +1,31 @@
+# Compression
+
+## Client side
+The preferred method for configuring message compression on a client is to pass `options` when the client object is instantiated.
+
+The two options need to be passed:
+
+**grpc.default_compression_algorithm** (integer)
+
+The option keeps the value of a compression algorithm.
+
+Possible values for this option are:
+- `0` - No compression
+- `1` - Compress with DEFLATE algorithm
+- `2` - Compress with GZIP algorithm
+- `3` - Stream compression with GZIP algorithm
+
+**grpc.default_compression_level** (integer)
+
+The option keeps the value for the level of compression.
+
+Possible values for this option are:
+- `0` - None
+- `1` - Low level
+- `2` - Medium level
+- `3` - High level
+
+### Code example
+```javascript
+client = new ExampleClient("example.com", credentials.createInsecure(), {'grpc.default_compression_algorithm': 2, 'grpc.default_compression_level': 2});
+```

--- a/doc/compression.md
+++ b/doc/compression.md
@@ -7,7 +7,7 @@ These two options control compression behavior:
 
 **grpc.default_compression_algorithm** (int)
 
-Default compression algorithm for the channel. 
+Default compression algorithm for the channel, applies to sending messages.
 
 Possible values for this option are:
 - `0` - No compression
@@ -17,7 +17,7 @@ Possible values for this option are:
 
 **grpc.default_compression_level** (int)
 
-Default compression level for the channel.
+Default compression level for the channel, applies to receiving messages.
 
 Possible values for this option are:
 - `0` - None

--- a/doc/compression.md
+++ b/doc/compression.md
@@ -3,11 +3,11 @@
 ## Client side
 The preferred method for configuring message compression on a client is to pass `options` when the client object is instantiated.
 
-The two options need to be passed:
+These two options control compression behavior:
 
-**grpc.default_compression_algorithm** (integer)
+**grpc.default_compression_algorithm** (int)
 
-The option keeps the value of a compression algorithm.
+Default compression algorithm for the channel. 
 
 Possible values for this option are:
 - `0` - No compression
@@ -15,9 +15,9 @@ Possible values for this option are:
 - `2` - Compress with GZIP algorithm
 - `3` - Stream compression with GZIP algorithm
 
-**grpc.default_compression_level** (integer)
+**grpc.default_compression_level** (int)
 
-The option keeps the value for the level of compression.
+Default compression level for the channel.
 
 Possible values for this option are:
 - `0` - None


### PR DESCRIPTION
Adding compression documentation, I had spent some time to find the information is needed. I hope this will help others to start committing documentation too.

There are no server docs, since my server is on `Go` so I haven't explored that part.