### PR TITLE
Copy a file that was previously in the grpc submodule

### DIFF
--- a/packages/grpc-native-core/deps/grpc/tools/run_tests/interop/with_nvm.sh
+++ b/packages/grpc-native-core/deps/grpc/tools/run_tests/interop/with_nvm.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Makes sure NVM is loaded before executing the command passed as an argument
+# shellcheck disable=SC1090
+source ~/.nvm/nvm.sh
+"$@"


### PR DESCRIPTION
The interop scripts in the grpc/grpc repo reference that file at this path. This is the simplest solution to make the interop tests work again.