### PR TITLE
Do not override existing useragent

### DIFF
--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -687,7 +687,9 @@ export class Subchannel {
   ) {
     const headers = metadata.toHttp2Headers();
     headers[HTTP2_HEADER_AUTHORITY] = callStream.getHost();
-    headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;
+    if (!headers[HTTP2_HEADER_USER_AGENT]) {
+      headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;
+    }    
     headers[HTTP2_HEADER_CONTENT_TYPE] = 'application/grpc';
     headers[HTTP2_HEADER_METHOD] = 'POST';
     headers[HTTP2_HEADER_PATH] = callStream.getMethod();


### PR DESCRIPTION
It looks like the gRPC client always override the useragent passed in the metdata headers.
Would you accept such a change, where we only set the useragent if there is not one that is passed through the headers already? Happy to add tests if that looks good to you