### PR TITLE
(grpc-tools) Update node-pre-gyp dependency

### DIFF
--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -24,7 +24,7 @@
     "prepublishOnly": "git submodule update --init --recursive && node copy_well_known_protos.js"
   },
   "dependencies": {
-    "node-pre-gyp": "^0.15.0"
+    "@mapbox/node-pre-gyp": "^1.0.5"
   },
   "binary": {
     "module_name": "grpc_tools",


### PR DESCRIPTION
This versions of node-pre-gyp has some issues with some weird proxy configurations that can be solved updating this deprecated package.