### PR TITLE
feature(grpc-js): Add possibility to provide maxSessionMemory http2 option through ChannelOptions

### DIFF
--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -28,6 +28,7 @@ export interface ChannelOptions {
   'grpc.keepalive_permit_without_calls'?: number;
   'grpc.service_config'?: string;
   'grpc.max_concurrent_streams'?: number;
+  'grpc.max_session_memory'?: number;
   'grpc.initial_reconnect_backoff_ms'?: number;
   'grpc.max_reconnect_backoff_ms'?: number;
   'grpc.use_local_subchannel_pool'?: number;
@@ -53,6 +54,7 @@ export const recognizedOptions = {
   'grpc.keepalive_permit_without_calls': true,
   'grpc.service_config': true,
   'grpc.max_concurrent_streams': true,
+  'grpc.max_session_memory': true,
   'grpc.initial_reconnect_backoff_ms': true,
   'grpc.max_reconnect_backoff_ms': true,
   'grpc.use_local_subchannel_pool': true,

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -28,7 +28,6 @@ export interface ChannelOptions {
   'grpc.keepalive_permit_without_calls'?: number;
   'grpc.service_config'?: string;
   'grpc.max_concurrent_streams'?: number;
-  'grpc.max_session_memory'?: number;
   'grpc.initial_reconnect_backoff_ms'?: number;
   'grpc.max_reconnect_backoff_ms'?: number;
   'grpc.use_local_subchannel_pool'?: number;
@@ -37,6 +36,7 @@ export interface ChannelOptions {
   'grpc.enable_http_proxy'?: number;
   'grpc.http_connect_target'?: string;
   'grpc.http_connect_creds'?: string;
+  'grpc-node.max_session_memory'?: number;
   [key: string]: any;
 }
 
@@ -54,13 +54,13 @@ export const recognizedOptions = {
   'grpc.keepalive_permit_without_calls': true,
   'grpc.service_config': true,
   'grpc.max_concurrent_streams': true,
-  'grpc.max_session_memory': true,
   'grpc.initial_reconnect_backoff_ms': true,
   'grpc.max_reconnect_backoff_ms': true,
   'grpc.use_local_subchannel_pool': true,
   'grpc.max_send_message_length': true,
   'grpc.max_receive_message_length': true,
   'grpc.enable_http_proxy': true,
+  'grpc-node.max_session_memory': true,
 };
 
 export function channelOptionsEqual(

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -258,8 +258,11 @@ export class Server {
     }
 
     const serverOptions: http2.ServerOptions = {
-      maxSendHeaderBlockLength: Number.MAX_SAFE_INTEGER
+      maxSendHeaderBlockLength: Number.MAX_SAFE_INTEGER,
     };
+    if ('grpc.max_session_memory' in this.options) {
+      serverOptions.maxSessionMemory = this.options['grpc.max_session_memory'];
+    }
     if ('grpc.max_concurrent_streams' in this.options) {
       serverOptions.settings = {
         maxConcurrentStreams: this.options['grpc.max_concurrent_streams'],

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -258,10 +258,10 @@ export class Server {
     }
 
     const serverOptions: http2.ServerOptions = {
-      maxSendHeaderBlockLength: Number.MAX_SAFE_INTEGER,
+      maxSendHeaderBlockLength: Number.MAX_SAFE_INTEGER
     };
-    if ('grpc.max_session_memory' in this.options) {
-      serverOptions.maxSessionMemory = this.options['grpc.max_session_memory'];
+    if ('grpc-node.max_session_memory' in this.options) {
+      serverOptions.maxSessionMemory = this.options['grpc-node.max_session_memory'];
     }
     if ('grpc.max_concurrent_streams' in this.options) {
       serverOptions.settings = {

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -307,6 +307,9 @@ export class Subchannel {
     let connectionOptions: http2.SecureClientSessionOptions =
       this.credentials._getConnectionOptions() || {};
     connectionOptions.maxSendHeaderBlockLength = Number.MAX_SAFE_INTEGER;
+    if ('grpc.max_session_memory' in this.options) {
+      connectionOptions.maxSessionMemory = this.options['grpc.max_session_memory'];
+    }
     let addressScheme = 'http://';
     if ('secureContext' in connectionOptions) {
       addressScheme = 'https://';

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -307,8 +307,8 @@ export class Subchannel {
     let connectionOptions: http2.SecureClientSessionOptions =
       this.credentials._getConnectionOptions() || {};
     connectionOptions.maxSendHeaderBlockLength = Number.MAX_SAFE_INTEGER;
-    if ('grpc.max_session_memory' in this.options) {
-      connectionOptions.maxSessionMemory = this.options['grpc.max_session_memory'];
+    if ('grpc-node.max_session_memory' in this.options) {
+      connectionOptions.maxSessionMemory = this.options['grpc-node.max_session_memory'];
     }
     let addressScheme = 'http://';
     if ('secureContext' in connectionOptions) {


### PR DESCRIPTION
Currently there is no way to set the parameter maxSessionMemory for http2.createServer() and http2.connect() options. In case when queued data at session is become more than default value there thrown exception.