### PR TITLE
Native: add new Node and Electron versions, bump version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     name: All Simple Native Builds
     strategy:
       matrix:
-        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15']
+        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
         arch: [ia32, x64]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15']
+        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
     env:
       ARCH: x64
       VERSION: ${{matrix.node}}.0.0
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15']
+        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
         arch: [arm, arm64, s390x]
     env:
       ARCH: ${{matrix.arch}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     name: All Simple Native Builds
     strategy:
       matrix:
-        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
+        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15']
         arch: [ia32, x64]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
@@ -46,7 +46,7 @@ jobs:
     name: All Electron Builds
     strategy:
       matrix:
-        electron: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '2.0', '3.0', '3.1', '4.1', '4.2', '5.0', '6.0', '6.1', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3', '9.0']
+        electron: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '2.0', '3.0', '3.1', '4.1', '4.2', '5.0', '6.0', '6.1', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '9.0', '9.1', '9.2', '9.3', '10.0', '10.1']
         arch: [ia32, x64]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
+        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15']
     env:
       ARCH: x64
       VERSION: ${{matrix.node}}.0.0
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14']
+        node: ['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15']
         arch: [arm, arm64, s390x]
     env:
       ARCH: ${{matrix.arch}}

--- a/packages/grpc-native-core/README.md
+++ b/packages/grpc-native-core/README.md
@@ -1,7 +1,7 @@
 [![npm](https://img.shields.io/npm/v/grpc.svg)](https://www.npmjs.com/package/grpc)
 # Node.js gRPC Library
 
-**This library is now only receiving bug fixes and runtime compatibility updates. In April 2021 it will be deprecated and will no longer receive any updates.**
+**This library is now only receiving bug fixes and runtime compatibility updates. In April 2021 it will be deprecated and will no longer receive any updates. We recommend using [`@grpc/grpc-js`](https://www.npmjs.com/package/@grpc/grpc-js) instead.**
 
 ## PREREQUISITES
 - `node`: This requires `node` to be installed, version `4.0` or above. If you instead have the `nodejs` executable on Debian, you should install the [`nodejs-legacy`](https://packages.debian.org/sid/nodejs-legacy) package.

--- a/packages/grpc-native-core/README.md
+++ b/packages/grpc-native-core/README.md
@@ -8,6 +8,11 @@
 
 - **Note:** If you installed `node` via a package manager and the version is still less than `4.0`, try directly installing it from [nodejs.org](https://nodejs.org).
 
+## LATEST VERSIONS SUPPORTED
+
+ - Node: 15
+ - Electron: 10.1
+
 ## INSTALLATION
 
 Install the gRPC NPM package

--- a/packages/grpc-native-core/README.md
+++ b/packages/grpc-native-core/README.md
@@ -10,7 +10,7 @@
 
 ## LATEST VERSIONS SUPPORTED
 
- - Node: 15
+ - Node: 14
  - Electron: 10.1
 
 ## INSTALLATION

--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -91,7 +91,7 @@
       'GPR_BACKWARDS_COMPATIBILITY_MODE',
       'GRPC_ARES=1',
       'GRPC_UV',
-      'GRPC_NODE_VERSION="1.24.2"',
+      'GRPC_NODE_VERSION="1.24.4"',
       'CARES_STATICLIB',
       'CARES_SYMBOL_HIDING'
     ],

--- a/packages/grpc-native-core/binding.gyp
+++ b/packages/grpc-native-core/binding.gyp
@@ -72,7 +72,7 @@
       '-std=c99'
     ],
     'cflags_cc': [
-      '-std=c++1y'
+      '-std=c++14'
     ],
     'include_dirs': [
       'deps/grpc',

--- a/packages/grpc-native-core/build.yaml
+++ b/packages/grpc-native-core/build.yaml
@@ -1,3 +1,3 @@
 settings:
   '#': It's possible to have node_version here as a key to override the core's version.
-  node_version: 1.24.2
+  node_version: 1.24.4

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "author": "Google Inc.",
   "description": "gRPC Library for Node",
   "homepage": "https://grpc.io/",
@@ -30,7 +30,7 @@
     "lodash.camelcase": "^4.3.0",
     "lodash.clone": "^4.5.0",
     "nan": "^2.13.2",
-    "node-pre-gyp": "^0.15.0",
+    "node-pre-gyp": "^0.16.0",
     "protobufjs": "^5.0.3"
   },
   "devDependencies": {

--- a/packages/grpc-native-core/templates/binding.gyp.template
+++ b/packages/grpc-native-core/templates/binding.gyp.template
@@ -68,7 +68,7 @@
         '-std=c99'
       ],
       'cflags_cc': [
-        '-std=c++1y'
+        '-std=c++14'
       ],
       'include_dirs': [
         'deps/grpc',

--- a/packages/grpc-native-core/templates/package.json.template
+++ b/packages/grpc-native-core/templates/package.json.template
@@ -27,15 +27,12 @@
       "install": "node-pre-gyp install --fallback-to-build --library=static_library",
       "prepack": "git submodule update --init --recursive && npm install"
     },
-    "bundledDependencies": [
-      "node-pre-gyp"
-    ],
     "dependencies": {
       "@types/bytebuffer": "^5.0.40",
       "lodash.camelcase": "^4.3.0",
       "lodash.clone": "^4.5.0",
       "nan": "^2.13.2",
-      "node-pre-gyp": "^0.14.0",
+      "node-pre-gyp": "^0.16.0",
       "protobufjs": "^5.0.3"
     },
     "devDependencies": {


### PR DESCRIPTION
A couple of previous changes set the `package.json` file out of sync with the template and `build.yaml`, so I corrected that here.

Also add a note in the README specifying the latest version of Node and Electron that we support. We will only have to update that a few times before we stop updating the version support entirely.