### PR TITLE
grpc-js: round robin: re-resolve when subchannels go idle

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -128,14 +128,12 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
       this.subchannelStateCounts[previousState] -= 1;
       this.subchannelStateCounts[newState] += 1;
       this.calculateAndUpdateState();
-
-      if (newState === ConnectivityState.TRANSIENT_FAILURE) {
-        this.channelControlHelper.requestReresolution();
-      }
+      
       if (
         newState === ConnectivityState.TRANSIENT_FAILURE ||
         newState === ConnectivityState.IDLE
       ) {
+        this.channelControlHelper.requestReresolution();
         subchannel.startConnecting();
       }
     };


### PR DESCRIPTION
This should fix #1663. When a connected subchannel gets a GOAWAY it transitions to IDLE, and as of #1073 the same is true of other kinds of disconnects. Those are supposed to be signals to the round robin balancer that it should do name resolution again, so that's what we do here.