### PR TITLE
grpc-tools: add grpc_js param to grpc_out

### DIFF
--- a/packages/grpc-tools/src/node_generator.cc
+++ b/packages/grpc-tools/src/node_generator.cc
@@ -212,7 +212,8 @@ void PrintService(const ServiceDescriptor* service, Printer* out,
 void PrintImports(const FileDescriptor* file, Printer* out,
                   const Parameters& params) {
   if (!params.generate_package_definition) {
-    out->Print("var grpc = require('grpc');\n");
+    grpc::string package = params.grpc_js ? "@grpc/grpc-js" : "grpc";
+    out->Print("var grpc = require('$package$');\n", "package", package);
   }
   if (file->message_type_count() > 0) {
     grpc::string file_path =

--- a/packages/grpc-tools/src/node_generator.h
+++ b/packages/grpc-tools/src/node_generator.h
@@ -26,6 +26,8 @@ namespace grpc_node_generator {
 struct Parameters {
   // Generate a package definition object instead of Client classes
   bool generate_package_definition;
+  // Use pure JavaScript gRPC Client
+  bool grpc_js;
 };
 
 grpc::string GenerateFile(const grpc::protobuf::FileDescriptor* file,

--- a/packages/grpc-tools/src/node_plugin.cc
+++ b/packages/grpc-tools/src/node_plugin.cc
@@ -38,13 +38,16 @@ class NodeGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
                 grpc::string* error) const {
     grpc_node_generator::Parameters generator_parameters;
     generator_parameters.generate_package_definition = false;
+    generator_parameters.grpc_js = false;
     if (!parameter.empty()) {
-      std::vector<grpc::string> parameters_list =	
-          grpc_generator::tokenize(parameter, ",");	
-      for (auto parameter_string = parameters_list.begin();	
+      std::vector<grpc::string> parameters_list =
+          grpc_generator::tokenize(parameter, ",");
+      for (auto parameter_string = parameters_list.begin();
            parameter_string != parameters_list.end(); parameter_string++) {
         if (*parameter_string == "generate_package_definition") {
           generator_parameters.generate_package_definition = true;
+        } else if (*parameter_string == "grpc_js") {
+          generator_parameters.grpc_js = true;
         }
       }
     }


### PR DESCRIPTION
This is a minor change to use the pure JavaScript gRPC Client `@grpc/grpc-js` instead of the (now deprecated) `grpc` node package when generating javascript files using the proto compiler. This change is very similar to the `generate_package_definition` param.

Reasoning: 

I understand that it's recommended to use `@grpc/proto-loader` to the load protos files. 

I have some hesitation to adopt this approach, as when using TypeScript, I have to typecast using [type assertions](https://www.typescriptlang.org/docs/handbook/basic-types.html#type-assertions) to type the grpc client as a [`ServiceClientConstructor`](https://github.com/grpc/grpc-node/blob/4ec023c271890a0f8ecb2548ba2001357ae31c79/packages/grpc-js/src/make-client.ts#L87-L94), for example:

```ts
const echoService = loadProtoFile(protoFile)
      .EchoService as ServiceClientConstructor;
```

My client is then defined as:

https://github.com/grpc/grpc-node/blob/4ec023c271890a0f8ecb2548ba2001357ae31c79/packages/grpc-js/src/make-client.ts#L83-L85

..and I loose all the benefits of (for example) IntelliSense in my IDE. I also don't know if my method calls are correct until I compile the TypeScript to JS. It's not a great developer experience.

The change i'm proposing is to support "grpc_js" within the proto compiler. This will allow me to generate static javascript files that require `@grpc/grpc-js` instead of `grpc`, and will allow existing tools to then generate types from those files. 

I also feel this a good change to support existing projects & tooling that would like to switch over to using `@grpc/grpc-js`. It will allow for better adoption as the required changes in the consuming projects are minimal. 