### PR TITLE
Remove 'only' that was left over from test fixes

### DIFF
--- a/test/api/interop_extra_test.js
+++ b/test/api/interop_extra_test.js
@@ -51,7 +51,7 @@ function echoMetadataGenerator(options, callback) {
 
 const credentials = grpc.credentials.createFromMetadataGenerator(echoMetadataGenerator);
 
-describe.only(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, function() {
+describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, function() {
   describe('Interop-adjacent tests', function() {
     let server;
     let client;


### PR DESCRIPTION
This was accidentally included in a commit in #1479.