### PR TITLE
grpc-js: fix target in tracing logs

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -406,7 +406,7 @@ export class ChannelImplementation implements Channel {
     trace(
       LogVerbosity.DEBUG,
       'connectivity_state',
-      this.target +
+      uriToString(this.target) +
         ' ' +
         ConnectivityState[this.connectivityState] +
         ' -> ' +
@@ -496,7 +496,7 @@ export class ChannelImplementation implements Channel {
     trace(
       LogVerbosity.DEBUG,
       'channel',
-      this.target +
+      uriToString(this.target) +
         ' createCall [' +
         callNumber +
         '] method="' +

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -136,7 +136,7 @@ export function mapProxyName(
   const serverHost = hostPort.host;
   for (const host of getNoProxyHostList()) {
     if (host === serverHost) {
-      trace('Not using proxy for target in no_proxy list: ' + target);
+      trace('Not using proxy for target in no_proxy list: ' + uriToString(target));
       return noProxyResult;
     }
   }

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -111,7 +111,7 @@ class DnsResolver implements Resolver {
 
     this.defaultResolutionError = {
       code: Status.UNAVAILABLE,
-      details: `Name resolution failed for target ${this.target}`,
+      details: `Name resolution failed for target ${uriToString(this.target)}`,
       metadata: new Metadata(),
     };
   }
@@ -122,7 +122,7 @@ class DnsResolver implements Resolver {
    */
   private startResolution() {
     if (this.ipResult !== null) {
-      trace('Returning IP address for target ' + this.target);
+      trace('Returning IP address for target ' + uriToString(this.target));
       setImmediate(() => {
         this.listener.onSuccessfulResolution(this.ipResult!, null, null);
       });
@@ -132,7 +132,7 @@ class DnsResolver implements Resolver {
       setImmediate(() => {
         this.listener.onError({
           code: Status.UNAVAILABLE,
-          details: `Failed to parse DNS address ${this.target}`,
+          details: `Failed to parse DNS address ${uriToString(this.target)}`,
           metadata: new Metadata(),
         });
       });
@@ -171,7 +171,7 @@ class DnsResolver implements Resolver {
             ']';
           trace(
             'Resolved addresses for target ' +
-              this.target +
+              uriToString(this.target) +
               ': ' +
               allAddressesString
           );
@@ -192,7 +192,7 @@ class DnsResolver implements Resolver {
         (err) => {
           trace(
             'Resolution error for target ' +
-              this.target +
+              uriToString(this.target) +
               ': ' +
               (err as Error).message
           );
@@ -254,7 +254,7 @@ class DnsResolver implements Resolver {
   }
 
   updateResolution() {
-    trace('Resolution update requested for target ' + this.target);
+    trace('Resolution update requested for target ' + uriToString(this.target));
     if (this.pendingLookupPromise === null) {
       this.startResolution();
     }

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -35,7 +35,7 @@ import { Metadata } from './metadata';
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
 import { SubchannelAddress } from './subchannel';
-import { GrpcUri } from './uri-parser';
+import { GrpcUri, uriToString } from './uri-parser';
 
 const TRACER_NAME = 'resolving_load_balancer';
 
@@ -353,7 +353,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
 
   private updateState(connectivitystate: ConnectivityState, picker: Picker) {
     trace(
-      this.target +
+      uriToString(this.target) +
         ' ' +
         ConnectivityState[this.currentState] +
         ' -> ' +


### PR DESCRIPTION
I'm attempting to debug a random "failed to parse server response" error and this is what i'm seeing in my logs (note the `[object Object]`):

```
2020-04-23T06:13:06.747Z | dns_resolver | Resolved addresses for target [object Object]: [::1:57426,127.0.0.1:57426]
2020-04-23T06:13:06.747Z | pick_first | IDLE -> IDLE
2020-04-23T06:13:06.748Z | resolving_load_balancer | [object Object] CONNECTING -> IDLE
2020-04-23T06:13:06.748Z | connectivity_state | [object Object] CONNECTING -> IDLE
2020-04-23T06:13:06.748Z | dns_resolver | Resolution update requested for target [object Object]
2020-04-23T06:13:06.748Z | resolving_load_balancer | [object Object] IDLE -> CONNECTING
2020-04-23T06:13:06.748Z | connectivity_state | [object Object] IDLE -> CONNECTING
2020-04-23T06:13:06.748Z | resolving_load_balancer | [object Object] CONNECTING -> CONNECTING
```

I guess this is related to https://github.com/grpc/grpc-node/pull/1364