### PR TITLE
grpc-js: Add ConfigSelector to Resolver API and plumb it through the channel

### DIFF
--- a/packages/grpc-js-xds/src/resolver-xds.ts
+++ b/packages/grpc-js-xds/src/resolver-xds.ts
@@ -60,7 +60,7 @@ class XdsResolver implements Resolver {
           onValidUpdate: (update: ServiceConfig) => {
             trace('Resolved service config for target ' + uriToString(this.target) + ': ' + JSON.stringify(update));
             this.hasReportedSuccess = true;
-            this.listener.onSuccessfulResolution([], update, null, {
+            this.listener.onSuccessfulResolution([], update, null, null, {
               xdsClient: xdsClient,
             });
           },

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -293,14 +293,16 @@ export class ChannelImplementation implements Channel {
   }
 
   private callRefTimerRef() {
-    if (!this.callRefTimer.hasRef()) {
+    // If the hasRef function does not exist, always run the code
+    if (!this.callRefTimer.hasRef?.()) {
       trace(LogVerbosity.DEBUG, 'channel', 'callRefTimer.ref | configSelectionQueue.length=' + this.configSelectionQueue.length + ' pickQueue.length=' + this.pickQueue.length);
       this.callRefTimer.ref?.();
     }
   }
 
   private callRefTimerUnref() {
-    if (this.callRefTimer.hasRef()) {
+    // If the hasRef function does not exist, always run the code
+    if ((!this.callRefTimer.hasRef) || (this.callRefTimer.hasRef())) {
       trace(LogVerbosity.DEBUG, 'channel', 'callRefTimer.unref | configSelectionQueue.length=' + this.configSelectionQueue.length + ' pickQueue.length=' + this.pickQueue.length);
       this.callRefTimer.unref?.();
     }

--- a/packages/grpc-js/src/picker.ts
+++ b/packages/grpc-js/src/picker.ts
@@ -85,6 +85,7 @@ export interface DropCallPickResult extends PickResult {
 
 export interface PickArgs {
   metadata: Metadata;
+  extraPickInfo: {[key: string]: string};
 }
 
 /**

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -129,7 +129,7 @@ class DnsResolver implements Resolver {
     if (this.ipResult !== null) {
       trace('Returning IP address for target ' + uriToString(this.target));
       setImmediate(() => {
-        this.listener.onSuccessfulResolution(this.ipResult!, null, null, {});
+        this.listener.onSuccessfulResolution(this.ipResult!, null, null, null, {});
       });
       return;
     }
@@ -192,6 +192,7 @@ class DnsResolver implements Resolver {
             this.latestLookupResult,
             this.latestServiceConfig,
             this.latestServiceConfigError,
+            null,
             {}
           );
         },
@@ -237,6 +238,7 @@ class DnsResolver implements Resolver {
                 this.latestLookupResult,
                 this.latestServiceConfig,
                 this.latestServiceConfigError,
+                null,
                 {}
               );
             }

--- a/packages/grpc-js/src/resolver-uds.ts
+++ b/packages/grpc-js/src/resolver-uds.ts
@@ -40,6 +40,7 @@ class UdsResolver implements Resolver {
       this.addresses,
       null,
       null,
+      null,
       {}
     );
   }

--- a/packages/grpc-js/src/resolver.ts
+++ b/packages/grpc-js/src/resolver.ts
@@ -15,13 +15,30 @@
  *
  */
 
-import { ServiceConfig } from './service-config';
+import { MethodConfig, ServiceConfig } from './service-config';
 import * as resolver_dns from './resolver-dns';
 import * as resolver_uds from './resolver-uds';
 import { StatusObject } from './call-stream';
 import { SubchannelAddress } from './subchannel';
 import { GrpcUri, uriToString } from './uri-parser';
 import { ChannelOptions } from './channel-options';
+import { Metadata } from './metadata';
+import { Status } from './constants';
+
+export interface CallConfig {
+  methodConfig: MethodConfig;
+  onCommitted?: () => void;
+  pickInformation: {[key: string]: string};
+  status: Status;
+}
+
+/**
+ * Selects a configuration for a method given the name and metadata. Defined in
+ * https://github.com/grpc/proposal/blob/master/A31-xds-timeout-support-and-config-selector.md#new-functionality-in-grpc
+ */
+export interface ConfigSelector {
+  (methodName: string, metadata: Metadata): CallConfig;
+}
 
 /**
  * A listener object passed to the resolver's constructor that provides name
@@ -41,6 +58,7 @@ export interface ResolverListener {
     addressList: SubchannelAddress[],
     serviceConfig: ServiceConfig | null,
     serviceConfigError: StatusObject | null,
+    configSelector: ConfigSelector | null,
     attributes: { [key: string]: unknown }
   ): void;
   /**

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -76,6 +76,10 @@ export interface ResolutionCallback {
   (configSelector: ConfigSelector): void;
 }
 
+export interface ResolutionFailureCallback {
+  (status: StatusObject): void;
+}
+
 export class ResolvingLoadBalancer implements LoadBalancer {
   /**
    * The resolver class constructed for the target address.
@@ -124,7 +128,8 @@ export class ResolvingLoadBalancer implements LoadBalancer {
     private readonly target: GrpcUri,
     private readonly channelControlHelper: ChannelControlHelper,
     private readonly channelOptions: ChannelOptions,
-    private readonly onSuccessfulResolution: ResolutionCallback
+    private readonly onSuccessfulResolution: ResolutionCallback,
+    private readonly onFailedResolution: ResolutionFailureCallback
   ) {
     if (channelOptions['grpc.service_config']) {
       this.defaultServiceConfig = validateServiceConfig(
@@ -261,6 +266,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
         ConnectivityState.TRANSIENT_FAILURE,
         new UnavailablePicker(error)
       );
+      this.onFailedResolution(error);
     }
     this.backoffTimeout.runOnce();
   }

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -23,7 +23,7 @@ import {
 } from './load-balancer';
 import { ServiceConfig, validateServiceConfig } from './service-config';
 import { ConnectivityState } from './channel';
-import { createResolver, Resolver } from './resolver';
+import { ConfigSelector, createResolver, Resolver } from './resolver';
 import { ServiceError } from './call';
 import { Picker, UnavailablePicker, QueuePicker } from './picker';
 import { BackoffTimeout } from './backoff-timeout';
@@ -45,6 +45,36 @@ function trace(text: string): void {
 }
 
 const DEFAULT_LOAD_BALANCER_NAME = 'pick_first';
+
+function getDefaultConfigSelector(serviceConfig: ServiceConfig | null): ConfigSelector {
+  return function defaultConfigSelector(methodName: string, metadata: Metadata) {
+    const splitName = methodName.split('/').filter(x => x.length > 0);
+    const service = splitName[0] ?? '';
+    const method = splitName[1] ?? '';
+    if (serviceConfig && serviceConfig.methodConfig) {
+      for (const methodConfig of serviceConfig.methodConfig) {
+        for (const name of methodConfig.name) {
+          if (name.service === service && (name.method === undefined || name.method === method)) {
+            return {
+              methodConfig: methodConfig,
+              pickInformation: {},
+              status: Status.OK
+            };
+          }
+        }
+      }
+    }
+    return {
+      methodConfig: {name: []},
+      pickInformation: {},
+      status: Status.OK
+    };
+  }
+}
+
+export interface ResolutionCallback {
+  (configSelector: ConfigSelector): void;
+}
 
 export class ResolvingLoadBalancer implements LoadBalancer {
   /**
@@ -93,7 +123,8 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   constructor(
     private readonly target: GrpcUri,
     private readonly channelControlHelper: ChannelControlHelper,
-    private readonly channelOptions: ChannelOptions
+    private readonly channelOptions: ChannelOptions,
+    private readonly onSuccessfulResolution: ResolutionCallback
   ) {
     if (channelOptions['grpc.service_config']) {
       this.defaultServiceConfig = validateServiceConfig(
@@ -134,6 +165,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
           addressList: SubchannelAddress[],
           serviceConfig: ServiceConfig | null,
           serviceConfigError: ServiceError | null,
+          configSelector: ConfigSelector | null,
           attributes: { [key: string]: unknown }
         ) => {
           let workingServiceConfig: ServiceConfig | null = null;
@@ -180,6 +212,8 @@ export class ResolvingLoadBalancer implements LoadBalancer {
             loadBalancingConfig,
             attributes
           );
+          const finalServiceConfig = workingServiceConfig ?? this.defaultServiceConfig;
+          this.onSuccessfulResolution(configSelector ?? getDefaultConfigSelector(finalServiceConfig));
         },
         onError: (error: StatusObject) => {
           this.handleResolutionFailure(error);


### PR DESCRIPTION
This is an implementation of the first part of [gRFC A31](https://github.com/grpc/proposal/blob/master/A31-xds-timeout-support-and-config-selector.md): the `ConfigSelector`. The purpose of this API is to enable the resolver to provide configuration information and especially routing information that can differ depending on the method and on the metadata. The resolver can return a `ConfigSelector` along with other name resolution information, and the `ResolvingLoadBalancer` passes that along to the channel. The channel calls it before before calling into the `Picker` that comes from the load balancer.

This change should not cause any observable behavior changes, it's just foundational.