### PR TITLE
Update @types/gulp-mocha dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/execa": "^0.8.0",
     "@types/gulp": "^4.0.5",
-    "@types/gulp-mocha": "0.0.31",
+    "@types/gulp-mocha": "0.0.33",
     "@types/ncp": "^2.0.1",
     "@types/node": "^8.0.32",
     "@types/pify": "^3.0.0",

--- a/packages/grpc-js/gulpfile.ts
+++ b/packages/grpc-js/gulpfile.ts
@@ -68,8 +68,7 @@ const copyTestFixtures = checkTask(() => ncpP(`${jsCoreDir}/test/fixtures`, `${o
 
 const runTests = checkTask(() => {
   return gulp.src(`${outDir}/test/**/*.js`)
-    .pipe(mocha({reporter: 'mocha-jenkins-reporter',
-                 require: ['ts-node/register']}));
+    .pipe(mocha({reporter: 'mocha-jenkins-reporter'}));
 });
 
 const test = gulp.series(install, copyTestFixtures, runTests);

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -17,9 +17,7 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.5.0",
     "@types/gulp": "^4.0.6",
-    "@types/gulp-mocha": "0.0.32",
     "@types/lodash": "^4.14.108",
-    "@types/mocha": "^5.2.6",
     "@types/ncp": "^2.0.1",
     "@types/node": "^12.7.5",
     "@types/pify": "^3.0.2",

--- a/packages/proto-loader/gulpfile.ts
+++ b/packages/proto-loader/gulpfile.ts
@@ -61,8 +61,7 @@ const compile = () => execNpmCommand('compile');
 const runTests = () => {
   if (semver.satisfies(process.version, ">=6")) {
     return gulp.src(`${outDir}/test/**/*.js`)
-      .pipe(mocha({reporter: 'mocha-jenkins-reporter',
-                    require: ['ts-node/register']}));
+      .pipe(mocha({reporter: 'mocha-jenkins-reporter'}));
   } else {
     console.log(`Skipping proto-loader tests for Node ${process.version}`);
     return Promise.resolve(null);


### PR DESCRIPTION
This fixes a breakage caused by an `@types/mocha` update.