### PR TITLE
grpc-js: Change function check to handle async functions

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -56,7 +56,7 @@ const INTERCEPTOR_PROVIDER_SYMBOL = Symbol();
 const CALL_INVOCATION_TRANSFORMER_SYMBOL = Symbol();
 
 function isFunction<ResponseType>(arg: Metadata | CallOptions | UnaryCallback<ResponseType> | undefined): arg is UnaryCallback<ResponseType>{
-  return Object.prototype.toString.call(arg) === '[object Function]'
+  return typeof arg === 'function';
 }
 
 export interface UnaryCallback<ResponseType> {


### PR DESCRIPTION
This is the same change as in #1786, but for grpc-js.