### PR TITLE
grpc-js: Fix a trace line, and add a few new ones

### DIFF
--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -34,6 +34,7 @@ import {
   Subchannel,
   ConnectivityStateListener,
   SubchannelAddress,
+  subchannelAddressToString,
 } from './subchannel';
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
@@ -335,7 +336,12 @@ export class PickFirstLoadBalancer implements LoadBalancer {
    */
   private connectToAddressList(): void {
     this.resetSubchannelList();
-    trace('Connect to address list ' + this.latestAddressList);
+    trace(
+      'Connect to address list ' +
+        this.latestAddressList.map(address =>
+          subchannelAddressToString(address)
+        )
+    );
     this.subchannels = this.latestAddressList.map(address =>
       this.channelControlHelper.createSubchannel(address, {})
     );

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -34,7 +34,16 @@ import {
   Subchannel,
   ConnectivityStateListener,
   SubchannelAddress,
+  subchannelAddressToString,
 } from './subchannel';
+import * as logging from './logging';
+import { LogVerbosity } from './constants';
+
+const TRACER_NAME = 'round_robin';
+
+function trace(text: string): void {
+  logging.trace(LogVerbosity.DEBUG, TRACER_NAME, text);
+}
 
 const TYPE_NAME = 'round_robin';
 
@@ -147,6 +156,11 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
   }
 
   private updateState(newState: ConnectivityState, picker: Picker) {
+    trace(
+      ConnectivityState[this.currentState] +
+        ' -> ' +
+        ConnectivityState[newState]
+    );
     if (newState === ConnectivityState.READY) {
       this.currentReadyPicker = picker as RoundRobinPicker;
     } else {
@@ -176,6 +190,10 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
     lbConfig: LoadBalancingConfig | null
   ): void {
     this.resetSubchannelList();
+    trace(
+      'Connect to address list ' +
+        addressList.map(address => subchannelAddressToString(address))
+    );
     this.subchannels = addressList.map(address =>
       this.channelControlHelper.createSubchannel(address, {})
     );

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -112,6 +112,14 @@ export function subchannelAddressEqual(
   }
 }
 
+export function subchannelAddressToString(address: SubchannelAddress): string {
+  if (isTcpSubchannelAddress(address)) {
+    return address.host + ':' + address.port;
+  } else {
+    return address.path;
+  }
+}
+
 export class Subchannel {
   /**
    * The subchannel's current connectivity state. Invariant: `session` === `null`
@@ -231,11 +239,7 @@ export class Subchannel {
         );
       }
     }, backoffOptions);
-    if (isTcpSubchannelAddress(subchannelAddress)) {
-      this.subchannelAddressString = `${subchannelAddress.host}:${subchannelAddress.port}`;
-    } else {
-      this.subchannelAddressString = `${subchannelAddress.path}`;
-    }
+    this.subchannelAddressString = subchannelAddressToString(subchannelAddress);
   }
 
   /**
@@ -390,6 +394,11 @@ export class Subchannel {
     session.once('error', error => {
       /* Do nothing here. Any error should also trigger a close event, which is
        * where we want to handle that.  */
+      trace(
+        this.subchannelAddressString +
+          ' connection closed with error ' +
+          (error as Error).message
+      );
     });
   }
 

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -525,7 +525,7 @@ export class Subchannel {
   ref() {
     trace(
       this.subchannelAddressString +
-        ' callRefcount ' +
+        ' refcount ' +
         this.refcount +
         ' -> ' +
         (this.refcount + 1)
@@ -536,7 +536,7 @@ export class Subchannel {
   unref() {
     trace(
       this.subchannelAddressString +
-        ' callRefcount ' +
+        ' refcount ' +
         this.refcount +
         ' -> ' +
         (this.refcount - 1)


### PR DESCRIPTION
This fixes the tracer in the pick first load balancer that outputs the list of addresses to properly stringify them. It also adds a tracer that shows the original error when an http2 session fails, and adds a couple of trace lines to the the round robin load balancer that are the same as in the pick first load balancer.