### PR TITLE
grpc-js and proto-loader: Publish ts and map files

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -58,7 +58,8 @@
     "semver": "^6.2.0"
   },
   "files": [
-    "build/src/*.{js,d.ts}",
+    "src/*.ts",
+    "build/src/*.{js,d.ts,js.map}",
     "LICENSE"
   ]
 }


### PR DESCRIPTION
I recently needed to use a debugger with grpc-js and it would have helped to have these files to see what was happening in the original code.