### PR TITLE
grpc-js: Add HTTP CONNECT support, i.e. egress proxy support

### DIFF
--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { URL, parse } from "url";
+import { log } from "./logging";
+import { LogVerbosity } from "./constants";
+import { parseTarget } from "./resolver-dns";
+import { Socket } from "net";
+import * as http from 'http';
+import * as logging from './logging';
+
+const TRACER_NAME = 'proxy';
+
+function trace(text: string): void {
+  logging.trace(LogVerbosity.DEBUG, TRACER_NAME, text);
+}
+
+interface ProxyInfo {
+  address?: string;
+  creds?: string;
+}
+
+function getProxyInfo(): ProxyInfo {
+  let proxyEnv: string = '';
+  let envVar: string = '';
+  /* Prefer using 'grpc_proxy'. Fallback on 'http_proxy' if it is not set.
+   * Also prefer using 'https_proxy' with fallback on 'http_proxy'. The
+   * fallback behavior can be removed if there's a demand for it.
+   */
+  if (process.env.grpc_proxy) {
+    envVar = 'grpc_proxy';
+    proxyEnv = process.env.grpc_proxy;
+  } else if (process.env.https_proxy) {
+    envVar = 'https_proxy';
+    proxyEnv = process.env.https_proxy;
+  } else if (process.env.http_proxy) {
+    envVar = 'http_proxy';
+    proxyEnv = process.env.http_proxy;
+  } else {
+    return {};
+  }
+  let proxyUrl: URL;
+  try {
+    proxyUrl = new URL(proxyEnv);
+  } catch (e) {
+    log(LogVerbosity.INFO, `cannot parse value of "${envVar}" env var`);
+    return {};
+  }
+  if (proxyUrl.protocol !== 'http') {
+    log(LogVerbosity.ERROR, `"${proxyUrl.protocol}" scheme not supported in proxy URI`);
+    return {};
+  }
+  let userCred: string | null = null;
+  if (proxyUrl.username) {
+    if (proxyUrl.password) {
+      log(LogVerbosity.INFO, 'userinfo found in proxy URI');
+      userCred = `${proxyUrl.username}:${proxyUrl.password}`;
+    } else {
+      userCred = proxyUrl.username;
+    }
+  }
+  const result: ProxyInfo = {
+    address: proxyUrl.host
+  };
+  if (userCred) {
+    result.creds = userCred;
+  }
+  trace('Proxy server ' + result.address + ' set by environment variable ' + envVar);
+  return result;
+}
+
+const PROXY_INFO = getProxyInfo();
+
+function getNoProxyHostList(): string[] {
+  /* Prefer using 'no_grpc_proxy'. Fallback on 'no_proxy' if it is not set. */
+  let noProxyStr: string | undefined = process.env.no_grpc_proxy;
+  let envVar: string = 'no_grpc_proxy';
+  if (!noProxyStr) {
+    noProxyStr = process.env.no_proxy;
+    envVar = 'no_proxy';
+  }
+  if (noProxyStr) {
+    trace('No proxy server list set by environment variable ' + envVar);
+    return noProxyStr.split(',');
+  } else {
+    return [];
+  }
+}
+
+const NO_PROXY_HOSTS = getNoProxyHostList();
+
+export function shouldUseProxy(target: string): boolean {
+  if (!PROXY_INFO.address) {
+    return false;
+  }
+  let serverHost: string;
+  const parsedTarget = parseTarget(target);
+  if (parsedTarget) {
+    serverHost = parsedTarget.host;
+  } else {
+    return false;
+  }
+  for (const host of NO_PROXY_HOSTS) {
+    if (host === serverHost) {
+      trace('Not using proxy for target in no_proxy list: ' + target);
+      return false;
+    }
+  }
+  return true;
+}
+
+export function getProxiedConnection(target: string, subchannelAddress: string): Promise<Socket> {
+  if (!(PROXY_INFO.address && shouldUseProxy(target))) {
+    return Promise.reject<Socket>();
+  }
+  trace('Using proxy ' + PROXY_INFO.address + ' to connect to ' + target + ' at ' + subchannelAddress);
+  const options: http.RequestOptions = {
+    method: 'CONNECT',
+    host: PROXY_INFO.address,
+    path: subchannelAddress
+  };
+  if (PROXY_INFO.creds) {
+    options.headers = {
+      'Proxy-Authorization': 'Basic ' + Buffer.from(PROXY_INFO.creds).toString('base64')
+    };
+  }
+  return new Promise<Socket>((resolve, reject) => {
+    const request = http.request(options);
+    request.once('connect', (res, socket, head) => {
+      request.removeAllListeners();
+      socket.removeAllListeners();
+      if (res.statusCode === http.STATUS_CODES.OK) {
+        trace('Successfully connected to ' + subchannelAddress + ' through proxy ' + PROXY_INFO.address);
+        resolve(socket);
+      } else {
+        trace('Failed to connect to ' + subchannelAddress + ' through proxy ' + PROXY_INFO.address);
+        reject();
+      }
+    });
+    request.once('error', (err) => {
+      request.removeAllListeners();
+      trace('Failed to connect to proxy ' + PROXY_INFO.address);
+      reject();
+    });
+  });
+}

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -322,3 +322,20 @@ export function setup(): void {
   registerResolver('dns:', DnsResolver);
   registerDefaultResolver(DnsResolver);
 }
+
+export interface dnsUrl {
+  host: string;
+  port?: string;
+}
+
+export function parseTarget(target: string): dnsUrl | null {
+  const match = IPV4_REGEX.exec(target) ?? IPV6_REGEX.exec(target) ?? IPV6_BRACKET_REGEX.exec(target) ?? DNS_REGEX.exec(target)
+  if (match) {
+    return {
+      host: match[0],
+      port: match[1] ?? undefined
+    };
+  } else {
+    return null;
+  }
+}


### PR DESCRIPTION
The implementation here is based pretty closely on the corresponding core code in https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/http_proxy.cc. The code for establishing the connection is loosely based on [this section of the `tunnel-agent` package](https://github.com/request/tunnel-agent/blob/master/index.js#L117-L182), which is used by the `request` package for establishing HTTP CONNECT tunnels.

With this change the library handles the environment variables `grpc_proxy`, `https_proxy`, `http_proxy`, `no_grpc_proxy`, and `no_proxy`.

I am considering this an experimental feature for now because I am not familiar with environments with those kinds of proxies and I don't know how to test it.