### PR TITLE
grpc-js: bump to 1.1.0

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
This release includes #1459, #1465, #1463, #1433, #1449, #1466, #1467, #1468, #1478, and #1479. I think those are all valid patch-level changes; the minor version bump is mainly to ensure that it goes through testing before getting picked up by `google-gax`, to validate that #1478 doesn't cause a regression of #1347.