### PR TITLE
Native: Copy slice data into Buffer when receiving binary metadata

### DIFF
--- a/packages/grpc-native-core/ext/call.cc
+++ b/packages/grpc-native-core/ext/call.cc
@@ -158,7 +158,7 @@ Local<Value> ParseMetadata(const grpc_metadata_array *metadata_array) {
       array = Local<Array>::Cast(maybe_array.ToLocalChecked());
     }
     if (grpc_is_binary_header(elem->key)) {
-      Nan::Set(array, array->Length(), CreateBufferFromSlice(elem->value));
+      Nan::Set(array, array->Length(), CopyBufferFromSlice(elem->value));
     } else {
       // TODO(murgatroid99): Use zero-copy string construction instead
       Nan::Set(array, array->Length(), CopyStringFromSlice(elem->value));

--- a/packages/grpc-native-core/ext/slice.cc
+++ b/packages/grpc-native-core/ext/slice.cc
@@ -33,12 +33,6 @@ using v8::String;
 using v8::Value;
 
 namespace {
-void SliceFreeCallback(char *data, void *hint) {
-  grpc_slice *slice = reinterpret_cast<grpc_slice *>(hint);
-  grpc_slice_unref(*slice);
-  delete slice;
-}
-
 void string_destroy_func(void *user_data) {
   delete reinterpret_cast<Nan::Utf8String *>(user_data);
 }
@@ -74,16 +68,13 @@ Local<String> CopyStringFromSlice(const grpc_slice slice) {
           .ToLocalChecked());
 }
 
-Local<Value> CreateBufferFromSlice(const grpc_slice slice) {
+Local<Value> CopyBufferFromSlice(const grpc_slice slice) {
   Nan::EscapableHandleScope scope;
-  grpc_slice *slice_ptr = new grpc_slice;
-  *slice_ptr = grpc_slice_ref(slice);
   return scope.Escape(
-      Nan::NewBuffer(
-          const_cast<char *>(
-              reinterpret_cast<const char *>(GRPC_SLICE_START_PTR(*slice_ptr))),
-          GRPC_SLICE_LENGTH(*slice_ptr), SliceFreeCallback, slice_ptr)
-          .ToLocalChecked());
+    Nan::CopyBuffer(
+      const_cast<char *>(
+        reinterpret_cast<const char *>(GRPC_SLICE_START_PTR(slice))),
+      GRPC_SLICE_LENGTH(slice)));
 }
 
 }  // namespace node

--- a/packages/grpc-native-core/ext/slice.cc
+++ b/packages/grpc-native-core/ext/slice.cc
@@ -71,10 +71,9 @@ Local<String> CopyStringFromSlice(const grpc_slice slice) {
 Local<Value> CopyBufferFromSlice(const grpc_slice slice) {
   Nan::EscapableHandleScope scope;
   return scope.Escape(
-    Nan::CopyBuffer(
-      const_cast<char *>(
-        reinterpret_cast<const char *>(GRPC_SLICE_START_PTR(slice))),
-      GRPC_SLICE_LENGTH(slice)));
+    Nan::CopyBuffer(reinterpret_cast<const char *>(GRPC_SLICE_START_PTR(slice)),
+      GRPC_SLICE_LENGTH(slice))
+    .ToLocalChecked());
 }
 
 }  // namespace node

--- a/packages/grpc-native-core/ext/slice.h
+++ b/packages/grpc-native-core/ext/slice.h
@@ -32,7 +32,7 @@ grpc_slice CreateSliceFromBuffer(const v8::Local<v8::Value> source);
 
 v8::Local<v8::String> CopyStringFromSlice(const grpc_slice slice);
 
-v8::Local<v8::Value> CreateBufferFromSlice(const grpc_slice slice);
+v8::Local<v8::Value> CopyBufferFromSlice(const grpc_slice slice);
 
 }  // namespace node
 }  // namespace grpc


### PR DESCRIPTION
This should fix #1407, or at least the reproduction demonstrated in https://github.com/grpc/grpc-node/issues/1407#issuecomment-717170288. This change is needed because of change in Node 14 that prohibits multiple `Buffer` objects from pointing to the same underlying memory. That makes the previous zero-copy function error-prone in some situations.