### PR TITLE
grpc-tools: Add compiler flag to fix error on Mac

### DIFF
--- a/packages/grpc-tools/CMakeLists.txt
+++ b/packages/grpc-tools/CMakeLists.txt
@@ -14,6 +14,7 @@ set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build protobuf tests")
 set(protobuf_WITH_ZLIB OFF CACHE BOOL "Build protobuf with zlib.")
 
 set(CMAKE_EXE_LINKER_FLAGS "-static-libstdc++")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-stack-protector")
 
 add_executable(grpc_node_plugin
   src/node_generator.cc

--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-tools",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": "Google Inc.",
   "description": "Tools for developing with gRPC on Node.js",
   "homepage": "https://grpc.io/",


### PR DESCRIPTION
This is apparently what is needed to fix #1484.