### PR TITLE
Update node-pre-gyp to pickup fix for #1362

### DIFF
--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -24,7 +24,7 @@
     "prepublishOnly": "git submodule update --init --recursive && node copy_well_known_protos.js"
   },
   "dependencies": {
-    "node-pre-gyp": "^0.12.0"
+    "node-pre-gyp": "^0.15.0"
   },
   "binary": {
     "module_name": "grpc_tools",


### PR DESCRIPTION
node-pre-gyp 0.12.0 uses needle 2.4.1 which has the bug in it.
Even with grpc 1.24.3, which refers to the updated version, it seems npm can decide to use the older version referenced by this package.