### PR TITLE
grpc-js: Don't try to call listener if it is unset

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -227,7 +227,7 @@ export class Http2CallStream implements Call {
       const filteredStatus = this.filterStack.receiveTrailers(
         this.finalStatus!
       );
-      this.listener!.onReceiveStatus(filteredStatus);
+      this.listener?.onReceiveStatus(filteredStatus);
       if (this.subchannel) {
         this.subchannel.callUnref();
         this.subchannel.removeDisconnectListener(this.disconnectListener);
@@ -289,7 +289,7 @@ export class Http2CallStream implements Call {
     );
     this.canPush = false;
     process.nextTick(() => {
-      this.listener!.onReceiveMessage(message);
+      this.listener?.onReceiveMessage(message);
       this.maybeOutputStatus();
     });
   }
@@ -465,7 +465,7 @@ export class Http2CallStream implements Call {
           }
           try {
             const finalMetadata = this.filterStack.receiveMetadata(metadata);
-            this.listener!.onReceiveMetadata(finalMetadata);
+            this.listener?.onReceiveMetadata(finalMetadata);
           } catch (error) {
             this.endCall({
               code: Status.UNKNOWN,


### PR DESCRIPTION
If the `Channel` API is used directly, it is possible for a call to end without `start` ever being called, so `this.listener` will be unset. In that case we might as well drop the event on the floor, because there's nothing waiting for it. This probably only impacts `onReceiveStatus` because the others require receiving something from the server, but the same change is valid for all of them.