### PR TITLE
grpc-js: fix explicit ipv6 addresses not resolving correctly

### DIFF
--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -115,14 +115,15 @@ const dnsLookupPromise = util.promisify(dns.lookup);
 function parseIP(target: string): string[] | null {
   /* These three regular expressions are all mutually exclusive, so we just
    * want the first one that matches the target string, if any do. */
+  const ipv4Match = IPV4_REGEX.exec(target);
   const match =
-    IPV4_REGEX.exec(target) ||
-    IPV6_REGEX.exec(target) ||
-    IPV6_BRACKET_REGEX.exec(target);
+    ipv4Match || IPV6_REGEX.exec(target) || IPV6_BRACKET_REGEX.exec(target);
   if (match === null) {
     return null;
   }
-  const addr = match[1];
+
+  // ipv6 addresses should be bracketed
+  const addr = ipv4Match ? match[1] : `[${match[1]}]`;
   let port: string;
   if (match[2]) {
     port = match[2];

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -67,6 +67,63 @@ describe('Name Resolver', () => {
       const resolver = resolverManager.createResolver(target, listener);
       resolver.updateResolution();
     });
+    it('Should correctly represent an ipv4 address', done => {
+      const target = '1.2.3.4';
+      const listener: resolverManager.ResolverListener = {
+        onSuccessfulResolution: (
+          addressList: string[],
+          serviceConfig: ServiceConfig | null,
+          serviceConfigError: StatusObject | null
+        ) => {
+          assert(addressList.includes('1.2.3.4:443'));
+          // We would check for the IPv6 address but it needs to be omitted on some Node versions
+          done();
+        },
+        onError: (error: StatusObject) => {
+          done(new Error(`Failed with status ${error.details}`));
+        },
+      };
+      const resolver = resolverManager.createResolver(target, listener);
+      resolver.updateResolution();
+    });
+    it('Should correctly represent an ipv6 address', done => {
+      const target = '::1';
+      const listener: resolverManager.ResolverListener = {
+        onSuccessfulResolution: (
+          addressList: string[],
+          serviceConfig: ServiceConfig | null,
+          serviceConfigError: StatusObject | null
+        ) => {
+          assert(addressList.includes('[::1]:443'));
+          // We would check for the IPv6 address but it needs to be omitted on some Node versions
+          done();
+        },
+        onError: (error: StatusObject) => {
+          done(new Error(`Failed with status ${error.details}`));
+        },
+      };
+      const resolver = resolverManager.createResolver(target, listener);
+      resolver.updateResolution();
+    });
+    it('Should correctly represent a bracketed ipv6 address', done => {
+      const target = '[::1]:50051';
+      const listener: resolverManager.ResolverListener = {
+        onSuccessfulResolution: (
+          addressList: string[],
+          serviceConfig: ServiceConfig | null,
+          serviceConfigError: StatusObject | null
+        ) => {
+          assert(addressList.includes('[::1]:50051'));
+          // We would check for the IPv6 address but it needs to be omitted on some Node versions
+          done();
+        },
+        onError: (error: StatusObject) => {
+          done(new Error(`Failed with status ${error.details}`));
+        },
+      };
+      const resolver = resolverManager.createResolver(target, listener);
+      resolver.updateResolution();
+    });
     it('Should resolve a public address', done => {
       const target = 'example.com';
       const listener: resolverManager.ResolverListener = {


### PR DESCRIPTION
Trying to connect to a Grpc server via an ipv6 address (e.g. `[::1]:58440`) fails with the following error:

```
internal/url.js:243
  throw new ERR_INVALID_URL(input);
  ^

TypeError [ERR_INVALID_URL]: Invalid URL: http://::1:58440
    at onParseError (internal/url.js:243:9)
    at new URL (internal/url.js:319:5)
    at Object.connect (internal/http2/core.js:2893:17)
    at Object.connect (/Users/james/Development/ortoo/api-service/node_modules/@google-cloud/trace-agent/build/src/plugins/plugin-http2.js:119:33)
    at Subchannel.startConnectingInternal (/Users/james/Development/ortoo/api-service/node_modules/@ortoo/infra-grpc-client/node_modules/@ortoo/grpc-utils/node_modules/@grpc/grpc-js/build/src/subchannel.js:183:31)
    at Subchannel.transitionToState (/Users/james/Development/ortoo/api-service/node_modules/@ortoo/infra-grpc-client/node_modules/@ortoo/grpc-utils/node_modules/@grpc/grpc-js/build/src/subchannel.js:250:22)
    at Subchannel.startConnecting (/Users/james/Development/ortoo/api-service/node_modules/@ortoo/infra-grpc-client/node_modules/@ortoo/grpc-utils/node_modules/@grpc/grpc-js/build/src/subchannel.js:358:19)
    at PickFirstLoadBalancer.exitIdle (/Users/james/Development/ortoo/api-service/node_modules/@ortoo/infra-grpc-client/node_modules/@ortoo/grpc-utils/node_modules/@grpc/grpc-js/build/src/load-balancer-pick-first.js:305:24)
    at ResolvingLoadBalancer.exitIdle (/Users/james/Development/ortoo/api-service/node_modules/@ortoo/infra-grpc-client/node_modules/@ortoo/grpc-utils/node_modules/@grpc/grpc-js/build/src/resolving-load-balancer.js:316:36)
    at /Users/james/Development/ortoo/api-service/node_modules/@ortoo/infra-grpc-client/node_modules/@ortoo/grpc-utils/node_modules/@grpc/grpc-js/build/src/picker.js:69:35 {
  input: 'http://::1:58440'
}
```

The problem is that the host part should be bracketed for ipv6 urls (`[::1]`), and the bug I think is in the dns resolver. I've tweaked it to always bracket ipv6 addresses in the same way as is done when resolving ipv6 addresses from an AAAA record ([see here](https://github.com/grpc/grpc-node/blob/9ec428bdd4680b8405a7b3e8346554a157d1adbd/packages/grpc-js/src/resolver-dns.ts#L231))