### PR TITLE
grpc-js: Update some types and type checks for compatibility with grpc-gcp

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -146,8 +146,10 @@ export class ChannelImplementation implements Channel {
     if (!(credentials instanceof ChannelCredentials)) {
       throw new TypeError('Channel credentials must be a ChannelCredentials object');
     }
-    if ((typeof options !== 'object') || !Object.values(options).every(value => typeof value === 'string' || typeof value === 'number')) {
-      throw new TypeError('Channel options must be an object with string or number values');
+    if (options) {
+      if ((typeof options !== 'object') || !Object.values(options).every(value => typeof value === 'string' || typeof value === 'number')) {
+        throw new TypeError('Channel options must be an object with string or number values');
+      }
     }
     /* The global boolean parameter to getSubchannelPool has the inverse meaning to what
      * the grpc.use_local_subchannel_pool channel option means. */

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -147,7 +147,7 @@ export class ChannelImplementation implements Channel {
       throw new TypeError('Channel credentials must be a ChannelCredentials object');
     }
     if (options) {
-      if ((typeof options !== 'object') || !Object.values(options).every(value => typeof value === 'string' || typeof value === 'number')) {
+      if ((typeof options !== 'object') || !Object.values(options).every(value => typeof value === 'string' || typeof value === 'number' || typeof value === 'undefined')) {
         throw new TypeError('Channel options must be an object with string or number values');
       }
     }

--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -48,6 +48,7 @@ import {
   InterceptorArguments,
   InterceptingCallInterface,
 } from './client-interceptors';
+import { ServerUnaryCall, ServerReadableStream, ServerWritableStream, ServerDuplexStream } from './server-call';
 
 const CHANNEL_SYMBOL = Symbol();
 const INTERCEPTOR_SYMBOL = Symbol();
@@ -61,8 +62,7 @@ export interface UnaryCallback<ResponseType> {
 export interface CallOptions {
   deadline?: Deadline;
   host?: string;
-  /* There should be a parent option here that will accept a server call,
-   * but the server is not yet implemented so it makes no sense to have it */
+  parent?: ServerUnaryCall<any, any> | ServerReadableStream<any, any> | ServerWritableStream<any, any> | ServerDuplexStream<any, any>
   propagate_flags?: number;
   credentials?: CallCredentials;
   interceptors?: Interceptor[];

--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -109,10 +109,28 @@ export class Client {
     credentials: ChannelCredentials,
     options: ClientOptions = {}
   ) {
+    options = Object.assign({}, options);
+    this[INTERCEPTOR_SYMBOL] = options.interceptors ?? [];
+    delete options.interceptors;
+    this[INTERCEPTOR_PROVIDER_SYMBOL] = options.interceptor_providers ?? [];
+    delete options.interceptor_providers;
+    if (
+      this[INTERCEPTOR_SYMBOL].length > 0 &&
+      this[INTERCEPTOR_PROVIDER_SYMBOL].length > 0
+    ) {
+      throw new Error(
+        'Both interceptors and interceptor_providers were passed as options ' +
+          'to the client constructor. Only one of these is allowed.'
+      );
+    }
+    this[CALL_INVOCATION_TRANSFORMER_SYMBOL] = options.callInvocationTransformer;
+    delete options.callInvocationTransformer;
     if (options.channelOverride) {
       this[CHANNEL_SYMBOL] = options.channelOverride;
     } else if (options.channelFactoryOverride) {
-      this[CHANNEL_SYMBOL] = options.channelFactoryOverride(
+      const channelFactoryOverride = options.channelFactoryOverride;
+      delete options.channelFactoryOverride;
+      this[CHANNEL_SYMBOL] = channelFactoryOverride(
         address,
         credentials,
         options
@@ -124,18 +142,6 @@ export class Client {
         options
       );
     }
-    this[INTERCEPTOR_SYMBOL] = options.interceptors ?? [];
-    this[INTERCEPTOR_PROVIDER_SYMBOL] = options.interceptor_providers ?? [];
-    if (
-      this[INTERCEPTOR_SYMBOL].length > 0 &&
-      this[INTERCEPTOR_PROVIDER_SYMBOL].length > 0
-    ) {
-      throw new Error(
-        'Both interceptors and interceptor_providers were passed as options ' +
-          'to the client constructor. Only one of these is allowed.'
-      );
-    }
-    this[CALL_INVOCATION_TRANSFORMER_SYMBOL] = options.callInvocationTransformer;
   }
 
   close(): void {

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -28,7 +28,7 @@ import { CallCredentials } from './call-credentials';
 import { Deadline, StatusObject } from './call-stream';
 import { Channel, ConnectivityState, ChannelImplementation } from './channel';
 import { ChannelCredentials } from './channel-credentials';
-import { CallOptions, Client } from './client';
+import { CallOptions, Client, CallInvocationTransformer, CallProperties } from './client';
 import { LogVerbosity, Status } from './constants';
 import * as logging from './logging';
 import {
@@ -199,7 +199,10 @@ export {
   loadPackageDefinition,
   makeClientConstructor,
   makeClientConstructor as makeGenericClientConstructor,
+  CallProperties,
+  CallInvocationTransformer,
   ChannelImplementation as Channel,
+  Channel as ChannelInterface
 };
 
 /**


### PR DESCRIPTION
This includes these changes:

 - Export a few types that are helpful in using some APIs
 - Fix the parent call option type
 - Update the channel interface to match the original proposal
 - Add some runtime type checks because grpc-gcp tests for those and the code won't work correctly anyway if they're wrong.

I successfully built and tested a modified grpc-gcp with these changes.