### PR TITLE
Use correct environment variables in new windows build script

### DIFF
--- a/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact.bat
+++ b/packages/grpc-native-core/tools/run_tests/artifacts/build_one_artifact.bat
@@ -45,13 +45,13 @@ if "%RUNTIME%"=="electron" (
   set "npm_config_disturl=https://atom.io/download/electron"
 )
 
-call .\node_modules\.bin\node-pre-gyp.cmd configure build --target=%%v --target_arch=%%a && goto :EOF
+call .\node_modules\.bin\node-pre-gyp.cmd configure build --target=%VERSION% --target_arch=%ARCH% && goto :EOF
 @rem Try again after removing openssl headers
-rmdir "%USERPROFILE%\.node-gyp\%%v\include\node\openssl" /S /Q
-rmdir "%USERPROFILE%\.node-gyp\iojs-%%v\include\node\openssl" /S /Q
-rmdir "%USERPROFILE%\AppData\Local\node-gyp\cache\%%v\include\node\openssl" /S /Q
-rmdir "%USERPROFILE%\AppData\Local\node-gyp\cache\iojs-%%v\include\node\openssl" /S /Q
-call .\node_modules\.bin\node-pre-gyp.cmd build package --target=%%v --target_arch=%%a || goto :error
+rmdir "%USERPROFILE%\.node-gyp\%VERSION%\include\node\openssl" /S /Q
+rmdir "%USERPROFILE%\.node-gyp\iojs-%VERSION%\include\node\openssl" /S /Q
+rmdir "%USERPROFILE%\AppData\Local\node-gyp\cache\%VERSION%\include\node\openssl" /S /Q
+rmdir "%USERPROFILE%\AppData\Local\node-gyp\cache\iojs-%VERSION%\include\node\openssl" /S /Q
+call .\node_modules\.bin\node-pre-gyp.cmd build package --target=%VERSION% --target_arch=%ARCH% || goto :error
 
 xcopy /Y /I /S build\stage\* %ARTIFACTS_OUT%\ || goto :error
 


### PR DESCRIPTION
I guess I copied and pasted some code from inside a loop in the older script, and forgot to change the variables it was referring to.