### PR TITLE
grpc-js: server calls: Don't try to send an error on stream error

### DIFF
--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -346,8 +346,11 @@ export class Http2ServerCallStream<
     super();
 
     this.stream.once('error', (err: ServerErrorResponse) => {
-      err.code = Status.INTERNAL;
-      this.sendError(err);
+      /* We need an error handler to avoid uncaught error event exceptions, but
+       * there is nothing we can reasonably do here. Any error event should
+       * have a corresponding close event, which handles emitting the cancelled
+       * event. And the stream is now in a bad state, so we can't reasonably
+       * expect to be able to send an error over it. */
     });
 
     this.stream.once('close', () => {


### PR DESCRIPTION
I expect that this will fix #1279. We shouldn't be trying to send trailers (or anything) over a stream that is in some kind of error state.