### PR TITLE
grpc-js-xds: Add functionality to the xDS interop client

### DIFF
--- a/packages/grpc-js-xds/interop/generated/grpc/testing/ClientConfigureRequest.ts
+++ b/packages/grpc-js-xds/interop/generated/grpc/testing/ClientConfigureRequest.ts
@@ -1,0 +1,68 @@
+// Original file: proto/grpc/testing/messages.proto
+
+
+/**
+ * Metadata to be attached for the given type of RPCs.
+ */
+export interface _grpc_testing_ClientConfigureRequest_Metadata {
+  'type'?: (_grpc_testing_ClientConfigureRequest_RpcType | keyof typeof _grpc_testing_ClientConfigureRequest_RpcType);
+  'key'?: (string);
+  'value'?: (string);
+}
+
+/**
+ * Metadata to be attached for the given type of RPCs.
+ */
+export interface _grpc_testing_ClientConfigureRequest_Metadata__Output {
+  'type': (keyof typeof _grpc_testing_ClientConfigureRequest_RpcType);
+  'key': (string);
+  'value': (string);
+}
+
+// Original file: proto/grpc/testing/messages.proto
+
+/**
+ * Type of RPCs to send.
+ */
+export enum _grpc_testing_ClientConfigureRequest_RpcType {
+  EMPTY_CALL = 0,
+  UNARY_CALL = 1,
+}
+
+/**
+ * Configurations for a test client.
+ */
+export interface ClientConfigureRequest {
+  /**
+   * The types of RPCs the client sends.
+   */
+  'types'?: (_grpc_testing_ClientConfigureRequest_RpcType | keyof typeof _grpc_testing_ClientConfigureRequest_RpcType)[];
+  /**
+   * The collection of custom metadata to be attached to RPCs sent by the client.
+   */
+  'metadata'?: (_grpc_testing_ClientConfigureRequest_Metadata)[];
+  /**
+   * The deadline to use, in seconds, for all RPCs.  If unset or zero, the
+   * client will use the default from the command-line.
+   */
+  'timeout_sec'?: (number);
+}
+
+/**
+ * Configurations for a test client.
+ */
+export interface ClientConfigureRequest__Output {
+  /**
+   * The types of RPCs the client sends.
+   */
+  'types': (keyof typeof _grpc_testing_ClientConfigureRequest_RpcType)[];
+  /**
+   * The collection of custom metadata to be attached to RPCs sent by the client.
+   */
+  'metadata': (_grpc_testing_ClientConfigureRequest_Metadata__Output)[];
+  /**
+   * The deadline to use, in seconds, for all RPCs.  If unset or zero, the
+   * client will use the default from the command-line.
+   */
+  'timeout_sec': (number);
+}

--- a/packages/grpc-js-xds/interop/generated/grpc/testing/ClientConfigureResponse.ts
+++ b/packages/grpc-js-xds/interop/generated/grpc/testing/ClientConfigureResponse.ts
@@ -1,0 +1,14 @@
+// Original file: proto/grpc/testing/messages.proto
+
+
+/**
+ * Response for updating a test client's configuration.
+ */
+export interface ClientConfigureResponse {
+}
+
+/**
+ * Response for updating a test client's configuration.
+ */
+export interface ClientConfigureResponse__Output {
+}

--- a/packages/grpc-js-xds/interop/generated/grpc/testing/LoadBalancerAccumulatedStatsRequest.ts
+++ b/packages/grpc-js-xds/interop/generated/grpc/testing/LoadBalancerAccumulatedStatsRequest.ts
@@ -1,0 +1,14 @@
+// Original file: proto/grpc/testing/messages.proto
+
+
+/**
+ * Request for retrieving a test client's accumulated stats.
+ */
+export interface LoadBalancerAccumulatedStatsRequest {
+}
+
+/**
+ * Request for retrieving a test client's accumulated stats.
+ */
+export interface LoadBalancerAccumulatedStatsRequest__Output {
+}

--- a/packages/grpc-js-xds/interop/generated/grpc/testing/LoadBalancerAccumulatedStatsResponse.ts
+++ b/packages/grpc-js-xds/interop/generated/grpc/testing/LoadBalancerAccumulatedStatsResponse.ts
@@ -1,0 +1,78 @@
+// Original file: proto/grpc/testing/messages.proto
+
+
+export interface _grpc_testing_LoadBalancerAccumulatedStatsResponse_MethodStats {
+  /**
+   * The number of RPCs that were started for this method.
+   */
+  'rpcs_started'?: (number);
+  /**
+   * The number of RPCs that completed with each status for this method.  The
+   * key is the integral value of a google.rpc.Code; the value is the count.
+   */
+  'result'?: ({[key: number]: number});
+}
+
+export interface _grpc_testing_LoadBalancerAccumulatedStatsResponse_MethodStats__Output {
+  /**
+   * The number of RPCs that were started for this method.
+   */
+  'rpcs_started': (number);
+  /**
+   * The number of RPCs that completed with each status for this method.  The
+   * key is the integral value of a google.rpc.Code; the value is the count.
+   */
+  'result': ({[key: number]: number});
+}
+
+/**
+ * Accumulated stats for RPCs sent by a test client.
+ */
+export interface LoadBalancerAccumulatedStatsResponse {
+  /**
+   * The total number of RPCs have ever issued for each type.
+   * Deprecated: use stats_per_method.rpcs_started instead.
+   */
+  'num_rpcs_started_by_method'?: ({[key: string]: number});
+  /**
+   * The total number of RPCs have ever completed successfully for each type.
+   * Deprecated: use stats_per_method.result instead.
+   */
+  'num_rpcs_succeeded_by_method'?: ({[key: string]: number});
+  /**
+   * The total number of RPCs have ever failed for each type.
+   * Deprecated: use stats_per_method.result instead.
+   */
+  'num_rpcs_failed_by_method'?: ({[key: string]: number});
+  /**
+   * Per-method RPC statistics.  The key is the RpcType in string form; e.g.
+   * 'EMPTY_CALL' or 'UNARY_CALL'
+   */
+  'stats_per_method'?: ({[key: string]: _grpc_testing_LoadBalancerAccumulatedStatsResponse_MethodStats});
+}
+
+/**
+ * Accumulated stats for RPCs sent by a test client.
+ */
+export interface LoadBalancerAccumulatedStatsResponse__Output {
+  /**
+   * The total number of RPCs have ever issued for each type.
+   * Deprecated: use stats_per_method.rpcs_started instead.
+   */
+  'num_rpcs_started_by_method': ({[key: string]: number});
+  /**
+   * The total number of RPCs have ever completed successfully for each type.
+   * Deprecated: use stats_per_method.result instead.
+   */
+  'num_rpcs_succeeded_by_method': ({[key: string]: number});
+  /**
+   * The total number of RPCs have ever failed for each type.
+   * Deprecated: use stats_per_method.result instead.
+   */
+  'num_rpcs_failed_by_method': ({[key: string]: number});
+  /**
+   * Per-method RPC statistics.  The key is the RpcType in string form; e.g.
+   * 'EMPTY_CALL' or 'UNARY_CALL'
+   */
+  'stats_per_method'?: ({[key: string]: _grpc_testing_LoadBalancerAccumulatedStatsResponse_MethodStats__Output});
+}

--- a/packages/grpc-js-xds/interop/generated/grpc/testing/LoadBalancerStatsService.ts
+++ b/packages/grpc-js-xds/interop/generated/grpc/testing/LoadBalancerStatsService.ts
@@ -1,6 +1,8 @@
 // Original file: proto/grpc/testing/test.proto
 
 import * as grpc from '@grpc/grpc-js'
+import { LoadBalancerAccumulatedStatsRequest as _grpc_testing_LoadBalancerAccumulatedStatsRequest, LoadBalancerAccumulatedStatsRequest__Output as _grpc_testing_LoadBalancerAccumulatedStatsRequest__Output } from '../../grpc/testing/LoadBalancerAccumulatedStatsRequest';
+import { LoadBalancerAccumulatedStatsResponse as _grpc_testing_LoadBalancerAccumulatedStatsResponse, LoadBalancerAccumulatedStatsResponse__Output as _grpc_testing_LoadBalancerAccumulatedStatsResponse__Output } from '../../grpc/testing/LoadBalancerAccumulatedStatsResponse';
 import { LoadBalancerStatsRequest as _grpc_testing_LoadBalancerStatsRequest, LoadBalancerStatsRequest__Output as _grpc_testing_LoadBalancerStatsRequest__Output } from '../../grpc/testing/LoadBalancerStatsRequest';
 import { LoadBalancerStatsResponse as _grpc_testing_LoadBalancerStatsResponse, LoadBalancerStatsResponse__Output as _grpc_testing_LoadBalancerStatsResponse__Output } from '../../grpc/testing/LoadBalancerStatsResponse';
 
@@ -8,6 +10,21 @@ import { LoadBalancerStatsResponse as _grpc_testing_LoadBalancerStatsResponse, L
  * A service used to obtain stats for verifying LB behavior.
  */
 export interface LoadBalancerStatsServiceClient extends grpc.Client {
+  /**
+   * Gets the accumulated stats for RPCs sent by a test client.
+   */
+  GetClientAccumulatedStats(argument: _grpc_testing_LoadBalancerAccumulatedStatsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_testing_LoadBalancerAccumulatedStatsResponse__Output) => void): grpc.ClientUnaryCall;
+  GetClientAccumulatedStats(argument: _grpc_testing_LoadBalancerAccumulatedStatsRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_testing_LoadBalancerAccumulatedStatsResponse__Output) => void): grpc.ClientUnaryCall;
+  GetClientAccumulatedStats(argument: _grpc_testing_LoadBalancerAccumulatedStatsRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_testing_LoadBalancerAccumulatedStatsResponse__Output) => void): grpc.ClientUnaryCall;
+  GetClientAccumulatedStats(argument: _grpc_testing_LoadBalancerAccumulatedStatsRequest, callback: (error?: grpc.ServiceError, result?: _grpc_testing_LoadBalancerAccumulatedStatsResponse__Output) => void): grpc.ClientUnaryCall;
+  /**
+   * Gets the accumulated stats for RPCs sent by a test client.
+   */
+  getClientAccumulatedStats(argument: _grpc_testing_LoadBalancerAccumulatedStatsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_testing_LoadBalancerAccumulatedStatsResponse__Output) => void): grpc.ClientUnaryCall;
+  getClientAccumulatedStats(argument: _grpc_testing_LoadBalancerAccumulatedStatsRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_testing_LoadBalancerAccumulatedStatsResponse__Output) => void): grpc.ClientUnaryCall;
+  getClientAccumulatedStats(argument: _grpc_testing_LoadBalancerAccumulatedStatsRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_testing_LoadBalancerAccumulatedStatsResponse__Output) => void): grpc.ClientUnaryCall;
+  getClientAccumulatedStats(argument: _grpc_testing_LoadBalancerAccumulatedStatsRequest, callback: (error?: grpc.ServiceError, result?: _grpc_testing_LoadBalancerAccumulatedStatsResponse__Output) => void): grpc.ClientUnaryCall;
+  
   /**
    * Gets the backend distribution for RPCs sent by a test client.
    */
@@ -29,6 +46,11 @@ export interface LoadBalancerStatsServiceClient extends grpc.Client {
  * A service used to obtain stats for verifying LB behavior.
  */
 export interface LoadBalancerStatsServiceHandlers extends grpc.UntypedServiceImplementation {
+  /**
+   * Gets the accumulated stats for RPCs sent by a test client.
+   */
+  GetClientAccumulatedStats(call: grpc.ServerUnaryCall<_grpc_testing_LoadBalancerAccumulatedStatsRequest__Output, _grpc_testing_LoadBalancerAccumulatedStatsResponse>, callback: grpc.sendUnaryData<_grpc_testing_LoadBalancerAccumulatedStatsResponse>): void;
+  
   /**
    * Gets the backend distribution for RPCs sent by a test client.
    */

--- a/packages/grpc-js-xds/interop/generated/grpc/testing/XdsUpdateClientConfigureService.ts
+++ b/packages/grpc-js-xds/interop/generated/grpc/testing/XdsUpdateClientConfigureService.ts
@@ -1,0 +1,37 @@
+// Original file: proto/grpc/testing/test.proto
+
+import * as grpc from '@grpc/grpc-js'
+import { ClientConfigureRequest as _grpc_testing_ClientConfigureRequest, ClientConfigureRequest__Output as _grpc_testing_ClientConfigureRequest__Output } from '../../grpc/testing/ClientConfigureRequest';
+import { ClientConfigureResponse as _grpc_testing_ClientConfigureResponse, ClientConfigureResponse__Output as _grpc_testing_ClientConfigureResponse__Output } from '../../grpc/testing/ClientConfigureResponse';
+
+/**
+ * A service to dynamically update the configuration of an xDS test client.
+ */
+export interface XdsUpdateClientConfigureServiceClient extends grpc.Client {
+  /**
+   * Update the tes client's configuration.
+   */
+  Configure(argument: _grpc_testing_ClientConfigureRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_testing_ClientConfigureResponse__Output) => void): grpc.ClientUnaryCall;
+  Configure(argument: _grpc_testing_ClientConfigureRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_testing_ClientConfigureResponse__Output) => void): grpc.ClientUnaryCall;
+  Configure(argument: _grpc_testing_ClientConfigureRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_testing_ClientConfigureResponse__Output) => void): grpc.ClientUnaryCall;
+  Configure(argument: _grpc_testing_ClientConfigureRequest, callback: (error?: grpc.ServiceError, result?: _grpc_testing_ClientConfigureResponse__Output) => void): grpc.ClientUnaryCall;
+  /**
+   * Update the tes client's configuration.
+   */
+  configure(argument: _grpc_testing_ClientConfigureRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_testing_ClientConfigureResponse__Output) => void): grpc.ClientUnaryCall;
+  configure(argument: _grpc_testing_ClientConfigureRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_testing_ClientConfigureResponse__Output) => void): grpc.ClientUnaryCall;
+  configure(argument: _grpc_testing_ClientConfigureRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_testing_ClientConfigureResponse__Output) => void): grpc.ClientUnaryCall;
+  configure(argument: _grpc_testing_ClientConfigureRequest, callback: (error?: grpc.ServiceError, result?: _grpc_testing_ClientConfigureResponse__Output) => void): grpc.ClientUnaryCall;
+  
+}
+
+/**
+ * A service to dynamically update the configuration of an xDS test client.
+ */
+export interface XdsUpdateClientConfigureServiceHandlers extends grpc.UntypedServiceImplementation {
+  /**
+   * Update the tes client's configuration.
+   */
+  Configure(call: grpc.ServerUnaryCall<_grpc_testing_ClientConfigureRequest__Output, _grpc_testing_ClientConfigureResponse>, callback: grpc.sendUnaryData<_grpc_testing_ClientConfigureResponse>): void;
+  
+}

--- a/packages/grpc-js-xds/interop/generated/test.ts
+++ b/packages/grpc-js-xds/interop/generated/test.ts
@@ -5,6 +5,7 @@ import { LoadBalancerStatsServiceClient as _grpc_testing_LoadBalancerStatsServic
 import { ReconnectServiceClient as _grpc_testing_ReconnectServiceClient } from './grpc/testing/ReconnectService';
 import { TestServiceClient as _grpc_testing_TestServiceClient } from './grpc/testing/TestService';
 import { UnimplementedServiceClient as _grpc_testing_UnimplementedServiceClient } from './grpc/testing/UnimplementedService';
+import { XdsUpdateClientConfigureServiceClient as _grpc_testing_XdsUpdateClientConfigureServiceClient } from './grpc/testing/XdsUpdateClientConfigureService';
 import { XdsUpdateHealthServiceClient as _grpc_testing_XdsUpdateHealthServiceClient } from './grpc/testing/XdsUpdateHealthService';
 
 type ConstructorArguments<Constructor> = Constructor extends new (...args: infer Args) => any ? Args: never;
@@ -16,9 +17,13 @@ export interface ProtoGrpcType {
   grpc: {
     testing: {
       BoolValue: MessageTypeDefinition
+      ClientConfigureRequest: MessageTypeDefinition
+      ClientConfigureResponse: MessageTypeDefinition
       EchoStatus: MessageTypeDefinition
       Empty: MessageTypeDefinition
       GrpclbRouteType: EnumTypeDefinition
+      LoadBalancerAccumulatedStatsRequest: MessageTypeDefinition
+      LoadBalancerAccumulatedStatsResponse: MessageTypeDefinition
       LoadBalancerStatsRequest: MessageTypeDefinition
       LoadBalancerStatsResponse: MessageTypeDefinition
       /**
@@ -50,6 +55,10 @@ export interface ProtoGrpcType {
        * that case.
        */
       UnimplementedService: SubtypeConstructor<typeof grpc.Client, _grpc_testing_UnimplementedServiceClient> & { service: ServiceDefinition }
+      /**
+       * A service to dynamically update the configuration of an xDS test client.
+       */
+      XdsUpdateClientConfigureService: SubtypeConstructor<typeof grpc.Client, _grpc_testing_XdsUpdateClientConfigureServiceClient> & { service: ServiceDefinition }
       /**
        * A service to remotely control health status of an xDS test server.
        */

--- a/packages/grpc-js-xds/proto/grpc/testing/messages.proto
+++ b/packages/grpc-js-xds/proto/grpc/testing/messages.proto
@@ -212,3 +212,59 @@ message LoadBalancerStatsResponse {
   int32 num_failures = 2;
   map<string, RpcsByPeer> rpcs_by_method = 3;
 }
+
+// Request for retrieving a test client's accumulated stats.
+message LoadBalancerAccumulatedStatsRequest {}
+
+// Accumulated stats for RPCs sent by a test client.
+message LoadBalancerAccumulatedStatsResponse {
+  // The total number of RPCs have ever issued for each type.
+  // Deprecated: use stats_per_method.rpcs_started instead.
+  map<string, int32> num_rpcs_started_by_method = 1 [deprecated = true];
+  // The total number of RPCs have ever completed successfully for each type.
+  // Deprecated: use stats_per_method.result instead.
+  map<string, int32> num_rpcs_succeeded_by_method = 2 [deprecated = true];
+  // The total number of RPCs have ever failed for each type.
+  // Deprecated: use stats_per_method.result instead.
+  map<string, int32> num_rpcs_failed_by_method = 3 [deprecated = true];
+
+  message MethodStats {
+    // The number of RPCs that were started for this method.
+    int32 rpcs_started = 1;
+
+    // The number of RPCs that completed with each status for this method.  The
+    // key is the integral value of a google.rpc.Code; the value is the count.
+    map<int32, int32> result = 2;
+  }
+
+  // Per-method RPC statistics.  The key is the RpcType in string form; e.g.
+  // 'EMPTY_CALL' or 'UNARY_CALL'
+  map<string, MethodStats> stats_per_method = 4;
+}
+
+// Configurations for a test client.
+message ClientConfigureRequest {
+  // Type of RPCs to send.
+  enum RpcType {
+    EMPTY_CALL = 0;
+    UNARY_CALL = 1;
+  }
+
+  // Metadata to be attached for the given type of RPCs.
+  message Metadata {
+    RpcType type = 1;
+    string key = 2;
+    string value = 3;
+  }
+
+  // The types of RPCs the client sends.
+  repeated RpcType types = 1;
+  // The collection of custom metadata to be attached to RPCs sent by the client.
+  repeated Metadata metadata = 2;
+  // The deadline to use, in seconds, for all RPCs.  If unset or zero, the
+  // client will use the default from the command-line.
+  int32 timeout_sec = 3;
+}
+
+// Response for updating a test client's configuration.
+message ClientConfigureResponse {}

--- a/packages/grpc-js-xds/proto/grpc/testing/test.proto
+++ b/packages/grpc-js-xds/proto/grpc/testing/test.proto
@@ -83,10 +83,20 @@ service LoadBalancerStatsService {
   // Gets the backend distribution for RPCs sent by a test client.
   rpc GetClientStats(LoadBalancerStatsRequest)
       returns (LoadBalancerStatsResponse) {}
+
+  // Gets the accumulated stats for RPCs sent by a test client.
+  rpc GetClientAccumulatedStats(LoadBalancerAccumulatedStatsRequest)
+      returns (LoadBalancerAccumulatedStatsResponse) {}
 }
 
 // A service to remotely control health status of an xDS test server.
 service XdsUpdateHealthService {
   rpc SetServing(grpc.testing.Empty) returns (grpc.testing.Empty);
   rpc SetNotServing(grpc.testing.Empty) returns (grpc.testing.Empty);
+}
+
+// A service to dynamically update the configuration of an xDS test client.
+service XdsUpdateClientConfigureService {
+  // Update the tes client's configuration.
+  rpc Configure(ClientConfigureRequest) returns (ClientConfigureResponse);
 }


### PR DESCRIPTION
This adds implementations of the `XdsUpdateClientConfigureService` service and the `GetClientAccumulatedStats` method in the `LoadBalancerStatsService`. The first of those in particular is needed to enable the `path_matching` and `header_matching` interop tests for testing those features.