### PR TITLE
Add build script and configs for Kokoro MacOS parallel build

### DIFF
--- a/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh
+++ b/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+nvm install 10
+nvm use 10
+npm install -g npm
+# https://github.com/mapbox/node-pre-gyp/issues/362
+npm install -g node-gyp
+
+set -ex
+cd $(dirname $0)/../../../../..
+base_dir=$(pwd)
+
+cd $base_dir/packages/grpc-native-core
+
+# Install gRPC and its submodules.
+git submodule update --init --recursive
+
+pip install mako
+./tools/buildgen/generate_projects.sh
+
+export JOBS=8
+export ARTIFACTS_OUT=$base_dir/artifacts
+
+mkdir -p ${ARTIFACTS_OUT}
+
+rm -rf build || true
+
+npm update
+
+case $RUNTIME in
+  electron)
+    HOME=~/.electron-gyp ./node_modules/.bin/node-pre-gyp configure rebuild package --runtime=electron --target=$VERSION --target_arch=$ARCH --disturl=https://atom.io/download/electron
+    cp -r build/stage/* "${ARTIFACTS_OUT}"/
+    ;;
+  node)
+    ./node_modules/.bin/node-pre-gyp configure rebuild package --target=$VERSION --target_arch=$ARCH
+    cp -r build/stage/* "${ARTIFACTS_OUT}"/
+    ;;
+esac

--- a/tools/release/kokoro/macos.cfg
+++ b/tools/release/kokoro/macos.cfg
@@ -1,0 +1,15 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)

--- a/tools/release/kokoro/macos/electron_1.0_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_1.0_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.0_x64.cfg
+++ b/tools/release/kokoro/macos/electron_1.0_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.1_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_1.1_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.1.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.1_x64.cfg
+++ b/tools/release/kokoro/macos/electron_1.1_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.1.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.2_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_1.2_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.2.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.2_x64.cfg
+++ b/tools/release/kokoro/macos/electron_1.2_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.2.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.3_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_1.3_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.3.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.3_x64.cfg
+++ b/tools/release/kokoro/macos/electron_1.3_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.3.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.4_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_1.4_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.4.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.4_x64.cfg
+++ b/tools/release/kokoro/macos/electron_1.4_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.4.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.5_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_1.5_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.5.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.5_x64.cfg
+++ b/tools/release/kokoro/macos/electron_1.5_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.5.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.6_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_1.6_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.6.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.6_x64.cfg
+++ b/tools/release/kokoro/macos/electron_1.6_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.6.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.7_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_1.7_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.7.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.7_x64.cfg
+++ b/tools/release/kokoro/macos/electron_1.7_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.7.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.8_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_1.8_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.8.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_1.8_x64.cfg
+++ b/tools/release/kokoro/macos/electron_1.8_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "1.8.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_2.0_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_2.0_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "2.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_2.0_x64.cfg
+++ b/tools/release/kokoro/macos/electron_2.0_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "2.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_3.0_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_3.0_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "3.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_3.0_x64.cfg
+++ b/tools/release/kokoro/macos/electron_3.0_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "3.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_3.1_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_3.1_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "3.1.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_3.1_x64.cfg
+++ b/tools/release/kokoro/macos/electron_3.1_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "3.1.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_4.1_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_4.1_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "4.1.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_4.1_x64.cfg
+++ b/tools/release/kokoro/macos/electron_4.1_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "4.1.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_4.2_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_4.2_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "4.2.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_4.2_x64.cfg
+++ b/tools/release/kokoro/macos/electron_4.2_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "4.2.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_5.0_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_5.0_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "5.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_5.0_x64.cfg
+++ b/tools/release/kokoro/macos/electron_5.0_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "5.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_6.0_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_6.0_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "6.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_6.0_x64.cfg
+++ b/tools/release/kokoro/macos/electron_6.0_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "6.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_6.1_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_6.1_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "6.1.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_6.1_x64.cfg
+++ b/tools/release/kokoro/macos/electron_6.1_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "6.1.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_7.0_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_7.0_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "7.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_7.0_x64.cfg
+++ b/tools/release/kokoro/macos/electron_7.0_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "7.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_7.1_ia32.cfg
+++ b/tools/release/kokoro/macos/electron_7.1_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "7.1.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/electron_7.1_x64.cfg
+++ b/tools/release/kokoro/macos/electron_7.1_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "electron"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "7.1.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_10_ia32.cfg
+++ b/tools/release/kokoro/macos/node_10_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "10.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_10_x64.cfg
+++ b/tools/release/kokoro/macos/node_10_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "10.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_11_ia32.cfg
+++ b/tools/release/kokoro/macos/node_11_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "11.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_11_x64.cfg
+++ b/tools/release/kokoro/macos/node_11_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "11.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_12_ia32.cfg
+++ b/tools/release/kokoro/macos/node_12_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "12.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_12_x64.cfg
+++ b/tools/release/kokoro/macos/node_12_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "12.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_13_ia32.cfg
+++ b/tools/release/kokoro/macos/node_13_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "13.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_13_x64.cfg
+++ b/tools/release/kokoro/macos/node_13_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "13.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_4_ia32.cfg
+++ b/tools/release/kokoro/macos/node_4_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "4.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_4_x64.cfg
+++ b/tools/release/kokoro/macos/node_4_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "4.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_5_ia32.cfg
+++ b/tools/release/kokoro/macos/node_5_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "5.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_5_x64.cfg
+++ b/tools/release/kokoro/macos/node_5_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "5.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_6_ia32.cfg
+++ b/tools/release/kokoro/macos/node_6_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "6.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_6_x64.cfg
+++ b/tools/release/kokoro/macos/node_6_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "6.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_7_ia32.cfg
+++ b/tools/release/kokoro/macos/node_7_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "7.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_7_x64.cfg
+++ b/tools/release/kokoro/macos/node_7_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "7.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_8_ia32.cfg
+++ b/tools/release/kokoro/macos/node_8_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "8.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_8_x64.cfg
+++ b/tools/release/kokoro/macos/node_8_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "8.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_9_ia32.cfg
+++ b/tools/release/kokoro/macos/node_9_ia32.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "ia32"
+}
+env_vars {
+  key: "VERSION"
+  value: "9.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}

--- a/tools/release/kokoro/macos/node_9_x64.cfg
+++ b/tools/release/kokoro/macos/node_9_x64.cfg
@@ -1,0 +1,35 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+build_file: "grpc-node/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact_macos.sh"
+env_vars {
+  key: "RUNTIME"
+  value: "node"
+}
+env_vars {
+  key: "ARCH"
+  value: "x64"
+}
+env_vars {
+  key: "VERSION"
+  value: "9.0.0"
+}
+action {
+  define_artifacts {
+    regex: "github/grpc-node/artifacts/**",
+    strip_prefix: "github/grpc-node/artifacts"
+  }
+}


### PR DESCRIPTION
The shell script is basically a combination of pieces of https://github.com/grpc/grpc-node/blob/master/tools/release/kokoro-nodejs.sh, https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/tools/run_tests/artifacts/build_artifact_node.sh, and https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/tools/run_tests/artifacts/build_artifact_electron.sh. The configuration files were generated with a script using the architecture and version lists in those files.