### PR TITLE
grpc-js: Move call to user code out of try block

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
The main fix here is to move the `onReceiveMessage` call out of the `try` block, because that function eventually calls `stream.push` or the equivalent unary handler function, and the result is that that function is called within the context of that `try` block and any errors it throws will be misinterpreted as response parsing errors.

This fixes #1661.