### PR TITLE
grpc-js: adjust ts definitions to equal native-core

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -35,6 +35,7 @@ import {
   Deserialize,
   loadPackageDefinition,
   makeClientConstructor,
+  MethodDefinition,
   Serialize,
   ServiceDefinition,
 } from './make-client';
@@ -230,6 +231,7 @@ export {
   ClientWritableStream,
   ClientDuplexStream,
   CallOptions,
+  MethodDefinition,
   StatusObject,
   ServiceError,
   ServerUnaryCall,

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -18,6 +18,7 @@
 import { ChannelCredentials } from './channel-credentials';
 import { ChannelOptions } from './channel-options';
 import { Client } from './client';
+import { UntypedServiceImplementation } from './server';
 
 export interface Serialize<T> {
   (value: T): Buffer;
@@ -49,9 +50,9 @@ export interface MethodDefinition<RequestType, ResponseType>
   extends ClientMethodDefinition<RequestType, ResponseType>,
     ServerMethodDefinition<RequestType, ResponseType> {}
 
-export interface ServiceDefinition {
+export type ServiceDefinition<ImplementationType = UntypedServiceImplementation> = {
   // tslint:disable-next-line no-any
-  [index: string]: MethodDefinition<any, any>;
+  readonly [index in keyof ImplementationType]: MethodDefinition<any, any>;
 }
 
 export interface ProtobufTypeDefinition {


### PR DESCRIPTION
## Why
I tried to use the @grpc/grpc-js package with typescript definitions generated by [grpc_tools_node_protoc_ts](https://github.com/agreatfool/grpc_tools_node_protoc_ts). But the miss export of type `MethodDefinition` (which is exported in [native-core's index.d.ts](https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/index.d.ts)) made it impossible. Also I adjusted the ServiceDefinition. 

This will also help to for #931

## Changes
Export `MethodDefinition` in index.ts and add generic `ImplementationType`
to `ServiceDefinition`.