### PR TITLE
grpc-js: Implement getPeer on the client and server

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -630,7 +630,7 @@ export class Http2CallStream implements Call {
   }
 
   getPeer(): string {
-    throw new Error('Not yet implemented');
+    return this.subchannel?.getAddress() ?? this.channel.getTarget();
   }
 
   getMethod(): string {

--- a/packages/grpc-js/src/call.ts
+++ b/packages/grpc-js/src/call.ts
@@ -93,7 +93,7 @@ export class ClientUnaryCallImpl extends EventEmitter
   }
 
   getPeer(): string {
-    return this.call?.getPeer() ?? '';
+    return this.call?.getPeer() ?? 'unknown';
   }
 }
 
@@ -109,7 +109,7 @@ export class ClientReadableStreamImpl<ResponseType> extends Readable
   }
 
   getPeer(): string {
-    return this.call?.getPeer() ?? '';
+    return this.call?.getPeer() ?? 'unknown';
   }
 
   _read(_size: number): void {
@@ -129,7 +129,7 @@ export class ClientWritableStreamImpl<RequestType> extends Writable
   }
 
   getPeer(): string {
-    return this.call?.getPeer() ?? '';
+    return this.call?.getPeer() ?? 'unknown';
   }
 
   _write(chunk: RequestType, encoding: string, cb: WriteCallback) {
@@ -164,7 +164,7 @@ export class ClientDuplexStreamImpl<RequestType, ResponseType> extends Duplex
   }
 
   getPeer(): string {
-    return this.call?.getPeer() ?? '';
+    return this.call?.getPeer() ?? 'unknown';
   }
 
   _read(_size: number): void {

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -112,7 +112,7 @@ export class ServerUnaryCallImpl<RequestType, ResponseType> extends EventEmitter
   }
 
   getPeer(): string {
-    throw new Error('not implemented yet');
+    return this.call.getPeer();
   }
 
   sendMetadata(responseMetadata: Metadata): void {
@@ -145,7 +145,7 @@ export class ServerReadableStreamImpl<RequestType, ResponseType>
   }
 
   getPeer(): string {
-    throw new Error('not implemented yet');
+    return this.call.getPeer();
   }
 
   sendMetadata(responseMetadata: Metadata): void {
@@ -178,7 +178,7 @@ export class ServerWritableStreamImpl<RequestType, ResponseType>
   }
 
   getPeer(): string {
-    throw new Error('not implemented yet');
+    return this.call.getPeer();
   }
 
   sendMetadata(responseMetadata: Metadata): void {
@@ -249,7 +249,7 @@ export class ServerDuplexStreamImpl<RequestType, ResponseType> extends Duplex
   }
 
   getPeer(): string {
-    throw new Error('not implemented yet');
+    return this.call.getPeer();
   }
 
   sendMetadata(responseMetadata: Metadata): void {
@@ -736,6 +736,19 @@ export class Http2ServerCallStream<
         readable,
         this.bufferedMessages.shift() as Buffer | null
       );
+    }
+  }
+
+  getPeer(): string {
+    const socket = this.stream.session.socket;
+    if (socket.remoteAddress) {
+      if (socket.remotePort) {
+        return `${socket.remoteAddress}:${socket.remotePort}`;
+      } else {
+        return socket.remoteAddress;
+      }
+    } else {
+      return 'unknown';
     }
   }
 }


### PR DESCRIPTION
Also, always return "unknown" when it doesn't have a better answer, for consistency with the core's behavior. This fixes #1483, in the sense that it provides the requested functionality in an existing method that previously threw a "not yet implemented" Error.