### PR TITLE
grpc-js: Loosen dependency on @types/node

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",
@@ -57,7 +57,7 @@
     "posttest": "npm run check"
   },
   "dependencies": {
-    "@types/node": "^12.12.47",
+    "@types/node": ">=12.12.47",
     "google-auth-library": "^6.1.1",
     "semver": "^6.2.0"
   },


### PR DESCRIPTION
This fixes #1679. TypeScript does not do module resolution the same way Node does, and one result is that it reintroduces the diamond dependency problem to a system that does not otherwise have it. The solution here is to declare a dependency with a version range so broad that npm's package deduplication logic will always apply, or at least that the constraint here is never the one that prevents it from applying.

This change may cause build problems in the future if there are relevant breaking changes in `@types/node`, but the existing dependency is causing build problems now so I consider that an acceptable tradeoff.