### PR TITLE
grpc-js: Timer ref and unref might not exist

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/backoff-timeout.ts
+++ b/packages/grpc-js/src/backoff-timeout.ts
@@ -76,7 +76,7 @@ export class BackoffTimeout {
       this.running = false;
     }, this.nextDelay);
     if (!this.hasRef) {
-      this.timerId.unref();
+      this.timerId.unref?.();
     }
     const nextBackoff = Math.min(
       this.nextDelay * this.multiplier,
@@ -109,11 +109,11 @@ export class BackoffTimeout {
 
   ref() {
     this.hasRef = true;
-    this.timerId.ref();
+    this.timerId.ref?.();
   }
 
   unref() {
     this.hasRef = false;
-    this.timerId.unref();
+    this.timerId.unref?.();
   }
 }


### PR DESCRIPTION
This fixes #1708. We actually ran into the same issue before in #1077 but I forgot when I implemented #1688.