### PR TITLE
grpc-js: initiate tls connection through http proxy

### DIFF
--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -207,7 +207,6 @@ export function getProxiedConnection(
         );
         var cts = tls.connect({
             ...connectionOptions,
-            host: options.host,
             socket: socket
         }, function () {
           resolve({

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -21,6 +21,7 @@ import { LogVerbosity } from './constants';
 import { parseTarget } from './resolver-dns';
 import { Socket } from 'net';
 import * as http from 'http';
+import * as tls from 'tls'
 import * as logging from './logging';
 import {
   SubchannelAddress,
@@ -202,9 +203,14 @@ export function getProxiedConnection(
             ' through proxy ' +
             proxyAddressString
         );
-        resolve({
-          socket,
-          realTarget,
+        var cts = tls.connect({
+            host: options.host,
+            socket: socket
+        }, function () {
+          resolve({
+            socket: cts,
+            realTarget,
+          });
         });
       } else {
         log(

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -21,6 +21,7 @@ import { LogVerbosity } from './constants';
 import { parseTarget } from './resolver-dns';
 import { Socket } from 'net';
 import * as http from 'http';
+import * as http2 from 'http2';
 import * as tls from 'tls'
 import * as logging from './logging';
 import {
@@ -158,7 +159,8 @@ export interface ProxyConnectionResult {
 
 export function getProxiedConnection(
   address: SubchannelAddress,
-  channelOptions: ChannelOptions
+  channelOptions: ChannelOptions,
+  connectionOptions: http2.SecureClientSessionOptions
 ): Promise<ProxyConnectionResult> {
   if (!('grpc.http_connect_target' in channelOptions)) {
     return Promise.resolve<ProxyConnectionResult>({});
@@ -204,6 +206,7 @@ export function getProxiedConnection(
             proxyAddressString
         );
         var cts = tls.connect({
+            ...connectionOptions,
             host: options.host,
             socket: socket
         }, function () {

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -24,7 +24,6 @@ import { Socket } from 'net';
 import * as http from 'http';
 import * as tls from 'tls';
 import * as logging from './logging';
-import { SecureClientSessionOptions } from 'http2'
 import {
   SubchannelAddress,
   isTcpSubchannelAddress,
@@ -161,7 +160,7 @@ export interface ProxyConnectionResult {
 export function getProxiedConnection(
   address: SubchannelAddress,
   channelOptions: ChannelOptions,
-  connectionOptions: SecureClientSessionOptions
+  connectionOptions: tls.ConnectionOptions
 ): Promise<ProxyConnectionResult> {
   if (!('grpc.http_connect_target' in channelOptions)) {
     return Promise.resolve<ProxyConnectionResult>({});

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -424,6 +424,7 @@ export class Subchannel {
       this.credentials._getConnectionOptions() || {};
 
     if ('secureContext' in connectionOptions) {
+      connectionOptions.ALPNProtocols = ['h2'];
       // If provided, the value of grpc.ssl_target_name_override should be used
       // to override the target hostname when checking server identity.
       // This option is used for testing only.

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -312,14 +312,14 @@ export class Subchannel {
       connectionOptions.createConnection = (authority, option) => {
         if (proxyConnectionResult.socket) {
           return proxyConnectionResult.socket;
+        } else {
+          /* net.NetConnectOpts is declared in a way that is more restrictive
+           * than what net.connect will actually accept, so we use the type
+           * assertion to work around that. */
+          return net.connect(this.subchannelAddress);
         }
-        /* net.NetConnectOpts is declared in a way that is more restrictive
-         * than what net.connect will actually accept, so we use the type
-         * assertion to work around that. */
-        return net.connect(this.subchannelAddress);
       };
     }
-
 
     connectionOptions = Object.assign(
       connectionOptions,
@@ -416,6 +416,10 @@ export class Subchannel {
   }
 
   private startConnectingInternal() {
+    /* Pass connection options through to the proxy so that it's able to
+     * upgrade it's connection to support tls if needed.
+     * This is a workaround for https://github.com/nodejs/node/issues/32922
+     * See https://github.com/grpc/grpc-node/pull/1369 for more info. */
     const connectionOptions: http2.SecureClientSessionOptions =
       this.credentials._getConnectionOptions() || {};
 

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -28,7 +28,7 @@ import * as logging from './logging';
 import { LogVerbosity } from './constants';
 import { getProxiedConnection, ProxyConnectionResult } from './http_proxy';
 import * as net from 'net';
-import * as tls from 'tls';
+import { ConnectionOptions } from 'tls';
 
 const clientVersion = require('../../package.json').version;
 
@@ -420,7 +420,7 @@ export class Subchannel {
      * upgrade it's connection to support tls if needed.
      * This is a workaround for https://github.com/nodejs/node/issues/32922
      * See https://github.com/grpc/grpc-node/pull/1369 for more info. */
-    const connectionOptions: http2.SecureClientSessionOptions =
+    const connectionOptions: ConnectionOptions =
       this.credentials._getConnectionOptions() || {};
 
     if ('secureContext' in connectionOptions) {

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -302,21 +302,20 @@ export class Subchannel {
       if (proxyConnectionResult.socket) {
         connectionOptions.socket = proxyConnectionResult.socket;
       }
-    } else {
-      /* In all but the most recent versions of Node, http2.connect does not use
-       * the options when establishing plaintext connections, so we need to
-       * establish that connection explicitly. */
-      connectionOptions.createConnection = (authority, option) => {
-        if (proxyConnectionResult.socket) {
-          return proxyConnectionResult.socket;
-        } else {
-          /* net.NetConnectOpts is declared in a way that is more restrictive
-           * than what net.connect will actually accept, so we use the type
-           * assertion to work around that. */
-          return net.connect(this.subchannelAddress);
-        }
-      };
     }
+    /* In all but the most recent versions of Node, http2.connect does not use
+     * the options when establishing plaintext connections, so we need to
+     * establish that connection explicitly. */
+    connectionOptions.createConnection = (authority, option) => {
+      if (proxyConnectionResult.socket) {
+        return proxyConnectionResult.socket;
+      } else {
+        /* net.NetConnectOpts is declared in a way that is more restrictive
+         * than what net.connect will actually accept, so we use the type
+         * assertion to work around that. */
+        return net.connect(this.subchannelAddress);
+      }
+    };
     connectionOptions = Object.assign(
       connectionOptions,
       this.subchannelAddress

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -300,21 +300,26 @@ export class Subchannel {
         };
         connectionOptions.servername = sslTargetNameOverride;
       }
-    }
-    /* In all but the most recent versions of Node, http2.connect does not use
-     * the options when establishing plaintext connections, so we need to
-     * establish that connection explicitly. */
-    connectionOptions.createConnection = (authority, option) => {
       if (proxyConnectionResult.socket) {
-        return proxyConnectionResult.socket;
-      } else if ('secureContext' in connectionOptions) {
-        return tls.connect(this.subchannelAddress);
+        connectionOptions.createConnection = (authority, option) => {
+          return proxyConnectionResult.socket!;
+        };
       }
-      /* net.NetConnectOpts is declared in a way that is more restrictive
-       * than what net.connect will actually accept, so we use the type
-       * assertion to work around that. */
-      return net.connect(this.subchannelAddress);
-    };
+    } else {
+      /* In all but the most recent versions of Node, http2.connect does not use
+       * the options when establishing plaintext connections, so we need to
+       * establish that connection explicitly. */
+      connectionOptions.createConnection = (authority, option) => {
+        if (proxyConnectionResult.socket) {
+          return proxyConnectionResult.socket;
+        }
+        /* net.NetConnectOpts is declared in a way that is more restrictive
+         * than what net.connect will actually accept, so we use the type
+         * assertion to work around that. */
+        return net.connect(this.subchannelAddress);
+      };
+    }
+
 
     connectionOptions = Object.assign(
       connectionOptions,


### PR DESCRIPTION
Trying to get ssl connection to establish correctly when connecting via proxy.

In reference to https://github.com/grpc/grpc-node/issues/992