### PR TITLE
grpc-js: Export handleClientStreamingCall type

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -57,6 +57,7 @@ import { StatusBuilder } from './status-builder';
 import {
   handleBidiStreamingCall,
   handleServerStreamingCall,
+  handleClientStreamingCall,
   handleUnaryCall,
   sendUnaryData,
   ServerUnaryCall,
@@ -186,7 +187,7 @@ export {
 
 /**** Server ****/
 
-export { handleBidiStreamingCall, handleServerStreamingCall, handleUnaryCall };
+export { handleBidiStreamingCall, handleServerStreamingCall, handleUnaryCall, handleClientStreamingCall };
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type Call =


### PR DESCRIPTION
This provides better compatibility with the legacy `grpc` package.
