### PR TITLE
Support parsing of file descriptor sets

### DIFF
--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -269,7 +269,7 @@ function createDefinition(
   }
 }
 
-function createPackageDefinition(
+export function createPackageDefinition(
   root: Protobuf.Root,
   options: Options
 ): PackageDefinition {


### PR DESCRIPTION
This change exports the createPackageDefinition function in order to
support tools and libraries that seek to use file descriptor sets in
order to generate package definitions.

Fixes #1627