### PR TITLE
grpc-js: Fix interactions between proxy code and new URI parsing

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -173,6 +173,9 @@ export class ChannelImplementation implements Channel {
     /* This ensures that the target has a scheme that is registered with the
      * resolver */
     const defaultSchemeMapResult = mapUriDefaultScheme(originalTargetUri);
+    if (defaultSchemeMapResult === null) {
+      throw new Error(`Could not find a default scheme for target name "${target}"`);
+    }
     if (this.options['grpc.default_authority']) {
       this.defaultAuthority = this.options['grpc.default_authority'] as string;
     } else {

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -18,6 +18,7 @@ import {
   Resolver,
   ResolverListener,
   registerResolver,
+  registerDefaultScheme,
 } from './resolver';
 import * as dns from 'dns';
 import * as util from 'util';
@@ -280,6 +281,7 @@ class DnsResolver implements Resolver {
  */
 export function setup(): void {
   registerResolver('dns', DnsResolver);
+  registerDefaultScheme('dns');
 }
 
 export interface DnsUrl {

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -18,7 +18,6 @@ import {
   Resolver,
   ResolverListener,
   registerResolver,
-  registerDefaultResolver,
 } from './resolver';
 import * as dns from 'dns';
 import * as util from 'util';
@@ -281,7 +280,6 @@ class DnsResolver implements Resolver {
  */
 export function setup(): void {
   registerResolver('dns', DnsResolver);
-  registerDefaultResolver(DnsResolver);
 }
 
 export interface DnsUrl {

--- a/packages/grpc-js/src/resolver-uds.ts
+++ b/packages/grpc-js/src/resolver-uds.ts
@@ -18,7 +18,6 @@ import {
   Resolver,
   ResolverListener,
   registerResolver,
-  registerDefaultResolver,
 } from './resolver';
 import { SubchannelAddress } from './subchannel';
 import { GrpcUri } from './uri-parser';

--- a/packages/grpc-js/src/resolver.ts
+++ b/packages/grpc-js/src/resolver.ts
@@ -131,15 +131,16 @@ export function getDefaultAuthority(target: GrpcUri): string {
   }
 }
 
-export function mapUriDefaultScheme(target: GrpcUri): GrpcUri {
+export function mapUriDefaultScheme(target: GrpcUri): GrpcUri | null {
   if (target.scheme === undefined || !(target.scheme in registeredResolvers)) {
     if (defaultScheme !== null) {
       return {
         scheme: defaultScheme,
+        authority: undefined,
         path: uriToString(target)
       };
     } else {
-      throw new Error(`Invalid target ${uriToString(target)}`);
+      return null;
     }
   }
   return target;

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -45,7 +45,7 @@ import {
 } from './server-call';
 import { ServerCredentials } from './server-credentials';
 import { ChannelOptions } from './channel-options';
-import { createResolver, ResolverListener } from './resolver';
+import { createResolver, ResolverListener, mapUriDefaultScheme } from './resolver';
 import { log } from './logging';
 import {
   SubchannelAddress,
@@ -226,9 +226,13 @@ export class Server {
       throw new TypeError('callback must be a function');
     }
 
-    const portUri = parseUri(port);
-    if (portUri === null) {
+    const initialPortUri = parseUri(port);
+    if (initialPortUri === null) {
       throw new Error(`Could not parse port "${port}"`);
+    }
+    const portUri = mapUriDefaultScheme(initialPortUri);
+    if (portUri === null) {
+      throw new Error(`Could not get a default scheme for port "${port}"`);
     }
 
     const serverOptions: http2.ServerOptions = {};

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -32,7 +32,7 @@ describe('Name Resolver', () => {
       resolverManager.registerAll();
     });
     it('Should resolve localhost properly', done => {
-      const target = parseUri('localhost:50051')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('localhost:50051')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -67,7 +67,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should default to port 443', done => {
-      const target = parseUri('localhost')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('localhost')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -102,7 +102,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should correctly represent an ipv4 address', done => {
-      const target = parseUri('1.2.3.4')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('1.2.3.4')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -129,7 +129,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should correctly represent an ipv6 address', done => {
-      const target = parseUri('::1')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('::1')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -156,7 +156,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should correctly represent a bracketed ipv6 address', done => {
-      const target = parseUri('[::1]:50051')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('[::1]:50051')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -183,7 +183,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should resolve a public address', done => {
-      const target = parseUri('example.com')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('example.com')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -203,7 +203,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should resolve a name with multiple dots', done => {
-      const target = parseUri('loopback4.unittest.grpc.io')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('loopback4.unittest.grpc.io')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -232,7 +232,7 @@ describe('Name Resolver', () => {
     /* TODO(murgatroid99): re-enable this test, once we can get the IPv6 result
      * consistently */
     it.skip('Should resolve a DNS name to an IPv6 address', done => {
-      const target = parseUri('loopback6.unittest.grpc.io')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('loopback6.unittest.grpc.io')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -259,7 +259,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should resolve a DNS name to IPv4 and IPv6 addresses', done => {
-      const target = parseUri('loopback46.unittest.grpc.io')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('loopback46.unittest.grpc.io')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -290,7 +290,7 @@ describe('Name Resolver', () => {
     it('Should resolve a name with a hyphen', done => {
       /* TODO(murgatroid99): Find or create a better domain name to test this with.
        * This is just the first one I found with a hyphen. */
-      const target = parseUri('network-tools.com')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('network-tools.com')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -311,8 +311,8 @@ describe('Name Resolver', () => {
     });
     it('Should resolve gRPC interop servers', done => {
       let completeCount = 0;
-      const target1 = parseUri('grpc-test.sandbox.googleapis.com')!;
-      const target2 = parseUri('grpc-test4.sandbox.googleapis.com')!;
+      const target1 = resolverManager.mapUriDefaultScheme(parseUri('grpc-test.sandbox.googleapis.com')!)!;
+      const target2 = resolverManager.mapUriDefaultScheme(parseUri('grpc-test4.sandbox.googleapis.com')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -339,7 +339,7 @@ describe('Name Resolver', () => {
   });
   describe('UDS Names', () => {
     it('Should handle a relative Unix Domain Socket name', done => {
-      const target = parseUri('unix:socket')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('unix:socket')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -363,7 +363,7 @@ describe('Name Resolver', () => {
       resolver.updateResolution();
     });
     it('Should handle an absolute Unix Domain Socket name', done => {
-      const target = parseUri('unix:///tmp/socket')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('unix:///tmp/socket')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
           addressList: SubchannelAddress[],
@@ -400,7 +400,7 @@ describe('Name Resolver', () => {
     }
 
     it('Should return the correct authority if a different resolver has been registered', () => {
-      const target = parseUri('other:name')!;
+      const target = resolverManager.mapUriDefaultScheme(parseUri('other:name')!)!;
       console.log(target);
       resolverManager.registerResolver('other', OtherResolver);
 

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -400,9 +400,9 @@ describe('Name Resolver', () => {
     }
 
     it('Should return the correct authority if a different resolver has been registered', () => {
+      resolverManager.registerResolver('other', OtherResolver);
       const target = resolverManager.mapUriDefaultScheme(parseUri('other:name')!)!;
       console.log(target);
-      resolverManager.registerResolver('other', OtherResolver);
 
       const authority = resolverManager.getDefaultAuthority(target);
       assert.equal(authority, 'other');

--- a/packages/grpc-js/test/test-uri-parser.ts
+++ b/packages/grpc-js/test/test-uri-parser.ts
@@ -17,6 +17,7 @@
 
 import * as assert from 'assert';
 import * as uriParser from '../src/uri-parser';
+import * as resolver from '../src/resolver';
 
 describe('URI Parser', function(){
   describe('parseUri', function() {
@@ -35,6 +36,23 @@ describe('URI Parser', function(){
       it (target, function() {
         assert.deepStrictEqual(uriParser.parseUri(target), result);
       });
+    }
+  });
+
+  describe('parseUri + mapUriDefaultScheme', function() {
+    const expectationList: {target: string, result: uriParser.GrpcUri | null}[] = [
+      {target: 'localhost', result: {scheme: 'dns', authority: undefined, path: 'localhost'}},
+      {target: 'localhost:80', result: {scheme: 'dns', authority: undefined, path: 'localhost:80'}},
+      {target: 'dns:localhost', result: {scheme: 'dns', authority: undefined, path: 'localhost'}},
+      {target: 'dns:///localhost', result: {scheme: 'dns', authority: '', path: 'localhost'}},
+      {target: 'dns://authority/localhost', result: {scheme: 'dns', authority: 'authority', path: 'localhost'}},
+      {target: 'unix:socket', result: {scheme: 'unix', authority: undefined, path: 'socket'}},
+      {target: 'bad:path', result: {scheme: 'dns', authority: undefined, path: 'bad:path'}}
+    ];
+    for (const {target, result} of expectationList) {
+      it(target, function() {
+        assert.deepStrictEqual(resolver.mapUriDefaultScheme(uriParser.parseUri(target) ?? {path: 'null'}), result);
+      })
     }
   });
   


### PR DESCRIPTION
There were multiple issues here:

 - We expect a proxy URL in the form `http://host:port`, but this does not actually fit with our naming scheme, so the URI parser parses it wrong. The solution is to revert to a previous version of `getProxyInfo` that parses the proxy address using the `URL` class.

 - If the target had no scheme and was parsed weirdly into the `GrpcUri` structure, the resolver knew how to deal with that, but the proxy didn't, and it was making a bad request to the proxy. The solution is to stop using a default resolver, and instead modify the target at channel construction time so that it has a known scheme.

 - The channel constructor was just overwriting the target after it got modified by the proxy.

 - The proxy map result target didn't have an explicit scheme, even though it would definitely need to be interpreted as a DNS name. Added a scheme to fix that.