### PR TITLE
Revert "fix(grpc-js): Add support for impl type to server.addService"

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -144,13 +144,9 @@ export class Server {
     throw new Error('Not implemented. Use addService() instead');
   }
 
-  addService<
-    ImplementationType extends {
-      [key: string]: any
-    }
-  >(
-    service: ServiceDefinition<ImplementationType>,
-    implementation: ImplementationType
+  addService(
+    service: ServiceDefinition,
+    implementation: UntypedServiceImplementation
   ): void {
     if (this.started === true) {
       throw new Error("Can't add a service to a started server.");

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -181,7 +181,7 @@ describe('Server', () => {
       const server = new Server();
 
       assert.throws(() => {
-        server.addService(({} as any), dummyImpls);
+        server.addService({}, dummyImpls);
       }, /Cannot add an empty service to a server/);
     });
 


### PR DESCRIPTION
Reverts grpc/grpc-node#1556. That change broke #1552. Breakage error log: https://source.cloud.google.com/results/invocations/a9b120c7-c487-453a-82c8-0d29b91b73ce/targets/grpc%2Fnode%2Fpull_request%2Flinux/log