### PR TITLE
Add security policy doc

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+For information on gRPC Security Policy and reporting potentional security issues, please see [gRPC CVE Process](https://github.com/grpc/proposal/blob/master/P4-grpc-cve-process.md).


### PR DESCRIPTION
Adding SECURITY.md to point to the CVE process. This is also show up as "Report a security vulnerability" option when creating a new issue.