### PR TITLE
grpc-js: Add port to :authority, leave it out of service_url

### DIFF
--- a/packages/grpc-js/src/call-credentials-filter.ts
+++ b/packages/grpc-js/src/call-credentials-filter.ts
@@ -20,6 +20,7 @@ import { Channel } from './channel';
 import { BaseFilter, Filter, FilterFactory } from './filter';
 import { Metadata } from './metadata';
 import { Status } from './constants';
+import { splitHostPort } from './uri-parser';
 
 export class CallCredentialsFilter extends BaseFilter implements Filter {
   private serviceUrl: string;
@@ -38,9 +39,10 @@ export class CallCredentialsFilter extends BaseFilter implements Filter {
     if (splitPath.length >= 2) {
       serviceName = splitPath[1];
     }
+    const hostname = splitHostPort(stream.getHost()).host;
     /* Currently, call credentials are only allowed on HTTPS connections, so we
      * can assume that the scheme is "https" */
-    this.serviceUrl = `https://${stream.getHost()}/${serviceName}`;
+    this.serviceUrl = `https://${hostname}/${serviceName}`;
   }
 
   async sendMetadata(metadata: Promise<Metadata>): Promise<Metadata> {

--- a/packages/grpc-js/src/call-credentials-filter.ts
+++ b/packages/grpc-js/src/call-credentials-filter.ts
@@ -39,7 +39,7 @@ export class CallCredentialsFilter extends BaseFilter implements Filter {
     if (splitPath.length >= 2) {
       serviceName = splitPath[1];
     }
-    const hostname = splitHostPort(stream.getHost()).host;
+    const hostname = splitHostPort(stream.getHost())?.host ?? 'localhost';
     /* Currently, call credentials are only allowed on HTTPS connections, so we
      * can assume that the scheme is "https" */
     this.serviceUrl = `https://${hostname}/${serviceName}`;

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -269,12 +269,7 @@ class DnsResolver implements Resolver {
    * @param target
    */
   static getDefaultAuthority(target: GrpcUri): string {
-    const hostPort = splitHostPort(target.path);
-    if (hostPort !== null) {
-      return hostPort.host;
-    } else {
-      throw new Error(`Failed to parse target ${uriToString(target)}`);
-    }
+    return target.path;
   }
 }
 


### PR DESCRIPTION
Experimentally, this behavior matches the behavior of `grpc`. This fixes #1475, and I'm pretty sure it will avoid a regression of #1347.