### PR TITLE
Message parameter removing from cancel requester description

### DIFF
--- a/packages/grpc-native-core/src/client_interceptors.js
+++ b/packages/grpc-native-core/src/client_interceptors.js
@@ -51,7 +51,7 @@
  * `halfClose(next)`
  * * To continue, call next().
  *
- * `cancel(message, next)`
+ * `cancel(next)`
  * * To continue, call next().
  *
  * A listener is a POJO with one or more of the following methods:
@@ -109,7 +109,7 @@
  *     halfClose: function(next) {
  *       next();
  *     },
- *     cancel: function(message, next) {
+ *     cancel: function(next) {
  *       next();
  *     }
  *   });


### PR DESCRIPTION
Cancel requester description in `client_interceptors.js` does not match with `CancelRequester` typing.
It might be confusing for someone who wants to write such an interceptor.