### PR TITLE
grpc-js: Make calls use the min of parent and own deadline when both are provided

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -630,7 +630,11 @@ export class Http2CallStream implements Call {
 
   getDeadline(): Deadline {
     if (this.options.parentCall && this.options.flags & Propagate.DEADLINE) {
-      return this.options.parentCall.getDeadline();
+      const parentDeadline = this.options.parentCall.getDeadline();
+      const selfDeadline = this.options.deadline;
+      const parentDeadlineMsecs = parentDeadline instanceof Date ? parentDeadline.getTime() : parentDeadline;
+      const selfDeadlineMsecs = selfDeadline instanceof Date ? selfDeadline.getTime() : selfDeadline;
+      return Math.min(parentDeadlineMsecs, selfDeadlineMsecs);
     } else {
       return this.options.deadline;
     }


### PR DESCRIPTION
This fixes #1632.