### PR TITLE
tests: Update google-auth-library dependency from 0.9 to 6.1

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "express": "^4.16.3",
-    "google-auth-library": "^0.9.2",
+    "google-auth-library": "^6.1.0",
     "grpc": "^1.24.2",
     "lodash": "^4.17.4",
     "poisson-process": "^1.0.0"


### PR DESCRIPTION
Version 0.9.x of the google-auth-library package was so old that it was using an old metadata server version that is no longer supported. The modifications here are mostly inferred based on the documentation. Hopefully they don't break anything.