### PR TITLE
grpc-js-xds: Remove env var protection for routing feature

### DIFF
--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -51,7 +51,6 @@ grpc/tools/run_tests/helper_scripts/prep_xds.sh
 GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver \
   GRPC_NODE_VERBOSITY=DEBUG \
   NODE_XDS_INTEROP_VERBOSITY=1 \
-  GRPC_XDS_EXPERIMENTAL_ROUTING=true \
   python3 grpc/tools/run_tests/run_xds_tests.py \
     --test_case="all,path_matching,header_matching" \
     --project_id=grpc-testing \

--- a/packages/grpc-js-xds/src/environment.ts
+++ b/packages/grpc-js-xds/src/environment.ts
@@ -14,9 +14,3 @@
  * limitations under the License.
  *
  */
-
-/**
- * Environment variable protection for traffic splitting and routing
- * https://github.com/grpc/proposal/blob/master/A28-xds-traffic-splitting-and-routing.md#xds-resolver-and-xds-client
- */
-export const GRPC_XDS_EXPERIMENTAL_ROUTING = (process.env.GRPC_XDS_EXPERIMENTAL_ROUTING === 'true');


### PR DESCRIPTION
The environment variable protection for these features is only needed until the corresponding interop tests are passing. That was accomplished with #1724. (Hide whitespace changes).