### PR TITLE
grpc-js: Prevent prototype pollution in loadPackageDefinition

### DIFF
--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -122,6 +122,9 @@ export function makeClientConstructor(
   }
 
   Object.keys(methods).forEach((name) => {
+    if (name === '__proto__') {
+      return;
+    }
     const attrs = methods[name];
     let methodType: keyof typeof requesterFuncs;
     // TODO(murgatroid99): Verify that we don't need this anymore
@@ -152,7 +155,7 @@ export function makeClientConstructor(
     ServiceClientImpl.prototype[name] = methodFunc;
     // Associate all provided attributes with the method
     Object.assign(ServiceClientImpl.prototype[name], attrs);
-    if (attrs.originalName) {
+    if (attrs.originalName && attrs.originalName !== '__proto__') {
       ServiceClientImpl.prototype[attrs.originalName] =
         ServiceClientImpl.prototype[name];
     }
@@ -201,6 +204,9 @@ export function loadPackageDefinition(
     if (Object.prototype.hasOwnProperty.call(packageDef, serviceFqn)) {
       const service = packageDef[serviceFqn];
       const nameComponents = serviceFqn.split('.');
+      if (nameComponents.some(comp => comp === '__proto__')) {
+        continue;
+      }
       const serviceName = nameComponents[nameComponents.length - 1];
       let current = result;
       for (const packageName of nameComponents.slice(0, -1)) {

--- a/packages/grpc-js/test/test-prototype-pollution.ts
+++ b/packages/grpc-js/test/test-prototype-pollution.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import * as assert from 'assert';
+
+import { loadPackageDefinition } from '../src';
+
+describe('loadPackageDefinition', () => {
+  it('Should not allow prototype pollution', () => {
+      loadPackageDefinition({'__proto__.polluted': true} as any);
+      assert.notStrictEqual(({} as any).polluted, true);
+  });
+});


### PR DESCRIPTION
This bug was reported to us in an email. The test is directly adapted from that report. There will be a similar PR for the other implementation.