### PR TITLE
grpc: Fix prototype pollution possibility in loadPackageDefinition

### DIFF
--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -161,7 +161,7 @@ exports.loadPackageDefinition = function loadPackageDefintion(packageDef) {
   for (const serviceFqn in packageDef) {
     const service = packageDef[serviceFqn];
     const nameComponents = serviceFqn.split('.');
-    if (nameComponents.some(comp => comp === '__proto__')) {
+    if (nameComponents.some(comp => common.isPrototypePolluted(comp))) {
       continue;
     }
     const serviceName = nameComponents[nameComponents.length-1];

--- a/packages/grpc-native-core/package.json
+++ b/packages/grpc-native-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc",
-  "version": "1.24.5",
+  "version": "1.24.6",
   "author": "Google Inc.",
   "description": "gRPC Library for Node",
   "homepage": "https://grpc.io/",

--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -992,7 +992,7 @@ exports.makeClientConstructor = function(methods, serviceName,
 
   Object.keys(methods).forEach(name => {
     const attrs = methods[name];
-    if (name === '__proto__') {
+    if (common.isPrototypePolluted(name)) {
       return;
     }
     if (name.indexOf('$') === 0) {
@@ -1014,7 +1014,7 @@ exports.makeClientConstructor = function(methods, serviceName,
     ServiceClient.prototype.$method_names[attrs.path] = name;
     // Associate all provided attributes with the method
     Object.assign(ServiceClient.prototype[name], attrs);
-    if (attrs.originalName && attrs.originalName !== '__proto__') {
+    if (attrs.originalName && !common.isPrototypePolluted(attrs.originalName)) {
       ServiceClient.prototype[attrs.originalName] =
         ServiceClient.prototype[name];
     }

--- a/packages/grpc-native-core/src/common.js
+++ b/packages/grpc-native-core/src/common.js
@@ -155,7 +155,7 @@ exports.zipObject = function(props, values) {
  * @return {Boolean}
  */
 exports.isPrototypePolluted = function(key) {
-  return ['__proto__', 'prototype', 'constructor'].includes(key);
+  return ['__proto__', 'prototype', 'constructor'].indexOf(key) >= 0;
 }
 
 // JSDoc definitions that are used in multiple other modules

--- a/packages/grpc-native-core/src/common.js
+++ b/packages/grpc-native-core/src/common.js
@@ -148,6 +148,16 @@ exports.zipObject = function(props, values) {
   }, {});
 }
 
+/**
+ * Returns true, if given key is included in the blacklisted
+ * keys.
+ * @param key {String} key for check, string.
+ * @return {Boolean}
+ */
+exports.isPrototypePolluted = function(key) {
+  return ['__proto__', 'prototype', 'constructor'].includes(key);
+}
+
 // JSDoc definitions that are used in multiple other modules
 
 /**


### PR DESCRIPTION
This is a port of #1654 to the old grpc library.

Credit to @d3v53c for the original fix.