### PR TITLE
proto-loader: Warn if file not found in imports

### DIFF
--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -302,6 +302,7 @@ function addIncludePathResolver(root: Protobuf.Root, includePaths: string[]) {
         continue;
       }
     }
+    process.emitWarning(`${target} not found in any of the include paths ${includePaths}`);
     return originalResolvePath(origin, target);
   };
 }


### PR DESCRIPTION
This fixes #1298. I'm not changing any behavior, just adding an informative warning.