### PR TITLE
Don't use gts clean in npm clean to avoid errors on Node 8

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -33,6 +33,7 @@
     "mocha-jenkins-reporter": "^0.4.1",
     "ncp": "^2.0.0",
     "pify": "^4.0.1",
+    "rimraf": "^3.0.2",
     "ts-node": "^8.3.0",
     "typescript": "^3.7.2"
   },
@@ -43,7 +44,7 @@
   ],
   "scripts": {
     "build": "npm run compile",
-    "clean": "gts clean",
+    "clean": "node -e 'require(\"rimraf\")(\"./build\", () => {})'",
     "compile": "tsc -p .",
     "format": "clang-format -i -style=\"{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}\" src/*.ts test/*.ts",
     "lint": "npm run check",

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -14,7 +14,7 @@
   "typings": "build/src/index.d.ts",
   "scripts": {
     "build": "npm run compile",
-    "clean": "gts clean",
+    "clean": "node -e 'require(\"rimraf\")(\"./build\", () => {})'",
     "compile": "tsc -p .",
     "format": "clang-format -i -style=\"{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}\" src/*.ts test/*.ts",
     "lint": "tslint -c node_modules/google-ts-style/tslint.json -p . -t codeFrame --type-check",
@@ -47,6 +47,7 @@
     "@types/node": "^10.12.5",
     "clang-format": "^1.2.2",
     "gts": "^1.1.0",
+    "rimraf": "^3.0.2",
     "typescript": "~3.3.3333"
   },
   "engines": {


### PR DESCRIPTION
We're calling that in our tests, and we need to test on Node 8, and `gts` now throws if you call it from Node 8. This is just making the script explicitly do what `gts clean` does.