### PR TITLE
Backport of "Set the default port of 80 explicitly in http_proxy" to 1.1.x

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -84,8 +84,16 @@ function getProxyInfo(): ProxyInfo {
       userCred = proxyUrl.username;
     }
   }
+  const hostname = proxyUrl.hostname;
+  let port = proxyUrl.port;
+  /* The proxy URL uses the scheme "http:", which has a default port number of
+   * 80. We need to set that explicitly here if it is omitted because otherwise
+   * it will use gRPC's default port 443. */
+  if (port === '') {
+    port = '80';
+  }
   const result: ProxyInfo = {
-    address: proxyUrl.host,
+    address: `${hostname}:${port}`
   };
   if (userCred) {
     result.creds = userCred;


### PR DESCRIPTION
Backport #1609 to 1.1.x so that we can publish it more quickly.