### PR TITLE
grpc-js: Throw in watchConnectivityState if channel is closed

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -480,6 +480,9 @@ export class ChannelImplementation implements Channel {
     deadline: Date | number,
     callback: (error?: Error) => void
   ): void {
+    if (this.connectivityState === ConnectivityState.SHUTDOWN) {
+      throw new Error('Channel has been shut down');
+    }
     let timer = null;
     if(deadline !== Infinity) {
       const deadlineDate: Date =


### PR DESCRIPTION
`Channel#waitForReady` expects this error to be thrown (https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/client.ts#L178-L186). This is the same error that is thrown by `Channel#createCall` if the channel is closed.

This was discovered because of someone noting in https://github.com/googleapis/nodejs-pubsub/issues/1190#issuecomment-797580406 that the `watchConnectivityState` timer can keep the process running even after the channel is closed.