### PR TITLE
Increase timeout for tests that timeout under emulator (part 2)

### DIFF
--- a/test/api/interop_extra_test.js
+++ b/test/api/interop_extra_test.js
@@ -147,7 +147,8 @@ describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, functio
       });
     });
     it('should receive all messages in a long stream', function(done) {
-      this.timeout(20000);
+      // the test is slow under aarch64 emulator
+      this.timeout(80000);
       var arg = {
         response_type: 'COMPRESSABLE',
         response_parameters: [


### PR DESCRIPTION
Increasing one more timeout. With this change, the emulated tests suite will finally be green (based on a few adhoc runs).

part 1: https://github.com/grpc/grpc-node/pull/1803

Example green runs:
https://source.cloud.google.com/results/invocations/b59c8b3d-c57c-4360-8b51-ee2162c7ad37/targets/github%2Fgrpc-node%2Freports%2Fnode12/tests;query=should%20receive%20all%20messages%20in%20a%20long%20stream;group=js%20client%20-%3E%20native%20server%20Interop-adjacent%20tests;test=should%20receive%20all%20messages%20in%20a%20long%20stream;row=3
https://source.cloud.google.com/results/invocations/e38ca58a-1b14-4221-a6d8-199d3300f6b0/targets/github%2Fgrpc-node%2Freports%2Fnode12/tests;query=should%20receive%20all%20messages%20in%20a%20long%20stream;group=js%20client%20-%3E%20native%20server%20Interop-adjacent%20tests;test=should%20receive%20all%20messages%20in%20a%20long%20stream;row=3
https://source.cloud.google.com/results/invocations/b650a9a0-1520-42f0-904a-58d9d3199abd/targets/github%2Fgrpc-node%2Freports%2Fnode12/tests;group=js%20client%20-%3E%20native%20server%20Interop-adjacent%20tests;test=should%20receive%20all%20messages%20in%20a%20long%20stream;row=3
