### PR TITLE
Fix @types/mocha compatibility issue

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@types/lodash.camelcase": "^4.3.4",
+    "@types/mocha": "^5.2.7",
     "@types/node": "^10.12.5",
     "clang-format": "^1.2.2",
     "gts": "^1.1.0",


### PR DESCRIPTION
This is the same change as in #1500 because that branch was deleted.