### PR TITLE
grpc-tools: Bump protobuf dependency to 3.15.6

### DIFF
--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-tools",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "author": "Google Inc.",
   "description": "Tools for developing with gRPC on Node.js",
   "homepage": "https://grpc.io/",


### PR DESCRIPTION
The previous version was 3.14.0. This notably enables default support for proto3 `optional` fields to fix #1717.