### PR TITLE
Don't install docker in the docker image

### DIFF
--- a/tools/release/native/Dockerfile
+++ b/tools/release/native/Dockerfile
@@ -6,7 +6,6 @@ RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt
 RUN apt-get update
 RUN apt-get -t jessie-backports install -y cmake
 RUN apt-get install -y curl build-essential python libc6-dev-i386 lib32stdc++-4.9-dev jq
-RUN curl -fsSL get.docker.com | bash
 
 RUN mkdir /usr/local/nvm
 ENV NVM_DIR /usr/local/nvm


### PR DESCRIPTION
This doesn't work anymore because the newest version of docker doesn't support the version of Debian we're using in this docker image. And we don't need it anymore; this is only used in the grpc-tools build now, and that doesn't use nested docker containers.