### PR TITLE
grpc 1.24 updates from master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     name: All Simple Native Builds
     strategy:
       matrix:
-        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13']
+        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
         arch: [ia32, x64]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
@@ -46,7 +46,7 @@ jobs:
     name: All Electron Builds
     strategy:
       matrix:
-        electron: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '2.0', '3.0', '3.1', '4.1', '4.2', '5.0', '6.0', '7.0']
+        electron: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '2.0', '3.0', '3.1', '4.1', '4.2', '5.0', '6.0', '6.1', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3', '9.0']
         arch: [ia32, x64]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13']
+        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
     env:
       ARCH: x64
       VERSION: ${{matrix.node}}.0.0
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13']
+        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
         arch: [arm, arm64, s390x]
     env:
       ARCH: ${{matrix.arch}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         submodules: recursive
     - uses: actions/setup-node@v1.1.0
       with:
-        node-version: 12
+        node-version: 14
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.0
       if: ${{matrix.os == 'windows-latest'}}
@@ -61,7 +61,7 @@ jobs:
         submodules: recursive
     - uses: actions/setup-node@v1.1.0
       with:
-        node-version: 12
+        node-version: 14
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.0
       if: ${{matrix.os == 'windows-latest'}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - uses: actions/setup-node@v1.1.0
+    - uses: actions/setup-node@v1.4.2
       with:
         node-version: 14
     - name: Setup MSBuild
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - uses: actions/setup-node@v1.1.0
+    - uses: actions/setup-node@v1.4.2
       with:
         node-version: 14
     - name: Setup MSBuild

--- a/packages/grpc-native-core/README.md
+++ b/packages/grpc-native-core/README.md
@@ -1,6 +1,8 @@
 [![npm](https://img.shields.io/npm/v/grpc.svg)](https://www.npmjs.com/package/grpc)
 # Node.js gRPC Library
 
+**This library is now only receiving bug fixes and runtime compatibility updates. In April 2021 it will be deprecated and will no longer receive any updates.**
+
 ## PREREQUISITES
 - `node`: This requires `node` to be installed, version `4.0` or above. If you instead have the `nodejs` executable on Debian, you should install the [`nodejs-legacy`](https://packages.debian.org/sid/nodejs-legacy) package.
 

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -30,7 +30,7 @@
     "lodash.camelcase": "^4.3.0",
     "lodash.clone": "^4.5.0",
     "nan": "^2.13.2",
-    "node-pre-gyp": "^0.14.0",
+    "node-pre-gyp": "^0.15.0",
     "protobufjs": "^5.0.3"
   },
   "devDependencies": {

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "author": "Google Inc.",
   "description": "gRPC Library for Node",
   "homepage": "https://grpc.io/",

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -25,9 +25,6 @@
     "install": "node-pre-gyp install --fallback-to-build --library=static_library",
     "prepack": "git submodule update --init --recursive && npm install"
   },
-  "bundledDependencies": [
-    "node-pre-gyp"
-  ],
   "dependencies": {
     "@types/bytebuffer": "^5.0.40",
     "lodash.camelcase": "^4.3.0",

--- a/packages/grpc-native-core/src/metadata.js
+++ b/packages/grpc-native-core/src/metadata.js
@@ -22,6 +22,9 @@ var clone = require('lodash.clone');
 
 var grpc = require('./grpc_extension');
 
+const common = require('./common');
+const logVerbosity = require('./constants').logVerbosity;
+
 const IDEMPOTENT_REQUEST_FLAG = 0x10;
 const WAIT_FOR_READY_FLAG = 0x20;
 const CACHEABLE_REQUEST_FLAG = 0x40;
@@ -231,6 +234,12 @@ Metadata._fromCoreRepresentation = function(metadata) {
   if (metadata) {
     Object.keys(metadata.metadata).forEach(key => {
       const value = metadata.metadata[key];
+      if (!grpc.metadataKeyIsLegal(key)) {
+        common.log(logVerbosity.ERROR,
+          "Warning: possibly corrupted metadata key received: " +
+          key + ": " + value +
+          ". Please report this at https://github.com/grpc/grpc-node/issues/1173.");
+      }
       newMetadata._internal_repr[key] = clone(value);
     });
   }

--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -23,7 +23,6 @@
     "install": "node-pre-gyp install",
     "prepublishOnly": "git submodule update --init --recursive && node copy_well_known_protos.js"
   },
-  "bundledDependencies": ["node-pre-gyp"],
   "dependencies": {
     "node-pre-gyp": "^0.12.0"
   },

--- a/tools/release/alpine_artifact/Dockerfile
+++ b/tools/release/alpine_artifact/Dockerfile
@@ -1,2 +1,2 @@
-FROM node:10-alpine
+FROM node:14-alpine
 RUN apk add --no-cache python curl bash build-base

--- a/tools/release/cross/Dockerfile
+++ b/tools/release/cross/Dockerfile
@@ -10,4 +10,4 @@ ENV NVM_DIR /usr/local/nvm
 
 RUN curl curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 
-RUN /bin/bash -l -c "nvm install 12"
+RUN /bin/bash -l -c "nvm install 14"

--- a/tools/release/native/Dockerfile
+++ b/tools/release/native/Dockerfile
@@ -13,4 +13,4 @@ ENV NVM_DIR /usr/local/nvm
 
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 
-RUN /bin/bash -l -c "nvm install 12"
+RUN /bin/bash -l -c "nvm install 14"


### PR DESCRIPTION
Cherry pick #1371 and #1224, add the new versions of Node and Electron to the build matrix, and bump the version.