### PR TITLE
grpc-js: xDS: add support for dropping calls and reporting drops

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -48,7 +48,7 @@
     "clean": "node -e 'require(\"rimraf\")(\"./build\", () => {})'",
     "compile": "tsc -p .",
     "format": "clang-format -i -style=\"{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}\" src/*.ts test/*.ts",
-    "generate-types": "proto-loader-gen-types --keepCase --longs String --enums String --defaults --oneofs --json --includeComments --includeDirs deps/envoy-api/ deps/udpa/ deps/googleapis/ deps/protoc-gen-validate/ -O src/generated/ --grpcLib ../index envoy/service/discovery/v2/ads.proto envoy/api/v2/listener.proto envoy/api/v2/route.proto envoy/api/v2/cluster.proto envoy/api/v2/endpoint.proto",
+    "generate-types": "proto-loader-gen-types --keepCase --longs String --enums String --defaults --oneofs --json --includeComments --includeDirs deps/envoy-api/ deps/udpa/ deps/googleapis/ deps/protoc-gen-validate/ -O src/generated/ --grpcLib ../index envoy/service/discovery/v2/ads.proto envoy/service/load_stats/v2/lrs.proto envoy/api/v2/listener.proto envoy/api/v2/route.proto envoy/api/v2/cluster.proto envoy/api/v2/endpoint.proto",
     "lint": "npm run check",
     "prepare": "npm run compile",
     "test": "gulp test",

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -390,6 +390,12 @@ export class ChannelImplementation implements Channel {
           );
         }
         break;
+      case PickResultType.DROP:
+        callStream.cancelWithStatus(
+          pickResult.status!.code,
+          pickResult.status!.details
+        );
+        break;
       default:
         throw new Error(
           `Invalid state: unknown pickResultType ${pickResult.pickResultType}`

--- a/packages/grpc-js/src/generated/envoy/api/v2/endpoint/ClusterStats.ts
+++ b/packages/grpc-js/src/generated/envoy/api/v2/endpoint/ClusterStats.ts
@@ -1,0 +1,117 @@
+// Original file: deps/envoy-api/envoy/api/v2/endpoint/load_report.proto
+
+import { UpstreamLocalityStats as _envoy_api_v2_endpoint_UpstreamLocalityStats, UpstreamLocalityStats__Output as _envoy_api_v2_endpoint_UpstreamLocalityStats__Output } from '../../../../envoy/api/v2/endpoint/UpstreamLocalityStats';
+import { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../../google/protobuf/Duration';
+import { Long } from '@grpc/proto-loader';
+
+export interface _envoy_api_v2_endpoint_ClusterStats_DroppedRequests {
+  /**
+   * Identifier for the policy specifying the drop.
+   */
+  'category'?: (string);
+  /**
+   * Total number of deliberately dropped requests for the category.
+   */
+  'dropped_count'?: (number | string | Long);
+}
+
+export interface _envoy_api_v2_endpoint_ClusterStats_DroppedRequests__Output {
+  /**
+   * Identifier for the policy specifying the drop.
+   */
+  'category': (string);
+  /**
+   * Total number of deliberately dropped requests for the category.
+   */
+  'dropped_count': (string);
+}
+
+/**
+ * Per cluster load stats. Envoy reports these stats a management server in a
+ * :ref:`LoadStatsRequest<envoy_api_msg_service.load_stats.v2.LoadStatsRequest>`
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ * Next ID: 7
+ * [#next-free-field: 7]
+ */
+export interface ClusterStats {
+  /**
+   * The name of the cluster.
+   */
+  'cluster_name'?: (string);
+  /**
+   * Need at least one.
+   */
+  'upstream_locality_stats'?: (_envoy_api_v2_endpoint_UpstreamLocalityStats)[];
+  /**
+   * Cluster-level stats such as total_successful_requests may be computed by
+   * summing upstream_locality_stats. In addition, below there are additional
+   * cluster-wide stats.
+   * 
+   * The total number of dropped requests. This covers requests
+   * deliberately dropped by the drop_overload policy and circuit breaking.
+   */
+  'total_dropped_requests'?: (number | string | Long);
+  /**
+   * Period over which the actual load report occurred. This will be guaranteed to include every
+   * request reported. Due to system load and delays between the *LoadStatsRequest* sent from Envoy
+   * and the *LoadStatsResponse* message sent from the management server, this may be longer than
+   * the requested load reporting interval in the *LoadStatsResponse*.
+   */
+  'load_report_interval'?: (_google_protobuf_Duration);
+  /**
+   * Information about deliberately dropped requests for each category specified
+   * in the DropOverload policy.
+   */
+  'dropped_requests'?: (_envoy_api_v2_endpoint_ClusterStats_DroppedRequests)[];
+  /**
+   * The eds_cluster_config service_name of the cluster.
+   * It's possible that two clusters send the same service_name to EDS,
+   * in that case, the management server is supposed to do aggregation on the load reports.
+   */
+  'cluster_service_name'?: (string);
+}
+
+/**
+ * Per cluster load stats. Envoy reports these stats a management server in a
+ * :ref:`LoadStatsRequest<envoy_api_msg_service.load_stats.v2.LoadStatsRequest>`
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ * Next ID: 7
+ * [#next-free-field: 7]
+ */
+export interface ClusterStats__Output {
+  /**
+   * The name of the cluster.
+   */
+  'cluster_name': (string);
+  /**
+   * Need at least one.
+   */
+  'upstream_locality_stats': (_envoy_api_v2_endpoint_UpstreamLocalityStats__Output)[];
+  /**
+   * Cluster-level stats such as total_successful_requests may be computed by
+   * summing upstream_locality_stats. In addition, below there are additional
+   * cluster-wide stats.
+   * 
+   * The total number of dropped requests. This covers requests
+   * deliberately dropped by the drop_overload policy and circuit breaking.
+   */
+  'total_dropped_requests': (string);
+  /**
+   * Period over which the actual load report occurred. This will be guaranteed to include every
+   * request reported. Due to system load and delays between the *LoadStatsRequest* sent from Envoy
+   * and the *LoadStatsResponse* message sent from the management server, this may be longer than
+   * the requested load reporting interval in the *LoadStatsResponse*.
+   */
+  'load_report_interval'?: (_google_protobuf_Duration__Output);
+  /**
+   * Information about deliberately dropped requests for each category specified
+   * in the DropOverload policy.
+   */
+  'dropped_requests': (_envoy_api_v2_endpoint_ClusterStats_DroppedRequests__Output)[];
+  /**
+   * The eds_cluster_config service_name of the cluster.
+   * It's possible that two clusters send the same service_name to EDS,
+   * in that case, the management server is supposed to do aggregation on the load reports.
+   */
+  'cluster_service_name': (string);
+}

--- a/packages/grpc-js/src/generated/envoy/api/v2/endpoint/EndpointLoadMetricStats.ts
+++ b/packages/grpc-js/src/generated/envoy/api/v2/endpoint/EndpointLoadMetricStats.ts
@@ -1,0 +1,41 @@
+// Original file: deps/envoy-api/envoy/api/v2/endpoint/load_report.proto
+
+import { Long } from '@grpc/proto-loader';
+
+/**
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ */
+export interface EndpointLoadMetricStats {
+  /**
+   * Name of the metric; may be empty.
+   */
+  'metric_name'?: (string);
+  /**
+   * Number of calls that finished and included this metric.
+   */
+  'num_requests_finished_with_metric'?: (number | string | Long);
+  /**
+   * Sum of metric values across all calls that finished with this metric for
+   * load_reporting_interval.
+   */
+  'total_metric_value'?: (number | string);
+}
+
+/**
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ */
+export interface EndpointLoadMetricStats__Output {
+  /**
+   * Name of the metric; may be empty.
+   */
+  'metric_name': (string);
+  /**
+   * Number of calls that finished and included this metric.
+   */
+  'num_requests_finished_with_metric': (string);
+  /**
+   * Sum of metric values across all calls that finished with this metric for
+   * load_reporting_interval.
+   */
+  'total_metric_value': (number | string);
+}

--- a/packages/grpc-js/src/generated/envoy/api/v2/endpoint/UpstreamEndpointStats.ts
+++ b/packages/grpc-js/src/generated/envoy/api/v2/endpoint/UpstreamEndpointStats.ts
@@ -1,0 +1,106 @@
+// Original file: deps/envoy-api/envoy/api/v2/endpoint/load_report.proto
+
+import { Address as _envoy_api_v2_core_Address, Address__Output as _envoy_api_v2_core_Address__Output } from '../../../../envoy/api/v2/core/Address';
+import { EndpointLoadMetricStats as _envoy_api_v2_endpoint_EndpointLoadMetricStats, EndpointLoadMetricStats__Output as _envoy_api_v2_endpoint_EndpointLoadMetricStats__Output } from '../../../../envoy/api/v2/endpoint/EndpointLoadMetricStats';
+import { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from '../../../../google/protobuf/Struct';
+import { Long } from '@grpc/proto-loader';
+
+/**
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ * [#next-free-field: 8]
+ */
+export interface UpstreamEndpointStats {
+  /**
+   * Upstream host address.
+   */
+  'address'?: (_envoy_api_v2_core_Address);
+  /**
+   * The total number of requests successfully completed by the endpoints in the
+   * locality. These include non-5xx responses for HTTP, where errors
+   * originate at the client and the endpoint responded successfully. For gRPC,
+   * the grpc-status values are those not covered by total_error_requests below.
+   */
+  'total_successful_requests'?: (number | string | Long);
+  /**
+   * The total number of unfinished requests for this endpoint.
+   */
+  'total_requests_in_progress'?: (number | string | Long);
+  /**
+   * The total number of requests that failed due to errors at the endpoint.
+   * For HTTP these are responses with 5xx status codes and for gRPC the
+   * grpc-status values:
+   * 
+   * - DeadlineExceeded
+   * - Unimplemented
+   * - Internal
+   * - Unavailable
+   * - Unknown
+   * - DataLoss
+   */
+  'total_error_requests'?: (number | string | Long);
+  /**
+   * Stats for multi-dimensional load balancing.
+   */
+  'load_metric_stats'?: (_envoy_api_v2_endpoint_EndpointLoadMetricStats)[];
+  /**
+   * Opaque and implementation dependent metadata of the
+   * endpoint. Envoy will pass this directly to the management server.
+   */
+  'metadata'?: (_google_protobuf_Struct);
+  /**
+   * The total number of requests that were issued to this endpoint
+   * since the last report. A single TCP connection, HTTP or gRPC
+   * request or stream is counted as one request.
+   */
+  'total_issued_requests'?: (number | string | Long);
+}
+
+/**
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ * [#next-free-field: 8]
+ */
+export interface UpstreamEndpointStats__Output {
+  /**
+   * Upstream host address.
+   */
+  'address'?: (_envoy_api_v2_core_Address__Output);
+  /**
+   * The total number of requests successfully completed by the endpoints in the
+   * locality. These include non-5xx responses for HTTP, where errors
+   * originate at the client and the endpoint responded successfully. For gRPC,
+   * the grpc-status values are those not covered by total_error_requests below.
+   */
+  'total_successful_requests': (string);
+  /**
+   * The total number of unfinished requests for this endpoint.
+   */
+  'total_requests_in_progress': (string);
+  /**
+   * The total number of requests that failed due to errors at the endpoint.
+   * For HTTP these are responses with 5xx status codes and for gRPC the
+   * grpc-status values:
+   * 
+   * - DeadlineExceeded
+   * - Unimplemented
+   * - Internal
+   * - Unavailable
+   * - Unknown
+   * - DataLoss
+   */
+  'total_error_requests': (string);
+  /**
+   * Stats for multi-dimensional load balancing.
+   */
+  'load_metric_stats': (_envoy_api_v2_endpoint_EndpointLoadMetricStats__Output)[];
+  /**
+   * Opaque and implementation dependent metadata of the
+   * endpoint. Envoy will pass this directly to the management server.
+   */
+  'metadata'?: (_google_protobuf_Struct__Output);
+  /**
+   * The total number of requests that were issued to this endpoint
+   * since the last report. A single TCP connection, HTTP or gRPC
+   * request or stream is counted as one request.
+   */
+  'total_issued_requests': (string);
+}

--- a/packages/grpc-js/src/generated/envoy/api/v2/endpoint/UpstreamLocalityStats.ts
+++ b/packages/grpc-js/src/generated/envoy/api/v2/endpoint/UpstreamLocalityStats.ts
@@ -1,0 +1,108 @@
+// Original file: deps/envoy-api/envoy/api/v2/endpoint/load_report.proto
+
+import { Locality as _envoy_api_v2_core_Locality, Locality__Output as _envoy_api_v2_core_Locality__Output } from '../../../../envoy/api/v2/core/Locality';
+import { EndpointLoadMetricStats as _envoy_api_v2_endpoint_EndpointLoadMetricStats, EndpointLoadMetricStats__Output as _envoy_api_v2_endpoint_EndpointLoadMetricStats__Output } from '../../../../envoy/api/v2/endpoint/EndpointLoadMetricStats';
+import { UpstreamEndpointStats as _envoy_api_v2_endpoint_UpstreamEndpointStats, UpstreamEndpointStats__Output as _envoy_api_v2_endpoint_UpstreamEndpointStats__Output } from '../../../../envoy/api/v2/endpoint/UpstreamEndpointStats';
+import { Long } from '@grpc/proto-loader';
+
+/**
+ * These are stats Envoy reports to GLB every so often. Report frequency is
+ * defined by
+ * :ref:`LoadStatsResponse.load_reporting_interval<envoy_api_field_service.load_stats.v2.LoadStatsResponse.load_reporting_interval>`.
+ * Stats per upstream region/zone and optionally per subzone.
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ * [#next-free-field: 9]
+ */
+export interface UpstreamLocalityStats {
+  /**
+   * Name of zone, region and optionally endpoint group these metrics were
+   * collected from. Zone and region names could be empty if unknown.
+   */
+  'locality'?: (_envoy_api_v2_core_Locality);
+  /**
+   * The total number of requests successfully completed by the endpoints in the
+   * locality.
+   */
+  'total_successful_requests'?: (number | string | Long);
+  /**
+   * The total number of unfinished requests
+   */
+  'total_requests_in_progress'?: (number | string | Long);
+  /**
+   * The total number of requests that failed due to errors at the endpoint,
+   * aggregated over all endpoints in the locality.
+   */
+  'total_error_requests'?: (number | string | Long);
+  /**
+   * Stats for multi-dimensional load balancing.
+   */
+  'load_metric_stats'?: (_envoy_api_v2_endpoint_EndpointLoadMetricStats)[];
+  /**
+   * [#not-implemented-hide:] The priority of the endpoint group these metrics
+   * were collected from.
+   */
+  'priority'?: (number);
+  /**
+   * Endpoint granularity stats information for this locality. This information
+   * is populated if the Server requests it by setting
+   * :ref:`LoadStatsResponse.report_endpoint_granularity<envoy_api_field_service.load_stats.v2.LoadStatsResponse.report_endpoint_granularity>`.
+   */
+  'upstream_endpoint_stats'?: (_envoy_api_v2_endpoint_UpstreamEndpointStats)[];
+  /**
+   * The total number of requests that were issued by this Envoy since
+   * the last report. This information is aggregated over all the
+   * upstream endpoints in the locality.
+   */
+  'total_issued_requests'?: (number | string | Long);
+}
+
+/**
+ * These are stats Envoy reports to GLB every so often. Report frequency is
+ * defined by
+ * :ref:`LoadStatsResponse.load_reporting_interval<envoy_api_field_service.load_stats.v2.LoadStatsResponse.load_reporting_interval>`.
+ * Stats per upstream region/zone and optionally per subzone.
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ * [#next-free-field: 9]
+ */
+export interface UpstreamLocalityStats__Output {
+  /**
+   * Name of zone, region and optionally endpoint group these metrics were
+   * collected from. Zone and region names could be empty if unknown.
+   */
+  'locality'?: (_envoy_api_v2_core_Locality__Output);
+  /**
+   * The total number of requests successfully completed by the endpoints in the
+   * locality.
+   */
+  'total_successful_requests': (string);
+  /**
+   * The total number of unfinished requests
+   */
+  'total_requests_in_progress': (string);
+  /**
+   * The total number of requests that failed due to errors at the endpoint,
+   * aggregated over all endpoints in the locality.
+   */
+  'total_error_requests': (string);
+  /**
+   * Stats for multi-dimensional load balancing.
+   */
+  'load_metric_stats': (_envoy_api_v2_endpoint_EndpointLoadMetricStats__Output)[];
+  /**
+   * [#not-implemented-hide:] The priority of the endpoint group these metrics
+   * were collected from.
+   */
+  'priority': (number);
+  /**
+   * Endpoint granularity stats information for this locality. This information
+   * is populated if the Server requests it by setting
+   * :ref:`LoadStatsResponse.report_endpoint_granularity<envoy_api_field_service.load_stats.v2.LoadStatsResponse.report_endpoint_granularity>`.
+   */
+  'upstream_endpoint_stats': (_envoy_api_v2_endpoint_UpstreamEndpointStats__Output)[];
+  /**
+   * The total number of requests that were issued by this Envoy since
+   * the last report. This information is aggregated over all the
+   * upstream endpoints in the locality.
+   */
+  'total_issued_requests': (string);
+}

--- a/packages/grpc-js/src/generated/envoy/service/load_stats/v2/LoadReportingService.ts
+++ b/packages/grpc-js/src/generated/envoy/service/load_stats/v2/LoadReportingService.ts
@@ -1,0 +1,108 @@
+// Original file: deps/envoy-api/envoy/service/load_stats/v2/lrs.proto
+
+import * as grpc from '../../../../../index'
+import { LoadStatsRequest as _envoy_service_load_stats_v2_LoadStatsRequest, LoadStatsRequest__Output as _envoy_service_load_stats_v2_LoadStatsRequest__Output } from '../../../../envoy/service/load_stats/v2/LoadStatsRequest';
+import { LoadStatsResponse as _envoy_service_load_stats_v2_LoadStatsResponse, LoadStatsResponse__Output as _envoy_service_load_stats_v2_LoadStatsResponse__Output } from '../../../../envoy/service/load_stats/v2/LoadStatsResponse';
+
+export interface LoadReportingServiceClient extends grpc.Client {
+  /**
+   * Advanced API to allow for multi-dimensional load balancing by remote
+   * server. For receiving LB assignments, the steps are:
+   * 1, The management server is configured with per cluster/zone/load metric
+   * capacity configuration. The capacity configuration definition is
+   * outside of the scope of this document.
+   * 2. Envoy issues a standard {Stream,Fetch}Endpoints request for the clusters
+   * to balance.
+   * 
+   * Independently, Envoy will initiate a StreamLoadStats bidi stream with a
+   * management server:
+   * 1. Once a connection establishes, the management server publishes a
+   * LoadStatsResponse for all clusters it is interested in learning load
+   * stats about.
+   * 2. For each cluster, Envoy load balances incoming traffic to upstream hosts
+   * based on per-zone weights and/or per-instance weights (if specified)
+   * based on intra-zone LbPolicy. This information comes from the above
+   * {Stream,Fetch}Endpoints.
+   * 3. When upstream hosts reply, they optionally add header <define header
+   * name> with ASCII representation of EndpointLoadMetricStats.
+   * 4. Envoy aggregates load reports over the period of time given to it in
+   * LoadStatsResponse.load_reporting_interval. This includes aggregation
+   * stats Envoy maintains by itself (total_requests, rpc_errors etc.) as
+   * well as load metrics from upstream hosts.
+   * 5. When the timer of load_reporting_interval expires, Envoy sends new
+   * LoadStatsRequest filled with load reports for each cluster.
+   * 6. The management server uses the load reports from all reported Envoys
+   * from around the world, computes global assignment and prepares traffic
+   * assignment destined for each zone Envoys are located in. Goto 2.
+   */
+  StreamLoadStats(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_envoy_service_load_stats_v2_LoadStatsRequest, _envoy_service_load_stats_v2_LoadStatsResponse__Output>;
+  StreamLoadStats(options?: grpc.CallOptions): grpc.ClientDuplexStream<_envoy_service_load_stats_v2_LoadStatsRequest, _envoy_service_load_stats_v2_LoadStatsResponse__Output>;
+  /**
+   * Advanced API to allow for multi-dimensional load balancing by remote
+   * server. For receiving LB assignments, the steps are:
+   * 1, The management server is configured with per cluster/zone/load metric
+   * capacity configuration. The capacity configuration definition is
+   * outside of the scope of this document.
+   * 2. Envoy issues a standard {Stream,Fetch}Endpoints request for the clusters
+   * to balance.
+   * 
+   * Independently, Envoy will initiate a StreamLoadStats bidi stream with a
+   * management server:
+   * 1. Once a connection establishes, the management server publishes a
+   * LoadStatsResponse for all clusters it is interested in learning load
+   * stats about.
+   * 2. For each cluster, Envoy load balances incoming traffic to upstream hosts
+   * based on per-zone weights and/or per-instance weights (if specified)
+   * based on intra-zone LbPolicy. This information comes from the above
+   * {Stream,Fetch}Endpoints.
+   * 3. When upstream hosts reply, they optionally add header <define header
+   * name> with ASCII representation of EndpointLoadMetricStats.
+   * 4. Envoy aggregates load reports over the period of time given to it in
+   * LoadStatsResponse.load_reporting_interval. This includes aggregation
+   * stats Envoy maintains by itself (total_requests, rpc_errors etc.) as
+   * well as load metrics from upstream hosts.
+   * 5. When the timer of load_reporting_interval expires, Envoy sends new
+   * LoadStatsRequest filled with load reports for each cluster.
+   * 6. The management server uses the load reports from all reported Envoys
+   * from around the world, computes global assignment and prepares traffic
+   * assignment destined for each zone Envoys are located in. Goto 2.
+   */
+  streamLoadStats(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_envoy_service_load_stats_v2_LoadStatsRequest, _envoy_service_load_stats_v2_LoadStatsResponse__Output>;
+  streamLoadStats(options?: grpc.CallOptions): grpc.ClientDuplexStream<_envoy_service_load_stats_v2_LoadStatsRequest, _envoy_service_load_stats_v2_LoadStatsResponse__Output>;
+  
+}
+
+export interface LoadReportingServiceHandlers {
+  /**
+   * Advanced API to allow for multi-dimensional load balancing by remote
+   * server. For receiving LB assignments, the steps are:
+   * 1, The management server is configured with per cluster/zone/load metric
+   * capacity configuration. The capacity configuration definition is
+   * outside of the scope of this document.
+   * 2. Envoy issues a standard {Stream,Fetch}Endpoints request for the clusters
+   * to balance.
+   * 
+   * Independently, Envoy will initiate a StreamLoadStats bidi stream with a
+   * management server:
+   * 1. Once a connection establishes, the management server publishes a
+   * LoadStatsResponse for all clusters it is interested in learning load
+   * stats about.
+   * 2. For each cluster, Envoy load balances incoming traffic to upstream hosts
+   * based on per-zone weights and/or per-instance weights (if specified)
+   * based on intra-zone LbPolicy. This information comes from the above
+   * {Stream,Fetch}Endpoints.
+   * 3. When upstream hosts reply, they optionally add header <define header
+   * name> with ASCII representation of EndpointLoadMetricStats.
+   * 4. Envoy aggregates load reports over the period of time given to it in
+   * LoadStatsResponse.load_reporting_interval. This includes aggregation
+   * stats Envoy maintains by itself (total_requests, rpc_errors etc.) as
+   * well as load metrics from upstream hosts.
+   * 5. When the timer of load_reporting_interval expires, Envoy sends new
+   * LoadStatsRequest filled with load reports for each cluster.
+   * 6. The management server uses the load reports from all reported Envoys
+   * from around the world, computes global assignment and prepares traffic
+   * assignment destined for each zone Envoys are located in. Goto 2.
+   */
+  StreamLoadStats(call: grpc.ServerDuplexStream<_envoy_service_load_stats_v2_LoadStatsRequest, _envoy_service_load_stats_v2_LoadStatsResponse__Output>): void;
+  
+}

--- a/packages/grpc-js/src/generated/envoy/service/load_stats/v2/LoadStatsRequest.ts
+++ b/packages/grpc-js/src/generated/envoy/service/load_stats/v2/LoadStatsRequest.ts
@@ -1,0 +1,34 @@
+// Original file: deps/envoy-api/envoy/service/load_stats/v2/lrs.proto
+
+import { Node as _envoy_api_v2_core_Node, Node__Output as _envoy_api_v2_core_Node__Output } from '../../../../envoy/api/v2/core/Node';
+import { ClusterStats as _envoy_api_v2_endpoint_ClusterStats, ClusterStats__Output as _envoy_api_v2_endpoint_ClusterStats__Output } from '../../../../envoy/api/v2/endpoint/ClusterStats';
+
+/**
+ * A load report Envoy sends to the management server.
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ */
+export interface LoadStatsRequest {
+  /**
+   * Node identifier for Envoy instance.
+   */
+  'node'?: (_envoy_api_v2_core_Node);
+  /**
+   * A list of load stats to report.
+   */
+  'cluster_stats'?: (_envoy_api_v2_endpoint_ClusterStats)[];
+}
+
+/**
+ * A load report Envoy sends to the management server.
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ */
+export interface LoadStatsRequest__Output {
+  /**
+   * Node identifier for Envoy instance.
+   */
+  'node'?: (_envoy_api_v2_core_Node__Output);
+  /**
+   * A list of load stats to report.
+   */
+  'cluster_stats': (_envoy_api_v2_endpoint_ClusterStats__Output)[];
+}

--- a/packages/grpc-js/src/generated/envoy/service/load_stats/v2/LoadStatsResponse.ts
+++ b/packages/grpc-js/src/generated/envoy/service/load_stats/v2/LoadStatsResponse.ts
@@ -1,0 +1,71 @@
+// Original file: deps/envoy-api/envoy/service/load_stats/v2/lrs.proto
+
+import { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../../google/protobuf/Duration';
+
+/**
+ * The management server sends envoy a LoadStatsResponse with all clusters it
+ * is interested in learning load stats about.
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ */
+export interface LoadStatsResponse {
+  /**
+   * Clusters to report stats for.
+   * Not populated if *send_all_clusters* is true.
+   */
+  'clusters'?: (string)[];
+  /**
+   * The minimum interval of time to collect stats over. This is only a minimum for two reasons:
+   * 1. There may be some delay from when the timer fires until stats sampling occurs.
+   * 2. For clusters that were already feature in the previous *LoadStatsResponse*, any traffic
+   * that is observed in between the corresponding previous *LoadStatsRequest* and this
+   * *LoadStatsResponse* will also be accumulated and billed to the cluster. This avoids a period
+   * of inobservability that might otherwise exists between the messages. New clusters are not
+   * subject to this consideration.
+   */
+  'load_reporting_interval'?: (_google_protobuf_Duration);
+  /**
+   * Set to *true* if the management server supports endpoint granularity
+   * report.
+   */
+  'report_endpoint_granularity'?: (boolean);
+  /**
+   * If true, the client should send all clusters it knows about.
+   * Only clients that advertise the "envoy.lrs.supports_send_all_clusters" capability in their
+   * :ref:`client_features<envoy_api_field_core.Node.client_features>` field will honor this field.
+   */
+  'send_all_clusters'?: (boolean);
+}
+
+/**
+ * The management server sends envoy a LoadStatsResponse with all clusters it
+ * is interested in learning load stats about.
+ * [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+ */
+export interface LoadStatsResponse__Output {
+  /**
+   * Clusters to report stats for.
+   * Not populated if *send_all_clusters* is true.
+   */
+  'clusters': (string)[];
+  /**
+   * The minimum interval of time to collect stats over. This is only a minimum for two reasons:
+   * 1. There may be some delay from when the timer fires until stats sampling occurs.
+   * 2. For clusters that were already feature in the previous *LoadStatsResponse*, any traffic
+   * that is observed in between the corresponding previous *LoadStatsRequest* and this
+   * *LoadStatsResponse* will also be accumulated and billed to the cluster. This avoids a period
+   * of inobservability that might otherwise exists between the messages. New clusters are not
+   * subject to this consideration.
+   */
+  'load_reporting_interval'?: (_google_protobuf_Duration__Output);
+  /**
+   * Set to *true* if the management server supports endpoint granularity
+   * report.
+   */
+  'report_endpoint_granularity': (boolean);
+  /**
+   * If true, the client should send all clusters it knows about.
+   * Only clients that advertise the "envoy.lrs.supports_send_all_clusters" capability in their
+   * :ref:`client_features<envoy_api_field_core.Node.client_features>` field will honor this field.
+   */
+  'send_all_clusters': (boolean);
+}

--- a/packages/grpc-js/src/generated/lrs.ts
+++ b/packages/grpc-js/src/generated/lrs.ts
@@ -1,0 +1,146 @@
+import * as grpc from '../index';
+import { ServiceDefinition, EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
+
+import { LoadReportingServiceClient as _envoy_service_load_stats_v2_LoadReportingServiceClient } from './envoy/service/load_stats/v2/LoadReportingService';
+
+type ConstructorArguments<Constructor> = Constructor extends new (...args: infer Args) => any ? Args: never;
+type SubtypeConstructor<Constructor, Subtype> = {
+  new(...args: ConstructorArguments<Constructor>): Subtype;
+}
+
+export interface ProtoGrpcType {
+  envoy: {
+    api: {
+      v2: {
+        core: {
+          Address: MessageTypeDefinition
+          AsyncDataSource: MessageTypeDefinition
+          BackoffStrategy: MessageTypeDefinition
+          BindConfig: MessageTypeDefinition
+          BuildVersion: MessageTypeDefinition
+          CidrRange: MessageTypeDefinition
+          ControlPlane: MessageTypeDefinition
+          DataSource: MessageTypeDefinition
+          Extension: MessageTypeDefinition
+          HeaderMap: MessageTypeDefinition
+          HeaderValue: MessageTypeDefinition
+          HeaderValueOption: MessageTypeDefinition
+          HttpUri: MessageTypeDefinition
+          Locality: MessageTypeDefinition
+          Metadata: MessageTypeDefinition
+          Node: MessageTypeDefinition
+          Pipe: MessageTypeDefinition
+          RemoteDataSource: MessageTypeDefinition
+          RequestMethod: EnumTypeDefinition
+          RetryPolicy: MessageTypeDefinition
+          RoutingPriority: EnumTypeDefinition
+          RuntimeDouble: MessageTypeDefinition
+          RuntimeFeatureFlag: MessageTypeDefinition
+          RuntimeFractionalPercent: MessageTypeDefinition
+          RuntimeUInt32: MessageTypeDefinition
+          SocketAddress: MessageTypeDefinition
+          SocketOption: MessageTypeDefinition
+          TcpKeepalive: MessageTypeDefinition
+          TrafficDirection: EnumTypeDefinition
+          TransportSocket: MessageTypeDefinition
+        }
+        endpoint: {
+          ClusterStats: MessageTypeDefinition
+          EndpointLoadMetricStats: MessageTypeDefinition
+          UpstreamEndpointStats: MessageTypeDefinition
+          UpstreamLocalityStats: MessageTypeDefinition
+        }
+      }
+    }
+    service: {
+      load_stats: {
+        v2: {
+          LoadReportingService: SubtypeConstructor<typeof grpc.Client, _envoy_service_load_stats_v2_LoadReportingServiceClient> & { service: ServiceDefinition }
+          LoadStatsRequest: MessageTypeDefinition
+          LoadStatsResponse: MessageTypeDefinition
+        }
+      }
+    }
+    type: {
+      FractionalPercent: MessageTypeDefinition
+      Percent: MessageTypeDefinition
+      SemanticVersion: MessageTypeDefinition
+    }
+  }
+  google: {
+    protobuf: {
+      Any: MessageTypeDefinition
+      BoolValue: MessageTypeDefinition
+      BytesValue: MessageTypeDefinition
+      DescriptorProto: MessageTypeDefinition
+      DoubleValue: MessageTypeDefinition
+      Duration: MessageTypeDefinition
+      EnumDescriptorProto: MessageTypeDefinition
+      EnumOptions: MessageTypeDefinition
+      EnumValueDescriptorProto: MessageTypeDefinition
+      EnumValueOptions: MessageTypeDefinition
+      FieldDescriptorProto: MessageTypeDefinition
+      FieldOptions: MessageTypeDefinition
+      FileDescriptorProto: MessageTypeDefinition
+      FileDescriptorSet: MessageTypeDefinition
+      FileOptions: MessageTypeDefinition
+      FloatValue: MessageTypeDefinition
+      GeneratedCodeInfo: MessageTypeDefinition
+      Int32Value: MessageTypeDefinition
+      Int64Value: MessageTypeDefinition
+      ListValue: MessageTypeDefinition
+      MessageOptions: MessageTypeDefinition
+      MethodDescriptorProto: MessageTypeDefinition
+      MethodOptions: MessageTypeDefinition
+      NullValue: EnumTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition
+      OneofOptions: MessageTypeDefinition
+      ServiceDescriptorProto: MessageTypeDefinition
+      ServiceOptions: MessageTypeDefinition
+      SourceCodeInfo: MessageTypeDefinition
+      StringValue: MessageTypeDefinition
+      Struct: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition
+      UInt32Value: MessageTypeDefinition
+      UInt64Value: MessageTypeDefinition
+      UninterpretedOption: MessageTypeDefinition
+      Value: MessageTypeDefinition
+    }
+  }
+  udpa: {
+    annotations: {
+      FieldMigrateAnnotation: MessageTypeDefinition
+      FileMigrateAnnotation: MessageTypeDefinition
+      MigrateAnnotation: MessageTypeDefinition
+      PackageVersionStatus: EnumTypeDefinition
+      StatusAnnotation: MessageTypeDefinition
+    }
+  }
+  validate: {
+    AnyRules: MessageTypeDefinition
+    BoolRules: MessageTypeDefinition
+    BytesRules: MessageTypeDefinition
+    DoubleRules: MessageTypeDefinition
+    DurationRules: MessageTypeDefinition
+    EnumRules: MessageTypeDefinition
+    FieldRules: MessageTypeDefinition
+    Fixed32Rules: MessageTypeDefinition
+    Fixed64Rules: MessageTypeDefinition
+    FloatRules: MessageTypeDefinition
+    Int32Rules: MessageTypeDefinition
+    Int64Rules: MessageTypeDefinition
+    KnownRegex: EnumTypeDefinition
+    MapRules: MessageTypeDefinition
+    MessageRules: MessageTypeDefinition
+    RepeatedRules: MessageTypeDefinition
+    SFixed32Rules: MessageTypeDefinition
+    SFixed64Rules: MessageTypeDefinition
+    SInt32Rules: MessageTypeDefinition
+    SInt64Rules: MessageTypeDefinition
+    StringRules: MessageTypeDefinition
+    TimestampRules: MessageTypeDefinition
+    UInt32Rules: MessageTypeDefinition
+    UInt64Rules: MessageTypeDefinition
+  }
+}
+

--- a/packages/grpc-js/src/load-balancer-eds.ts
+++ b/packages/grpc-js/src/load-balancer-eds.ts
@@ -87,9 +87,9 @@ export class EdsLoadBalancer implements LoadBalancer {
 
   constructor(private readonly channelControlHelper: ChannelControlHelper) {
     this.childBalancer = new ChildLoadBalancerHandler({
-      createSubchannel: (subchannelAddres, subchannelArgs) =>
+      createSubchannel: (subchannelAddress, subchannelArgs) =>
         this.channelControlHelper.createSubchannel(
-          subchannelAddres,
+          subchannelAddress,
           subchannelArgs
         ),
       requestReresolution: () =>
@@ -385,10 +385,13 @@ export class EdsLoadBalancer implements LoadBalancer {
       this.isWatcherActive = true;
     }
 
-    this.clusterDropStats = this.xdsClient.addClusterDropStats(
-      lbConfig.eds.cluster,
-      lbConfig.eds.edsServiceName ?? ''
-    );
+    if (lbConfig.eds.lrsLoadReportingServerName) {
+      this.clusterDropStats = this.xdsClient.addClusterDropStats(
+        lbConfig.eds.lrsLoadReportingServerName,
+        lbConfig.eds.cluster,
+        lbConfig.eds.edsServiceName ?? ''
+      );
+    }
 
     /* If updateAddressList is called after receiving an update and the update
      * is still valid, we want to update the child config with the information

--- a/packages/grpc-js/src/picker.ts
+++ b/packages/grpc-js/src/picker.ts
@@ -26,6 +26,7 @@ export enum PickResultType {
   COMPLETE,
   QUEUE,
   TRANSIENT_FAILURE,
+  DROP,
 }
 
 export interface PickResult {
@@ -68,6 +69,14 @@ export interface QueuePickResult extends PickResult {
 
 export interface TransientFailurePickResult extends PickResult {
   pickResultType: PickResultType.TRANSIENT_FAILURE;
+  subchannel: null;
+  status: StatusObject;
+  extraFilterFactory: null;
+  onCallStarted: null;
+}
+
+export interface DropCallPickResult extends PickResult {
+  pickResultType: PickResultType.DROP;
   subchannel: null;
   status: StatusObject;
   extraFilterFactory: null;

--- a/packages/grpc-js/src/xds-client.ts
+++ b/packages/grpc-js/src/xds-client.ts
@@ -791,10 +791,24 @@ export class XdsClient {
     }
   }
 
+  /**
+   * 
+   * @param lrsServer The target name of the server to send stats to. An empty
+   *     string indicates that the default LRS client should be used. Currently
+   *     only the empty string is supported here.
+   * @param clusterName 
+   * @param edsServiceName 
+   */
   addClusterDropStats(
+    lrsServer: string,
     clusterName: string,
     edsServiceName: string
   ): XdsClusterDropStats {
+    if (lrsServer !== '') {
+      return {
+        addCallDropped: category => {}
+      };
+    }
     const clusterStats = this.clusterStatsMap.getOrCreate(
       clusterName,
       edsServiceName
@@ -810,6 +824,8 @@ export class XdsClient {
   shutdown(): void {
     this.adsCall?.cancel();
     this.adsClient?.close();
+    this.lrsCall?.cancel();
+    this.lrsClient?.close();
     this.hasShutdown = true;
   }
 }


### PR DESCRIPTION
The code in `src/generated` is new generated code for the `LoadReportingService`, which is used here and in the upcoming `LrsLoadBalancer`.