### PR TITLE
Allow SSL credential parameters to be specified using (PEM) string.

### DIFF
--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -53,7 +53,7 @@ function bufferOrStringOrNullEqual(buf1: Buffer | string | null, buf2: Buffer | 
     return true;
   } else {
     return buf1 !== null && buf2 !== null && (buf1 === buf2 ||
-        (buf1 instanceof Buffer && buf2 instanceof Buffer && (<Buffer> buf1).equals(<Buffer> buf2)));
+        (buf1 instanceof Buffer && (buf1 as Buffer).equals(buf2 as Buffer)));
   }
 }
 

--- a/packages/grpc-js/test/test-channel-credentials.ts
+++ b/packages/grpc-js/test/test-channel-credentials.ts
@@ -59,6 +59,13 @@ const pFixtures = Promise.all(
 ).then(result => {
   return { ca: result[0], key: result[1], cert: result[2] };
 });
+const sFixtures = pFixtures.then(result => {
+  return {
+    ca: result.ca.toString('utf8'),
+    key: result.key.toString('utf8'),
+    cert: result.cert.toString('utf8')
+  };
+});
 
 describe('ChannelCredentials Implementation', () => {
   describe('createInsecure', () => {
@@ -110,6 +117,14 @@ describe('ChannelCredentials Implementation', () => {
       assert.throws(() => ChannelCredentials.createSsl(null, key));
       assert.throws(() => ChannelCredentials.createSsl(null, key, null));
       assert.throws(() => ChannelCredentials.createSsl(null, null, cert));
+    });
+
+    it('should work with three parameters specified as PEM string', async () => {
+      const { ca, key, cert } = await sFixtures;
+      const creds = assert2.noThrowAndReturn(() =>
+        ChannelCredentials.createSsl(ca, key, cert)
+      );
+      assert.ok(!!creds._getConnectionOptions());
     });
   });
 


### PR DESCRIPTION
This enables use of ssl credentials in browser-only environment (no Buffer available), as well as widens the supported API in nodejs environment thanks to 'tls' module supporting both kinds of parameters.