### PR TITLE
grpc-js-xds: Fix sending stats when reestablishing LRS stream

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {

--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -1020,12 +1020,14 @@ export class XdsClient {
 
     this.lrsBackoff.runOnce();
     this.lrsCall = this.lrsClient.streamLoadStats();
+    let receivedSettingsForThisStream = false;
     this.lrsCall.on('data', (message: LoadStatsResponse__Output) => {
       /* Once we get any response from the server, we assume that the stream is
        * in a good state, so we can reset the backoff timer. */
       this.lrsBackoff.stop();
       this.lrsBackoff.reset();
       if (
+        !receivedSettingsForThisStream ||
         message.load_reporting_interval?.seconds !==
           this.latestLrsSettings?.load_reporting_interval?.seconds ||
         message.load_reporting_interval?.nanos !==
@@ -1045,13 +1047,13 @@ export class XdsClient {
         }, loadReportingIntervalMs);
       }
       this.latestLrsSettings = message;
+      receivedSettingsForThisStream = true;
     });
     this.lrsCall.on('error', (error: ServiceError) => {
       trace(
         'LRS stream ended. code=' + error.code + ' details= ' + error.details
       );
       this.lrsCall = null;
-      this.latestLrsSettings = null;
       clearInterval(this.statsTimer);
       /* If the backoff timer is no longer running, we do not need to wait any
        * more to start the new call. */
@@ -1068,14 +1070,20 @@ export class XdsClient {
     if (!this.lrsCall) {
       return;
     }
+    if (!this.latestLrsSettings) {
+      this.lrsCall.write({
+        node: this.lrsNode!,
+      });
+      return;
+    }
     const clusterStats: ClusterStats[] = [];
     for (const [
       { clusterName, edsServiceName },
       stats,
     ] of this.clusterStatsMap.entries()) {
       if (
-        this.latestLrsSettings!.send_all_clusters ||
-        this.latestLrsSettings!.clusters.indexOf(clusterName) > 0
+        this.latestLrsSettings.send_all_clusters ||
+        this.latestLrsSettings.clusters.indexOf(clusterName) > 0
       ) {
         const upstreamLocalityStats: UpstreamLocalityStats[] = [];
         for (const localityStats of stats.localityStats) {


### PR DESCRIPTION
The issue here is that when a LRS stream was killed and then the client reestablished it, it would try sending any stats accumulated in the intervening time, but the settings would be `null`, including the settings for which stats to send.

I fixed this in two ways: First, ending the stream does not clear the settings, and cleared settings are no longer used as the primary signal to determine whether to start a timer when receiving new settings. Second, the code for sending stats checks whether the settings are there before trying to use them.