### PR TITLE
Add test for waitForReady on both implementations

### DIFF
--- a/packages/grpc-js/src/metadata.ts
+++ b/packages/grpc-js/src/metadata.ts
@@ -174,7 +174,7 @@ export class Metadata {
    * @return The newly cloned object.
    */
   clone(): Metadata {
-    const newMetadata = new Metadata();
+    const newMetadata = new Metadata(this.options);
     const newInternalRepr = newMetadata.internalRepr;
 
     this.internalRepr.forEach((value, key) => {

--- a/test/api/connectivity_test.js
+++ b/test/api/connectivity_test.js
@@ -66,19 +66,19 @@ describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, functio
     deadline.setSeconds(deadline.getSeconds() + 10);
     disconnectedClient.unary({}, {deadline: deadline}, (error, value) =>{
       assert(error);
-      assert.strictEqual(error.code, grpc.status.UNAVAILABLE);
+      assert.strictEqual(error.code, clientGrpc.status.UNAVAILABLE);
       done();
     });
   });
   it('client should wait for a connection with waitForReady on', function(done) {
     this.timeout(15000);
     const disconnectedClient = new TestServiceClient('foo.test.google.com:50051', clientGrpc.credentials.createInsecure());
-    const metadata = new grpc.Metadata({waitForReady: true});
+    const metadata = new clientGrpc.Metadata({waitForReady: true});
     const deadline = new Date();
     deadline.setSeconds(deadline.getSeconds() + 10);
     disconnectedClient.unary({}, metadata, {deadline: deadline}, (error, value) =>{
       assert(error);
-      assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
+      assert.strictEqual(error.code, clientGrpc.status.DEADLINE_EXCEEDED);
       done();
     });
   });

--- a/test/api/connectivity_test.js
+++ b/test/api/connectivity_test.js
@@ -59,6 +59,29 @@ const serviceImpl = {
 };
 
 describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, function() {
+  it('client should not wait for ready by default', function(done) {
+    this.timeout(15000);
+    const disconnectedClient = new TestServiceClient('foo.test.google.com:50051', grpc.credentials.createInsecure());
+    const deadline = new Date();
+    deadline.setSeconds(deadline.getSeconds() + 10);
+    disconnectedClient.unary({}, {deadline: deadline}, (error, value) =>{
+      assert(error);
+      assert.strictEqual(error.code, grpc.status.UNAVAILABLE);
+      done();
+    });
+  });
+  it('client should wait for a connection with waitForReady on', function(done) {
+    this.timeout(15000);
+    const disconnectedClient = new TestServiceClient('foo.test.google.com:50051', grpc.credentials.createInsecure());
+    const metadata = new grpc.Metadata({waitForReady: true});
+    const deadline = new Date();
+    deadline.setSeconds(deadline.getSeconds() + 10);
+    disconnectedClient.unary({}, metadata, {deadline: deadline}, (error, value) =>{
+      assert(error);
+      assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
+      done();
+    });
+  });
   describe('Reconnection', function() {
     let server1;
     let server2;

--- a/test/api/connectivity_test.js
+++ b/test/api/connectivity_test.js
@@ -61,7 +61,7 @@ const serviceImpl = {
 describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, function() {
   it('client should not wait for ready by default', function(done) {
     this.timeout(15000);
-    const disconnectedClient = new TestServiceClient('foo.test.google.com:50051', grpc.credentials.createInsecure());
+    const disconnectedClient = new TestServiceClient('foo.test.google.com:50051', clientGrpc.credentials.createInsecure());
     const deadline = new Date();
     deadline.setSeconds(deadline.getSeconds() + 10);
     disconnectedClient.unary({}, {deadline: deadline}, (error, value) =>{
@@ -72,7 +72,7 @@ describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, functio
   });
   it('client should wait for a connection with waitForReady on', function(done) {
     this.timeout(15000);
-    const disconnectedClient = new TestServiceClient('foo.test.google.com:50051', grpc.credentials.createInsecure());
+    const disconnectedClient = new TestServiceClient('foo.test.google.com:50051', clientGrpc.credentials.createInsecure());
     const metadata = new grpc.Metadata({waitForReady: true});
     const deadline = new Date();
     deadline.setSeconds(deadline.getSeconds() + 10);


### PR DESCRIPTION
This is tests from #796 and #899, but for both implementations. This should reproduce the same conditions as described in #1228.

This revealed a bug in the grpc-js implementation, so the fix for that is here too.