### PR TITLE
grpc-js: Add a few trace lines to the server

### DIFF
--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -20,7 +20,12 @@ import * as http2 from 'http2';
 import { Duplex, Readable, Writable } from 'stream';
 
 import { StatusObject } from './call-stream';
-import { Status, DEFAULT_MAX_SEND_MESSAGE_LENGTH, DEFAULT_MAX_RECEIVE_MESSAGE_LENGTH, LogVerbosity } from './constants';
+import {
+  Status,
+  DEFAULT_MAX_SEND_MESSAGE_LENGTH,
+  DEFAULT_MAX_RECEIVE_MESSAGE_LENGTH,
+  LogVerbosity,
+} from './constants';
 import { Deserialize, Serialize } from './make-client';
 import { Metadata } from './metadata';
 import { StreamDecoder } from './stream-decoder';
@@ -70,7 +75,7 @@ export type ServerErrorResponse = ServerStatusResponse & Error;
 
 export type ServerSurfaceCall = {
   cancelled: boolean;
-  readonly metadata: Metadata
+  readonly metadata: Metadata;
   getPeer(): string;
   sendMetadata(responseMetadata: Metadata): void;
 } & EventEmitter;
@@ -458,10 +463,13 @@ export class Http2ServerCallStream<
       stream.once('end', async () => {
         try {
           const requestBytes = Buffer.concat(chunks, totalLength);
-          if (this.maxReceiveMessageSize !== -1 && requestBytes.length > this.maxReceiveMessageSize) {
+          if (
+            this.maxReceiveMessageSize !== -1 &&
+            requestBytes.length > this.maxReceiveMessageSize
+          ) {
             this.sendError({
               code: Status.RESOURCE_EXHAUSTED,
-              details: `Received message larger than max (${requestBytes.length} vs. ${this.maxReceiveMessageSize})`
+              details: `Received message larger than max (${requestBytes.length} vs. ${this.maxReceiveMessageSize})`,
             });
             resolve();
           }
@@ -532,7 +540,14 @@ export class Http2ServerCallStream<
       return;
     }
 
-    trace('Request to method ' + this.handler?.path + ' ended with status code: ' + Status[statusObj.code] + ' details: ' + statusObj.details);
+    trace(
+      'Request to method ' +
+        this.handler?.path +
+        ' ended with status code: ' +
+        Status[statusObj.code] +
+        ' details: ' +
+        statusObj.details
+    );
 
     clearTimeout(this.deadline);
 
@@ -587,10 +602,13 @@ export class Http2ServerCallStream<
       return;
     }
 
-    if (this.maxSendMessageSize !== -1 && chunk.length > this.maxSendMessageSize) {
+    if (
+      this.maxSendMessageSize !== -1 &&
+      chunk.length > this.maxSendMessageSize
+    ) {
       this.sendError({
-        code: Status.RESOURCE_EXHAUSTED, 
-        details: `Sent message larger than max (${chunk.length} vs. ${this.maxSendMessageSize})`
+        code: Status.RESOURCE_EXHAUSTED,
+        details: `Sent message larger than max (${chunk.length} vs. ${this.maxSendMessageSize})`,
       });
       return;
     }
@@ -621,10 +639,13 @@ export class Http2ServerCallStream<
       const messages = decoder.write(data);
 
       for (const message of messages) {
-        if (this.maxReceiveMessageSize !== -1 && message.length > this.maxReceiveMessageSize) {
+        if (
+          this.maxReceiveMessageSize !== -1 &&
+          message.length > this.maxReceiveMessageSize
+        ) {
           this.sendError({
             code: Status.RESOURCE_EXHAUSTED,
-            details: `Received message larger than max (${message.length} vs. ${this.maxReceiveMessageSize})`
+            details: `Received message larger than max (${message.length} vs. ${this.maxReceiveMessageSize})`,
           });
           return;
         }

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -45,7 +45,11 @@ import {
 } from './server-call';
 import { ServerCredentials } from './server-credentials';
 import { ChannelOptions } from './channel-options';
-import { createResolver, ResolverListener, mapUriDefaultScheme } from './resolver';
+import {
+  createResolver,
+  ResolverListener,
+  mapUriDefaultScheme,
+} from './resolver';
 import * as logging from './logging';
 import {
   SubchannelAddress,
@@ -538,11 +542,20 @@ export class Server {
 
         try {
           const path = headers[http2.constants.HTTP2_HEADER_PATH] as string;
-          trace('Received call to method ' + path + ' at address ' + http2Server.address()?.toString());
+          trace(
+            'Received call to method ' +
+              path +
+              ' at address ' +
+              http2Server.address()?.toString()
+          );
           const handler = this.handlers.get(path);
 
           if (handler === undefined) {
-            trace('No handler registered for method ' + path + '. Sending UNIMPLEMENTED status.');
+            trace(
+              'No handler registered for method ' +
+                path +
+                '. Sending UNIMPLEMENTED status.'
+            );
             throw getUnimplementedStatusResponse(path);
           }
 

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -46,13 +46,20 @@ import {
 import { ServerCredentials } from './server-credentials';
 import { ChannelOptions } from './channel-options';
 import { createResolver, ResolverListener, mapUriDefaultScheme } from './resolver';
-import { log } from './logging';
+import * as logging from './logging';
 import {
   SubchannelAddress,
   TcpSubchannelAddress,
   isTcpSubchannelAddress,
+  subchannelAddressToString,
 } from './subchannel';
 import { parseUri } from './uri-parser';
+
+const TRACER_NAME = 'server';
+
+function trace(text: string): void {
+  logging.trace(LogVerbosity.DEBUG, TRACER_NAME, text);
+}
 
 interface BindResult {
   port: number;
@@ -269,6 +276,7 @@ export class Server {
       }
       return Promise.all(
         addressList.map((address) => {
+          trace('Attempting to bind ' + subchannelAddressToString(address));
           let addr: SubchannelAddress;
           if (isTcpSubchannelAddress(address)) {
             addr = {
@@ -288,6 +296,7 @@ export class Server {
             http2Server.once('error', onError);
 
             http2Server.listen(addr, () => {
+              trace('Successfully bound ' + subchannelAddressToString(address));
               this.http2ServerList.push(http2Server);
               const boundAddress = http2Server.address()!;
               if (typeof boundAddress === 'string') {
@@ -378,11 +387,11 @@ export class Server {
           (bindResult) => {
             if (bindResult.count === 0) {
               const errorString = `No address added out of total ${addressList.length} resolved`;
-              log(LogVerbosity.ERROR, errorString);
+              logging.log(LogVerbosity.ERROR, errorString);
               callback(new Error(errorString), 0);
             } else {
               if (bindResult.count < addressList.length) {
-                log(
+                logging.log(
                   LogVerbosity.INFO,
                   `WARNING Only ${bindResult.count} addresses added out of total ${addressList.length} resolved`
                 );
@@ -392,7 +401,7 @@ export class Server {
           },
           (error) => {
             const errorString = `No address added out of total ${addressList.length} resolved`;
-            log(LogVerbosity.ERROR, errorString);
+            logging.log(LogVerbosity.ERROR, errorString);
             callback(new Error(errorString), 0);
           }
         );
@@ -444,6 +453,7 @@ export class Server {
       serialize,
       deserialize,
       type,
+      path: name,
     } as UntypedHandler);
     return true;
   }
@@ -528,9 +538,11 @@ export class Server {
 
         try {
           const path = headers[http2.constants.HTTP2_HEADER_PATH] as string;
+          trace('Received call to method ' + path + ' at address ' + http2Server.address()?.toString());
           const handler = this.handlers.get(path);
 
           if (handler === undefined) {
+            trace('No handler registered for method ' + path + '. Sending UNIMPLEMENTED status.');
             throw getUnimplementedStatusResponse(path);
           }
 


### PR DESCRIPTION
Trace what ports the server binds, what requests the server receives, and what status it ends each call with. Currently, if the call is cancelled, that doesn't get logged, because logging it properly is a little tricky.

The first commit has the substantive changes. The rest is cleanup from the formatter.