### PR TITLE
grpc-js: Double the xds test job timeout

### DIFF
--- a/test/kokoro/xds-interop.cfg
+++ b/test/kokoro/xds-interop.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-node/packages/grpc-js/scripts/xds.sh"
-timeout_mins: 60
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "github/grpc/reports/**"


### PR DESCRIPTION
The test takes more than an hour to finish. The equivalent test job in grpc/grpc also uses a 2 hour timeout: https://github.com/grpc/grpc/blob/master/tools/internal_ci/linux/grpc_xds.cfg.