### PR TITLE
grpc-js: Don't transition out of idle when discarding subchannels

### DIFF
--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -598,7 +598,6 @@ export class Subchannel {
       this.transitionToState(
         [
           ConnectivityState.CONNECTING,
-          ConnectivityState.IDLE,
           ConnectivityState.READY,
         ],
         ConnectivityState.TRANSIENT_FAILURE


### PR DESCRIPTION
The purpose of transitioning to TRANSIENT_FAILURE here is to drop the connections that the subchannel is using, but an IDLE subchannel also doesn't have an active connection, making that transition pointless. Plus, the subchannel will immediately transition back to IDLE because there is no running backoff timer. The result is pointless log spam, as can be seen in https://github.com/googleapis/nodejs-pubsub/issues/1135#issuecomment-828023182 in the fourth log chunk.