### PR TITLE
grpc-js: Remove explicit version compatibility check

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -22,7 +22,6 @@
     "@types/mocha": "^5.2.6",
     "@types/ncp": "^2.0.1",
     "@types/pify": "^3.0.2",
-    "@types/semver": "^6.0.1",
     "@types/yargs": "^15.0.5",
     "clang-format": "^1.0.55",
     "execa": "^2.0.3",
@@ -57,8 +56,7 @@
     "posttest": "npm run check"
   },
   "dependencies": {
-    "@types/node": ">=12.12.47",
-    "semver": "^6.2.0"
+    "@types/node": ">=12.12.47"
   },
   "files": [
     "src/**/*.ts",

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -15,8 +15,6 @@
  *
  */
 
-import * as semver from 'semver';
-
 import {
   ClientDuplexStream,
   ClientReadableStream,
@@ -65,11 +63,6 @@ import {
   ServerWritableStream,
   ServerDuplexStream,
 } from './server-call';
-
-const supportedNodeVersions = require('../../package.json').engines.node;
-if (!semver.satisfies(process.version, supportedNodeVersions)) {
-  throw new Error(`@grpc/grpc-js only works on Node ${supportedNodeVersions}`);
-}
 
 export { OAuth2Client };
 


### PR DESCRIPTION
This is an alternative approach to #1693. With Node 8 being past EOL and Node 10 nearing the end of its maintenance window, the probability of a user using a version older than the supported version range is outweighed by the probability that a user will encounter the issue described in the linked PR with prerelease versions of Node.