### PR TITLE
grpc-js: transition out of TRANSIENT_FAILURE if backoff timer has ended

### DIFF
--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -231,19 +231,23 @@ export class Subchannel {
       maxDelay: options['grpc.max_reconnect_backoff_ms'],
     };
     this.backoffTimeout = new BackoffTimeout(() => {
-      if (this.continueConnecting) {
-        this.transitionToState(
-          [ConnectivityState.TRANSIENT_FAILURE],
-          ConnectivityState.CONNECTING
-        );
-      } else {
-        this.transitionToState(
-          [ConnectivityState.TRANSIENT_FAILURE],
-          ConnectivityState.IDLE
-        );
-      }
+      this.handleBackoffTimer();
     }, backoffOptions);
     this.subchannelAddressString = subchannelAddressToString(subchannelAddress);
+  }
+
+  private handleBackoffTimer() {
+    if (this.continueConnecting) {
+      this.transitionToState(
+        [ConnectivityState.TRANSIENT_FAILURE],
+        ConnectivityState.CONNECTING
+      );
+    } else {
+      this.transitionToState(
+        [ConnectivityState.TRANSIENT_FAILURE],
+        ConnectivityState.IDLE
+      );
+    }
   }
 
   /**
@@ -505,6 +509,14 @@ export class Subchannel {
         }
         this.session = null;
         this.stopKeepalivePings();
+        /* If the backoff timer has already ended by the time we get to the
+         * TRANSIENT_FAILURE state, we want to immediately transition out of
+         * TRANSIENT_FAILURE as though the backoff timer is ending right now */
+        if (!this.backoffTimeout.isRunning()) {
+          process.nextTick(() => {
+            this.handleBackoffTimer();
+          });
+        }
         break;
       case ConnectivityState.IDLE:
         /* Stopping the backoff timer here is probably redundant because we


### PR DESCRIPTION
If the backoff timer ends before the connection attempt fails, the subchannel needs to transition into TRANSIENT_FAILURE briefly to signal to the channel that the connection attempt failed, but then it needs to transition out of TRANSIENT_FAILURE to be able to try to connect again.

This fixes #1434.