### PR TITLE
grpc-js: Don't split header values by commas

### DIFF
--- a/packages/grpc-js/src/metadata.ts
+++ b/packages/grpc-js/src/metadata.ts
@@ -278,11 +278,7 @@ export class Metadata {
               result.add(key, value);
             });
           } else if (values !== undefined) {
-            if (isCustomMetadata(key)) {
-              values.split(',').forEach((v) => result.add(key, v.trim()));
-            } else {
-              result.add(key, values);
-            }
+            result.add(key, values);
           }
         }
       } catch (error) {

--- a/packages/grpc-js/test/test-metadata.ts
+++ b/packages/grpc-js/test/test-metadata.ts
@@ -295,6 +295,7 @@ describe('Metadata', () => {
         key1: 'value1',
         key2: ['value2'],
         key3: ['value3a', 'value3b'],
+        key4: ['part1, part2'],
         'key-bin': [
           'AAECAwQFBgcICQoLDA0ODw==',
           'EBESExQVFhcYGRobHB0eHw==',
@@ -307,6 +308,7 @@ describe('Metadata', () => {
         ['key1', ['value1']],
         ['key2', ['value2']],
         ['key3', ['value3a', 'value3b']],
+        ['key4', ['part1, part2']],
         [
           'key-bin',
           [


### PR DESCRIPTION
According to #1412 the current grpc-js behavior is different from the other implementation's behavior, so we should change it.