### PR TITLE
grpc-js: Don't include the port in :authority

### DIFF
--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -298,16 +298,10 @@ class DnsResolver implements Resolver {
       IPV6_REGEX.exec(target) ||
       IPV6_BRACKET_REGEX.exec(target);
     if (ipMatch) {
-      if (ipMatch[2]) {
-        return ipMatch[1] + ':' + ipMatch[2];
-      }
       return ipMatch[1];
     }
     const dnsMatch = DNS_REGEX.exec(target);
     if (dnsMatch) {
-      if (dnsMatch[2]) {
-        return dnsMatch[1] + ':' + dnsMatch[2];
-      }
       return dnsMatch[1];
     }
     throw new Error(`Failed to parse target ${target}`);


### PR DESCRIPTION
#1341 was the only change from 0.7.6 to 0.7.7 and this looks like the only part of it that could reasonably explain #1347.