### PR TITLE
grpc-js: Fix status check when connecting to proxy

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -58,7 +58,7 @@ function getProxyInfo(): ProxyInfo {
   try {
     proxyUrl = new URL(proxyEnv);
   } catch (e) {
-    log(LogVerbosity.INFO, `cannot parse value of "${envVar}" env var`);
+    log(LogVerbosity.ERROR, `cannot parse value of "${envVar}" env var`);
     return {};
   }
   if (proxyUrl.protocol !== 'http:') {
@@ -145,17 +145,17 @@ export function getProxiedConnection(target: string, subchannelAddress: Subchann
     request.once('connect', (res, socket, head) => {
       request.removeAllListeners();
       socket.removeAllListeners();
-      if (res.statusCode === http.STATUS_CODES.OK) {
+      if (res.statusCode === 200) {
         trace('Successfully connected to ' + subchannelAddress + ' through proxy ' + PROXY_INFO.address);
         resolve(socket);
       } else {
-        trace('Failed to connect to ' + subchannelAddress + ' through proxy ' + PROXY_INFO.address);
+        log(LogVerbosity.ERROR, 'Failed to connect to ' + subchannelAddress + ' through proxy ' + PROXY_INFO.address);
         reject();
       }
     });
     request.once('error', (err) => {
       request.removeAllListeners();
-      trace('Failed to connect to proxy ' + PROXY_INFO.address);
+      log(LogVerbosity.ERROR, 'Failed to connect to proxy ' + PROXY_INFO.address);
       reject();
     });
   });


### PR DESCRIPTION
It turns out that `http.STATUS_CODES` does not actually map status code names to status code numbers as I thought.

I also upgraded the verbosity of some logs so that if one of the environment variables is set and the proxy cannot be used, the user should always see at least one error log.