### PR TITLE
feat: allow headers other than authorization

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -85,11 +85,11 @@ export interface OAuth2Client {
     callback: (
       err: Error | null,
       headers?: {
-        Authorization: string;
+        [index: string]: string;
       }
     ) => void
   ) => void;
-  getRequestHeaders: (url?: string) => Promise<{ Authorization: string }>;
+  getRequestHeaders: (url?: string) => Promise<{ [index: string]: string }>;
 }
 
 /**** Client Credentials ****/
@@ -109,7 +109,7 @@ export const credentials = mixin(
         (options, callback) => {
           // google-auth-library pre-v2.0.0 does not have getRequestHeaders
           // but has getRequestMetadata, which is deprecated in v2.0.0
-          let getHeaders: Promise<{ Authorization: string }>;
+          let getHeaders: Promise<{ [index: string]: string }>;
           if (typeof googleCredentials.getRequestHeaders === 'function') {
             getHeaders = googleCredentials.getRequestHeaders(
               options.service_url
@@ -131,7 +131,9 @@ export const credentials = mixin(
           getHeaders.then(
             headers => {
               const metadata = new Metadata();
-              metadata.add('authorization', headers.Authorization);
+              for (const key in headers) {
+                metadata.add(key, headers[key]);
+              }
               callback(null, metadata);
             },
             err => {

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -131,7 +131,7 @@ export const credentials = mixin(
           getHeaders.then(
             headers => {
               const metadata = new Metadata();
-              for (const key in headers) {
+              for (const key of Object.keys(headers)) {
                 metadata.add(key, headers[key]);
               }
               callback(null, metadata);

--- a/packages/grpc-native-core/src/credentials.js
+++ b/packages/grpc-native-core/src/credentials.js
@@ -187,20 +187,20 @@ function getAuthorizationHeaderFromGoogleCredential(google_credential, url, call
   // but has getRequestMetadata, which is deprecated in v2.0.0
   if (typeof google_credential.getRequestHeaders === 'function') {
     google_credential.getRequestHeaders(url)
-      .then(function(header) {
-        callback(null, header.Authorization);
+      .then(function(headers) {
+        callback(null, headers);
       })
       .catch(function(err) {
         callback(err);
         return;
       });
   } else {
-    google_credential.getRequestMetadata(url, function(err, header) {
+    google_credential.getRequestMetadata(url, function(err, headers) {
       if (err) {
         callback(err);
         return;
       }
-      callback(null, header.Authorization);
+      callback(null, headers);
     });
   }
 }
@@ -217,14 +217,16 @@ exports.createFromGoogleCredential = function(google_credential) {
   return exports.createFromMetadataGenerator(function(auth_context, callback) {
     var service_url = auth_context.service_url;
     getAuthorizationHeaderFromGoogleCredential(google_credential, service_url,
-      function(err, authHeader) {
+      function(err, headers) {
         if (err) {
           common.log(constants.logVerbosity.INFO, 'Auth error:' + err);
           callback(err);
           return;
         }
         var metadata = new Metadata();
-        metadata.add('authorization', authHeader);
+        for (const key of Object.keys(headers)) {
+          metadata.add(key, headers[key]);
+        }
         callback(null, metadata);
       });
   });

--- a/packages/grpc-native-core/src/credentials.js
+++ b/packages/grpc-native-core/src/credentials.js
@@ -182,7 +182,7 @@ exports.createFromMetadataGenerator = function(metadata_generator) {
   });
 };
 
-function getAuthorizationHeaderFromGoogleCredential(google_credential, url, callback) {
+function getHeadersFromGoogleCredential(google_credential, url, callback) {
   // google-auth-library pre-v2.0.0 does not have getRequestHeaders
   // but has getRequestMetadata, which is deprecated in v2.0.0
   if (typeof google_credential.getRequestHeaders === 'function') {
@@ -216,7 +216,7 @@ function getAuthorizationHeaderFromGoogleCredential(google_credential, url, call
 exports.createFromGoogleCredential = function(google_credential) {
   return exports.createFromMetadataGenerator(function(auth_context, callback) {
     var service_url = auth_context.service_url;
-    getAuthorizationHeaderFromGoogleCredential(google_credential, service_url,
+    getHeadersFromGoogleCredential(google_credential, service_url,
       function(err, headers) {
         if (err) {
           common.log(constants.logVerbosity.INFO, 'Auth error:' + err);


### PR DESCRIPTION
Our upstream authentication library has gradually added more keys that provide meta-information to the upstream gRPC API.

We could not think of a reason why we were fetching only the `authorization` header, let's move away from this approach and simply populate all headers populated by `google-auth-library`.

CC: @murgatroid99, @alexander-fenster 