### PR TITLE
grpc-js: Improve error handling in a few places

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -541,6 +541,15 @@ export class Http2CallStream implements Call {
             code = Status.PERMISSION_DENIED;
             details = 'Protocol not secure enough';
             break;
+          case http2.constants.NGHTTP2_INTERNAL_ERROR:
+            code = Status.INTERNAL;
+            /* This error code was previously handled in the default case, and
+             * there are several instances of it online, so I wanted to
+             * preserve the original error message so that people find existing
+             * information in searches, but also include the more recognizable
+             * "Internal server error" message. */
+            details = `Received RST_STREAM with code ${stream.rstCode} (Internal server error)`;
+            break;
           default:
             code = Status.INTERNAL;
             details = `Received RST_STREAM with code ${stream.rstCode}`;


### PR DESCRIPTION
There are a few different error handling-related changes here:

 1. Update the error message "Received RST_STREAM with code 2" to add the string "Internal server error". We have seen several reports of people seeing the original error message and not understanding it.

 2. Add trace logs for GOAWAYs. Node's http2 internals seem to automatically translate GOAWAYs to RST_STREAMs on streams still open in that session. Logging this will help distinguish between real RST_STREAM errors and GOAWAYs.

 3. Transition a subchannel to TRANSIENT_FAILURE whenever its session fails to create a stream. This addresses a failure reported at https://github.com/googleapis/nodejs-firestore/issues/1023#issuecomment-653204096 where an error is thrown from `session.request` with the code `ERR_HTTP2_GOAWAY_SESSION`, but we never see a 'goaway' or 'close' event, so we just keep using that session forever and it never works.

I also bumped the version to 1.1.2 because I would like to publish that third change.