### PR TITLE
PickFirstLoadBalancer: Only change to TRANSIENT_FAILURE when all channels fail

### DIFF
--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -173,8 +173,8 @@ export class PickFirstLoadBalancer implements LoadBalancer {
             if (this.subchannelStateCounts[ConnectivityState.CONNECTING] > 0) {
               newLBState = ConnectivityState.CONNECTING;
             } else if (
-              this.subchannelStateCounts[ConnectivityState.TRANSIENT_FAILURE] >
-              0
+              this.subchannelStateCounts[ConnectivityState.TRANSIENT_FAILURE] ==
+              this.subchannels.length
             ) {
               newLBState = ConnectivityState.TRANSIENT_FAILURE;
             } else {


### PR DESCRIPTION
This happens when a device doesn't have IPv6 address, but the endpoint
address is resolved to both IPv4 and IPv6 addresses.

The automatic attempt to reconnect that fails is detected as another channel
failure, which leads the load balancer to abort the connection.

Fixes #664
Fixes #692