### PR TITLE
Revert "Update google-auth-library in interop tests"

### DIFF
--- a/test/interop/interop_client.js
+++ b/test/interop/interop_client.js
@@ -22,7 +22,7 @@ var fs = require('fs');
 var path = require('path');
 var grpc = require('../any_grpc').client;
 var protoLoader = require('../../packages/proto-loader');
-var GoogleAuth = require('google-auth-library').GoogleAuth;
+var GoogleAuth = require('google-auth-library');
 
 var protoPackage = protoLoader.loadSync(
     'src/proto/grpc/testing/test.proto',
@@ -463,14 +463,17 @@ function oauth2Test(client, done, extra) {
 }
 
 function perRpcAuthTest(client, done, extra) {
-  const auth = new GoogleAuth({scopes: extra.oauth_scope});
-  auth.getClient().then(authClient => {
+  (new GoogleAuth()).getApplicationDefault(function(err, credential) {
     assert.ifError(err);
     var arg = {
       fill_username: true,
       fill_oauth_scope: true
     };
-    var creds = grpc.credentials.createFromGoogleCredential(authClient);
+    var scope = extra.oauth_scope;
+    if (credential.createScopedRequired() && scope) {
+      credential = credential.createScoped(scope);
+    }
+    var creds = grpc.credentials.createFromGoogleCredential(credential);
     client.unaryCall(arg, {credentials: creds}, function(err, resp) {
       assert.ifError(err);
       assert.strictEqual(resp.username, SERVICE_ACCOUNT_EMAIL);
@@ -479,31 +482,41 @@ function perRpcAuthTest(client, done, extra) {
         done();
       }
     });
-  }, error => {
-    assert.fail(error);
   });
 }
 
 function getApplicationCreds(scope, callback) {
-  const auth = new GoogleAuth({scopes: scope});
-  auth.getClient().then(client => {
-    callback(grpc.credentials.createFromGoogleCredential(client));
-  }, (error) => {
-    assert.fail(error);
+  (new GoogleAuth()).getApplicationDefault(function(err, credential) {
+    if (err) {
+      callback(err);
+      return;
+    }
+    if (credential.createScopedRequired() && scope) {
+      credential = credential.createScoped(scope);
+    }
+    callback(null, grpc.credentials.createFromGoogleCredential(credential));
   });
 }
 
 function getOauth2Creds(scope, callback) {
-  const auth = new GoogleAuth({scopes: scope});
-  auth.getClient().then(client => client.getAccessToken()).then((token) => {
-    const updateMd = (service_url, callback)  => {
-      const metadata = new grpc.Metadata();
-      metadata.add('authorization', 'Bearer ' + token);
-      callback(null, metadata);
-    };
-    callback(null, grpc.credentials.createFromMetadataGenerator(updateMd));
-  }).catch(error => {
-    assert.fail(error);
+  (new GoogleAuth()).getApplicationDefault(function(err, credential) {
+    if (err) {
+      callback(err);
+      return;
+    }
+    credential = credential.createScoped(scope);
+    credential.getAccessToken(function(err, token) {
+      if (err) {
+        callback(err);
+        return;
+      }
+      var updateMd = function(service_url, callback) {
+        var metadata = new grpc.Metadata();
+        metadata.add('authorization', 'Bearer ' + token);
+        callback(null, metadata);
+      };
+      callback(null, grpc.credentials.createFromMetadataGenerator(updateMd));
+    });
   });
 }
 

--- a/test/package.json
+++ b/test/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "express": "^4.16.3",
-    "google-auth-library": "^5.5.1",
+    "google-auth-library": "^0.9.2",
     "lodash": "^4.17.4",
     "poisson-process": "^1.0.0"
   }


### PR DESCRIPTION
Reverts grpc/grpc-node#1206. Apparently it broke the cloud-to-prod interop tests.