### PR TITLE
grpc-js: Interact with proxies properly

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -145,7 +145,7 @@ export function mapProxyName(
     extraOptions['grpc.http_connect_creds'] = proxyInfo.creds;
   }
   return {
-    target: `dns:///${proxyInfo.address}`,
+    target: `dns:${proxyInfo.address}`,
     extraOptions: extraOptions,
   };
 }

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -171,7 +171,15 @@ class DnsResolver implements Resolver {
       });
       return;
     }
-    if (this.dnsHostname !== null) {
+    if (this.dnsHostname === null) {
+      setImmediate(() => {
+        this.listener.onError({
+          code: Status.UNAVAILABLE,
+          details: `Failed to parse DNS address ${this.target}`,
+          metadata: new Metadata(),
+        });
+      });
+    } else {
       /* We clear out latestLookupResult here to ensure that it contains the
        * latest result since the last time we started resolving. That way, the
        * TXT resolution handler can use it, but only if it finishes second. We


### PR DESCRIPTION
This makes grpc-js handle proxies the same way the C core library does: the proxy address is treated as the channel target for name resolution and creating subchannels, and the original target is stored in a channel option until it is needed when the subchannel establishes a connection.

In `http_proxy.ts`, `mapProxyName` corresponds to [`HttpProxyMapper::MapName`](https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/http_proxy.cc#L100) and `getProxiedConnection` corresponds to [`HttpConnectHandshaker::DoHandshake`](https://github.com/grpc/grpc/blob/433439bc77a796552f23e432cbcc46c30d75f6b5/src/core/ext/filters/client_channel/http_connect_handshaker.cc#L278).

Local testing on my own computer shows the proxy server responding with an error, but I have a feeling the proxy server isn't happy trying to connect to `localhost` because it's running in a Docker container.