### PR TITLE
grpc-js: do not prematurely resolve proxy socket

### DIFF
--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -147,7 +147,7 @@ export function mapProxyName(
     extraOptions['grpc.http_connect_creds'] = proxyInfo.creds;
   }
   return {
-    target: { 
+    target: {
       scheme: 'dns',
       path: proxyInfo.address
     },
@@ -207,10 +207,6 @@ export function getProxiedConnection(
             ' through proxy ' +
             proxyAddressString
         );
-        resolve({
-          socket,
-          realTarget: parsedTarget,
-        });
         if ('secureContext' in connectionOptions) {
           /* The proxy is connecting to a TLS server, so upgrade this socket
            * connection to a TLS connection.


### PR DESCRIPTION
This resolves the last remaining issue with tls proxy support mentioned here https://github.com/grpc/grpc-node/pull/1369#issuecomment-617946074

Probably the result of a merge conflict but the issue is that the proxy socket is being unconditionally resolved prematurely, essentially bypassing the creation of the tls enabled socket.