### PR TITLE
Fix ClientOptions types

### DIFF
--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -33,7 +33,9 @@ export interface ChannelOptions {
   'grpc.max_send_message_length'?: number;
   'grpc.max_receive_message_length'?: number;
   'grpc.enable_http_proxy'?: number;
-  [key: string]: string | number | undefined;
+  'grpc.http_connect_target'?: string;
+  'grpc.http_connect_creds'?: string;
+  [key: string]: any;
 }
 
 /**


### PR DESCRIPTION
Remove index signature from ChannelOptions to fix intersection error
described in #1558 which causes issues on using ClientOptions direct
fields with TypeScript.

Removing of index signature required few minor changes:
 - adding few constant types that were used throughout the app
 - using `as const` assertion in xds-client
 - using not-so-great type cast in channelOptionsEqual

Alternative solution would be removing the index signature from
ChannelOptions explicitly in ClientOptions definition, which is not
trivial and probably calls for a generic type helper.

See: https://github.com/grpc/grpc-node/issues/1558
Fixes: 1558