### PR TITLE
grpc-js: Clean up call even if status throws an error

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -227,7 +227,15 @@ export class Http2CallStream implements Call {
       const filteredStatus = this.filterStack.receiveTrailers(
         this.finalStatus!
       );
-      this.listener?.onReceiveStatus(filteredStatus);
+      /* We delay the actual action of bubbling up the status to insulate the
+       * cleanup code in this class from any errors that may be thrown in the
+       * upper layers as a result of bubbling up the status. In particular,
+       * if the status is not OK, the "error" event may be emitted
+       * synchronously at the top level, which will result in a thrown error if
+       * the user does not handle that event. */
+      process.nextTick(() => {
+        this.listener?.onReceiveStatus(filteredStatus);
+      });
       if (this.subchannel) {
         this.subchannel.callUnref();
         this.subchannel.removeDisconnectListener(this.disconnectListener);
@@ -602,6 +610,7 @@ export class Http2CallStream implements Call {
       } else {
         code = http2.constants.NGHTTP2_CANCEL;
       }
+      this.trace('close http2 stream with code ' + code);
       this.http2Stream.close(code);
     }
   }

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -373,6 +373,12 @@ export class Http2ServerCallStream<
     });
 
     this.stream.once('close', () => {
+      trace(
+        'Request to method ' +
+          this.handler?.path +
+          ' stream closed with rstCode ' +
+          this.stream.rstCode
+      );
       this.cancelled = true;
       this.emit('cancelled', 'cancelled');
     });

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -543,11 +543,21 @@ export class Server {
 
         try {
           const path = headers[http2.constants.HTTP2_HEADER_PATH] as string;
+          const serverAddress = http2Server.address();
+          let serverAddressString = 'null';
+          if (serverAddress) {
+            if (typeof serverAddress === 'string') {
+              serverAddressString = serverAddress;
+            } else {
+              serverAddressString =
+                serverAddress.address + ':' + serverAddress.port;
+            }
+          }
           trace(
             'Received call to method ' +
               path +
               ' at address ' +
-              http2Server.address()?.toString()
+              serverAddressString
           );
           const handler = this.handlers.get(path);
 

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -415,7 +415,7 @@ export class Subchannel {
             );
           }
           trace(
-            this.subchannelAddress +
+            this.subchannelAddressString +
               ' connection closed by GOAWAY with code ' +
               errorCode
           );


### PR DESCRIPTION
The main functional change here is calling `listener.onReceiveStatus` in `process.nextTick` in `call-stream.ts` so that the call stream cleanup code can finish before the status can bubble up to the surface API and result in an error being thrown. In particular, this means that the client will properly `close` the underlying http2 stream, so this is a fix for #1523.

The rest of the PR is adding and fixing trace log output.