### PR TITLE
Enable path_matching and header_matching xDS interop tests

### DIFF
--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -303,6 +303,8 @@ function main() {
       currentConfig.callTypes = call.request.types;
       currentConfig.metadata = callMetadata;
       currentConfig.timeoutSec = call.request.timeout_sec
+      console.log('Received new client configuration: ' + JSON.stringify(currentConfig, undefined, 2));
+      callback(null, {});
     }
   }
 

--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -291,6 +291,8 @@ function main() {
     }
     currentConfig.metadata[method].add(key, value);
   }
+  console.log('EmptyCall metadata: ' + currentConfig.metadata.EmptyCall.getMap());
+  console.log('UnaryCall metadata: ' + currentConfig.metadata.UnaryCall.getMap());
   const callStatsTracker = new CallStatsTracker();
   for (let i = 0; i < argv.num_channels; i++) {
     /* The 'unique' channel argument is there solely to ensure that the

--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -281,7 +281,7 @@ function main() {
     .argv;
   console.log('Starting xDS interop client. Args: ', argv);
   currentConfig.callTypes = argv.rpc.split(',').filter(value => value === 'EmptyCall' || value === 'UnaryCall') as CallType[];
-  for (const item in argv.metadata.split(',')) {
+  for (const item of argv.metadata.split(',')) {
     const [method, key, value] = item.split(':');
     if (value === undefined) {
       continue;

--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -291,8 +291,8 @@ function main() {
     }
     currentConfig.metadata[method].add(key, value);
   }
-  console.log('EmptyCall metadata: ' + currentConfig.metadata.EmptyCall.getMap());
-  console.log('UnaryCall metadata: ' + currentConfig.metadata.UnaryCall.getMap());
+  console.log('EmptyCall metadata: ' + JSON.stringify(currentConfig.metadata.EmptyCall.getMap()));
+  console.log('UnaryCall metadata: ' + JSON.stringify(currentConfig.metadata.UnaryCall.getMap()));
   const callStatsTracker = new CallStatsTracker();
   for (let i = 0; i < argv.num_channels; i++) {
     /* The 'unique' channel argument is there solely to ensure that the

--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -53,7 +53,7 @@ GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weigh
   NODE_XDS_INTEROP_VERBOSITY=1 \
   GRPC_XDS_EXPERIMENTAL_ROUTING=true \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case="all" \
+    --test_case="all,path_matching,header_matching" \
     --project_id=grpc-testing \
     --source_image=projects/grpc-testing/global/images/xds-test-server-2 \
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \

--- a/packages/grpc-js-xds/src/load-balancer-eds.ts
+++ b/packages/grpc-js-xds/src/load-balancer-eds.ts
@@ -191,7 +191,7 @@ export class EdsLoadBalancer implements LoadBalancer {
     });
     this.watcher = {
       onValidUpdate: (update) => {
-        trace('Received EDS update for ' + this.edsServiceName + ': ' + JSON.stringify(update));
+        trace('Received EDS update for ' + this.edsServiceName + ': ' + JSON.stringify(update, undefined, 2));
         this.latestEdsUpdate = update;
         this.updateChild();
       },

--- a/packages/grpc-js-xds/src/load-balancer-xds-cluster-manager.ts
+++ b/packages/grpc-js-xds/src/load-balancer-xds-cluster-manager.ts
@@ -32,7 +32,7 @@ import getFirstUsableConfig = experimental.getFirstUsableConfig;
 import ChannelControlHelper = experimental.ChannelControlHelper;
 import registerLoadBalancerType = experimental.registerLoadBalancerType;
 
-const TRACER_NAME = 'weighted_target';
+const TRACER_NAME = 'xds_cluster_manager';
 
 function trace(text: string): void {
   experimental.trace(logVerbosity.DEBUG, TRACER_NAME, text);
@@ -247,6 +247,7 @@ class XdsClusterManager implements LoadBalancer {
       trace('Discarding address list update with unrecognized config ' + JSON.stringify(lbConfig.toJsonObject(), undefined, 2));
       return;
     }
+    trace('Received update with config: ' + JSON.stringify(lbConfig.toJsonObject(), undefined, 2));
     const configChildren = lbConfig.getChildren();
     // Delete children that are not in the new config
     const namesToRemove: string[] = [];

--- a/packages/grpc-js-xds/src/matcher.ts
+++ b/packages/grpc-js-xds/src/matcher.ts
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Metadata } from "@grpc/grpc-js";
+import { RE2 } from "re2-wasm";
+
+/**
+ * An object representing a predicate that determines whether a given
+ * combination of a methodName and metadata matches some internal conditions.
+ */
+export interface Matcher {
+  toString(): string;
+  apply(methodName: string, metadata: Metadata): boolean;
+}
+
+/**
+ * An object representing a predicate that determines whether a given string
+ * value matches some internal conditions.
+ */
+export interface ValueMatcher {
+  toString(): string;
+  apply(value: string): boolean;
+}
+
+export class ExactValueMatcher implements ValueMatcher {
+  constructor(private targetValue: string) {}
+
+  apply(value: string) {
+    return value === this.targetValue;
+  }
+
+  toString() {
+    return 'Exact(' + this.targetValue + ')';
+  }
+}
+
+export class SafeRegexValueMatcher implements ValueMatcher {
+  private targetRegexImpl: RE2;
+  constructor(targetRegex: string) {
+    this.targetRegexImpl = new RE2(`^${targetRegex}$`, 'u');
+  }
+
+  apply(value: string) {
+    return this.targetRegexImpl.test(value);
+  }
+
+  toString() {
+    return 'SafeRegex(' + this.targetRegexImpl.toString() + ')';
+  }
+}
+
+const numberRegex = new RE2(/^-?\d+$/u);
+
+export class RangeValueMatcher implements ValueMatcher {
+  constructor(private start: BigInt, private end: BigInt) {}
+
+  apply(value: string) {
+    if (!numberRegex.test(value)) {
+      return false;
+    }
+    const numberValue = BigInt(value);
+    return this.start <= numberValue && numberValue < this.end;
+  }
+
+  toString() {
+    return 'Range(' + this.start + ', ' + this.end + ')';
+  }
+}
+
+export class PresentValueMatcher implements ValueMatcher {
+  constructor() {}
+
+  apply(value: string) {
+    return true;
+  }
+
+  toString() {
+    return 'Present()';
+  }
+}
+
+export class PrefixValueMatcher implements ValueMatcher {
+  constructor(private prefix: string) {}
+
+  apply(value: string) {
+    return value.startsWith(this.prefix);
+  }
+
+  toString() {
+    return 'Prefix(' + this.prefix + ')';
+  }
+}
+
+export class SuffixValueMatcher implements ValueMatcher {
+  constructor(private suffix: string) {}
+
+  apply(value: string) {
+    return value.endsWith(this.suffix);
+  }
+
+  toString() {
+    return 'Suffix(' + this.suffix + ')';
+  }
+}
+
+export class RejectValueMatcher implements ValueMatcher {
+  constructor() {}
+
+  apply(value: string) {
+    return false;
+  }
+
+  toString() {
+    return 'Reject()';
+  }
+}
+
+export class HeaderMatcher implements Matcher {
+  constructor(private headerName: string, private valueMatcher: ValueMatcher, private invertMatch: boolean) {}
+
+  private applyHelper(methodName: string, metadata: Metadata) {
+    if (this.headerName.endsWith('-bin')) {
+      return false;
+    }
+    let value: string;
+    if (this.headerName === 'content-type') {
+      value = 'application/grpc';
+    } else {
+      const valueArray = metadata.get(this.headerName);
+      if (valueArray.length === 0) {
+        return false;
+      } else {
+        value = valueArray.join(',');
+      }
+    }
+    return this.valueMatcher.apply(value);
+  }
+
+  apply(methodName: string, metadata: Metadata) {
+    const result = this.applyHelper(methodName, metadata);
+    if (this.invertMatch) {
+      return !result;
+    } else {
+      return result;
+    }
+  }
+
+  toString() {
+    return 'HeaderMatch(' + this.headerName + ', ' + this.valueMatcher.toString() + ')';
+  }
+}
+
+export class PathPrefixValueMatcher {
+  constructor(private prefix: string, private caseInsensitive: boolean) {}
+
+  apply(value: string) {
+    if (this.caseInsensitive) {
+      return value.toLowerCase().startsWith(this.prefix.toLowerCase());
+    } else {
+      return value.startsWith(this.prefix);
+    }
+  }
+
+  toString() {
+    return 'Prefix(' + this.prefix + ', ' + this.caseInsensitive + ')';
+  }
+}
+
+export class PathExactValueMatcher {
+  constructor(private targetValue: string, private caseInsensitive: boolean) {}
+
+  apply(value: string) {
+    if (this.caseInsensitive) {
+      return value.toLowerCase().startsWith(this.targetValue.toLowerCase());
+    } else {
+      return value === this.targetValue;
+    }
+  }
+
+  toString() {
+    return 'Exact(' + this.targetValue + ', ' + this.caseInsensitive + ')';
+  }
+}
+
+export class PathSafeRegexValueMatcher {
+  private targetRegexImpl: RE2;
+  constructor(targetRegex: string, caseInsensitive: boolean) {
+    this.targetRegexImpl = new RE2(`^${targetRegex}$`, caseInsensitive ? 'iu' : 'u');
+  }
+
+  apply(value: string) {
+    return this.targetRegexImpl.test(value);
+  }
+
+  toString() {
+    return 'SafeRegex(' + this.targetRegexImpl.toString() + ')';
+  }
+}
+
+export interface Fraction {
+  numerator: number;
+  denominator: number;
+}
+
+function fractionToString(fraction: Fraction): string {
+  return `${fraction.numerator}/${fraction.denominator}`;
+}
+
+export class FullMatcher implements Matcher {
+  constructor(private pathMatcher: ValueMatcher, private headerMatchers: Matcher[], private fraction: Fraction | null) {}
+
+  apply(methodName: string, metadata: Metadata) {
+    if (!this.pathMatcher.apply(methodName)) {
+      return false;
+    }
+    if (!this.headerMatchers.every(matcher => matcher.apply(methodName, metadata))) {
+      return false;
+    }
+    if (this.fraction === null) {
+      return true;
+    } else {
+      const randomNumber = Math.random() * this.fraction.denominator;
+      return randomNumber < this.fraction.numerator;
+    }
+  }
+
+  toString() {
+    return `path: ${this.pathMatcher}
+    headers: ${this.headerMatchers.map(matcher => matcher.toString()).join('\n\t')}
+    fraction: ${this.fraction ? fractionToString(this.fraction): 'none'}`;
+  }
+}

--- a/packages/grpc-js-xds/src/resolver-xds.ts
+++ b/packages/grpc-js-xds/src/resolver-xds.ts
@@ -338,14 +338,9 @@ class XdsResolver implements Resolver {
           this.clusterRefcounts.set(name, {inLastConfig: true, refCount: 0});
         }
       }
-      let configSelectorLogCounter = 0;
       const configSelector: ConfigSelector = (methodName, metadata) => {
         for (const {matcher, action} of matchList) {
           if (matcher.apply(methodName, metadata)) {
-            // 37 is coprime with most relevant numbers
-            if (configSelectorLogCounter % 37 === 0) {
-              trace('Call with method ' + methodName + ' and metadata ' + JSON.stringify(metadata.getMap(), undefined, 2) + ' matched ' + matcher.toString());
-            }
             const clusterName = action.getCluster();
             this.refCluster(clusterName);
             const onCommitted = () => {

--- a/packages/grpc-js-xds/src/route-action.ts
+++ b/packages/grpc-js-xds/src/route-action.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface RouteAction {
+  toString(): string;
+  getCluster(): string;
+}
+
+export class SingleClusterRouteAction implements RouteAction {
+  constructor(private cluster: string) {}
+
+  getCluster() {
+    return this.cluster;
+  }
+
+  toString() {
+    return 'SingleCluster(' + this.cluster + ')';
+  }
+}
+
+export interface WeightedCluster {
+  name: string;
+  weight: number;
+}
+
+interface ClusterChoice {
+  name: string;
+  numerator: number;
+}
+
+export class WeightedClusterRouteAction implements RouteAction {
+  /**
+   * The weighted cluster choices represented as a CDF
+   */
+  private clusterChoices: ClusterChoice[];
+  constructor(private clusters: WeightedCluster[], private totalWeight: number) {
+    this.clusterChoices = [];
+    let lastNumerator = 0;
+    for (const clusterWeight of clusters) {
+      lastNumerator += clusterWeight.weight;
+      this.clusterChoices.push({name: clusterWeight.name, numerator: lastNumerator});
+    }
+  }
+
+  getCluster() {
+    const randomNumber = Math.random() * this.totalWeight;
+    for (const choice of this.clusterChoices) {
+      if (randomNumber < choice.numerator) {
+        return choice.name;
+      }
+    }
+    // This should be prevented by the validation rules
+    return '';
+  }
+
+  toString() {
+    return 'WeightedCluster(' + this.clusters.map(({name, weight}) => '(' + name + ':' + weight + ')').join(', ') + ')';
+  }
+}

--- a/test/kokoro/linux.cfg
+++ b/test/kokoro/linux.cfg
@@ -15,10 +15,10 @@
 # Config file for Kokoro (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc-node/test/kokoro.sh"
-timeout_mins: 60
+build_file: "grpc-node/packages/grpc-js-xds/scripts/xds.sh"
+timeout_mins: 120
 action {
   define_artifacts {
-    regex: "github/grpc-node/reports/**/sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }

--- a/test/kokoro/linux.cfg
+++ b/test/kokoro/linux.cfg
@@ -15,10 +15,10 @@
 # Config file for Kokoro (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc-node/packages/grpc-js-xds/scripts/xds.sh"
-timeout_mins: 120
+build_file: "grpc-node/test/kokoro.sh"
+timeout_mins: 60
 action {
   define_artifacts {
-    regex: "github/grpc/reports/**"
+    regex: "github/grpc-node/reports/**/sponge_log.xml"
   }
 }


### PR DESCRIPTION
These are the additional interop tests enabled by #1715.

This PR includes a major refactor of the matching and route action logic in the xDS resolver class, moving them into separate files and multiple classes. The main purpose was to improve the ability to log them for debugging, but that should also improve readability. The refactor also fixed a bug with how the safe regex header match configuration was handled.