### PR TITLE
Fix interop test breakage

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@types/lodash.camelcase": "^4.3.4",
+    "@types/mocha": "^5.2.6",
     "@types/node": "^10.12.5",
     "clang-format": "^1.2.2",
     "gts": "^1.1.0",


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/23466

To reproduce locally:

```
$ git clone https://github.com/grpc/grpc-node
$ cd grpc-node
$ git submodule update --init --recursive 
$ npm install gulp
$ npm install
$ cd packages/proto-loader
$ npm install
```


Got
```
> protobufjs@6.10.0 postinstall /usr/local/google/home/stanleycheung/grpc-node-test2/packages/proto-loader/node_modules/protobufjs
> node scripts/postinstall

> @grpc/proto-loader@0.5.5 prepare /usr/local/google/home/stanleycheung/grpc-node-test2/packages/proto-loader
> npm run compile

> @grpc/proto-loader@0.5.5 compile /usr/local/google/home/stanleycheung/grpc-node-test2/packages/proto-loader
> tsc -p .

../../node_modules/@types/gulp-mocha/index.d.ts:10:39 - error TS2304: Cannot find name 'MochaSetupOptions'.

10 declare function mocha(setupOptions?: MochaSetupOptions): NodeJS.ReadWriteStream;
                                         ~~~~~~~~~~~~~~~~~
Found 2 errors.
```


The fix is basically copying this line: https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/package.json#L22