### PR TITLE
grpc-js: Export propagate constants for type parity with grpc

### DIFF
--- a/packages/grpc-js/src/constants.ts
+++ b/packages/grpc-js/src/constants.ts
@@ -41,6 +41,18 @@ export enum LogVerbosity {
   ERROR,
 }
 
+/**
+ * NOTE: This enum is not currently used in any implemented API in this
+ * library. It is included only for type parity with the other implementation.
+ */
+export enum Propagate {
+  DEADLINE = 1,
+  CENSUS_STATS_CONTEXT = 2,
+  CENSUS_TRACING_CONTEXT = 4,
+  CANCELLATION = 8,
+  DEFAULTS = 65536,
+}
+
 // -1 means unlimited
 export const DEFAULT_MAX_SEND_MESSAGE_LENGTH = -1;
 

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -36,7 +36,7 @@ import {
   CallProperties,
   UnaryCallback,
 } from './client';
-import { LogVerbosity, Status } from './constants';
+import { LogVerbosity, Status, Propagate } from './constants';
 import * as logging from './logging';
 import {
   Deserialize,
@@ -127,6 +127,7 @@ export {
   LogVerbosity as logVerbosity,
   Status as status,
   ConnectivityState as connectivityState,
+  Propagate as propagate,
   // TODO: Other constants as well
 };
 


### PR DESCRIPTION
This fixes #1457