### PR TITLE
grpc-tools: fix output is unparseable error

### DIFF
--- a/packages/grpc-tools/src/node_plugin.cc
+++ b/packages/grpc-tools/src/node_plugin.cc
@@ -43,7 +43,6 @@ class NodeGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
           grpc_generator::tokenize(parameter, ",");	
       for (auto parameter_string = parameters_list.begin();	
            parameter_string != parameters_list.end(); parameter_string++) {
-        printf("%s", parameter_string);
         if (*parameter_string == "generate_package_definition") {
           generator_parameters.generate_package_definition = true;
         }


### PR DESCRIPTION
This fixes the "Plugin output is unparseable" error when using the `generate_package_definition` flag in grpc-tools. I got the error message when running in macOS and linux. After removing the `printf` the plugin would complete successfully with the `generate_package_definition` flag.
