### PR TITLE
Fix bug where streaming errors put http2 session into broken state

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -638,12 +638,12 @@ export class Http2CallStream implements Call {
        * RST_STREAM as a result after we have the status */
       let code: number;
       if (this.finalStatus?.code === Status.OK) {
-        code = http2.constants.NGHTTP2_NO_ERROR;
+        this.http2Stream.close(http2.constants.NGHTTP2_NO_ERROR);
+        this.trace('close http2 stream with code ' + http2.constants.NGHTTP2_NO_ERROR);
       } else {
-        code = http2.constants.NGHTTP2_CANCEL;
+        this.http2Stream.destroy(new Error('Stream error'));
+        this.trace('destroy http2 stream after error ');
       }
-      this.trace('close http2 stream with code ' + code);
-      this.http2Stream.close(code);
     }
   }
 

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -716,6 +716,9 @@ export class Subchannel {
     }
     logging.trace(LogVerbosity.DEBUG, 'call_stream', 'Starting stream on subchannel ' + this.subchannelAddressString + ' with headers\n' + headersString);
     callStream.attachHttp2Stream(http2Stream, this, extraFilterFactory);
+    http2Stream.on('error', () => {
+      this.session?.close();
+    });
   }
 
   /**


### PR DESCRIPTION
Currently there is an issue where errors streaming requests can put the http2 session into a broken state, causing all future requests to timeout. fixes #1490