### PR TITLE
grpc-js: Export ServerErrorResponse type, which is used in public APIs

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -62,6 +62,7 @@ import {
   ServerReadableStream,
   ServerWritableStream,
   ServerDuplexStream,
+  ServerErrorResponse,
 } from './server-call';
 
 export { OAuth2Client };
@@ -173,6 +174,7 @@ export {
   ServerReadableStream,
   ServerWritableStream,
   ServerDuplexStream,
+  ServerErrorResponse,
   ServiceDefinition,
   UntypedHandleCall,
   UntypedServiceImplementation,


### PR DESCRIPTION
A solution for the problems described in #1805.