### PR TITLE
grpc-js: Move @types/node to a production dependency

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -21,7 +21,6 @@
     "@types/lodash": "^4.14.108",
     "@types/mocha": "^5.2.6",
     "@types/ncp": "^2.0.1",
-    "@types/node": "^12.7.5",
     "@types/pify": "^3.0.2",
     "@types/semver": "^6.0.1",
     "clang-format": "^1.0.55",
@@ -58,6 +57,7 @@
     "posttest": "npm run check"
   },
   "dependencies": {
+    "@types/node": "^12.12.47",
     "semver": "^6.2.0"
   },
   "files": [


### PR DESCRIPTION
I don't remember why we omitted this before, but the published types depend on the stream classes and `EventEmitter` from the `@types/node` package so we should have a production dependency on that for people trying to compile TypeScript code against grpc-js. This rarely causes problems because people often have their own dependency on `@types/node` to be able to use any Node builtins, but occasionally, as in #1538, they have a version of the types package that is incompatible with grpc-js and it causes compilation errors. We can't actually avoid that entirely because TypeScript's package resolution algorithm violates some assumptions that npm's package layout algorithm makes, but this is the best thing we can do to minimize the chance of that error.

The `@types/node` package is the only one that our public APIs depend on, which is why that's the only one I'm moving here.