### PR TITLE
Avoid unused definition imports from proto-loader

### DIFF
--- a/packages/proto-loader/golden-generated/echo.ts
+++ b/packages/proto-loader/golden-generated/echo.ts
@@ -1,5 +1,5 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { ServiceDefinition, EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
+import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
 import type { OperationsClient as _google_longrunning_OperationsClient, OperationsDefinition as _google_longrunning_OperationsDefinition } from './google/longrunning/Operations';
 import type { EchoClient as _google_showcase_v1beta1_EchoClient, EchoDefinition as _google_showcase_v1beta1_EchoDefinition } from './google/showcase/v1beta1/Echo';


### PR DESCRIPTION
Since proto files don't always contain enums and messages, it was possible to get into a state where generated code contained unused imports which caused TS errors. This change makes those imports conditional on the existence of the corresponding definitions in the proto file.

Co-authored-by: Austin Puri <austin.puri@gmail.com>
Co-authored-by: Joe Porpeglia <josephp@spotify.com>