### PR TITLE
grpc-js: Don't wait for TXT record to return DNS lookup result

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -321,6 +321,8 @@ export class Server {
 
     const resolverListener: ResolverListener = {
       onSuccessfulResolution: (addressList, serviceConfig, serviceConfigError) => {
+        // We only want one resolution result. Discard all future results
+        resolverListener.onSuccessfulResolution = () => {}
         if (addressList.length === 0) {
           callback(new Error(`No addresses resolved for port ${port}`), 0);
           return;

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -38,6 +38,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(
             addressList.some(
               addr =>
@@ -71,6 +73,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(
             addressList.some(
               addr =>
@@ -104,6 +108,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(
             addressList.some(
               addr =>
@@ -129,6 +135,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(
             addressList.some(
               addr =>
@@ -154,6 +162,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(
             addressList.some(
               addr =>
@@ -179,6 +189,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(addressList.length > 0);
           done();
         },
@@ -197,6 +209,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(
             addressList.some(
               addr =>
@@ -224,6 +238,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(
             addressList.some(
               addr =>
@@ -249,6 +265,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(
             addressList.some(
               addr =>
@@ -278,6 +296,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(addressList.length > 0);
           done();
         },
@@ -290,16 +310,6 @@ describe('Name Resolver', () => {
     });
     it('Should resolve gRPC interop servers', done => {
       let completeCount = 0;
-      function done2(error?: Error) {
-        if (error) {
-          done(error);
-        } else {
-          completeCount += 1;
-          if (completeCount === 2) {
-            done();
-          }
-        }
-      }
       const target1 = 'grpc-test.sandbox.googleapis.com';
       const target2 = 'grpc-test4.sandbox.googleapis.com';
       const listener: resolverManager.ResolverListener = {
@@ -309,10 +319,15 @@ describe('Name Resolver', () => {
           serviceConfigError: StatusObject | null
         ) => {
           assert(addressList.length > 0);
-          done2();
+          completeCount += 1;
+          if (completeCount === 2) {
+            // Only handle the first resolution result
+            listener.onSuccessfulResolution = () => {};
+            done();
+          }
         },
         onError: (error: StatusObject) => {
-          done2(new Error(`Failed with status ${error.details}`));
+          done(new Error(`Failed with status ${error.details}`));
         },
       };
       const resolver1 = resolverManager.createResolver(target1, listener);
@@ -330,6 +345,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(
             addressList.some(
               addr => !isTcpSubchannelAddress(addr) && addr.path === 'socket'
@@ -352,6 +369,8 @@ describe('Name Resolver', () => {
           serviceConfig: ServiceConfig | null,
           serviceConfigError: StatusObject | null
         ) => {
+          // Only handle the first resolution result
+          listener.onSuccessfulResolution = () => {};
           assert(
             addressList.some(
               addr =>


### PR DESCRIPTION
This change makes the DNS resolver return a `null` service config if it gets the addresses before the TXT record, and then update the service config later if and when it gets one.

Currently the service config is only used to set which load balancing policy is used, so the most significant possible functional impact from this change is that the a client that is supposed to use round robin will send all requests to one address for a few seconds before switching to round robin. And round robin will start sending requests to the first address that connects anyway.

Also, I put IPv6 addresses before IPv4 in the merge call on purpose. It was always supposed to be that way.