### PR TITLE
fix(grpc-js): Add support for impl type to server.addService

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -145,10 +145,9 @@ export class Server {
   }
 
   addService<
-    ImplementationType extends Record<
-      string,
-      UntypedHandleCall
-    > = UntypedServiceImplementation
+    ImplementationType extends {
+      readonly [index in keyof ImplementationType]: UntypedHandleCall;
+    }
   >(
     service: ServiceDefinition<ImplementationType>,
     implementation: ImplementationType
@@ -166,7 +165,7 @@ export class Server {
       throw new Error('addService() requires two objects as arguments');
     }
 
-    const serviceKeys = Object.keys(service);
+    const serviceKeys = Object.keys(service) as Array<keyof ImplementationType>;
 
     if (serviceKeys.length === 0) {
       throw new Error('Cannot add an empty service to a server');
@@ -194,13 +193,13 @@ export class Server {
       let impl;
 
       if (implFn === undefined && typeof attrs.originalName === 'string') {
-        implFn = implementation[attrs.originalName];
+        implFn = implementation[attrs.originalName as keyof ImplementationType];
       }
 
       if (implFn !== undefined) {
-        impl = implFn.bind(implementation);
+        impl = implFn.bind(implementation as any);
       } else {
-        impl = getDefaultHandler(methodType, name);
+        impl = getDefaultHandler(methodType, name as string);
       }
 
       const success = this.register(

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -144,9 +144,14 @@ export class Server {
     throw new Error('Not implemented. Use addService() instead');
   }
 
-  addService(
-    service: ServiceDefinition,
-    implementation: UntypedServiceImplementation
+  addService<
+    ImplementationType extends Record<
+      string,
+      UntypedHandleCall
+    > = UntypedServiceImplementation
+  >(
+    service: ServiceDefinition<ImplementationType>,
+    implementation: ImplementationType
   ): void {
     if (this.started === true) {
       throw new Error("Can't add a service to a started server.");

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -146,7 +146,7 @@ export class Server {
 
   addService<
     ImplementationType extends {
-      readonly [index in keyof ImplementationType]: UntypedHandleCall;
+      [key: string]: any
     }
   >(
     service: ServiceDefinition<ImplementationType>,
@@ -165,7 +165,7 @@ export class Server {
       throw new Error('addService() requires two objects as arguments');
     }
 
-    const serviceKeys = Object.keys(service) as Array<keyof ImplementationType>;
+    const serviceKeys = Object.keys(service);
 
     if (serviceKeys.length === 0) {
       throw new Error('Cannot add an empty service to a server');
@@ -193,13 +193,13 @@ export class Server {
       let impl;
 
       if (implFn === undefined && typeof attrs.originalName === 'string') {
-        implFn = implementation[attrs.originalName as keyof ImplementationType];
+        implFn = implementation[attrs.originalName];
       }
 
       if (implFn !== undefined) {
-        impl = implFn.bind(implementation as any);
+        impl = implFn.bind(implementation);
       } else {
-        impl = getDefaultHandler(methodType, name as string);
+        impl = getDefaultHandler(methodType, name);
       }
 
       const success = this.register(

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -181,7 +181,7 @@ describe('Server', () => {
       const server = new Server();
 
       assert.throws(() => {
-        server.addService({} as any, dummyImpls);
+        server.addService(({} as any), dummyImpls);
       }, /Cannot add an empty service to a server/);
     });
 

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -181,7 +181,7 @@ describe('Server', () => {
       const server = new Server();
 
       assert.throws(() => {
-        server.addService({}, dummyImpls);
+        server.addService({} as any, dummyImpls);
       }, /Cannot add an empty service to a server/);
     });
 


### PR DESCRIPTION
Adding support for `ImplementationType` to `server.addService(...)`.

It seems like the original (non-js) `grpc` type definitions support this - https://github.com/grpc/grpc-node/blob/grpc%401.24.x/packages/grpc-native-core/index.d.ts#L266.

Not sure if there was a reason not to do it in grpc-js?

Thanks!