### PR TITLE
grpc-js: Destroy http2 stream when a call ends in any way

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -163,6 +163,9 @@ export class Http2CallStream extends Duplex implements Call {
    * @param status The status of the call.
    */
   private endCall(status: StatusObject): void {
+    /* Once endCall is called, we are definitely not using the http2 stream
+     * anymore, so we can always safely destroy it here */
+    this.destroyHttp2Stream();
     if (this.finalStatus === null) {
       this.trace(
         'ended with status: code=' +


### PR DESCRIPTION
This should ensure that if a call ends as a result of a client-side error, e.g. when parsing or filtering incoming metadata, the information that the call has ended propagates back to the server. I don't actually know if this fixes any real problems, but I think the code is more correct with this line than without it.