### PR TITLE
feat(client): export `ClientOptions` type

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -31,6 +31,7 @@ import { ChannelCredentials } from './channel-credentials';
 import {
   CallOptions,
   Client,
+  ClientOptions,
   CallInvocationTransformer,
   CallProperties,
   UnaryCallback,
@@ -133,6 +134,7 @@ export {
 
 export {
   Client,
+  ClientOptions,
   loadPackageDefinition,
   makeClientConstructor,
   makeClientConstructor as makeGenericClientConstructor,


### PR DESCRIPTION
We have a wrapper around the base Client, and being able to annotate with this type helps it be a bit more seamless