### PR TITLE
grpc-js: Detect and error on multiple auth headers

### DIFF
--- a/packages/grpc-js/src/call-credentials-filter.ts
+++ b/packages/grpc-js/src/call-credentials-filter.ts
@@ -20,6 +20,7 @@ import { Call } from './call-stream';
 import { Channel } from './channel';
 import { BaseFilter, Filter, FilterFactory } from './filter';
 import { Metadata } from './metadata';
+import { Status } from './constants';
 
 export class CallCredentialsFilter extends BaseFilter implements Filter {
   private serviceUrl: string;
@@ -50,6 +51,12 @@ export class CallCredentialsFilter extends BaseFilter implements Filter {
     });
     const resultMetadata = await metadata;
     resultMetadata.merge(await credsMetadata);
+    if (resultMetadata.get('authorization').length > 1) {
+      this.stream.cancelWithStatus(
+        Status.INTERNAL,
+        '"authorization" metadata cannot have multiple values'
+      );
+    }
     return resultMetadata;
   }
 }


### PR DESCRIPTION
In the metadata, if the "authorization" header has multiple values, it will be rejected by the http2 library (see e.g. #894). We want to detect this early and report an error so that we don't get into a retry loop when the http2 library fails to start a stream. We shouldn't just arbitrarily use one of the values because this error indicates either a user error, which the user needs to know about, or a library error, which we need to know about.