### PR TITLE
Add CI tests for linux aarch64 (and run them under an emulator).

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -46,6 +46,7 @@ export JOBS=8
 export JUNIT_REPORT_STACK=1
 
 OS=$(uname)
+ARCH=$(uname -m)
 
 # TODO(mlumish): Add electron tests
 
@@ -87,7 +88,7 @@ if [ "$FAILED" = "true" ]
 then
   exit 1
 else
-  if [ "$OS" = "Linux" ]
+  if [ "$OS" = "Linux" ] && [ "$ARCH" != "aarch64"]
   then
     # If we can't download the token file, just skip reporting coverage
     gsutil cp gs://grpc-testing-secrets/coveralls_credentials/grpc-node.rc /tmp || exit 0

--- a/test/aarch64/prepare_qemu.sh
+++ b/test/aarch64/prepare_qemu.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Setup and configure qemu userspace emulator on kokoro worker so that we can seamlessly emulate processes running
+# inside docker containers.
+
+set -ex
+
+# show pre-existing qemu registration
+cat /proc/sys/fs/binfmt_misc/qemu-aarch64
+
+# Kokoro ubuntu1604 workers have already qemu-user and qemu-user-static packages installed, but it's and old version that:
+# * prints warning about some syscalls (e.g "qemu: Unsupported syscall: 278")
+# * doesn't register with binfmt_misc with the persistent ("F") flag we need (see below)
+#
+# To overcome the above limitations, we use the https://github.com/multiarch/qemu-user-static
+# docker image to provide a new enough version of qemu-user-static and register it with
+# the desired binfmt_misc flags. The most important flag we need is "F" (set by "--persistent yes"),
+# which allows the qemu-aarch64-static binary to be loaded eagerly at the time of registration with binfmt_misc.
+# That way, we can emulate aarch64 binaries running inside docker containers transparently, without needing the emulator
+# binary to be accessible from the docker image we're emulating.
+# Note that on newer distributions (such as glinux), simply "apt install qemu-user-static" is sufficient
+# to install qemu-user-static with the right flags.
+docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset --credential yes --persistent yes
+
+# Print current qemu reqistration to make sure everything is setup correctly.
+cat /proc/sys/fs/binfmt_misc/qemu-aarch64

--- a/test/kokoro/linux_aarch64.cfg
+++ b/test/kokoro/linux_aarch64.cfg
@@ -1,0 +1,24 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-node/test/kokoro_linux_aarch64.sh"
+timeout_mins: 60
+action {
+  define_artifacts {
+    regex: "github/grpc-node/reports/**/sponge_log.xml"
+  }
+}

--- a/test/kokoro_linux_aarch64.sh
+++ b/test/kokoro_linux_aarch64.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+cd $(dirname $0)/..
+
+test/aarch64/prepare_qemu.sh
+
+# better update submodules here. We could update the submodule when running
+# under an emulator as well, but it comes with performance penalty.
+git submodule update --init --recursive
+
+if [[ -t 0 ]]; then
+  DOCKER_TTY_ARGS="-it"
+else
+  # The input device on kokoro is not a TTY, so -it does not work.
+  DOCKER_TTY_ARGS=
+fi
+
+# the test command to run under an emulated aarch64 docker container.
+# we only run tests for a single version of node, since tests under an emulator are significantly slower.
+TEST_NODE_COMMAND="node_versions='8' ./run-tests.sh"
+
+# use an actual aarch64 docker image (with a real aarch64 node) to run build & test grpc-js under an emulator
+# * mount the protobuf root as /work to be able to access the crosscompiled files
+# * to avoid running the process inside docker as root (which can pollute the workspace with files owned by root), we force
+#   running under current user's UID and GID. To be able to do that, we need to provide a home directory for the user
+#   otherwise the UID would be homeless under the docker container (which can lead to various issues). For simplicity,
+#   we just run map the user's home to a throwaway temporary directory.
+docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work arm64v8/node:8-buster bash -c "$TEST_NODE_COMMAND"

--- a/test/kokoro_linux_aarch64.sh
+++ b/test/kokoro_linux_aarch64.sh
@@ -31,7 +31,7 @@ fi
 
 # the test command to run under an emulated aarch64 docker container.
 # we only run tests for a single version of node, since tests under an emulator are significantly slower.
-TEST_NODE_COMMAND="node_versions='8' ./run-tests.sh"
+TEST_NODE_COMMAND="node_versions='12' ./run-tests.sh"
 
 # use an actual aarch64 docker image (with a real aarch64 node) to run build & test grpc-js under an emulator
 # * mount the protobuf root as /work to be able to access the crosscompiled files
@@ -39,4 +39,4 @@ TEST_NODE_COMMAND="node_versions='8' ./run-tests.sh"
 #   running under current user's UID and GID. To be able to do that, we need to provide a home directory for the user
 #   otherwise the UID would be homeless under the docker container (which can lead to various issues). For simplicity,
 #   we just run map the user's home to a throwaway temporary directory.
-docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work arm64v8/node:8-buster bash -c "$TEST_NODE_COMMAND"
+docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work arm64v8/node:12-buster bash -c "$TEST_NODE_COMMAND"


### PR DESCRIPTION
Run unit tests under an aarch64 docker container and use qemu to emulate. Similar approach is already being used for several protobuf languages and for grpc-java and grpc-go.