### PR TITLE
grpc-js: Apply timeouts from service configs

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -509,6 +509,11 @@ export class ChannelImplementation implements Channel {
   }
 
   private tryGetConfig(stream: Http2CallStream, metadata: Metadata) {
+    if (stream.getStatus() !== null) {
+      /* If the stream has a status, it has already finished and we don't need
+       * to take any more actions on it. */
+      return;
+    }
     if (this.configSelector === null) {
       /* This branch will only be taken at the beginning of the channel's life,
        * before the resolver ever returns a result. So, the

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -523,6 +523,14 @@ export class ChannelImplementation implements Channel {
     } else {
       const callConfig = this.configSelector(stream.getMethod(), metadata);
       if (callConfig.status === Status.OK) {
+        if (callConfig.methodConfig.timeout) {
+          const deadline = new Date();
+          deadline.setSeconds(deadline.getSeconds() + callConfig.methodConfig.timeout.seconds);
+          deadline.setMilliseconds(deadline.getMilliseconds() + callConfig.methodConfig.timeout.nanos / 1_000_000);
+          stream.setConfigDeadline(deadline);
+          // Refreshing the filters makes the deadline filter pick up the new deadline
+          stream.filterStack.refresh();
+        }
         this.tryPick(stream, metadata, callConfig);
       } else {
         stream.cancelWithStatus(callConfig.status, "Failed to route call to method " + stream.getMethod());

--- a/packages/grpc-js/src/filter-stack.ts
+++ b/packages/grpc-js/src/filter-stack.ts
@@ -71,6 +71,12 @@ export class FilterStack implements Filter {
 
     return result;
   }
+
+  refresh(): void {
+    for (const filter of this.filters) {
+      filter.refresh();
+    }
+  }
 }
 
 export class FilterStackFactory implements FilterFactory<FilterStack> {

--- a/packages/grpc-js/src/filter.ts
+++ b/packages/grpc-js/src/filter.ts
@@ -32,6 +32,8 @@ export interface Filter {
   receiveMessage(message: Promise<Buffer>): Promise<Buffer>;
 
   receiveTrailers(status: StatusObject): StatusObject;
+
+  refresh(): void;
 }
 
 export abstract class BaseFilter implements Filter {
@@ -53,6 +55,9 @@ export abstract class BaseFilter implements Filter {
 
   receiveTrailers(status: StatusObject): StatusObject {
     return status;
+  }
+
+  refresh(): void {
   }
 }
 


### PR DESCRIPTION
This is the grpc-js side of the timeout part of [proposal A31](https://github.com/grpc/proposal/blob/master/A31-xds-timeout-support-and-config-selector.md): the mechanism for applying a timeout from a service config to each individual request. The xDS side uses xDS v3-specific fields, so I will do that after #1765 is merged.

I changed the method config definition to more closely match [the spec](https://github.com/grpc/grpc/blob/master/doc/service_config.md). The validation code still accepts the same inputs it accepted before, so that shouldn't break anything.

This puts the deadline filter in a weird state. It already had some implicit coupling with the deadline exposed by the call stream class, but now that deadline can change and the filter needs to take action when that happens. I don't really know what to do about that, so I'm deferring that to another time.