### PR TITLE
fix(grpc-js): Add support for typed add service

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -144,9 +144,13 @@ export class Server {
     throw new Error('Not implemented. Use addService() instead');
   }
 
-  addService(
-    service: ServiceDefinition,
-    implementation: UntypedServiceImplementation
+  addService<
+    ImplementationType extends {
+      [key: string]: any
+    }
+  >(
+    service: ServiceDefinition<Partial<ImplementationType>>,
+    implementation: ImplementationType
   ): void {
     if (this.started === true) {
       throw new Error("Can't add a service to a started server.");


### PR DESCRIPTION
Adds improved support for typed `addService`.

Previous attempt (https://github.com/grpc/grpc-node/pull/1556) broke due to https://source.cloud.google.com/results/invocations/a9b120c7-c487-453a-82c8-0d29b91b73ce/targets/grpc%2Fnode%2Fpull_request%2Flinux/log.