### PR TITLE
grpc-js: Don't propagate non-numeric errors from auth plugins

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -384,7 +384,7 @@ export class ChannelImplementation implements Channel {
               (error: Error & { code: number }) => {
                 // We assume the error code isn't 0 (Status.OK)
                 callStream.cancelWithStatus(
-                  error.code || Status.UNKNOWN,
+                  (typeof error.code === 'number') ? error.code : Status.UNKNOWN,
                   `Getting metadata from plugin failed with error: ${error.message}`
                 );
               }


### PR DESCRIPTION
This has two complementary changes: in the channel, only propagate error codes from metadata filters if they are numbers, and in the call credentials filter, explicitly set the UNAUTHENTICATED error code instead of letting errors from the credentials plugin implicitly bubble up.

This should fix the reports from googleapis/nodejs-pubsub#1063 of the error code `ERR_OSSL_PEM_NO_START_LINE` getting propagated from a Node crypto module error.