### PR TITLE
grpc-js-xds: Bubble up xds client initialization error details

### DIFF
--- a/packages/grpc-js-xds/src/resolver-xds.ts
+++ b/packages/grpc-js-xds/src/resolver-xds.ts
@@ -39,12 +39,12 @@ class XdsResolver implements Resolver {
     private channelOptions: ChannelOptions
   ) {}
 
-  private reportResolutionError() {
+  private reportResolutionError(reason: string) {
     this.listener.onError({
       code: status.UNAVAILABLE,
       details: `xDS name resolution failed for target ${uriToString(
         this.target
-      )}`,
+      )}: ${reason}`,
       metadata: new Metadata(),
     });
   }
@@ -68,12 +68,12 @@ class XdsResolver implements Resolver {
              * not already provided a ServiceConfig for the upper layer to use */
             if (!this.hasReportedSuccess) {
               trace('Resolution error for target ' + uriToString(this.target) + ' due to xDS client transient error ' + error.details);
-              this.reportResolutionError();
+              this.reportResolutionError(error.details);
             }
           },
           onResourceDoesNotExist: () => {
             trace('Resolution error for target ' + uriToString(this.target) + ': resource does not exist');
-            this.reportResolutionError();
+            this.reportResolutionError("Resource does not exist");
           },
         },
         this.channelOptions

--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -1155,7 +1155,7 @@ export class XdsClient {
   }
 
   removeClusterWatcher(clusterName: string, watcher: Watcher<Cluster__Output>) {
-    trace('Watcher removed for endpoint ' + clusterName);
+    trace('Watcher removed for cluster ' + clusterName);
     this.adsState[CDS_TYPE_URL].removeWatcher(clusterName, watcher);
   }
 


### PR DESCRIPTION
I noticed when I was working on #1674 that the error details passed through the xds resolver, particularly from [here](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js-xds/src/xds-client.ts#L813) and [here](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js-xds/src/xds-client.ts#L838), wouldn't be visible to the user unless tracing was on, but those are errors the user needs to see.