### PR TITLE
grpc-js: Change resolver to look at registeredResolvers when invoking getDefaultAuthority

### DIFF
--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -140,7 +140,11 @@ function mergeArrays<T>(...arrays: T[][]): T[] {
   const result: T[] = [];
   for (
     let i = 0;
-    i < Math.max.apply(null, arrays.map(array => array.length));
+    i <
+    Math.max.apply(
+      null,
+      arrays.map(array => array.length)
+    );
     i++
   ) {
     for (const array of arrays) {

--- a/packages/grpc-js/src/resolver.ts
+++ b/packages/grpc-js/src/resolver.ts
@@ -125,7 +125,7 @@ export function createResolver(
  * @param target
  */
 export function getDefaultAuthority(target: string): string {
-  for (const prefix of Object.keys(registerDefaultResolver)) {
+  for (const prefix of Object.keys(registeredResolvers)) {
     if (target.startsWith(prefix)) {
       return registeredResolvers[prefix].getDefaultAuthority(target);
     }

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -194,4 +194,23 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
   });
+  describe('getDefaultAuthority', () => {
+    class OtherResolver implements resolverManager.Resolver {
+      updateResolution() {
+        return [];
+      }
+
+      static getDefaultAuthority(target: string): string {
+        return 'other';
+      }
+    }
+
+    it('Should return the correct authority if a different resolver has been registered', () => {
+      const target = 'other://name';
+      resolverManager.registerResolver('other:', OtherResolver);
+
+      const authority = resolverManager.getDefaultAuthority(target);
+      assert.equal(authority, 'other');
+    });
+  });
 });


### PR DESCRIPTION
Previously, it was calling `Object.keys` on a function which would never return the appropriate prefixes for registered resolvers and always fallback to the DNS resolver.

Fixes #1054 