### PR TITLE
grpc-js: Don't time out connection attempts

### DIFF
--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -230,12 +230,12 @@ export class Subchannel {
     this.backoffTimeout = new BackoffTimeout(() => {
       if (this.continueConnecting) {
         this.transitionToState(
-          [ConnectivityState.TRANSIENT_FAILURE, ConnectivityState.CONNECTING],
+          [ConnectivityState.TRANSIENT_FAILURE],
           ConnectivityState.CONNECTING
         );
       } else {
         this.transitionToState(
-          [ConnectivityState.TRANSIENT_FAILURE, ConnectivityState.CONNECTING],
+          [ConnectivityState.TRANSIENT_FAILURE],
           ConnectivityState.IDLE
         );
       }


### PR DESCRIPTION
The purpose of the backoff timer is to enforce a minimum time between connection attempts. Transitioning from from CONNECTING to IDLE does not serve that purpose. I think that we can trust that Node will eventually time out connection attempts on its own, and that will result in a proper transition to TRANSIENT_FAILURE.

The reason I want to do this is to fix the problem described in https://github.com/grpc/grpc-node/pull/1322#issuecomment-606237127.