### PR TITLE
grpc-js: Fix how package.json is loaded

### DIFF
--- a/packages/grpc-js/.eslintrc
+++ b/packages/grpc-js/.eslintrc
@@ -5,6 +5,7 @@
     "node/no-unpublished-import": ["error", {
         "tryExtensions": [".ts", ".js", ".json", ".node"]
     }],
-    "@typescript-eslint/no-unused-vars": "off"
+    "@typescript-eslint/no-unused-vars": "off",
+    "node/no-unpublished-require": "off"
   }
 }

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -62,8 +62,7 @@ import {
   ServerDuplexStream,
 } from './server-call';
 
-import { engines as supportedEngines } from '../package.json';
-const supportedNodeVersions = supportedEngines.node;
+const supportedNodeVersions = require('../../package.json').engines.node;
 if (!semver.satisfies(process.version, supportedNodeVersions)) {
   throw new Error(`@grpc/grpc-js only works on Node ${supportedNodeVersions}`);
 }

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -29,7 +29,7 @@ import { LogVerbosity } from './constants';
 import { shouldUseProxy, getProxiedConnection } from './http_proxy';
 import * as net from 'net';
 
-import { version as clientVersion } from '../package.json';
+const clientVersion = require('../../package.json').version;
 
 const TRACER_NAME = 'subchannel';
 


### PR DESCRIPTION
Apparently if you `import` your `package.json` file in a TypeScript project, the TypeScript compiler puts a copy of `package.json` into the `build` directory. And this apparently causes `npm` to not publish any `.js` files from that directory, completely breaking the package.

So, I'm putting it back to a `require` call and disabling the `gts` rule that told us to use `import` in the first place.

This fixes #1357.