### PR TITLE
Fixed connectivity to Google PubSub over proxy

### DIFF
--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -217,7 +217,7 @@ export function getProxiedConnection(
            * See https://github.com/grpc/grpc-node/pull/1369 for more info. */
           const targetPath = getDefaultAuthority(parsedTarget);
           const hostPort = splitHostPort(targetPath);
-          const remoteHost = (hostPort !== null) ? hostPort.host : targetPath;
+          const remoteHost = hostPort?.host ?? targetPath;
           
           const cts = tls.connect(
             {

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -215,8 +215,10 @@ export function getProxiedConnection(
            * connection to a TLS connection.
            * This is a workaround for https://github.com/nodejs/node/issues/32922
            * See https://github.com/grpc/grpc-node/pull/1369 for more info. */
-          const remoteHost = getDefaultAuthority(parsedTarget);
-
+          const targetPath = getDefaultAuthority(parsedTarget);
+          const hostPort = splitHostPort(targetPath);
+          const remoteHost = (hostPort !== null) ? hostPort.host : targetPath;
+          
           const cts = tls.connect(
             {
               host: remoteHost,

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -268,7 +268,13 @@ class DnsResolver implements Resolver {
    * @param target
    */
   static getDefaultAuthority(target: GrpcUri): string {
-    return target.path;
+    const hostPort = uri_parser_1.splitHostPort(target.path);
+    if (hostPort !== null) {
+      return hostPort.host;
+    }
+    else {
+      throw new Error(`Failed to parse target ${uri_parser_1.uriToString(target)}`);
+    }
   }
 }
 

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -268,13 +268,7 @@ class DnsResolver implements Resolver {
    * @param target
    */
   static getDefaultAuthority(target: GrpcUri): string {
-    const hostPort = uri_parser_1.splitHostPort(target.path);
-    if (hostPort !== null) {
-      return hostPort.host;
-    }
-    else {
-      throw new Error(`Failed to parse target ${uri_parser_1.uriToString(target)}`);
-    }
+    return target.path;
   }
 }
 

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -467,11 +467,13 @@ export class Subchannel {
            * if a connection is successfully established through the proxy.
            * If the proxy is not used, these connectionOptions are discarded
            * anyway */
-          connectionOptions.servername = getDefaultAuthority(
+          const targetPath = getDefaultAuthority(
             parseUri(this.options['grpc.http_connect_target'] as string) ?? {
               path: 'localhost',
             }
           );
+          const hostPort = splitHostPort(targetPath);
+          connectionOptions.servername = (hostPort !== null) ? hostPort.host : targetPath;
         }
       }
     }

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -473,7 +473,7 @@ export class Subchannel {
             }
           );
           const hostPort = splitHostPort(targetPath);
-          connectionOptions.servername = (hostPort !== null) ? hostPort.host : targetPath;
+          connectionOptions.servername = hostPort?.host ?? : targetPath;
         }
       }
     }

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -473,7 +473,7 @@ export class Subchannel {
             }
           );
           const hostPort = splitHostPort(targetPath);
-          connectionOptions.servername = hostPort?.host ?? : targetPath;
+          connectionOptions.servername = hostPort?.host ?? targetPath;
         }
       }
     }


### PR DESCRIPTION
Latest version has caused @google-cloud/pubsub fail to connect over a proxy connection.


Snapshot of error:

2020-08-29T10:52:45.340Z | proxy | Successfully connected to pubsub.googleapis.c
om:443 through proxy 172.16.52.252:443
2020-08-29T10:52:45.370Z | subchannel | 172.16.52.252:443 CONNECTING -> TRANSIEN
T_FAILURE
2020-08-29T10:52:45.372Z | pick_first | CONNECTING -> TRANSIENT_FAILURE
2020-08-29T10:52:45.373Z | resolving_load_balancer | dns:172.16.52.252:443 CONNE
CTING -> TRANSIENT_FAILURE
2020-08-29T10:52:45.375Z | channel | Pick result: TRANSIENT_FAILURE subchannel:
undefined status: 14 No connection established
2020-08-29T10:52:45.377Z | call_stream | [11] cancelWithStatus code: 14 details:
 "No connection established"
2020-08-29T10:52:45.379Z | call_stream | [11] ended with status: code=14 details
="No connection established"
2020-08-29T10:52:45.381Z | connectivity_state | dns:172.16.52.252:443 CONNECTING
 -> TRANSIENT_FAILURE


Before proposed fix:

    static getDefaultAuthority(target) {
        return target.path;  // this returns "pubsub.googleapis.com:443"
    }

After proposed fix:

    static getDefaultAuthority(target) {
        const hostPort = uri_parser_1.splitHostPort(target.path);  // target.path is "pubsub.googleapis.com:443"
        if (hostPort !== null) {
            return hostPort.host; // this returns "pubsub.googleapis.com"
        }
        else {
            throw new Error(`Failed to parse target ${uri_parser_1.uriToString(target)}`);
        }
    }