### PR TITLE
grpc-js: Make GRPC_VERBOSITY accept lower-case values

### DIFF
--- a/packages/grpc-js/src/logging.ts
+++ b/packages/grpc-js/src/logging.ts
@@ -22,7 +22,7 @@ let _logVerbosity: LogVerbosity = LogVerbosity.ERROR;
 
 const verbosityString = process.env.GRPC_NODE_VERBOSITY ?? process.env.GRPC_VERBOSITY ?? '';
 
-switch (verbosityString) {
+switch (verbosityString.toUpperCase()) {
   case 'DEBUG':
     _logVerbosity = LogVerbosity.DEBUG;
     break;


### PR DESCRIPTION
A few people have reported that the core library accepts lower case values for `GRPC_VERBOSITY`, so this library should do the same.