### PR TITLE
grpc-js: server: cull closed sessions from list, check for closed in tryShutdown

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -500,7 +500,6 @@ export class Server {
       }
     }
 
-    pendingChecks += this.sessions.size;
     this.sessions.forEach((session) => {
       if (!session.closed) {
         pendingChecks += 1;

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -500,10 +500,12 @@ export class Server {
       }
     }
 
-    // If any sessions are active, close them gracefully.
     pendingChecks += this.sessions.size;
     this.sessions.forEach((session) => {
-      session.close(maybeCallback);
+      if (!session.closed) {
+        pendingChecks += 1;
+        session.close(maybeCallback);
+      }
     });
     if (pendingChecks === 0) {
       callback();
@@ -608,6 +610,10 @@ export class Server {
       }
 
       this.sessions.add(session);
+
+      session.on('close', () => {
+        this.sessions.delete(session);
+      });
     });
   }
 }


### PR DESCRIPTION
As currently written, the `sessions` field tracks every HTTP/2 session that has ever been established with the server, which can grow without bound. If we remove the ones that are closed, it should be bounded by network connection limits. The check for `session.closed` in `tryShutdown` should avoid potential race conditions, where we get to that line and the `close` event is pending but has not fired yet.

I think this will fix #1458.