### PR TITLE
Prototype pollution fix - checking magic attributes - grpc-js

### DIFF
--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -48,14 +48,14 @@ export interface ServerMethodDefinition<RequestType, ResponseType> {
 
 export interface MethodDefinition<RequestType, ResponseType>
   extends ClientMethodDefinition<RequestType, ResponseType>,
-  ServerMethodDefinition<RequestType, ResponseType> { }
+    ServerMethodDefinition<RequestType, ResponseType> {}
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type ServiceDefinition<
   ImplementationType = UntypedServiceImplementation
-  > = {
-    readonly [index in keyof ImplementationType]: MethodDefinition<any, any>;
-  };
+> = {
+  readonly [index in keyof ImplementationType]: MethodDefinition<any, any>;
+};
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 export interface ProtobufTypeDefinition {
@@ -85,7 +85,7 @@ export interface ServiceClient extends Client {
 }
 
 export interface ServiceClientConstructor {
-  new(
+  new (
     address: string,
     credentials: ChannelCredentials,
     options?: Partial<ChannelOptions>
@@ -123,9 +123,9 @@ export function makeClientConstructor(
 
   Object.keys(methods).forEach((name) => {
     if (
-      name === 'prototype' ||
+      name === '__proto__' ||
       name === 'constructor' ||
-      name === '__proto__'
+      name === 'prototype' 
     ) {
       return;
     }
@@ -159,7 +159,7 @@ export function makeClientConstructor(
     ServiceClientImpl.prototype[name] = methodFunc;
     // Associate all provided attributes with the method
     Object.assign(ServiceClientImpl.prototype[name], attrs);
-    if (attrs.originalName && attrs.originalName !== '__proto__' && attrs.originalName !== 'constructor' && attrs.originalName !== 'prototype') {
+    if (attrs.originalName && attrs.originalName !== '__proto__' && attrs.originalName !== 'prototype' && attrs.originalName !== 'constructor') {
       ServiceClientImpl.prototype[attrs.originalName] =
         ServiceClientImpl.prototype[name];
     }
@@ -184,9 +184,9 @@ function partial(
 
 export interface GrpcObject {
   [index: string]:
-  | GrpcObject
-  | ServiceClientConstructor
-  | ProtobufTypeDefinition;
+    | GrpcObject
+    | ServiceClientConstructor
+    | ProtobufTypeDefinition;
 }
 
 function isProtobufTypeDefinition(
@@ -211,9 +211,9 @@ export function loadPackageDefinition(
       if (
         nameComponents.some(
           (comp) =>
-            comp === 'prototype' ||
+            comp === '__proto__' ||
             comp === 'constructor' ||
-            comp === '__proto__'
+            comp === 'prototype'
         )
       ) {
         continue;

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -164,7 +164,7 @@ export function makeClientConstructor(
     ServiceClientImpl.prototype[name] = methodFunc;
     // Associate all provided attributes with the method
     Object.assign(ServiceClientImpl.prototype[name], attrs);
-    if (attrs.originalName && isPrototypePolluted(attrs.originalName)) {
+    if (attrs.originalName && !isPrototypePolluted(attrs.originalName)) {
       ServiceClientImpl.prototype[attrs.originalName] =
         ServiceClientImpl.prototype[name];
     }

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -48,14 +48,14 @@ export interface ServerMethodDefinition<RequestType, ResponseType> {
 
 export interface MethodDefinition<RequestType, ResponseType>
   extends ClientMethodDefinition<RequestType, ResponseType>,
-    ServerMethodDefinition<RequestType, ResponseType> {}
+  ServerMethodDefinition<RequestType, ResponseType> { }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type ServiceDefinition<
   ImplementationType = UntypedServiceImplementation
-> = {
-  readonly [index in keyof ImplementationType]: MethodDefinition<any, any>;
-};
+  > = {
+    readonly [index in keyof ImplementationType]: MethodDefinition<any, any>;
+  };
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 export interface ProtobufTypeDefinition {
@@ -85,7 +85,7 @@ export interface ServiceClient extends Client {
 }
 
 export interface ServiceClientConstructor {
-  new (
+  new(
     address: string,
     credentials: ChannelCredentials,
     options?: Partial<ChannelOptions>
@@ -122,7 +122,11 @@ export function makeClientConstructor(
   }
 
   Object.keys(methods).forEach((name) => {
-    if (name === '__proto__') {
+    if (
+      name === 'prototype' ||
+      name === 'constructor' ||
+      name === '__proto__'
+    ) {
       return;
     }
     const attrs = methods[name];
@@ -155,7 +159,7 @@ export function makeClientConstructor(
     ServiceClientImpl.prototype[name] = methodFunc;
     // Associate all provided attributes with the method
     Object.assign(ServiceClientImpl.prototype[name], attrs);
-    if (attrs.originalName && attrs.originalName !== '__proto__') {
+    if (attrs.originalName && attrs.originalName !== '__proto__' && attrs.originalName !== 'constructor' && attrs.originalName !== 'prototype') {
       ServiceClientImpl.prototype[attrs.originalName] =
         ServiceClientImpl.prototype[name];
     }
@@ -180,9 +184,9 @@ function partial(
 
 export interface GrpcObject {
   [index: string]:
-    | GrpcObject
-    | ServiceClientConstructor
-    | ProtobufTypeDefinition;
+  | GrpcObject
+  | ServiceClientConstructor
+  | ProtobufTypeDefinition;
 }
 
 function isProtobufTypeDefinition(

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -204,7 +204,7 @@ export function loadPackageDefinition(
     if (Object.prototype.hasOwnProperty.call(packageDef, serviceFqn)) {
       const service = packageDef[serviceFqn];
       const nameComponents = serviceFqn.split('.');
-      if (nameComponents.some(comp => comp === '__proto__')) {
+      if (nameComponents.some(comp => comp === '__proto__' || comp === 'constructor' || comp === 'prototype')) {
         continue;
       }
       const serviceName = nameComponents[nameComponents.length - 1];

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -48,14 +48,14 @@ export interface ServerMethodDefinition<RequestType, ResponseType> {
 
 export interface MethodDefinition<RequestType, ResponseType>
   extends ClientMethodDefinition<RequestType, ResponseType>,
-    ServerMethodDefinition<RequestType, ResponseType> {}
+  ServerMethodDefinition<RequestType, ResponseType> { }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type ServiceDefinition<
   ImplementationType = UntypedServiceImplementation
-> = {
-  readonly [index in keyof ImplementationType]: MethodDefinition<any, any>;
-};
+  > = {
+    readonly [index in keyof ImplementationType]: MethodDefinition<any, any>;
+  };
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 export interface ProtobufTypeDefinition {
@@ -85,7 +85,7 @@ export interface ServiceClient extends Client {
 }
 
 export interface ServiceClientConstructor {
-  new (
+  new(
     address: string,
     credentials: ChannelCredentials,
     options?: Partial<ChannelOptions>
@@ -98,7 +98,7 @@ export interface ServiceClientConstructor {
  * keys.
  * @param key key for check, string.
  */
-const isPrototypePolluted = (key: string) => {
+function isPrototypePolluted(key: string): Boolean {
   return ['__proto__', 'prototype', 'constructor'].includes(key);
 }
 
@@ -189,9 +189,9 @@ function partial(
 
 export interface GrpcObject {
   [index: string]:
-    | GrpcObject
-    | ServiceClientConstructor
-    | ProtobufTypeDefinition;
+  | GrpcObject
+  | ServiceClientConstructor
+  | ProtobufTypeDefinition;
 }
 
 function isProtobufTypeDefinition(

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -204,7 +204,14 @@ export function loadPackageDefinition(
     if (Object.prototype.hasOwnProperty.call(packageDef, serviceFqn)) {
       const service = packageDef[serviceFqn];
       const nameComponents = serviceFqn.split('.');
-      if (nameComponents.some(comp => comp === '__proto__' || comp === 'constructor' || comp === 'prototype')) {
+      if (
+        nameComponents.some(
+          (comp) =>
+            comp === 'prototype' ||
+            comp === 'constructor' ||
+            comp === '__proto__'
+        )
+      ) {
         continue;
       }
       const serviceName = nameComponents[nameComponents.length - 1];

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -213,9 +213,7 @@ export function loadPackageDefinition(
     if (Object.prototype.hasOwnProperty.call(packageDef, serviceFqn)) {
       const service = packageDef[serviceFqn];
       const nameComponents = serviceFqn.split('.');
-      if (
-        nameComponents.some((comp: string) => isPrototypePolluted(comp))
-      ) {
+      if (nameComponents.some((comp: string) => isPrototypePolluted(comp))) {
         continue;
       }
       const serviceName = nameComponents[nameComponents.length - 1];

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -48,14 +48,14 @@ export interface ServerMethodDefinition<RequestType, ResponseType> {
 
 export interface MethodDefinition<RequestType, ResponseType>
   extends ClientMethodDefinition<RequestType, ResponseType>,
-  ServerMethodDefinition<RequestType, ResponseType> { }
+    ServerMethodDefinition<RequestType, ResponseType> {}
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type ServiceDefinition<
   ImplementationType = UntypedServiceImplementation
-  > = {
-    readonly [index in keyof ImplementationType]: MethodDefinition<any, any>;
-  };
+> = {
+  readonly [index in keyof ImplementationType]: MethodDefinition<any, any>;
+};
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 export interface ProtobufTypeDefinition {
@@ -85,7 +85,7 @@ export interface ServiceClient extends Client {
 }
 
 export interface ServiceClientConstructor {
-  new(
+  new (
     address: string,
     credentials: ChannelCredentials,
     options?: Partial<ChannelOptions>
@@ -189,9 +189,9 @@ function partial(
 
 export interface GrpcObject {
   [index: string]:
-  | GrpcObject
-  | ServiceClientConstructor
-  | ProtobufTypeDefinition;
+    | GrpcObject
+    | ServiceClientConstructor
+    | ProtobufTypeDefinition;
 }
 
 function isProtobufTypeDefinition(


### PR DESCRIPTION
### 📊 Metadata *

grpc is vulnerable to Prototype Pollution. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

`// poc.js`
`var grpc =require('grpc')`
`grpc.loadPackageDefinition({'constructor.prototype.polluted': "Yes! Its Polluted"});`
`console.log({}.polluted)`

Execute the following commands in another terminal:

`npm i grpc # Install affected module`
`node poc.js #  Run the PoC`

Check the Output:

[Function: ServiceClient] { service: 'Yes! Its Polluted' }`

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/99915170-0887ee80-2d28-11eb-8c66-9fbb0beada03.png)

After:
![image](https://user-images.githubusercontent.com/64132745/99915196-379e6000-2d28-11eb-8b0f-0cf584f21463.png)


### 👍 User Acceptance Testing (UAT)

After fix functionality is unaffected.


![grpc-proto-test-1](https://user-images.githubusercontent.com/64132745/99915042-3e78a300-2d27-11eb-9ba6-436969149a90.png)

![grpc-proto-test-2](https://user-images.githubusercontent.com/64132745/99915046-43d5ed80-2d27-11eb-8d57-758bd0b34a61.png)
![grpc-proto-test-3](https://user-images.githubusercontent.com/64132745/99915049-48020b00-2d27-11eb-99db-d7f5b354ae54.png)
![grpc-proto-test-4](https://user-images.githubusercontent.com/64132745/99915054-4cc6bf00-2d27-11eb-85b1-743e1d1d2fe6.png)
![grpc-proto-test-5](https://user-images.githubusercontent.com/64132745/99915051-4b959200-2d27-11eb-9243-c95099cc0497.png)
![grpc-proto-test-6](https://user-images.githubusercontent.com/64132745/99915052-4c2e2880-2d27-11eb-902f-0a1f9115d8e4.png)
![grpc-proto-test-7](https://user-images.githubusercontent.com/64132745/99915053-4c2e2880-2d27-11eb-8cad-e9b67d749cc8.png)
