### PR TITLE
grpc-js-xds: Propagate timeouts from xDS responses to method config

### DIFF
--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -52,9 +52,9 @@ GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weigh
   GRPC_NODE_VERBOSITY=DEBUG \
   NODE_XDS_INTEROP_VERBOSITY=1 \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case="all,path_matching,header_matching" \
+    --test_case="all,timeout" \
     --project_id=grpc-testing \
-    --source_image=projects/grpc-testing/global/images/xds-test-server-2 \
+    --source_image=projects/grpc-testing/global/images/xds-test-server-4 \
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \

--- a/packages/grpc-js-xds/src/route-action.ts
+++ b/packages/grpc-js-xds/src/route-action.ts
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
+import { experimental } from '@grpc/grpc-js';
+import Duration = experimental.Duration;
+
 export interface RouteAction {
   toString(): string;
   getCluster(): string;
+  getTimeout(): Duration | undefined;
 }
 
 export class SingleClusterRouteAction implements RouteAction {
-  constructor(private cluster: string) {}
+  constructor(private cluster: string, private timeout: Duration | undefined) {}
 
   getCluster() {
     return this.cluster;
@@ -28,6 +32,10 @@ export class SingleClusterRouteAction implements RouteAction {
 
   toString() {
     return 'SingleCluster(' + this.cluster + ')';
+  }
+
+  getTimeout() {
+    return this.timeout;
   }
 }
 
@@ -46,7 +54,7 @@ export class WeightedClusterRouteAction implements RouteAction {
    * The weighted cluster choices represented as a CDF
    */
   private clusterChoices: ClusterChoice[];
-  constructor(private clusters: WeightedCluster[], private totalWeight: number) {
+  constructor(private clusters: WeightedCluster[], private totalWeight: number, private timeout: Duration | undefined) {
     this.clusterChoices = [];
     let lastNumerator = 0;
     for (const clusterWeight of clusters) {
@@ -68,5 +76,9 @@ export class WeightedClusterRouteAction implements RouteAction {
 
   toString() {
     return 'WeightedCluster(' + this.clusters.map(({name, weight}) => '(' + name + ':' + weight + ')').join(', ') + ')';
+  }
+
+  getTimeout() {
+    return this.timeout;
   }
 }

--- a/packages/grpc-js-xds/src/route-action.ts
+++ b/packages/grpc-js-xds/src/route-action.ts
@@ -23,6 +23,15 @@ export interface RouteAction {
   getTimeout(): Duration | undefined;
 }
 
+function durationToLogString(duration: Duration) {
+  const millis = Math.floor(duration.nanos / 1_000_000);
+  if (millis > 0) {
+    return duration.seconds + '.' + millis;
+  } else {
+    return '' + duration.seconds;
+  }
+}
+
 export class SingleClusterRouteAction implements RouteAction {
   constructor(private cluster: string, private timeout: Duration | undefined) {}
 
@@ -31,7 +40,11 @@ export class SingleClusterRouteAction implements RouteAction {
   }
 
   toString() {
-    return 'SingleCluster(' + this.cluster + ')';
+    if (this.timeout) {
+      return 'SingleCluster(' + this.cluster + ', ' + 'timeout=' + durationToLogString(this.timeout) + 's)';
+    } else {
+      return 'SingleCluster(' + this.cluster + ')';
+    }
   }
 
   getTimeout() {
@@ -75,7 +88,12 @@ export class WeightedClusterRouteAction implements RouteAction {
   }
 
   toString() {
-    return 'WeightedCluster(' + this.clusters.map(({name, weight}) => '(' + name + ':' + weight + ')').join(', ') + ')';
+    const clusterListString = this.clusters.map(({name, weight}) => '(' + name + ':' + weight + ')').join(', ')
+    if (this.timeout) {
+      return 'WeightedCluster(' + clusterListString + ', ' + 'timeout=' + durationToLogString(this.timeout) + 's)';
+    } else {
+      return 'WeightedCluster(' + clusterListString + ')';
+    }
   }
 
   getTimeout() {

--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -1,7 +1,7 @@
 export { trace } from './logging';
 export { Resolver, ResolverListener, registerResolver, ConfigSelector } from './resolver';
 export { GrpcUri, uriToString } from './uri-parser';
-export { ServiceConfig } from './service-config';
+export { ServiceConfig, Duration } from './service-config';
 export { BackoffTimeout } from './backoff-timeout';
 export { LoadBalancer, LoadBalancingConfig, ChannelControlHelper, registerLoadBalancerType, getFirstUsableConfig, validateLoadBalancingConfig } from './load-balancer';
 export { SubchannelAddress, subchannelAddressToString } from './subchannel';

--- a/packages/grpc-js/src/metadata.ts
+++ b/packages/grpc-js/src/metadata.ts
@@ -243,6 +243,18 @@ export class Metadata {
   }
 
   /**
+   * This modifies the behavior of JSON.stringify to show an object
+   * representation of the metadata map.
+   */
+  toJSON() {
+    const result: {[key: string]: MetadataValue[]} = {};
+    for (const [key, values] of this.internalRepr.entries()) {
+      result[key] = values;
+    }
+    return result;
+  }
+
+  /**
    * Returns a new Metadata object based fields in a given IncomingHttpHeaders
    * object.
    * @param headers An IncomingHttpHeaders object.

--- a/packages/grpc-js/test/test-deadline.ts
+++ b/packages/grpc-js/test/test-deadline.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import * as assert from 'assert';
+
+import * as grpc from '../src';
+import { experimental } from '../src';
+import { ServerCredentials } from '../src';
+import { ServiceClient, ServiceClientConstructor } from '../src/make-client';
+import { loadProtoFile } from './common';
+import ServiceConfig = experimental.ServiceConfig;
+
+const clientInsecureCreds = grpc.credentials.createInsecure();
+const serverInsecureCreds = ServerCredentials.createInsecure();
+
+const TIMEOUT_SERVICE_CONFIG: ServiceConfig = {
+  loadBalancingConfig: [],
+  methodConfig: [{
+    name: [
+      {service: 'TestService'}
+    ],
+    timeout: {
+      seconds: 1,
+      nanos: 0
+    }
+  }]
+};
+
+describe('Client with configured timeout', () => {
+  let server: grpc.Server;
+  let Client: ServiceClientConstructor;
+  let client: ServiceClient;
+  
+  before(done => {
+    Client = loadProtoFile(__dirname + '/fixtures/test_service.proto').TestService as ServiceClientConstructor;
+    server = new grpc.Server();
+    server.addService(Client.service, {
+      unary: () => {},
+      clientStream: () => {},
+      serverStream: () => {},
+      bidiStream: () => {}
+    });
+    server.bindAsync('localhost:0', grpc.ServerCredentials.createInsecure(), (error, port) => {
+      if (error) {
+        done(error);
+        return;
+      }
+      server.start();
+      client = new Client(`localhost:${port}`, grpc.credentials.createInsecure(), {'grpc.service_config': JSON.stringify(TIMEOUT_SERVICE_CONFIG)});
+      done();
+    });
+  });
+
+  after(done => {
+    client.close();
+    server.tryShutdown(done);
+  });
+
+  it('Should end calls without explicit deadline with DEADLINE_EXCEEDED', done => {
+    client.unary({}, (error: grpc.ServiceError, value: unknown) =>{
+      assert(error);
+      assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
+      done();
+    });
+  });
+
+  it('Should end calls with a long explicit deadline with DEADLINE_EXCEEDED', done => {
+    const deadline = new Date();
+    deadline.setSeconds(deadline.getSeconds() + 20);
+    client.unary({}, (error: grpc.ServiceError, value: unknown) =>{
+      assert(error);
+      assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
+      done();
+    });
+  });
+});

--- a/test/kokoro/xds-interop.cfg
+++ b/test/kokoro/xds-interop.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-node/packages/grpc-js-xds/scripts/xds.sh"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "github/grpc/reports/**"

--- a/test/kokoro/xds-v3-interop.cfg
+++ b/test/kokoro/xds-v3-interop.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-node/packages/grpc-js-xds/scripts/xds-v3.sh"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "github/grpc/reports/**"


### PR DESCRIPTION
And add the corresponding interop test. This is the xDS side of [A31](https://github.com/grpc/proposal/blob/master/A31-xds-timeout-support-and-config-selector.md#supported-fields), following up from #1785.