### PR TITLE
fix: make stream.write() synchronous in server-call

### DIFF
--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -172,14 +172,14 @@ export class ServerWritableStreamImpl<RequestType, ResponseType>
     this.call.sendMetadata(responseMetadata);
   }
 
-  async _write(
+  _write(
     chunk: ResponseType,
     encoding: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     callback: (...args: any[]) => void
   ) {
     try {
-      const response = await this.call.serializeMessage(chunk);
+      const response = this.call.serializeMessage(chunk);
 
       if (!this.call.write(response)) {
         this.call.once('drain', callback);
@@ -454,7 +454,7 @@ export class Http2ServerCallStream<
             resolve();
           }
 
-          resolve(await this.deserializeMessage(requestBytes));
+          resolve(this.deserializeMessage(requestBytes));
         } catch (err) {
           err.code = Status.INTERNAL;
           this.sendError(err);
@@ -476,7 +476,7 @@ export class Http2ServerCallStream<
     return output;
   }
 
-  async deserializeMessage(bytes: Buffer) {
+  deserializeMessage(bytes: Buffer) {
     // TODO(cjihrig): Call compression aware deserializeMessage().
     const receivedMessage = bytes.slice(5);
 
@@ -505,7 +505,7 @@ export class Http2ServerCallStream<
     }
 
     try {
-      const response = await this.serializeMessage(value!);
+      const response = this.serializeMessage(value!);
 
       this.write(response);
       this.sendStatus({ code: Status.OK, details: 'OK', metadata });

--- a/packages/grpc-js/test/fixtures/test_service.proto
+++ b/packages/grpc-js/test/fixtures/test_service.proto
@@ -20,6 +20,7 @@ syntax = "proto3";
 message Request {
   bool error = 1;
   string message = 2;
+  int32 errorAfter = 3;
 }
 
 message Response {


### PR DESCRIPTION
`stream.write()` in server stream code is asynchronous for no apparent reason. As a result, it breaks the perfectly reasonable RPC implementation code like this one:

```js
stream.write(data);
stream.write(data);
stream.emit('error', err);
```

since `write` being `async` for no reason delays its execution and an error is emitted first within the same event loop.

Note that `grpc` server implementation works properly in this case.

We had this problem in [nodejs-spanner](https://github.com/googleapis/nodejs-spanner/blob/master/test/mockserver/mockspanner.ts#L499-L503) test code where they are using gRPC server to emulate some conditions for testing the client, and it blocks migrating this library from `grpc` to `@grpc/grpc-js`.