### PR TITLE
grpc-js: tests: skip checking for IPv6 addresses from DNS servers

### DIFF
--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -214,7 +214,9 @@ describe('Name Resolver', () => {
       const resolver = resolverManager.createResolver(target, listener);
       resolver.updateResolution();
     });
-    it('Should resolve a DNS name to an IPv6 address', done => {
+    /* TODO(murgatroid99): re-enable this test, once we can get the IPv6 result
+     * consistently */
+    it.skip('Should resolve a DNS name to an IPv6 address', done => {
       const target = 'loopback6.unittest.grpc.io';
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
@@ -255,14 +257,8 @@ describe('Name Resolver', () => {
                 addr.port === 443
             )
           );
-          assert(
-            addressList.some(
-              addr =>
-                isTcpSubchannelAddress(addr) &&
-                addr.host === '::1' &&
-                addr.port === 443
-            )
-          );
+          /* TODO(murgatroid99): check for IPv6 result, once we can get that
+           * consistently */
           done();
         },
         onError: (error: StatusObject) => {


### PR DESCRIPTION
This should fix #1289. I think this is the right way to move forward until changes can be made to Node itself to allow us to get AAAA records more consistently using `dns.lookup`.