### PR TITLE
Omit port number from servername option

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -28,7 +28,7 @@ import * as logging from './logging';
 import { LogVerbosity } from './constants';
 import { getProxiedConnection, ProxyConnectionResult } from './http_proxy';
 import * as net from 'net';
-import { GrpcUri, parseUri } from './uri-parser';
+import { GrpcUri, parseUri, splitHostPort } from './uri-parser';
 import { ConnectionOptions } from 'tls';
 import { FilterFactory, Filter } from './filter';
 
@@ -309,8 +309,9 @@ export class Subchannel {
         };
         connectionOptions.servername = sslTargetNameOverride;
       } else {
+        const authorityHostname = splitHostPort(targetAuthority)?.host ?? 'localhost';
         // We want to always set servername to support SNI
-        connectionOptions.servername = targetAuthority;
+        connectionOptions.servername = authorityHostname;
       }
       if (proxyConnectionResult.socket) {
         /* This is part of the workaround for


### PR DESCRIPTION
This was a bad interaction between #1466 and #1478. SNI is just supposed to use the hostname, not the full `host:port` string.