### PR TITLE
grpc-js: Unref timers for keepalive functionality

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -280,6 +280,7 @@ export class Subchannel {
     this.keepaliveTimeoutId = setTimeout(() => {
       this.transitionToState([ConnectivityState.READY], ConnectivityState.IDLE);
     }, this.keepaliveTimeoutMs);
+    this.keepaliveTimeoutId.unref?.();
     this.session!.ping(
       (err: Error | null, duration: number, payload: Buffer) => {
         clearTimeout(this.keepaliveTimeoutId);
@@ -291,6 +292,7 @@ export class Subchannel {
     this.keepaliveIntervalId = setInterval(() => {
       this.sendPing();
     }, this.keepaliveTimeMs);
+    this.keepaliveIntervalId.unref?.()
     /* Don't send a ping immediately because whatever caused us to start
      * sending pings should also involve some network activity. */
   }


### PR DESCRIPTION
I'm pretty sure that we don't need to keep those timers ref'd to keep the process alive when it needs to be alive, and with the `grpc.keepalive_permit_without_calls` option in particular, they can keep the process open even if gRPC is otherwise unused. I think this will fix #1825.