### PR TITLE
grpc-js: support adding/removing services on started server

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -208,6 +208,21 @@ export class Server {
     });
   }
 
+  removeService(service: ServiceDefinition): void {
+    if (
+      service === null ||
+      typeof service !== 'object'
+    ) {
+      throw new Error('removeService() requires object as argument');
+    }
+
+    const serviceKeys = Object.keys(service);
+    serviceKeys.forEach((name) => {
+      const attrs = service[name];
+      this.unregister(attrs.path);
+    });
+  }
+
   bind(port: string, creds: ServerCredentials): void {
     throw new Error('Not implemented. Use bindAsync() instead');
   }

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -458,6 +458,10 @@ export class Server {
     return true;
   }
 
+  unregister(name: string): boolean {
+    return this.handlers.delete(name);
+  }
+
   start(): void {
     if (
       this.http2ServerList.length === 0 ||

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -148,10 +148,6 @@ export class Server {
     service: ServiceDefinition,
     implementation: UntypedServiceImplementation
   ): void {
-    if (this.started === true) {
-      throw new Error("Can't add a service to a started server.");
-    }
-
     if (
       service === null ||
       typeof service !== 'object' ||
@@ -637,7 +633,7 @@ async function handleUnary<RequestType, ResponseType>(
   if (request === undefined || call.cancelled) {
     return;
   }
-  
+
   const emitter = new ServerUnaryCallImpl<RequestType, ResponseType>(
     call,
     metadata,

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -202,7 +202,7 @@ describe('Server', () => {
       });
     });
 
-    it('fails if the server has been started', done => {
+    it('succeeds after server has been started', done => {
       const server = new Server();
 
       server.bindAsync(
@@ -211,9 +211,9 @@ describe('Server', () => {
         (err, port) => {
           assert.ifError(err);
           server.start();
-          assert.throws(() => {
+          assert.doesNotThrow(() => {
             server.addService(mathServiceAttrs, dummyImpls);
-          }, /Can't add a service to a started server\./);
+          });
           server.tryShutdown(done);
         }
       );


### PR DESCRIPTION
This PR includes:

- removing the requirement of `Server#addService(...)` for non-started server
- adding `Server#unregister(...)` and `Server#removeService(...)` - the counterparts of `Server#register(...)` and `Server#addService`

workaround for https://github.com/grpc/grpc-node/issues/1547