### PR TITLE
grpc-js: Remove peerDependency on google-auth-library

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -59,9 +59,6 @@
   "dependencies": {
     "semver": "^6.2.0"
   },
-  "peerDependencies": {
-    "google-auth-library": "5.x || 6.x"
-  },
   "files": [
     "src/*.ts",
     "build/src/*.{js,d.ts,js.map}",


### PR DESCRIPTION
I have been convinced by the discussion on #1443 that having this `peerDependencies` entry is not beneficial, and is sometimes detrimental.