### PR TITLE
grpc-js: Support Unix domain sockets and Named pipes

### DIFF
--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -312,6 +312,10 @@ class DnsResolver implements Resolver {
     }
     throw new Error(`Failed to parse target ${target}`);
   }
+
+  static isIPC(): boolean {
+    return false;
+  }
 }
 
 /**

--- a/packages/grpc-js/src/resolver-named-pipe.ts
+++ b/packages/grpc-js/src/resolver-named-pipe.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Resolver,
+  ResolverListener,
+  registerResolver,
+  registerDefaultResolver,
+} from './resolver';
+
+class NamedPipeResolver implements Resolver {
+  private addresses: string[] = [];
+  constructor(target: string, private listener: ResolverListener) {
+    this.addresses = [target];
+  }
+  updateResolution(): void {
+    process.nextTick(
+      this.listener.onSuccessfulResolution,
+      this.addresses,
+      null,
+      null
+    );
+  }
+
+  static getDefaultAuthority(target: string): string {
+    return 'localhost';
+  }
+
+  static isIPC(): boolean {
+    return true;
+  }
+}
+
+export function setup() {
+  registerResolver('\\\\.\\pipe\\', NamedPipeResolver);
+  registerResolver('//./pipe/', NamedPipeResolver);
+}

--- a/packages/grpc-js/src/resolver-uds.ts
+++ b/packages/grpc-js/src/resolver-uds.ts
@@ -50,6 +50,10 @@ class UdsResolver implements Resolver {
   static getDefaultAuthority(target: string): string {
     return 'localhost';
   }
+
+  static isIPC(): boolean {
+    return true;
+  }
 }
 
 export function setup() {

--- a/packages/grpc-js/src/resolver.ts
+++ b/packages/grpc-js/src/resolver.ts
@@ -19,6 +19,7 @@ import { ServiceError } from './call';
 import { ServiceConfig } from './service-config';
 import * as resolver_dns from './resolver-dns';
 import * as resolver_uds from './resolver-uds';
+import * as resolver_named_pipe from './resolver-named-pipe';
 import { StatusObject } from './call-stream';
 
 /**
@@ -162,4 +163,5 @@ export function isIPC(target: string): boolean {
 export function registerAll() {
   resolver_dns.setup();
   resolver_uds.setup();
+  resolver_named_pipe.setup();
 }

--- a/packages/grpc-js/src/resolver.ts
+++ b/packages/grpc-js/src/resolver.ts
@@ -70,6 +70,12 @@ export interface ResolverConstructor {
    * @param target
    */
   getDefaultAuthority(target: string): string;
+
+  /**
+   * Returns wheter or not the connection should be an IPC connection. Throws an error if
+   * no registered name resolver can parse that target string.
+   */
+  isIPC(): boolean;
 }
 
 const registeredResolvers: { [prefix: string]: ResolverConstructor } = {};
@@ -132,6 +138,23 @@ export function getDefaultAuthority(target: string): string {
   }
   if (defaultResolver !== null) {
     return defaultResolver.getDefaultAuthority(target);
+  }
+  throw new Error(`Invalid target ${target}`);
+}
+
+/**
+ * Returns wheter or not the connection should be an IPC connection. Throws an error if
+ * no registered name resolver can parse that target string.
+ * @param target
+ */
+export function isIPC(target: string): boolean {
+  for (const prefix of Object.keys(registeredResolvers)) {
+    if (target.startsWith(prefix)) {
+      return registeredResolvers[prefix].isIPC();
+    }
+  }
+  if (defaultResolver !== null) {
+    return defaultResolver.isIPC();
   }
   throw new Error(`Invalid target ${target}`);
 }

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -260,6 +260,10 @@ describe('Name Resolver', () => {
       static getDefaultAuthority(target: string): string {
         return 'other';
       }
+
+      static isIPC(): boolean {
+        return false;
+      }
     }
 
     it('Should return the correct authority if a different resolver has been registered', () => {


### PR DESCRIPTION
This is an attempt at implementing support for UDS and Named pipes as discussed in #258. I'm not sure if the design of this solution is the way to go here or if there's a better way to do it. 

As I understand the http2-library, it isn't able to create a connection over a Unix domain socket or a Named pipe. To solve that I opened a connection using the net-library and supplied that connection to `http2.connect`, as in the example by @jcantwell-JC in the issue mentioned above.

I added a method to the resolver which decides if the connection should be an IPC connection, which works well, but I'm not sure if this is the best way to accomplish this.