### PR TITLE
grpc-js: don't send accept-encoding: gzip

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/compression-filter.ts
+++ b/packages/grpc-js/src/compression-filter.ts
@@ -170,7 +170,7 @@ export class CompressionFilter extends BaseFilter implements Filter {
   async sendMetadata(metadata: Promise<Metadata>): Promise<Metadata> {
     const headers: Metadata = await metadata;
     headers.set('grpc-accept-encoding', 'identity,deflate,gzip');
-    headers.set('accept-encoding', 'identity,gzip');
+    headers.set('accept-encoding', 'identity');
     return headers;
   }
 


### PR DESCRIPTION
It turns out that if the server sends gzip-encoded content, you have to actually do gzip decompression. grpc-js does not currently have that functionality, so putting `gzip` in the `accept-encoding` header is inaccurate. It can always be added again later.

This should fix #1719.