### PR TITLE
Update Google Credentials interface to the current version from google-auth-library-nodejs

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -991,7 +991,7 @@ declare module "grpc" {
      * @param googleCredential The Google credential object to use
      * @return The resulting credentials object
      */
-    createFromGoogleCredential(googleCredential: GoogleOAuth2Client): CallCredentials;
+    createFromGoogleCredential(googleCredential: GoogleCredentialsClient): CallCredentials;
 
     /**
      * Combine a ChannelCredentials with any number of CallCredentials into a single
@@ -1057,12 +1057,12 @@ declare module "grpc" {
   }
 
   /**
-   * This is the required interface from the OAuth2Client object
+   * This is the required interface from the CredentialsClient object
    * from https://github.com/google/google-auth-library-nodejs lib.
-   * The definition is copied from `ts/lib/auth/oauth2client.ts`
+   * The definition is copied from `src/auth/authclient.ts`
    */
-  export interface GoogleOAuth2Client {
-    getRequestMetadata(optUri: string, metadataCallback: (err: Error, headers: any) => void): void;
+  export interface GoogleCredentialsClient {
+    getRequestHeaders(url?: string): Promise<Headers>;
   }
 
   /**


### PR DESCRIPTION
The current interface `GoogleOAuth2Client` with `getRequestMetadata` function is very old, the function is already removed.

Now `getRequestHeaders` is the function to be used for CallCredentials.

https://github.com/googleapis/google-auth-library-nodejs/blob/6d2fe39d96e5ca607eb4b195aa77936a808c8454/src/auth/authclient.ts#L60

It's better to update the interface so that we can use it in TypeScript 😄 