### PR TITLE
grpc-tools: Use PrintRaw when outputting comments

### DIFF
--- a/packages/grpc-tools/src/node_generator.cc
+++ b/packages/grpc-tools/src/node_generator.cc
@@ -181,7 +181,7 @@ void PrintMethod(const MethodDescriptor* method, Printer* out) {
 void PrintService(const ServiceDescriptor* service, Printer* out,
                   const Parameters& params) {
   map<grpc::string, grpc::string> template_vars;
-  out->Print(GetNodeComments(service, true).c_str());
+  out->PrintRaw(GetNodeComments(service, true).c_str());
   template_vars["name"] = service->name();
   template_vars["full_name"] = service->full_name();
   if (params.generate_package_definition) {
@@ -193,11 +193,11 @@ void PrintService(const ServiceDescriptor* service, Printer* out,
   for (int i = 0; i < service->method_count(); i++) {
     grpc::string method_name =
         grpc_generator::LowercaseFirstLetter(service->method(i)->name());
-    out->Print(GetNodeComments(service->method(i), true).c_str());
+    out->PrintRaw(GetNodeComments(service->method(i), true).c_str());
     out->Print("$method_name$: ", "method_name", method_name);
     PrintMethod(service->method(i), out);
     out->Print(",\n");
-    out->Print(GetNodeComments(service->method(i), false).c_str());
+    out->PrintRaw(GetNodeComments(service->method(i), false).c_str());
   }
   out->Outdent();
   out->Print("};\n\n");
@@ -206,7 +206,7 @@ void PrintService(const ServiceDescriptor* service, Printer* out,
                "exports.$name$Client = "
                "grpc.makeGenericClientConstructor($name$Service);\n");
   }
-  out->Print(GetNodeComments(service, false).c_str());
+  out->PrintRaw(GetNodeComments(service, false).c_str());
 }
 
 void PrintImports(const FileDescriptor* file, Printer* out,
@@ -276,7 +276,7 @@ grpc::string GenerateFile(const FileDescriptor* file,
 
     PrintServices(file, &out, params);
 
-    out.Print(GetNodeComments(file, false).c_str());
+    out.PrintRaw(GetNodeComments(file, false).c_str());
   }
   return output;
 }


### PR DESCRIPTION
This should fix #1204 by preventing the printer from trying to interpolate variables whenever the `$` character appears in comments.