### PR TITLE
grpc-js: clear noop server call deadline

### DIFF
--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -341,15 +341,13 @@ export type Handler<RequestType, ResponseType> =
 
 export type HandlerType = 'bidi' | 'clientStream' | 'serverStream' | 'unary';
 
-const noopTimer: NodeJS.Timer = setTimeout(() => {}, 0);
-
 // Internal class that wraps the HTTP2 request.
 export class Http2ServerCallStream<
   RequestType,
   ResponseType
 > extends EventEmitter {
   cancelled = false;
-  deadline: NodeJS.Timer = noopTimer;
+  deadline: NodeJS.Timer = setTimeout(() => {}, 0);
   private wantTrailers = false;
   private metadataSent = false;
   private canPush = false;
@@ -389,6 +387,9 @@ export class Http2ServerCallStream<
     if ('grpc.max_receive_message_length' in options) {
       this.maxReceiveMessageSize = options['grpc.max_receive_message_length']!;
     }
+
+    // Clear noop timer
+    clearTimeout(this.deadline);
   }
 
   private checkCancelled(): boolean {


### PR DESCRIPTION
addresses: https://github.com/googleapis/nodejs-logging-winston/issues/414

this fixes an issue with open handles when running tests with jest. the timeout is created on import of this file and not cleaned up.

at a glance, i couldn't tell if a singleton was necessary, so this could be solved by just creating a separate timer for each stream, but figured this was closer to the current implementation.

a singleton still has issues if people are creating a server in their tests, but figure this will be rare compared to people just importing grpc-js for client usages