### PR TITLE
Don't clean after testing on each Node version

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -71,7 +71,6 @@ do
   node -e 'process.exit(process.version.startsWith("v'$version'") ? 0 : -1)'
 
   # Install dependencies and link packages together.
-  ./node_modules/.bin/gulp cleanAll
   ./node_modules/.bin/gulp setup
 
   # npm test calls nyc gulp test


### PR DESCRIPTION
Without the native library in this branch, this step may not be needed at all.