### PR TITLE
fix(grpc-js): preserve original error code when the handler of a readable stream throws an error

### DIFF
--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -743,7 +743,10 @@ export class Http2ServerCallStream<
       // Ignore any remaining messages when errors occur.
       this.bufferedMessages.length = 0;
 
-      err.code = Status.INTERNAL;
+      if(!err.code){
+        err.code = Status.INTERNAL;
+      }
+      
       readable.emit('error', err);
     }
 

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -739,15 +739,24 @@ export class Http2ServerCallStream<
       } else {
         this.messagesToPush.push(deserialized);
       }
-    } catch (err) {
+    } catch (error) {
       // Ignore any remaining messages when errors occur.
       this.bufferedMessages.length = 0;
 
-      if(!err.code){
-        err.code = Status.INTERNAL;
+      if (
+        !(
+          'code' in error &&
+          typeof error.code === 'number' &&
+          Number.isInteger(error.code) &&
+          error.code >= Status.OK &&
+          error.code <= Status.UNAUTHENTICATED
+        )
+      ) {
+        // The error code is not a valid gRPC code so its being overwritten.
+        error.code = Status.INTERNAL;
       }
-      
-      readable.emit('error', err);
+
+      readable.emit('error', error);
     }
 
     this.isPushPending = false;


### PR DESCRIPTION
When writing a small decorator for allowing developers write their code with throwing errors I stumbled upon an issue.

It looks like the grpc-js library overwrites the error code of an error being thrown even if `code` is present. An example is the following:
```ts
const streamHandlerDecorator = <RequestType, ResponseType>(
  handler: (
    sessionId: string,
    stream: ServerWritableStream<RequestType, ResponseType>,
  ) => Promise<void>,
): ((
  stream: ServerWritableStream<RequestType, ResponseType>,
) => Promise<void>) => async (
  stream: ServerWritableStream<RequestType, ResponseType>,
): Promise<void> => {
  try {
    await handler(stream);
  } catch (error) {
    const maybeConvertedError =
      error instanceof GrpcError
        ? error
        : new GrpcError('An unknown error ocurred.', status.INTERNAL);

    stream.emit('error', maybeConvertedError);
  }
};
```

`GrpcError` is basically a wrapper around the `ServiceError` type exported by `grpc-js`. 

This snippet of code works perfectly for `ServerWritableStream`, but not for `ServerDuplexStream` or `ServerReadableStream`.