### PR TITLE
grpc-js: Properly back off when transitioning through IDLE

### DIFF
--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -507,10 +507,6 @@ export class Subchannel {
         this.stopKeepalivePings();
         break;
       case ConnectivityState.IDLE:
-        /* Stopping the backoff timer here is probably redundant because we
-         * should only transition to the IDLE state as a result of the timer
-         * ending, but we still want to reset the backoff timeout. */
-        this.stopBackoff();
         if (this.session) {
           this.session.close();
         }


### PR DESCRIPTION
The comment that was previously there is wrong: we don't want to reset the backoff here. If we're in the case where we want to back off, i.e. the application indicates that it wants to keep trying to connect, and we keep failing to connect, the state transition sequence looks like this:

 1. IDLE -> CONNECTING (start connecting)
 2. CONNECTING -> TRANSIENT_FAILURE (fail to connect)
 3. TRANSIENT_FAILURE -> IDLE (backoff timer ends)
 4. IDLE -> CONNECTING (the queue picker from step 3 kicks the subchannel out of IDLE)
 5. ...

The previous code resets the backoff timeout in step 3 of that sequence, which is exactly what we don't want to happen. The backoff timeout should only be reset when transitioning to READY, and that is handled already on line 490.