### PR TITLE
grpc-js: Fix handling of unsuccessful TXT record lookups

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -237,19 +237,13 @@ class DnsResolver implements Resolver {
             }
           },
           (err) => {
-            this.latestServiceConfigError = {
-              code: Status.UNAVAILABLE,
-              details: 'TXT query failed',
-              metadata: new Metadata(),
-            };
-            if (this.latestLookupResult !== null) {
-              this.listener.onSuccessfulResolution(
-                this.latestLookupResult,
-                this.latestServiceConfig,
-                this.latestServiceConfigError,
-                {}
-              );
-            }
+            /* If TXT lookup fails we should do nothing, which means that we
+             * continue to use the result of the most recent successful lookup,
+             * or the default null config object if there has never been a
+             * successful lookup. We do not set the latestServiceConfigError
+             * here because that is specifically used for response validation
+             * errors. We still need to handle this error so that it does not
+             * bubble up as an unhandled promise rejection. */
           }
         );
       }

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -60,10 +60,10 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   /**
    * The service config object from the last successful resolution, if
    * available. A value of undefined indicates that there has not yet
-   * been a successful resolution. A value of null indicates that the last
-   * successful resolution explicitly provided a null service config.
+   * been a successful resolution, or that the last succesful resolution
+   * explicitly provided a null service config.
    */
-  private previousServiceConfig: ServiceConfig | null | undefined = undefined;
+  private previousServiceConfig: ServiceConfig | null = null;
 
   /**
    * The backoff timer for handling name resolution failures.
@@ -131,19 +131,13 @@ export class ResolvingLoadBalancer implements LoadBalancer {
           // Step 4 and 5
           if (serviceConfigError === null) {
             // Step 5
-            this.previousServiceConfig = serviceConfig;
+            this.previousServiceConfig = this.defaultServiceConfig;
             workingServiceConfig = this.defaultServiceConfig;
           } else {
             // Step 4
-            if (this.previousServiceConfig === undefined) {
+            if (this.previousServiceConfig === null) {
               // Step 4.ii
-              if (this.defaultServiceConfig === null) {
-                // Step 4.ii.b
-                this.handleResolutionFailure(serviceConfigError);
-              } else {
-                // Step 4.ii.a
-                workingServiceConfig = this.defaultServiceConfig;
-              }
+              this.handleResolutionFailure(serviceConfigError);
             } else {
               // Step 4.i
               workingServiceConfig = this.previousServiceConfig;

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -59,9 +59,8 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   private currentState: ConnectivityState = ConnectivityState.IDLE;
   /**
    * The service config object from the last successful resolution, if
-   * available. A value of undefined indicates that there has not yet
-   * been a successful resolution, or that the last succesful resolution
-   * explicitly provided a null service config.
+   * available. A value of null indicates that we have not yet received a valid
+   * service config from the resolver.
    */
   private previousServiceConfig: ServiceConfig | null = null;
 
@@ -131,7 +130,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
           // Step 4 and 5
           if (serviceConfigError === null) {
             // Step 5
-            this.previousServiceConfig = this.defaultServiceConfig;
+            this.previousServiceConfig = null;
             workingServiceConfig = this.defaultServiceConfig;
           } else {
             // Step 4


### PR DESCRIPTION
This should fix #1510 by changing how TXT record lookup failures are handled. Specifically, now no action is taken when that happens.

I also updated the config handling codepath to address updates that have been made to [the spec](https://github.com/grpc/proposal/blob/master/A21-service-config-error-handling.md) since this implementation was originally written. In addition to that, I simplified the logic somewhat to more consistently fall back to using the default service config when we do not retrieve one.