### PR TITLE
grpc-js: Source nvm.sh in profile files in xds script to get nvm in subprocesses

### DIFF
--- a/packages/grpc-js/scripts/xds.sh
+++ b/packages/grpc-js/scripts/xds.sh
@@ -29,6 +29,11 @@ nvm install 12
 set -exu -o pipefail
 [[ -f /VERSION ]] && cat /VERSION
 
+# Make nvm available to the subprocess that the python script spawns
+echo "source $NVM_DIR/nvm.sh" > ~/.profile
+echo "source $NVM_DIR/nvm.sh" > ~/.shrc
+export ENV=~/.shrc
+
 cd $base
 npm install
 


### PR DESCRIPTION
The test logs show that the Node xDS interop client can't load the `http2` module. The most likely explanation for that is that it is using an old version of Node. The main test log shows `nvm` installing correctly and using Node 12, so my guess is that we are encountering nvm-sh/nvm#1866. Based on [this post](https://unix.stackexchange.com/a/46856/9579), this change is my best guess for properly using the version of Node from `nvm` in the test client.