### PR TITLE
grpc-js: Backport logging changes to 1.3.x

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/constants.ts
+++ b/packages/grpc-js/src/constants.ts
@@ -39,6 +39,7 @@ export enum LogVerbosity {
   DEBUG = 0,
   INFO,
   ERROR,
+  NONE,
 }
 
 /**


### PR DESCRIPTION
Backport the logging changes from #1820 to 1.3.x so that the behavior of the released library is consistent with the documentation.