### PR TITLE
Load google/protobuf/* into common using require

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "author": "Google Inc.",
   "contributors": [
     {

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -369,23 +369,29 @@ export function loadSync(
 }
 
 // Load Google's well-known proto files that aren't exposed by Protobuf.js.
-{
-  // Protobuf.js exposes: any, duration, empty, field_mask, struct, timestamp,
-  // and wrappers. compiler/plugin is excluded in Protobuf.js and here.
-  const wellKnownProtos = ['api', 'descriptor', 'source_context', 'type'];
-  const sourceDir = path.join(
-    path.dirname(require.resolve('protobufjs')),
-    'google',
-    'protobuf'
-  );
 
-  for (const proto of wellKnownProtos) {
-    const file = path.join(sourceDir, `${proto}.proto`);
-    const descriptor = Protobuf.loadSync(file).toJSON();
+// Protobuf.js exposes: any, duration, empty, field_mask, struct, timestamp,
+// and wrappers. compiler/plugin is excluded in Protobuf.js and here.
 
-    Protobuf.common(
-      proto,
-      (descriptor.nested!.google as Protobuf.INamespace).nested!
-    );
-  }
-}
+// Using constant strings for compatibility with tools like Webpack
+const apiDescriptor = require('protobufjs/google/protobuf/api.json');
+const descriptorDescriptor = require('protobufjs/google/protobuf/descriptor.json');
+const sourceContextDescriptor = require('protobufjs/google/protobuf/source_context.json');
+const typeDescriptor = require('protobufjs/google/protobuf/type.json');
+
+Protobuf.common(
+  'api',
+  apiDescriptor.nested.google.nested.protobuf.nested
+);
+Protobuf.common(
+  'descriptor',
+  descriptorDescriptor.nested.google.nested.protobuf.nested
+);
+Protobuf.common(
+  'source_context',
+  sourceContextDescriptor.nested.google.nested.protobuf.nested
+);
+Protobuf.common(
+  'type',
+  typeDescriptor.nested.google.nested.protobuf.nested
+);

--- a/packages/proto-loader/test_protos/well_known.proto
+++ b/packages/proto-loader/test_protos/well_known.proto
@@ -19,3 +19,7 @@ import "google/protobuf/descriptor.proto";
 extend google.protobuf.FieldOptions {
   bool redact = 52000;
 }
+
+message DescriptorHolder {
+  google.protobuf.DescriptorProto descriptor = 1;
+}


### PR DESCRIPTION
Protobuf.js provides both the `google/protobuf/*.proto` files that it doesn't load into `common` itself, along with the JSON generated files for those `.proto` files. It turns out that those JSON files have exactly the format that can be loaded into `common`, and `require` can load JSON files directly, so we can load these files without using `require.resolve` at all. I replaced the loop with constant strings so that a tool like webpack that needs to manipulate `require` calls would be able to understand it.

This should fix #969.