### PR TITLE
Prevent mutation of default headers

### DIFF
--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -413,7 +413,7 @@ export class Http2ServerCallStream<
     this.metadataSent = true;
     const custom = customMetadata ? customMetadata.toHttp2Headers() : null;
     // TODO(cjihrig): Include compression headers.
-    const headers = Object.assign(defaultResponseHeaders, custom);
+    const headers = Object.assign({}, defaultResponseHeaders, custom);
     this.stream.respond(headers, defaultResponseOptions);
   }
 


### PR DESCRIPTION
Right now, the `defaultResponseHeaders` global is mutated on every request. This is a **huge** security vulnerability if there's any auth data in the metadata. 