### PR TITLE
Fix Channel#getConnectivityState API and behavior

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -304,8 +304,12 @@ export class ChannelImplementation implements Channel {
     return this.target;
   }
 
-  getConnectivityState() {
-    return this.connectivityState;
+  getConnectivityState(tryToConnect: boolean) {
+    const connectivityState = this.connectivityState;
+    if (tryToConnect) {
+      this.resolvingLoadBalancer.exitIdle();
+    }
+    return connectivityState;
   }
 
   watchConnectivityState(


### PR DESCRIPTION
This is what [the spec](https://github.com/grpc/proposal/blob/master/L32-node-channel-API.md) says that method should do. This part of the functionality got lost when the `Channel` class was rewritten in #1015.

This is probably what's causing googleapis/nodejs-pubsub#818.