### PR TITLE
grpc-js: xDS: Do not remove watchers in onResourceDoesNotExist

### DIFF
--- a/packages/grpc-js/src/load-balancer-cds.ts
+++ b/packages/grpc-js/src/load-balancer-cds.ts
@@ -86,10 +86,6 @@ export class CdsLoadBalancer implements LoadBalancer {
         );
       },
       onResourceDoesNotExist: () => {
-        this.xdsClient?.removeClusterWatcher(
-          this.latestConfig!.cds.cluster,
-          this.watcher
-        );
         this.isWatcherActive = false;
         this.channelControlHelper.updateState(ConnectivityState.TRANSIENT_FAILURE, new UnavailablePicker({code: Status.UNAVAILABLE, details: 'CDS resource does not exist', metadata: new Metadata()}));
         this.childBalancer.destroy();

--- a/packages/grpc-js/src/load-balancer-eds.ts
+++ b/packages/grpc-js/src/load-balancer-eds.ts
@@ -140,10 +140,6 @@ export class EdsLoadBalancer implements LoadBalancer {
         this.updateChild();
       },
       onResourceDoesNotExist: () => {
-        this.xdsClient?.removeEndpointWatcher(
-          this.edsServiceName!,
-          this.watcher
-        );
         this.isWatcherActive = false;
         this.channelControlHelper.updateState(ConnectivityState.TRANSIENT_FAILURE, new UnavailablePicker({code: Status.UNAVAILABLE, details: 'EDS resource does not exist', metadata: new Metadata()}));
         this.childBalancer.destroy();


### PR DESCRIPTION
The `onResourceDoesNotExist` event is triggered in the CDS LB policy when a CDS update does not have the requested cluster name, and in the EDS LB policy when an EDS update does not have the requested cluster/service name, and when a CDS update does not have any resources with the requested name.

In the first two cases we do not want to remove the watcher because we want to know if the requested resource exists again later. In the last case, we do want to remove the watcher, but that update should also result in the EDS policy either getting removed or getting a new configuration with a new cluster/service name, and either of those events will cause the watcher to be removed or replaced.