### PR TITLE
grpc-tools: make the plugin compatible with proto3 optional fields

### DIFF
--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-tools",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": "Google Inc.",
   "description": "Tools for developing with gRPC on Node.js",
   "homepage": "https://grpc.io/",

--- a/packages/grpc-tools/src/node_plugin.cc
+++ b/packages/grpc-tools/src/node_plugin.cc
@@ -65,6 +65,10 @@ class NodeGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     coded_out.WriteRaw(code.data(), code.size());
     return true;
   }
+
+  uint64_t GetSupportedFeatures() const override {
+    return FEATURE_PROTO3_OPTIONAL;
+  }
 };
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
The requirement for this change isn't documented anywhere, I just copied it from [the corresponding PR in the protobuf repo to enable the feature in the JS generator](https://github.com/protocolbuffers/protobuf/pull/7592/files#diff-a76a32283775a91e5c13baedb0617723fea7abf4295d302ecc4db8927720faeb). This fixes #1717. I manually tested it this time; it successfully handles fields that cause errors with the current version.