### PR TITLE
grpc-js: Fix pick_first handling of IDLE subchannels.

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -130,7 +130,6 @@ export class PickFirstLoadBalancer implements LoadBalancer {
    *     this load balancer's owner.
    */
   constructor(private channelControlHelper: ChannelControlHelper) {
-    this.updateState(ConnectivityState.IDLE, new QueuePicker(this));
     this.subchannelStateCounts = {
       [ConnectivityState.CONNECTING]: 0,
       [ConnectivityState.IDLE]: 0,
@@ -168,6 +167,8 @@ export class PickFirstLoadBalancer implements LoadBalancer {
            * basic IDLE state where there is no subchannel list to avoid
            * holding unused resources */
           this.resetSubchannelList();
+          this.updateState(ConnectivityState.IDLE, new QueuePicker(this));
+          return;
         }
         if (this.currentPick === null) {
           if (this.triedAllSubchannels) {

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -95,7 +95,6 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
   private currentReadyPicker: RoundRobinPicker | null = null;
 
   constructor(private channelControlHelper: ChannelControlHelper) {
-    this.updateState(ConnectivityState.IDLE, new QueuePicker(this));
     this.subchannelStateCounts = {
       [ConnectivityState.CONNECTING]: 0,
       [ConnectivityState.IDLE]: 0,


### PR DESCRIPTION
This fixes #1411 (specifically, the new line 170 and 171 of `load-balancer-pick-first.ts` fixes that)

Also stop reporting IDLE on LB creation. That was causing pointless state change churn.