### PR TITLE
Move google-auth-library to a peer dependency

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -26,6 +26,7 @@
     "@types/semver": "^6.0.1",
     "clang-format": "^1.0.55",
     "execa": "^2.0.3",
+    "google-auth-library": "^6.0.0",
     "gts": "^2.0.0",
     "gulp": "^4.0.2",
     "gulp-mocha": "^6.0.0",
@@ -56,8 +57,10 @@
     "posttest": "npm run check"
   },
   "dependencies": {
-    "google-auth-library": "^6.0.0",
     "semver": "^6.2.0"
+  },
+  "peerDependencies": {
+    "google-auth-library": "5.x || 6.x"
   },
   "files": [
     "src/*.ts",


### PR DESCRIPTION
This fixes #1442. The code path that calls into `google-auth-library` can't actually be triggered from the current public APIs, so if someone doesn't have the peer dependency they'll be fine. Firebase depends on `google-gax` 1.x, which depends on `google-auth-library` 5.x, and other client libraries depend on `google-gax` 2.x, which depends on `google-auth-library` 6.x. The peer dependency will be satisfied in either case.

We also need to add the dev dependency because we need it at build time for the type definitions.

Once the xDS stuff is done (or we want to create a `credentials.createGoogleDefault` public API) and that code path can actually be triggered, we should switch back to a direct dependency on `google-auth-library` 5.x to ensure that we still support Node 8. Hopefully we can eventually drop Node 8 and switch the dependency to 6.x.