### PR TITLE
grpc-js: Add support for grpc.enable_http_proxy channel option

### DIFF
--- a/PACKAGE-COMPARISON.md
+++ b/PACKAGE-COMPARISON.md
@@ -43,5 +43,6 @@ In addition, all channel arguments defined in [this header file](https://github.
  - `grpc.use_local_subchannel_pool`
  - `grpc.max_send_message_length`
  - `grpc.max_receive_message_length`
+ - `grpc.enable_http_proxy`
  - `channelOverride`
  - `channelFactoryOverride`

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -32,6 +32,7 @@ export interface ChannelOptions {
   'grpc.use_local_subchannel_pool'?: number;
   'grpc.max_send_message_length'?: number;
   'grpc.max_receive_message_length'?: number;
+  'grpc.enable_http_proxy'?: number;
   [key: string]: string | number | undefined;
 }
 
@@ -53,6 +54,7 @@ export const recognizedOptions = {
   'grpc.use_local_subchannel_pool': true,
   'grpc.max_send_message_length': true,
   'grpc.max_receive_message_length': true,
+  'grpc.enable_http_proxy': true,
 };
 
 export function channelOptionsEqual(

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -125,6 +125,9 @@ export function mapProxyName(
     target: target,
     extraOptions: {},
   };
+  if ((options['grpc.enable_http_proxy'] ?? 1) === 0) {
+    return noProxyResult;
+  }
   const proxyInfo = getProxyInfo();
   if (!proxyInfo.address) {
     return noProxyResult;


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-node/issues/1453

This change adds support for the [`grpc.enable_http_proxy`](https://grpc.github.io/grpc/core/group__grpc__arg__keys.html#gaa3f69f6e1e789e36d2d9c6083fec0257) channel option.


