### PR TITLE
grpc-js: Add support for TLS-related environment variables

### DIFF
--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -18,7 +18,7 @@
 import { ConnectionOptions, createSecureContext, PeerCertificate } from 'tls';
 
 import { CallCredentials } from './call-credentials';
-import { Call } from '.';
+import {CIPHER_SUITES, getDefaultRootsData} from './tls-helpers';
 
 // tslint:disable-next-line:no-any
 function verifyIsBufferOrNull(obj: any, friendlyName: string): void {
@@ -141,7 +141,7 @@ export abstract class ChannelCredentials {
       );
     }
     return new SecureChannelCredentialsImpl(
-      rootCerts || null,
+      rootCerts || getDefaultRootsData(),
       privateKey || null,
       certChain || null,
       verifyOptions || {}
@@ -190,6 +190,7 @@ class SecureChannelCredentialsImpl extends ChannelCredentials {
       ca: rootCerts || undefined,
       key: privateKey || undefined,
       cert: certChain || undefined,
+      ciphers: CIPHER_SUITES
     });
     this.connectionOptions = { secureContext };
     if (verifyOptions && verifyOptions.checkServerIdentity) {

--- a/packages/grpc-js/src/server-credentials.ts
+++ b/packages/grpc-js/src/server-credentials.ts
@@ -16,6 +16,7 @@
  */
 
 import { SecureServerOptions } from 'http2';
+import {CIPHER_SUITES, getDefaultRootsData} from './tls-helpers';
 
 export interface KeyCertPair {
   private_key: Buffer;
@@ -70,10 +71,11 @@ export abstract class ServerCredentials {
     }
 
     return new SecureServerCredentials({
-      ca: rootCerts || undefined,
+      ca: rootCerts || getDefaultRootsData() || undefined,
       cert,
       key,
       requestCert: checkClientCertificate,
+      ciphers: CIPHER_SUITES
     });
   }
 }

--- a/packages/grpc-js/src/tls-helpers.ts
+++ b/packages/grpc-js/src/tls-helpers.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import * as fs from 'fs';
+
+export const CIPHER_SUITES: string | undefined = process.env.GRPC_SSL_CIPHER_SUITES;
+
+const DEFAULT_ROOTS_FILE_PATH = process.env.GRPC_DEFAULT_SSL_ROOTS_FILE_PATH;
+
+let defaultRootsData: Buffer | null = null;
+
+export function getDefaultRootsData(): Buffer | null {
+  if (DEFAULT_ROOTS_FILE_PATH) {
+    if (defaultRootsData === null) {
+      defaultRootsData = fs.readFileSync(DEFAULT_ROOTS_FILE_PATH);
+    }
+    return defaultRootsData;
+  }
+  return null;
+}

--- a/packages/grpc-js/test/test-server-credentials.ts
+++ b/packages/grpc-js/test/test-server-credentials.ts
@@ -41,24 +41,16 @@ describe('Server Credentials', () => {
       const creds = ServerCredentials.createSsl(ca, []);
 
       assert.strictEqual(creds._isSecure(), true);
-      assert.deepStrictEqual(creds._getSettings(), {
-        ca,
-        cert: [],
-        key: [],
-        requestCert: false,
-      });
+      assert.strictEqual(creds._getSettings()?.ca, ca);
     });
 
     it('accepts a boolean as the third argument', () => {
       const creds = ServerCredentials.createSsl(ca, [], true);
 
       assert.strictEqual(creds._isSecure(), true);
-      assert.deepStrictEqual(creds._getSettings(), {
-        ca,
-        cert: [],
-        key: [],
-        requestCert: true,
-      });
+      const settings = creds._getSettings();
+      assert.strictEqual(settings?.ca, ca);
+      assert.strictEqual(settings?.requestCert, true);
     });
 
     it('accepts an object with two buffers in the second argument', () => {
@@ -66,12 +58,9 @@ describe('Server Credentials', () => {
       const creds = ServerCredentials.createSsl(null, keyCertPairs);
 
       assert.strictEqual(creds._isSecure(), true);
-      assert.deepStrictEqual(creds._getSettings(), {
-        ca: undefined,
-        cert: [cert],
-        key: [key],
-        requestCert: false,
-      });
+      const settings = creds._getSettings();
+      assert.deepStrictEqual(settings?.cert, [cert]);
+      assert.deepStrictEqual(settings?.key, [key]);
     });
 
     it('accepts multiple objects in the second argument', () => {
@@ -82,12 +71,9 @@ describe('Server Credentials', () => {
       const creds = ServerCredentials.createSsl(null, keyCertPairs, false);
 
       assert.strictEqual(creds._isSecure(), true);
-      assert.deepStrictEqual(creds._getSettings(), {
-        ca: undefined,
-        cert: [cert, cert],
-        key: [key, key],
-        requestCert: false,
-      });
+      const settings = creds._getSettings();
+      assert.deepStrictEqual(settings?.cert, [cert, cert]);
+      assert.deepStrictEqual(settings?.key, [key, key]);
     });
 
     it('fails if the second argument is not an Array', () => {


### PR DESCRIPTION
This adds support for the `GRPC_SSL_CIPHER_SUITES` and `GRPC_DEFAULT_SSL_ROOTS_FILE_PATH` environment variables as documented [here](https://github.com/grpc/grpc/blob/master/doc/environment_variables.md). After this the only unsupported environment variable that is relevant to this library will be `http_proxy`.

This should fix #804.