### PR TITLE
grpc-js: Move a couple of dev dependencies to prod

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",
@@ -15,7 +15,6 @@
   "types": "build/src/index.d.ts",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grpc/proto-loader": "^0.6.0-pre6",
     "@types/gulp": "^4.0.6",
     "@types/gulp-mocha": "0.0.32",
     "@types/lodash": "^4.14.108",
@@ -25,7 +24,6 @@
     "@types/semver": "^6.0.1",
     "clang-format": "^1.0.55",
     "execa": "^2.0.3",
-    "google-auth-library": "^6.0.0",
     "gts": "^2.0.0",
     "gulp": "^4.0.2",
     "gulp-mocha": "^6.0.0",
@@ -57,7 +55,9 @@
     "posttest": "npm run check"
   },
   "dependencies": {
+    "@grpc/proto-loader": "^0.6.0-pre14",
     "@types/node": "^12.12.47",
+    "google-auth-library": "^6.0.0",
     "semver": "^6.2.0"
   },
   "files": [


### PR DESCRIPTION
I had `google-auth-library` and `@grpc/proto-loader` in dev dependencies because the code that requires them at runtime was supposed to be unreachable but as #1550 shows, that's fragile. So I'm just moving them to production dependencies now so that won't happen.

This fixes #1550.