### PR TITLE
grpc-js: Make some headers conform to what the other library does

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/compression-filter.ts
+++ b/packages/grpc-js/src/compression-filter.ts
@@ -169,8 +169,8 @@ export class CompressionFilter extends BaseFilter implements Filter {
   private receiveCompression: CompressionHandler = new IdentityHandler();
   async sendMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
     const headers: Metadata = await metadata;
-    headers.set('grpc-encoding', 'identity');
     headers.set('grpc-accept-encoding', 'identity,deflate,gzip');
+    headers.set('accept-encoding', 'identity,gzip');
     return headers;
   }
 

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -298,10 +298,16 @@ class DnsResolver implements Resolver {
       IPV6_REGEX.exec(target) ||
       IPV6_BRACKET_REGEX.exec(target);
     if (ipMatch) {
+      if (ipMatch[2]) {
+        return ipMatch[1] + ':' + ipMatch[2];
+      }
       return ipMatch[1];
     }
     const dnsMatch = DNS_REGEX.exec(target);
     if (dnsMatch) {
+      if (dnsMatch[2]) {
+        return dnsMatch[1] + ':' + dnsMatch[2];
+      }
       return dnsMatch[1];
     }
     throw new Error(`Failed to parse target ${target}`);

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -298,8 +298,6 @@ export class Subchannel {
           return checkServerIdentity(sslTargetNameOverride, cert);
         };
         connectionOptions.servername = sslTargetNameOverride;
-      } else {
-        connectionOptions.servername = getDefaultAuthority(this.channelTarget);
       }
       if (socket) {
         connectionOptions.socket = socket;
@@ -589,6 +587,11 @@ export class Subchannel {
     headers[HTTP2_HEADER_PATH] = callStream.getMethod();
     headers[HTTP2_HEADER_TE] = 'trailers';
     const http2Stream = this.session!.request(headers);
+    let headersString = '';
+    for (const header of Object.keys(headers)) {
+      headersString += '\t\t' + header + ': ' + headers[header] + '\n'
+    }
+    trace('Starting stream with headers\n' + headersString);
     callStream.attachHttp2Stream(http2Stream, this);
   }
 


### PR DESCRIPTION
This changes a few headers:

 - `:authority` now includes the port number if it was specified in the channel target
 - `accept-encoding: identity, gzip` is now sent
 - `grpc-encoding: identity` is now omitted

I also added more detailed header tracing. For technical reasons the initial client header trace does not have a call number. We can plumb that through later but for now this is better than nothing.

I also added separate explicit tracing for receiving status code and details in the trailing metadata. Technically it's redundant with the trailing metadata tracing but I think it's easier to see when traced separately like that.