### PR TITLE
grpc-js: Add internal "Google default" channel credentials

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -55,6 +55,7 @@
     "posttest": "npm run check"
   },
   "dependencies": {
+    "google-auth-library": "^6.0.0",
     "semver": "^6.2.0"
   },
   "files": [

--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -19,6 +19,7 @@ import { ConnectionOptions, createSecureContext, PeerCertificate } from 'tls';
 
 import { CallCredentials } from './call-credentials';
 import { CIPHER_SUITES, getDefaultRootsData } from './tls-helpers';
+import { GoogleAuth } from 'google-auth-library';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function verifyIsBufferOrNull(obj: any, friendlyName: string): void {
@@ -277,4 +278,12 @@ class ComposedChannelCredentialsImpl extends ChannelCredentials {
       return false;
     }
   }
+}
+
+export function createGoogleDefaultCredentials(): ChannelCredentials {
+  const sslCreds = ChannelCredentials.createSsl();
+  const googleAuthCreds = CallCredentials.createFromGoogleCredential(
+    new GoogleAuth()
+  );
+  return sslCreds.compose(googleAuthCreds);
 }

--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -19,7 +19,7 @@ import { ConnectionOptions, createSecureContext, PeerCertificate } from 'tls';
 
 import { CallCredentials } from './call-credentials';
 import { CIPHER_SUITES, getDefaultRootsData } from './tls-helpers';
-import { GoogleAuth } from 'google-auth-library';
+import { GoogleAuth as GoogleAuthType } from 'google-auth-library';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function verifyIsBufferOrNull(obj: any, friendlyName: string): void {
@@ -281,6 +281,8 @@ class ComposedChannelCredentialsImpl extends ChannelCredentials {
 }
 
 export function createGoogleDefaultCredentials(): ChannelCredentials {
+  const GoogleAuth = require('google-auth-library')
+    .GoogleAuth as typeof GoogleAuthType;
   const sslCreds = ChannelCredentials.createSsl();
   const googleAuthCreds = CallCredentials.createFromGoogleCredential(
     new GoogleAuth()


### PR DESCRIPTION
`grpc-js` now depends on `google-auth-library`. I moved the `createFromGoogleCredential` function into the `CallCredentials` class so that it could be more easily accessed from `channel-credentials.ts`, and I changed the `OAuth2Client` type definition slightly to match what actually comes from `google-auth-library`; the only change is that it requires at least one of the specified functions, instead of both of them. The only change to `createFromGoogleCredential` is to replace `if (typeof googleCredentials.getRequestHeaders === 'function')` with `if (isCurrentOauth2Client(googleCredentials))`.

`createGoogleDefaultCredentials` is currently private because it hasn't gone through any API review, but it could easily be turned into `ChannelCredentials.createGoogleDefault` or something to make it public.