### PR TITLE
grpc-js: End calls faster if the deadline has already passed

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/deadline-filter.ts
+++ b/packages/grpc-js/src/deadline-filter.ts
@@ -56,10 +56,14 @@ export class DeadlineFilter extends BaseFilter implements Filter {
     }
     const now: number = new Date().getTime();
     let timeout = this.deadline - now;
-    if (timeout < 0) {
-      timeout = 0;
-    }
-    if (this.deadline !== Infinity) {
+    if (timeout <= 0) {
+      process.nextTick(() => {
+        callStream.cancelWithStatus(
+          Status.DEADLINE_EXCEEDED,
+          'Deadline exceeded'
+        );
+      });
+    } else if (this.deadline !== Infinity) {
       this.timer = setTimeout(() => {
         callStream.cancelWithStatus(
           Status.DEADLINE_EXCEEDED,


### PR DESCRIPTION
This should fix #1636.

`process.nextTick` queues a function to be called in the current phase of the event loop, while `setTimeout` will wait until the timer handling phase. We still want to call `cancelWithStatus` asynchronously for consistency.