### PR TITLE
grpc-js: Ref and unref backoff timer

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {
@@ -45,7 +45,7 @@
     "@grpc/proto-loader": "^0.6.0-pre14"
   },
   "peerDependencies": {
-    "@grpc/grpc-js": "~1.2.2"
+    "@grpc/grpc-js": "~1.2.7"
   },
   "engines": {
     "node": ">=10.10.0"

--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -774,9 +774,11 @@ export class XdsClient {
     this.adsBackoff = new BackoffTimeout(() => {
       this.maybeStartAdsStream();
     });
+    this.adsBackoff.unref();
     this.lrsBackoff = new BackoffTimeout(() => {
       this.maybeStartLrsStream();
-    })
+    });
+    this.lrsBackoff.unref();
 
     Promise.all([loadBootstrapInfo(), loadAdsProtos()]).then(
       ([bootstrapInfo, protoDefinitions]) => {

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/backoff-timeout.ts
+++ b/packages/grpc-js/src/backoff-timeout.ts
@@ -44,6 +44,7 @@ export class BackoffTimeout {
   private nextDelay: number;
   private timerId: NodeJS.Timer;
   private running = false;
+  private hasRef = true;
 
   constructor(private callback: () => void, options?: BackoffOptions) {
     if (options) {
@@ -74,6 +75,9 @@ export class BackoffTimeout {
       this.callback();
       this.running = false;
     }, this.nextDelay);
+    if (!this.hasRef) {
+      this.timerId.unref();
+    }
     const nextBackoff = Math.min(
       this.nextDelay * this.multiplier,
       this.maxDelay
@@ -101,5 +105,15 @@ export class BackoffTimeout {
 
   isRunning() {
     return this.running;
+  }
+
+  ref() {
+    this.hasRef = true;
+    this.timerId.ref();
+  }
+
+  unref() {
+    this.hasRef = false;
+    this.timerId.unref();
   }
 }

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -196,6 +196,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
         this.updateState(this.latestChildState, this.latestChildPicker);
       }
     });
+    this.backoffTimeout.unref();
   }
 
   private updateResolution() {

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -615,6 +615,7 @@ export class Subchannel {
       if (this.session) {
         this.session.ref();
       }
+      this.backoffTimeout.ref();
       if (!this.keepaliveWithoutCalls) {
         this.startKeepalivePings();
       }
@@ -635,6 +636,7 @@ export class Subchannel {
       if (this.session) {
         this.session.unref();
       }
+      this.backoffTimeout.unref();
       if (!this.keepaliveWithoutCalls) {
         this.stopKeepalivePings();
       }


### PR DESCRIPTION
We want the gRPC library to hold the Node process open if and only if there is an active request. The channel is responsible for this while a call has not yet been assigned to a subchannel, and the subchannel is responsible for this after the call has been assigned, until the call ends. In the subchannel, there is always either an http session, or an active backoff timer (or both). So, we ref both of those as long as the subchannel has at least one call. Since the resolving load balancer is never responsible for keeping the process open, we always unref its backoff timer. The same is true of the xDS client, which always operates as a subordinate of another channel.