### PR TITLE
grpc-js: Handle error when starting call on subchannel

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -216,10 +216,17 @@ export class ChannelImplementation implements Channel {
                   pickResult.subchannel!.getConnectivityState() ===
                   ConnectivityState.READY
                 ) {
-                  pickResult.subchannel!.startCallStream(
-                    finalMetadata,
-                    callStream
-                  );
+                  try {
+                    pickResult.subchannel!.startCallStream(
+                      finalMetadata,
+                      callStream
+                    );
+                  } catch (error) {
+                    callStream.cancelWithStatus(
+                      Status.UNAVAILABLE,
+                      'Failed to start call on picked subchannel'
+                    );
+                  }
                 } else {
                   callStream.cancelWithStatus(
                     Status.UNAVAILABLE,


### PR DESCRIPTION
This should always handle the error for #734.