### PR TITLE
grpc-js: Rearrange connectivity state enum to match the native library

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -41,10 +41,10 @@ import { mapProxyName } from './http_proxy';
 import { GrpcUri, parseUri, uriToString } from './uri-parser';
 
 export enum ConnectivityState {
+  IDLE,
   CONNECTING,
   READY,
   TRANSIENT_FAILURE,
-  IDLE,
   SHUTDOWN,
 }
 


### PR DESCRIPTION
[The corresponding enum in the native library](https://github.com/grpc/grpc-node/blob/grpc%401.24.x/packages/grpc-native-core/src/constants.js#L260-L266). This fixes #1620.