### PR TITLE
grpc-js: xds: Add more logging around adding and removing eds and cds watchers

### DIFF
--- a/packages/grpc-js/src/load-balancer-eds.ts
+++ b/packages/grpc-js/src/load-balancer-eds.ts
@@ -401,7 +401,7 @@ export class EdsLoadBalancer implements LoadBalancer {
       trace('Discarding address list update missing xdsClient attribute');
       return;
     }
-    trace('Received update with config: ' + JSON.stringify(lbConfig));
+    trace('Received update with config: ' + JSON.stringify(lbConfig, undefined, 2));
     this.lastestConfig = lbConfig;
     this.latestAttributes = attributes;
     this.xdsClient = attributes.xdsClient;
@@ -411,6 +411,7 @@ export class EdsLoadBalancer implements LoadBalancer {
     /* If the name is changing, disable the old watcher before adding the new
      * one */
     if (this.isWatcherActive && this.edsServiceName !== newEdsServiceName) {
+      trace('Removing old endpoint watcher for edsServiceName ' + this.edsServiceName)
       this.xdsClient.removeEndpointWatcher(this.edsServiceName!, this.watcher);
       /* Setting isWatcherActive to false here lets us have one code path for
        * calling addEndpointWatcher */
@@ -423,6 +424,7 @@ export class EdsLoadBalancer implements LoadBalancer {
     this.edsServiceName = newEdsServiceName;
 
     if (!this.isWatcherActive) {
+      trace('Adding new endpoint watcher for edsServiceName ' + this.edsServiceName);
       this.xdsClient.addEndpointWatcher(this.edsServiceName, this.watcher);
       this.isWatcherActive = true;
     }
@@ -447,6 +449,7 @@ export class EdsLoadBalancer implements LoadBalancer {
     this.childBalancer.resetBackoff();
   }
   destroy(): void {
+    trace('Destroying load balancer with edsServiceName ' + this.edsServiceName);
     if (this.edsServiceName) {
       this.xdsClient?.removeEndpointWatcher(this.edsServiceName, this.watcher);
     }

--- a/packages/grpc-js/src/xds-client.ts
+++ b/packages/grpc-js/src/xds-client.ts
@@ -261,7 +261,6 @@ class EdsState implements XdsStreamState<ClusterLoadAssignment__Output> {
     edsServiceName: string,
     watcher: Watcher<ClusterLoadAssignment__Output>
   ): void {
-    trace('Adding EDS watcher for edsServiceName ' + edsServiceName);
     let watchersEntry = this.watchers.get(edsServiceName);
     let addedServiceName = false;
     if (watchersEntry === undefined) {
@@ -269,6 +268,7 @@ class EdsState implements XdsStreamState<ClusterLoadAssignment__Output> {
       watchersEntry = [];
       this.watchers.set(edsServiceName, watchersEntry);
     }
+    trace('Adding EDS watcher (' + watchersEntry.length + ' ->' + (watchersEntry.length + 1) + ') for edsServiceName ' + edsServiceName);
     watchersEntry.push(watcher);
 
     /* If we have already received an update for the requested edsServiceName,
@@ -298,6 +298,7 @@ class EdsState implements XdsStreamState<ClusterLoadAssignment__Output> {
     if (watchersEntry !== undefined) {
       const entryIndex = watchersEntry.indexOf(watcher);
       if (entryIndex >= 0) {
+        trace('Removed EDS watcher (' + watchersEntry.length + ' -> ' + (watchersEntry.length - 1) + ') for edsServiceName ' + edsServiceName);
         watchersEntry.splice(entryIndex, 1);
       }
       if (watchersEntry.length === 0) {


### PR DESCRIPTION
This is an attempt to track down the cause of a flaky test in the xDS interop tests. The flake appears to be related to a watcher spuriously being removed, which results in the corresponding LB policy thinking that resource has been removed.