### PR TITLE
grpc-js: export InterceptorOptions

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -294,6 +294,7 @@ export {
   ListenerBuilder,
   RequesterBuilder,
   Interceptor,
+  InterceptorOptions,
   InterceptorProvider,
   InterceptingCall,
   InterceptorConfigurationError,


### PR DESCRIPTION
InterceptorOptions extends CallOptions with the addition of method_definition property