### PR TITLE
grpc-js: Fix the final proxy bugs

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -211,7 +211,8 @@ class SecureChannelCredentialsImpl extends ChannelCredentials {
   }
 
   _getConnectionOptions(): ConnectionOptions | null {
-    return this.connectionOptions;
+    // Copy to prevent callers from mutating this.connectionOptions
+    return { ...this.connectionOptions };
   }
   _isSecure(): boolean {
     return true;

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -322,10 +322,11 @@ export class Subchannel {
       };
     }
 
-    connectionOptions = Object.assign(
-      connectionOptions,
-      this.subchannelAddress
-    );
+    connectionOptions = {
+      ...connectionOptions,
+      ...this.subchannelAddress,
+    };
+
     /* http2.connect uses the options here:
      * https://github.com/nodejs/node/blob/70c32a6d190e2b5d7b9ff9d5b6a459d14e8b7d59/lib/internal/http2/core.js#L3028-L3036
      * The spread operator overides earlier values with later ones, so any port


### PR DESCRIPTION
There were a few more issues:

 - `ChannelCredentials#_getConnectionOptions` was returning a reference to a mutable object, which `Subchannel#createSession` was mutating. I changed both of those lines for defense in depth.

 - In `http_proxy.ts`, `getProxiedConnection` was resolving the promise before trying to connect with TLS. That is simply incorrect, and was probably a merge error.

 - Again in `getProxiedConnection`, `tls.connect` did not always get a `servername` option, which is required to set the SNI request in the TLS handshake. With that change, adding the original `connectionOptions` needs to be moved to the end so that the `servername` option from the `grpc.ssl_target_name_override` channel option takes precedence.

I tested this by successfully making a request to the prod interop server using TLS through an `HTTP CONNECT` proxy.