### PR TITLE
grpc-js: Use a more structured representation of URIs internally

### DIFF
--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -213,7 +213,7 @@ export function getProxiedConnection(
            * See https://github.com/grpc/grpc-node/pull/1369 for more info. */
           const cts = tls.connect({
               ...connectionOptions,
-              host: getDefaultAuthority(realTarget),
+              host: getDefaultAuthority(parsedTarget),
               socket: socket,
             }, () => {
               resolve({ socket: cts, realTarget: parsedTarget });

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -270,7 +270,7 @@ class DnsResolver implements Resolver {
     if (hostPort !== null) {
       return hostPort.host;
     } else {
-      throw new Error(`Failed to parse target ${target}`);
+      throw new Error(`Failed to parse target ${uriToString(target)}`);
     }
   }
 }

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -35,6 +35,7 @@ import { Metadata } from './metadata';
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
 import { SubchannelAddress } from './subchannel';
+import { GrpcUri } from './uri-parser';
 
 const TRACER_NAME = 'resolving_load_balancer';
 
@@ -126,7 +127,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
    *     implmentation
    */
   constructor(
-    private target: string,
+    private target: GrpcUri,
     private channelControlHelper: ChannelControlHelper,
     private defaultServiceConfig: ServiceConfig | null
   ) {

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -52,6 +52,7 @@ import {
   TcpSubchannelAddress,
   isTcpSubchannelAddress,
 } from './subchannel';
+import { parseUri } from './uri-parser';
 
 interface BindResult {
   port: number;
@@ -225,6 +226,11 @@ export class Server {
       throw new TypeError('callback must be a function');
     }
 
+    const portUri = parseUri(port);
+    if (portUri === null) {
+      throw new Error(`Could not parse port "${port}"`);
+    }
+
     const serverOptions: http2.ServerOptions = {};
     if ('grpc.max_concurrent_streams' in this.options) {
       serverOptions.settings = {
@@ -392,7 +398,7 @@ export class Server {
       },
     };
 
-    const resolver = createResolver(port, resolverListener);
+    const resolver = createResolver(portUri, resolverListener);
     resolver.updateResolution();
   }
 

--- a/packages/grpc-js/src/subchannel-pool.ts
+++ b/packages/grpc-js/src/subchannel-pool.ts
@@ -22,6 +22,7 @@ import {
   subchannelAddressEqual,
 } from './subchannel';
 import { ChannelCredentials } from './channel-credentials';
+import { GrpcUri, uriToString } from './uri-parser';
 
 // 10 seconds in milliseconds. This value is arbitrary.
 /**
@@ -114,13 +115,13 @@ export class SubchannelPool {
    * @param channelCredentials
    */
   getOrCreateSubchannel(
-    channelTarget: string,
+    channelTargetUri: GrpcUri,
     subchannelTarget: SubchannelAddress,
     channelArguments: ChannelOptions,
     channelCredentials: ChannelCredentials
   ): Subchannel {
     this.ensureCleanupTask();
-
+    const channelTarget = uriToString(channelTargetUri);
     if (channelTarget in this.pool) {
       const subchannelObjArray = this.pool[channelTarget];
       for (const subchannelObj of subchannelObjArray) {
@@ -141,7 +142,7 @@ export class SubchannelPool {
     }
     // If we get here, no matching subchannel was found
     const subchannel = new Subchannel(
-      channelTarget,
+      channelTargetUri,
       subchannelTarget,
       channelArguments,
       channelCredentials

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -28,6 +28,7 @@ import * as logging from './logging';
 import { LogVerbosity } from './constants';
 import { getProxiedConnection, ProxyConnectionResult } from './http_proxy';
 import * as net from 'net';
+import { GrpcUri } from './uri-parser';
 
 const clientVersion = require('../../package.json').version;
 
@@ -199,7 +200,7 @@ export class Subchannel {
    *     connection
    */
   constructor(
-    private channelTarget: string,
+    private channelTarget: GrpcUri,
     private subchannelAddress: SubchannelAddress,
     private options: ChannelOptions,
     private credentials: ChannelCredentials

--- a/packages/grpc-js/src/uri-parser.ts
+++ b/packages/grpc-js/src/uri-parser.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export interface GrpcUri {
+  scheme?: string;
+  authority?: string;
+  path: string;
+}
+
+/*
+ * The groups correspond to URI parts as follows:
+ * 1. scheme
+ * 2. authority
+ * 3. path
+ */
+const URI_REGEX = /^(?:([A-Za-z0-9+.-]+):)?(?:\/\/([^/]*)\/)?(.+)$/;
+
+export function parseUri(uriString: string): GrpcUri | null {
+  const parsedUri = URI_REGEX.exec(uriString);
+  if (parsedUri === null) {
+    return null;
+  }
+  return {
+    scheme: parsedUri[1],
+    authority: parsedUri[2],
+    path: parsedUri[3],
+  };
+}
+
+export interface HostPort {
+  host: string;
+  port?: number;
+}
+
+const NUMBER_REGEX = /^\d+$/;
+
+export function splitHostPort(path: string): HostPort | null {
+  if (path.startsWith('[')) {
+    const hostEnd = path.indexOf(']');
+    if (hostEnd === -1) {
+      return null;
+    }
+    const host = path.substring(1, hostEnd);
+    /* Only an IPv6 address should be in bracketed notation, and an IPv6
+     * address should have at least one colon */
+    if (host.indexOf(':') === -1) {
+      return null;
+    }
+    if (path.length > hostEnd + 1) {
+      if (path[hostEnd + 1] === ':') {
+        const portString = path.substring(hostEnd + 2);
+        if (NUMBER_REGEX.test(portString)) {
+          return {
+            host: host,
+            port: +portString,
+          };
+        } else {
+          return null;
+        }
+      } else {
+        return null;
+      }
+    } else {
+      return {
+        host,
+      };
+    }
+  } else {
+    const splitPath = path.split(':');
+    /* Exactly one colon means that this is host:port. Zero colons means that
+     * there is no port. And multiple colons means that this is a bare IPv6
+     * address with no port */
+    if (splitPath.length === 2) {
+      if (NUMBER_REGEX.test(splitPath[1])) {
+        return {
+          host: splitPath[0],
+          port: +splitPath[1],
+        };
+      } else {
+        return null;
+      }
+    } else {
+      return {
+        host: path,
+      };
+    }
+  }
+}
+
+export function uriToString(uri: GrpcUri): string {
+  let result = '';
+  if (uri.scheme !== undefined) {
+    result += uri.scheme + ':';
+  }
+  if (uri.authority !== undefined) {
+    result += '//' + uri.authority + '/';
+  }
+  result += uri.path;
+  return result;
+}

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -400,7 +400,7 @@ describe('Name Resolver', () => {
     }
 
     it('Should return the correct authority if a different resolver has been registered', () => {
-      const target = parseUri('other://name')!;
+      const target = parseUri('other:name')!;
       resolverManager.registerResolver('other:', OtherResolver);
 
       const authority = resolverManager.getDefaultAuthority(target);

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -22,6 +22,7 @@ import * as resolverManager from '../src/resolver';
 import { ServiceConfig } from '../src/service-config';
 import { StatusObject } from '../src/call-stream';
 import { SubchannelAddress, isTcpSubchannelAddress } from '../src/subchannel';
+import { parseUri, GrpcUri } from '../src/uri-parser';
 
 describe('Name Resolver', () => {
   describe('DNS Names', function() {
@@ -31,7 +32,7 @@ describe('Name Resolver', () => {
       resolverManager.registerAll();
     });
     it('Should resolve localhost properly', done => {
-      const target = 'localhost:50051';
+      const target = parseUri('localhost:50051')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -66,7 +67,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should default to port 443', done => {
-      const target = 'localhost';
+      const target = parseUri('localhost')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -101,7 +102,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should correctly represent an ipv4 address', done => {
-      const target = '1.2.3.4';
+      const target = parseUri('1.2.3.4')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -128,7 +129,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should correctly represent an ipv6 address', done => {
-      const target = '::1';
+      const target = parseUri('::1')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -155,7 +156,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should correctly represent a bracketed ipv6 address', done => {
-      const target = '[::1]:50051';
+      const target = parseUri('[::1]:50051')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -182,7 +183,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should resolve a public address', done => {
-      const target = 'example.com';
+      const target = parseUri('example.com')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -202,7 +203,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should resolve a name with multiple dots', done => {
-      const target = 'loopback4.unittest.grpc.io';
+      const target = parseUri('loopback4.unittest.grpc.io')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -231,7 +232,7 @@ describe('Name Resolver', () => {
     /* TODO(murgatroid99): re-enable this test, once we can get the IPv6 result
      * consistently */
     it.skip('Should resolve a DNS name to an IPv6 address', done => {
-      const target = 'loopback6.unittest.grpc.io';
+      const target = parseUri('loopback6.unittest.grpc.io')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -258,7 +259,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should resolve a DNS name to IPv4 and IPv6 addresses', done => {
-      const target = 'loopback46.unittest.grpc.io';
+      const target = parseUri('loopback46.unittest.grpc.io')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -289,7 +290,7 @@ describe('Name Resolver', () => {
     it('Should resolve a name with a hyphen', done => {
       /* TODO(murgatroid99): Find or create a better domain name to test this with.
        * This is just the first one I found with a hyphen. */
-      const target = 'network-tools.com';
+      const target = parseUri('network-tools.com')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -310,8 +311,8 @@ describe('Name Resolver', () => {
     });
     it('Should resolve gRPC interop servers', done => {
       let completeCount = 0;
-      const target1 = 'grpc-test.sandbox.googleapis.com';
-      const target2 = 'grpc-test4.sandbox.googleapis.com';
+      const target1 = parseUri('grpc-test.sandbox.googleapis.com')!;
+      const target2 = parseUri('grpc-test4.sandbox.googleapis.com')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -332,13 +333,13 @@ describe('Name Resolver', () => {
       };
       const resolver1 = resolverManager.createResolver(target1, listener);
       resolver1.updateResolution();
-      const resolver2 = resolverManager.createResolver(target1, listener);
+      const resolver2 = resolverManager.createResolver(target2, listener);
       resolver2.updateResolution();
     });
   });
   describe('UDS Names', () => {
     it('Should handle a relative Unix Domain Socket name', done => {
-      const target = 'unix:socket';
+      const target = parseUri('unix:socket')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -362,7 +363,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should handle an absolute Unix Domain Socket name', done => {
-      const target = 'unix:///tmp/socket';
+      const target = parseUri('unix:///tmp/socket')!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -393,13 +394,13 @@ describe('Name Resolver', () => {
         return [];
       }
 
-      static getDefaultAuthority(target: string): string {
+      static getDefaultAuthority(target: GrpcUri): string {
         return 'other';
       }
     }
 
     it('Should return the correct authority if a different resolver has been registered', () => {
-      const target = 'other://name';
+      const target = parseUri('other://name')!;
       resolverManager.registerResolver('other:', OtherResolver);
 
       const authority = resolverManager.getDefaultAuthority(target);

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -401,7 +401,8 @@ describe('Name Resolver', () => {
 
     it('Should return the correct authority if a different resolver has been registered', () => {
       const target = parseUri('other:name')!;
-      resolverManager.registerResolver('other:', OtherResolver);
+      console.log(target);
+      resolverManager.registerResolver('other', OtherResolver);
 
       const authority = resolverManager.getDefaultAuthority(target);
       assert.equal(authority, 'other');

--- a/packages/grpc-js/test/test-uri-parser.ts
+++ b/packages/grpc-js/test/test-uri-parser.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import * as assert from 'assert';
+import * as uriParser from '../src/uri-parser';
+
+describe('URI Parser', function(){
+  describe('parseUri', function() {
+    const expectationList: {target: string, result: uriParser.GrpcUri | null}[] = [
+      {target: 'localhost', result: {scheme: undefined, authority: undefined, path: 'localhost'}},
+      /* This looks weird, but it's OK because the resolver selection code will handle it */
+      {target: 'localhost:80', result: {scheme: 'localhost', authority: undefined, path: '80'}},
+      {target: 'dns:localhost', result: {scheme: 'dns', authority: undefined, path: 'localhost'}},
+      {target: 'dns:///localhost', result: {scheme: 'dns', authority: '', path: 'localhost'}},
+      {target: 'dns://authority/localhost', result: {scheme: 'dns', authority: 'authority', path: 'localhost'}},
+      {target: '//authority/localhost', result: {scheme: undefined, authority: 'authority', path: 'localhost'}},
+      // Regression test for https://github.com/grpc/grpc-node/issues/1359
+      {target: 'dns:foo-internal.aws-us-east-2.tracing.staging-edge.foo-data.net:443:443', result: {scheme: 'dns', authority: undefined, path: 'foo-internal.aws-us-east-2.tracing.staging-edge.foo-data.net:443:443'}}
+    ];
+    for (const {target, result} of expectationList) {
+      it (target, function() {
+        assert.deepStrictEqual(uriParser.parseUri(target), result);
+      });
+    }
+  });
+  
+  describe('splitHostPort', function() {
+    const expectationList: {path: string, result: uriParser.HostPort | null}[] = [
+      {path: 'localhost', result: {host: 'localhost'}},
+      {path: 'localhost:123', result: {host: 'localhost', port: 123}},
+      {path: '12345:6789', result: {host: '12345', port: 6789}},
+      {path: '[::1]:123', result: {host: '::1', port: 123}},
+      {path: '[::1]', result: {host: '::1'}},
+      {path: '[', result: null},
+      {path: '[123]', result: null},
+      // Regression test for https://github.com/grpc/grpc-node/issues/1359
+      {path: 'foo-internal.aws-us-east-2.tracing.staging-edge.foo-data.net:443:443', result: {host: 'foo-internal.aws-us-east-2.tracing.staging-edge.foo-data.net:443:443'}}
+    ];
+    for (const {path, result} of expectationList) {
+      it(path, function() {
+        assert.deepStrictEqual(uriParser.splitHostPort(path), result);
+      });
+    }
+  });
+});


### PR DESCRIPTION
This change is a result of a few things:

 1. When working on the proxy code, I noticed that there were a few pieces of code that performed overlapping but not identical operations related to parsing targets/addresses.
 2. #1359 was filed, and I realized that the easy fix would make the already unwieldy regexes in the DNS resolver even worse.
 3. I found [the core URI parsing code](https://github.com/grpc/grpc/blob/53657b5de385ffc54e33899b3f2a87ff78d2952b/src/core/lib/uri/uri_parser.cc) and I realized that a structured representation of URIs could solve both problems.

The new `parseUri` function is based on [`grpc_uri_parse`](https://github.com/grpc/grpc/blob/53657b5de385ffc54e33899b3f2a87ff78d2952b/src/core/lib/uri/uri_parser.cc#L188), except that I don't handle query parameters or fragments because they don't seem to be useful anywhere.

The new `splitHostPort` function is based on [`DoSplitHostPort`](https://github.com/grpc/grpc/blob/389d9baa6f5005f73abb42c4f58959736848d525/src/core/lib/gprpp/host_port.cc#L48).

One major thing to note: I realized after implementing this that for a target without a real scheme like `localhost:80`, a completely valid parsing of that target could have `scheme='localhost'` and `path='80'`, but that is not useful. So, if a target has an unknown scheme, the resolver uses the whole target as the path.

This fixes #1359.