### PR TITLE
Fix missing arg variable in perRpcCreds interop test

### DIFF
--- a/test/interop/interop_client.js
+++ b/test/interop/interop_client.js
@@ -464,6 +464,10 @@ function oauth2Test(client, done, extra) {
 }
 
 function perRpcAuthTest(client, done, extra) {
+  var arg = {
+    fill_username: true,
+    fill_oauth_scope: true
+  };
   const creds = grpc.credentials.createFromGoogleCredential(new GoogleAuth({scopes: extra.oauth_scope}));
   client.unaryCall(arg, {credentials: creds}, function(err, resp) {
     assert.ifError(err);


### PR DESCRIPTION
I accidentally removed this in #1596.