### PR TITLE
grpc-js: Don't initiate a read after receiving a message

### DIFF
--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -558,9 +558,7 @@ export class Client {
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       onReceiveMessage(message: any) {
-        if (stream.push(message)) {
-          call.startRead();
-        }
+        stream.push(message);
       },
       onReceiveStatus(status: StatusObject) {
         if (receivedStatus) {
@@ -656,9 +654,7 @@ export class Client {
         stream.emit('metadata', metadata);
       },
       onReceiveMessage(message: Buffer) {
-        if (stream.push(message)) {
-          call.startRead();
-        }
+        stream.push(message)
       },
       onReceiveStatus(status: StatusObject) {
         if (receivedStatus) {

--- a/test/api/interop_extra_test.js
+++ b/test/api/interop_extra_test.js
@@ -158,12 +158,13 @@ describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, functio
       call.on('data', (value) => {
         responseCount++;
       });
-      call.on('end', () => {
+      call.on('status', (status) => {
+        assert.strictEqual(status.code, grpc.status.OK);
         assert.strictEqual(responseCount, arg.response_parameters.length);
         done();
       });
-      call.on('status', function(status) {
-        assert.strictEqual(status.code, grpc.status.OK);
+      call.on('error', (error) => {
+        assert.ifError(error);
       });
     });
     describe('max message size', function() {

--- a/test/api/interop_extra_test.js
+++ b/test/api/interop_extra_test.js
@@ -144,6 +144,28 @@ describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, functio
         done();
       });
     });
+    it('should receive all messages in a long stream', function() {
+      var arg = {
+        response_type: 'COMPRESSABLE',
+        response_parameters: [
+        ]
+      };
+      for (let i = 0; i < 100_000; i++) {
+        arg.response_parameters.push({size: 0});
+      }
+      var call = client.streamingOutputCall(arg);
+      let responseCount = 0;
+      call.on('data', (value) => {
+        responseCount++;
+      });
+      call.on('end', () => {
+        assert.strictEqual(responseCount, arg.response_parameters.length);
+        done();
+      });
+      call.on('status', function(status) {
+        assert.strictEqual(status.code, grpc.status.OK);
+      });
+    });
     describe('max message size', function() {
       // A size that is larger than the default limit
       const largeMessageSize = 8 * 1024 * 1024;

--- a/test/api/interop_extra_test.js
+++ b/test/api/interop_extra_test.js
@@ -51,7 +51,7 @@ function echoMetadataGenerator(options, callback) {
 
 const credentials = grpc.credentials.createFromMetadataGenerator(echoMetadataGenerator);
 
-describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, function() {
+describe.only(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, function() {
   describe('Interop-adjacent tests', function() {
     let server;
     let client;
@@ -144,7 +144,8 @@ describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, functio
         done();
       });
     });
-    it('should receive all messages in a long stream', function() {
+    it('should receive all messages in a long stream', function(done) {
+      this.timeout(20000);
       var arg = {
         response_type: 'COMPRESSABLE',
         response_parameters: [

--- a/test/api/interop_extra_test.js
+++ b/test/api/interop_extra_test.js
@@ -150,7 +150,7 @@ describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, functio
         response_parameters: [
         ]
       };
-      for (let i = 0; i < 100_000; i++) {
+      for (let i = 0; i < 100000; i++) {
         arg.response_parameters.push({size: 0});
       }
       var call = client.streamingOutputCall(arg);

--- a/test/interop/async_delay_queue.js
+++ b/test/interop/async_delay_queue.js
@@ -39,9 +39,13 @@ AsyncDelayQueue.prototype.runNext = function() {
   var continueCallback = _.bind(this.runNext, this);
   if (next) {
     this.callback_pending = true;
-    setTimeout(function() {
+    if (next.delay === 0) {
       next.callback(continueCallback);
-    }, next.delay);
+    } else {
+      setTimeout(function() {
+        next.callback(continueCallback);
+      }, next.delay);
+    }
   } else {
     this.callback_pending = false;
   }


### PR DESCRIPTION
It turns out that the `Readable` stream class will aggressively call `_read` even if `push` returns `true`, so we don't also need to start another read after pushing. This fixes #1473, at least according to the test case provided in that issue.