### PR TITLE
grpc-js-xds: Shutdown the xDS client used by the resolver when the channel shuts down

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -45,7 +45,7 @@
     "@grpc/proto-loader": "^0.6.0-pre14"
   },
   "peerDependencies": {
-    "@grpc/grpc-js": "~1.2.0"
+    "@grpc/grpc-js": "~1.2.2"
   },
   "engines": {
     "node": ">=10.10.0"

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -262,6 +262,12 @@ class DnsResolver implements Resolver {
     }
   }
 
+  destroy() {
+    /* Do nothing. There is not a practical way to cancel in-flight DNS
+     * requests, and after this function is called we can expect that
+     * updateResolution will not be called again. */
+  }
+
   /**
    * Get the default authority for the given target. For IP targets, that is
    * the IP address. For DNS targets, it is the hostname.

--- a/packages/grpc-js/src/resolver-uds.ts
+++ b/packages/grpc-js/src/resolver-uds.ts
@@ -44,6 +44,10 @@ class UdsResolver implements Resolver {
     );
   }
 
+  destroy() {
+    // This resolver owns no resources, so we do nothing here.
+  }
+
   static getDefaultAuthority(target: GrpcUri): string {
     return 'localhost';
   }

--- a/packages/grpc-js/src/resolver.ts
+++ b/packages/grpc-js/src/resolver.ts
@@ -62,6 +62,11 @@ export interface Resolver {
    * called synchronously with the constructor or updateResolution.
    */
   updateResolution(): void;
+  
+  /**
+   * Destroy the resolver. Should be called when the owning channel shuts down.
+   */
+  destroy(): void;
 }
 
 export interface ResolverConstructor {

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -257,6 +257,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
 
   destroy() {
     this.childLoadBalancer.destroy();
+    this.innerResolver.destroy();
     this.updateState(ConnectivityState.SHUTDOWN, new UnavailablePicker());
   }
 

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -394,6 +394,9 @@ describe('Name Resolver', () => {
         return [];
       }
 
+      destroy() {
+      }
+
       static getDefaultAuthority(target: GrpcUri): string {
         return 'other';
       }


### PR DESCRIPTION
A channel that connects to an `xds:///` backend creates an internal client connected to an xDS server. Currently that client just always has an active call and holds the process open forever. This change makes it so that when that channel's `close` method is called, which calls its resolving load balancer's `destroy` method, that propagates to destroy the resolver, which then shuts down the xDS client, allowing the process to end.

*Technically*, this is a breaking change in the `experimental` namespace by adding an additional method to the `Resolver` interface that would need to be implemented by an implementing class. However, the real point of the `experimental` version compatibility guarantees is to avoid breaking grpc-js-xds, and since that's not out yet I don't consider it to be a real issue.