### PR TITLE
Bump grpc-js to 1.0 and stop calling it "beta"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Directory: [`packages/grpc-js`](https://github.com/grpc/grpc-node/tree/master/pa
 
 npm package: [@grpc/grpc-js](https://www.npmjs.com/package/@grpc/grpc-js)
 
-**This library is currently incomplete and experimental. It is built on the [http2 Node module](https://nodejs.org/api/http2.html).**
-
 This library implements the core functionality of gRPC purely in JavaScript, without a C++ addon. It works on the latest version of Node.js on all platforms that Node.js runs on.
 
 ## Other Packages

--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -1,10 +1,8 @@
 # Pure JavaScript gRPC Client
 
-**Note: This is an beta-level release. Some APIs may not yet be present and there may be bugs. Please report any that you encounter**
-
 ## Installation
 
-Node 10 is recommended. The exact set of compatible Node versions can be found in the `engines` field of the `package.json` file.
+Node 12 is recommended. The exact set of compatible Node versions can be found in the `engines` field of the `package.json` file.
 
 ```sh
 npm install @grpc/grpc-js
@@ -12,13 +10,17 @@ npm install @grpc/grpc-js
 
 ## Features
 
- - Unary and streaming calls
- - Cancellation
- - Deadlines
- - TLS channel credentials
- - Call credentials (for auth)
- - Simple reconnection
- - Channel API
+ - Clients
+ - Automatic reconnection
+ - Servers
+ - Streaming
+ - Metadata
+ - Partial compression support: clients can decompress response messages
+ - Pick first and round robin load balancing policies
+ - Client Interceptors
+ - Connection Keepalives
+ - HTTP Connect support (proxies)
+
 
 This library does not directly handle `.proto` files. To use `.proto` files with this library we recommend using the `@grpc/proto-loader` package.
 

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "0.8.1",
+  "version": "1.0.0",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
We're getting there.