### PR TITLE
Add absl support

### DIFF
--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -68,7 +68,7 @@
     "deps/grpc/include/grpc/**/*.h",
     "deps/grpc/src/core/**/*.{c,cc,h}",
     "deps/grpc/src/boringssl/err_data.c",
-    "deps/grpc/third_party/abseil-cpp/absl/**/*.{h,hh,inc}",
+    "deps/grpc/third_party/abseil-cpp/absl/**/*.{cc,h,inc}",
     "deps/grpc/third_party/boringssl/crypto/**/*.{c,cc,h}",
     "deps/grpc/third_party/boringssl/include/**/*.{c,cc,h}",
     "deps/grpc/third_party/boringssl/ssl/**/*.{c,cc,h}",

--- a/packages/grpc-native-core/templates/binding.gyp.template
+++ b/packages/grpc-native-core/templates/binding.gyp.template
@@ -20,7 +20,13 @@
   # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   # See the License for the specific language governing permissions and
   # limitations under the License.
-
+  <%
+  def gyp_target_name(lib_name):
+    if lib_name.startswith("absl/"):
+      return lib_name.replace("/", "__").replace(":", "__")
+    else:
+      return lib_name
+  %>
   # Some of this file is built with the help of
   # https://n8.io/converting-a-c-library-to-gyp/
   {
@@ -332,12 +338,12 @@
       % for lib in libs:
       % if lib.name == core.name or (lib.name in core.transitive_deps and lib.name not in ('boringssl', 'z')):
       {
-        'target_name': '${lib.name}',
+        'target_name': '${gyp_target_name(lib.name)}',
         'product_prefix': 'lib',
         'type': 'static_library',
         'dependencies': [
           % for dep in getattr(lib, 'deps', []):
-          '${dep}',
+          '${gyp_target_name(dep)}',
           % endfor
         ],
         'sources': [

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -70,7 +70,7 @@
       "deps/grpc/include/grpc/**/*.h",
       "deps/grpc/src/core/**/*.{c,cc,h}",
       "deps/grpc/src/boringssl/err_data.c",
-      "deps/grpc/third_party/abseil-cpp/absl/**/*.{h,hh,inc}",
+      "deps/grpc/third_party/abseil-cpp/absl/**/*.{cc,h,inc}",
       "deps/grpc/third_party/boringssl/crypto/**/*.{c,cc,h}",
       "deps/grpc/third_party/boringssl/include/**/*.{c,cc,h}",
       "deps/grpc/third_party/boringssl/ssl/**/*.{c,cc,h}",


### PR DESCRIPTION
Updated `grpc-native-core` project templates to add abseil targets properly.

Related to https://github.com/grpc/grpc/pull/20184.
