### PR TITLE
Move createGoogleDefaultCredentials from grpc-js to grpc-js-xds

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -42,7 +42,8 @@
     "yargs": "^15.4.1"
   },
   "dependencies": {
-    "@grpc/proto-loader": "^0.6.0-pre14"
+    "@grpc/proto-loader": "^0.6.0-pre14",
+    "google-auth-library": "^7.0.2"
   },
   "peerDependencies": {
     "@grpc/grpc-js": "~1.2.2"

--- a/packages/grpc-js-xds/src/google-default-credentials.ts
+++ b/packages/grpc-js-xds/src/google-default-credentials.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import { GoogleAuth } from 'google-auth-library';
+import { ChannelCredentials, CallCredentials } from '@grpc/grpc-js';
+
+export function createGoogleDefaultCredentials(): ChannelCredentials {
+  const sslCreds = ChannelCredentials.createSsl();
+  const googleAuthCreds = CallCredentials.createFromGoogleCredential(
+    new GoogleAuth()
+  );
+  return sslCreds.compose(googleAuthCreds);
+}

--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -48,7 +48,7 @@ import { RouteConfiguration__Output } from './generated/envoy/api/v2/RouteConfig
 import { Any__Output } from './generated/google/protobuf/Any';
 import BackoffTimeout = experimental.BackoffTimeout;
 import ServiceConfig = experimental.ServiceConfig;
-import createGoogleDefaultCredentials = experimental.createGoogleDefaultCredentials;
+import { createGoogleDefaultCredentials } from './google-default-credentials';
 import { CdsLoadBalancingConfig } from './load-balancer-cds';
 
 const TRACER_NAME = 'xds_client';

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "@types/node": "^12.12.47",
-    "google-auth-library": "^6.1.1",
     "semver": "^6.2.0"
   },
   "files": [

--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -19,7 +19,6 @@ import { ConnectionOptions, createSecureContext, PeerCertificate } from 'tls';
 
 import { CallCredentials } from './call-credentials';
 import { CIPHER_SUITES, getDefaultRootsData } from './tls-helpers';
-import { GoogleAuth as GoogleAuthType } from 'google-auth-library';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function verifyIsBufferOrNull(obj: any, friendlyName: string): void {
@@ -278,14 +277,4 @@ class ComposedChannelCredentialsImpl extends ChannelCredentials {
       return false;
     }
   }
-}
-
-export function createGoogleDefaultCredentials(): ChannelCredentials {
-  const GoogleAuth = require('google-auth-library')
-    .GoogleAuth as typeof GoogleAuthType;
-  const sslCreds = ChannelCredentials.createSsl();
-  const googleAuthCreds = CallCredentials.createFromGoogleCredential(
-    new GoogleAuth()
-  );
-  return sslCreds.compose(googleAuthCreds);
 }

--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -2,7 +2,6 @@ export { trace } from './logging';
 export { Resolver, ResolverListener, registerResolver } from './resolver';
 export { GrpcUri, uriToString } from './uri-parser';
 export { ServiceConfig } from './service-config';
-export { createGoogleDefaultCredentials } from './channel-credentials';
 export { BackoffTimeout } from './backoff-timeout';
 export { LoadBalancer, LoadBalancingConfig, ChannelControlHelper, registerLoadBalancerType, getFirstUsableConfig, validateLoadBalancingConfig } from './load-balancer';
 export { SubchannelAddress, subchannelAddressToString } from './subchannel';


### PR DESCRIPTION
Currently `createGoogleDefaultCredentials` is implemented using only `grpc-js`'s public APIs, and it is only used in `grpc-js-xds`, so we can move it to avoid needing a dependency on `google-auth-library` in `grpc-js`. This addresses #1695 without regressing on #1442. `grpc-js-xds` only guarantees compatibility with Node 10+, not Node 8, so the dependency on the newer version of `google-auth-library` here is OK.