### PR TITLE
grpc-js: Refactor code to eliminate runtime dependency cycles

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -29,6 +29,7 @@
     "gulp": "^4.0.2",
     "gulp-mocha": "^6.0.0",
     "lodash": "^4.17.4",
+    "madge": "^5.0.1",
     "mocha-jenkins-reporter": "^0.4.1",
     "ncp": "^2.0.0",
     "pify": "^4.0.1",
@@ -53,7 +54,7 @@
     "check": "gts check src/**/*.ts",
     "fix": "gts fix src/*.ts",
     "pretest": "npm run compile",
-    "posttest": "npm run check"
+    "posttest": "npm run check && madge -c ./build/src"
   },
   "dependencies": {
     "@types/node": ">=12.12.47"

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -35,20 +35,13 @@ import { DeadlineFilterFactory } from './deadline-filter';
 import { CompressionFilterFactory } from './compression-filter';
 import { CallConfig, ConfigSelector, getDefaultAuthority, mapUriDefaultScheme } from './resolver';
 import { trace, log } from './logging';
-import { SubchannelAddress } from './subchannel';
+import { SubchannelAddress } from "./subchannel-address";
 import { MaxMessageSizeFilterFactory } from './max-message-size-filter';
 import { mapProxyName } from './http_proxy';
 import { GrpcUri, parseUri, uriToString } from './uri-parser';
 import { ServerSurfaceCall } from './server-call';
 import { SurfaceCall } from './call';
-
-export enum ConnectivityState {
-  IDLE,
-  CONNECTING,
-  READY,
-  TRANSIENT_FAILURE,
-  SHUTDOWN,
-}
+import { ConnectivityState } from './connectivity-state';
 
 /**
  * See https://nodejs.org/api/timers.html#timers_setinterval_callback_delay_args

--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -30,7 +30,8 @@ import {
 } from './call';
 import { CallCredentials } from './call-credentials';
 import { Deadline, StatusObject } from './call-stream';
-import { Channel, ConnectivityState, ChannelImplementation } from './channel';
+import { Channel, ChannelImplementation } from './channel';
+import { ConnectivityState } from "./connectivity-state";
 import { ChannelCredentials } from './channel-credentials';
 import { ChannelOptions } from './channel-options';
 import { Status } from './constants';

--- a/packages/grpc-js/src/connectivity-state.ts
+++ b/packages/grpc-js/src/connectivity-state.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export enum ConnectivityState {
+  IDLE,
+  CONNECTING,
+  READY,
+  TRANSIENT_FAILURE,
+  SHUTDOWN
+}

--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -4,7 +4,7 @@ export { GrpcUri, uriToString } from './uri-parser';
 export { ServiceConfig, Duration } from './service-config';
 export { BackoffTimeout } from './backoff-timeout';
 export { LoadBalancer, LoadBalancingConfig, ChannelControlHelper, registerLoadBalancerType, getFirstUsableConfig, validateLoadBalancingConfig } from './load-balancer';
-export { SubchannelAddress, subchannelAddressToString } from './subchannel';
+export { SubchannelAddress, subchannelAddressToString } from './subchannel-address';
 export { ChildLoadBalancerHandler } from './load-balancer-child-handler';
 export { Picker, UnavailablePicker, QueuePicker, PickResult, PickArgs, PickResultType } from './picker';
 export { Call as CallStream } from './call-stream';

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -25,8 +25,8 @@ import * as logging from './logging';
 import {
   SubchannelAddress,
   isTcpSubchannelAddress,
-  subchannelAddressToString,
-} from './subchannel';
+  subchannelAddressToString
+} from "./subchannel-address";
 import { ChannelOptions } from './channel-options';
 import { GrpcUri, parseUri, splitHostPort, uriToString } from './uri-parser';
 import { URL } from 'url';

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -24,7 +24,8 @@ import {
 } from './call';
 import { CallCredentials, OAuth2Client } from './call-credentials';
 import { Deadline, StatusObject } from './call-stream';
-import { Channel, ConnectivityState, ChannelImplementation } from './channel';
+import { Channel, ChannelImplementation } from './channel';
+import { ConnectivityState } from "./connectivity-state";
 import { ChannelCredentials } from './channel-credentials';
 import {
   CallOptions,
@@ -246,10 +247,14 @@ export { ChannelOptions } from './channel-options';
 import * as experimental from './experimental';
 export { experimental };
 
-import * as resolver from './resolver';
-import * as load_balancer from './load-balancer';
+import * as resolver_dns from './resolver-dns';
+import * as resolver_uds from './resolver-uds';
+import * as load_balancer_pick_first from './load-balancer-pick-first';
+import * as load_balancer_round_robin from './load-balancer-round-robin';
 
 (() => {
-  resolver.registerAll();
-  load_balancer.registerAll();
+  resolver_dns.setup();
+  resolver_uds.setup();
+  load_balancer_pick_first.setup();
+  load_balancer_round_robin.setup();
 })();

--- a/packages/grpc-js/src/load-balancer-child-handler.ts
+++ b/packages/grpc-js/src/load-balancer-child-handler.ts
@@ -18,12 +18,13 @@
 import {
   LoadBalancer,
   ChannelControlHelper,
-  createLoadBalancer,
-  LoadBalancingConfig
+  LoadBalancingConfig,
+  createLoadBalancer
 } from './load-balancer';
-import { SubchannelAddress, Subchannel } from './subchannel';
+import { Subchannel } from './subchannel';
+import { SubchannelAddress } from "./subchannel-address";
 import { ChannelOptions } from './channel-options';
-import { ConnectivityState } from './channel';
+import { ConnectivityState } from "./connectivity-state";
 import { Picker } from './picker';
 
 const TYPE_NAME = 'child_load_balancer_helper';

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -18,10 +18,11 @@
 import {
   LoadBalancer,
   ChannelControlHelper,
-  registerLoadBalancerType,
-  LoadBalancingConfig
+  LoadBalancingConfig,
+  registerDefaultLoadBalancerType, 
+  registerLoadBalancerType
 } from './load-balancer';
-import { ConnectivityState } from './channel';
+import { ConnectivityState } from "./connectivity-state";
 import {
   QueuePicker,
   Picker,
@@ -33,9 +34,11 @@ import {
 import {
   Subchannel,
   ConnectivityStateListener,
-  SubchannelAddress,
-  subchannelAddressToString,
 } from './subchannel';
+import {
+  SubchannelAddress,
+  subchannelAddressToString
+} from "./subchannel-address";
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
 
@@ -458,4 +461,5 @@ export class PickFirstLoadBalancer implements LoadBalancer {
 
 export function setup(): void {
   registerLoadBalancerType(TYPE_NAME, PickFirstLoadBalancer, PickFirstLoadBalancingConfig);
+  registerDefaultLoadBalancerType(TYPE_NAME);
 }

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -18,10 +18,10 @@
 import {
   LoadBalancer,
   ChannelControlHelper,
-  registerLoadBalancerType,
-  LoadBalancingConfig
+  LoadBalancingConfig,
+  registerLoadBalancerType
 } from './load-balancer';
-import { ConnectivityState } from './channel';
+import { ConnectivityState } from "./connectivity-state";
 import {
   QueuePicker,
   Picker,
@@ -33,9 +33,11 @@ import {
 import {
   Subchannel,
   ConnectivityStateListener,
-  SubchannelAddress,
-  subchannelAddressToString,
 } from './subchannel';
+import {
+  SubchannelAddress,
+  subchannelAddressToString
+} from "./subchannel-address";
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
 

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -28,7 +28,7 @@ import { StatusObject } from './call-stream';
 import { Metadata } from './metadata';
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
-import { SubchannelAddress, TcpSubchannelAddress } from './subchannel';
+import { SubchannelAddress, TcpSubchannelAddress } from "./subchannel-address";
 import { GrpcUri, uriToString, splitHostPort } from './uri-parser';
 import { isIPv6, isIPv4 } from 'net';
 import { ChannelOptions } from './channel-options';

--- a/packages/grpc-js/src/resolver-uds.ts
+++ b/packages/grpc-js/src/resolver-uds.ts
@@ -15,7 +15,7 @@
  */
 
 import { Resolver, ResolverListener, registerResolver } from './resolver';
-import { SubchannelAddress } from './subchannel';
+import { SubchannelAddress } from "./subchannel-address";
 import { GrpcUri } from './uri-parser';
 import { ChannelOptions } from './channel-options';
 

--- a/packages/grpc-js/src/resolver.ts
+++ b/packages/grpc-js/src/resolver.ts
@@ -16,10 +16,8 @@
  */
 
 import { MethodConfig, ServiceConfig } from './service-config';
-import * as resolver_dns from './resolver-dns';
-import * as resolver_uds from './resolver-uds';
 import { StatusObject } from './call-stream';
-import { SubchannelAddress } from './subchannel';
+import { SubchannelAddress } from "./subchannel-address";
 import { GrpcUri, uriToString } from './uri-parser';
 import { ChannelOptions } from './channel-options';
 import { Metadata } from './metadata';
@@ -174,9 +172,4 @@ export function mapUriDefaultScheme(target: GrpcUri): GrpcUri | null {
     }
   }
   return target;
-}
-
-export function registerAll() {
-  resolver_dns.setup();
-  resolver_uds.setup();
 }

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -18,11 +18,11 @@
 import {
   ChannelControlHelper,
   LoadBalancer,
-  getFirstUsableConfig,
-  LoadBalancingConfig
+  LoadBalancingConfig,
+  getFirstUsableConfig
 } from './load-balancer';
 import { ServiceConfig, validateServiceConfig } from './service-config';
-import { ConnectivityState } from './channel';
+import { ConnectivityState } from "./connectivity-state";
 import { ConfigSelector, createResolver, Resolver } from './resolver';
 import { ServiceError } from './call';
 import { Picker, UnavailablePicker, QueuePicker } from './picker';
@@ -32,7 +32,7 @@ import { StatusObject } from './call-stream';
 import { Metadata } from './metadata';
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
-import { SubchannelAddress } from './subchannel';
+import { SubchannelAddress } from "./subchannel-address";
 import { GrpcUri, uriToString } from './uri-parser';
 import { ChildLoadBalancerHandler } from './load-balancer-child-handler';
 import { ChannelOptions } from './channel-options';

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -55,8 +55,8 @@ import {
   SubchannelAddress,
   TcpSubchannelAddress,
   isTcpSubchannelAddress,
-  subchannelAddressToString,
-} from './subchannel';
+  subchannelAddressToString
+} from "./subchannel-address";
 import { parseUri } from './uri-parser';
 
 const TRACER_NAME = 'server';

--- a/packages/grpc-js/src/subchannel-address.ts
+++ b/packages/grpc-js/src/subchannel-address.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export interface TcpSubchannelAddress {
+  port: number;
+  host: string;
+}
+
+export interface IpcSubchannelAddress {
+  path: string;
+}
+/**
+ * This represents a single backend address to connect to. This interface is a
+ * subset of net.SocketConnectOpts, i.e. the options described at
+ * https://nodejs.org/api/net.html#net_socket_connect_options_connectlistener.
+ * Those are in turn a subset of the options that can be passed to http2.connect.
+ */
+
+export type SubchannelAddress = TcpSubchannelAddress | IpcSubchannelAddress;
+
+export function isTcpSubchannelAddress(
+  address: SubchannelAddress
+): address is TcpSubchannelAddress {
+  return 'port' in address;
+}
+
+export function subchannelAddressEqual(
+  address1: SubchannelAddress,
+  address2: SubchannelAddress
+): boolean {
+  if (isTcpSubchannelAddress(address1)) {
+    return (
+      isTcpSubchannelAddress(address2) &&
+      address1.host === address2.host &&
+      address1.port === address2.port
+    );
+  } else {
+    return !isTcpSubchannelAddress(address2) && address1.path === address2.path;
+  }
+}
+
+export function subchannelAddressToString(address: SubchannelAddress): string {
+  if (isTcpSubchannelAddress(address)) {
+    return address.host + ':' + address.port;
+  } else {
+    return address.path;
+  }
+}

--- a/packages/grpc-js/src/subchannel-pool.ts
+++ b/packages/grpc-js/src/subchannel-pool.ts
@@ -18,9 +18,11 @@
 import { ChannelOptions, channelOptionsEqual } from './channel-options';
 import {
   Subchannel,
-  SubchannelAddress,
-  subchannelAddressEqual,
 } from './subchannel';
+import {
+  SubchannelAddress,
+  subchannelAddressEqual
+} from "./subchannel-address";
 import { ChannelCredentials } from './channel-credentials';
 import { GrpcUri, uriToString } from './uri-parser';
 

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -21,7 +21,7 @@ import { Metadata } from './metadata';
 import { Http2CallStream } from './call-stream';
 import { ChannelOptions } from './channel-options';
 import { PeerCertificate, checkServerIdentity } from 'tls';
-import { ConnectivityState } from './channel';
+import { ConnectivityState } from "./connectivity-state";
 import { BackoffTimeout, BackoffOptions } from './backoff-timeout';
 import { getDefaultAuthority } from './resolver';
 import * as logging from './logging';
@@ -31,6 +31,7 @@ import * as net from 'net';
 import { GrpcUri, parseUri, splitHostPort, uriToString } from './uri-parser';
 import { ConnectionOptions } from 'tls';
 import { FilterFactory, Filter } from './filter';
+import { SubchannelAddress, subchannelAddressToString } from './subchannel-address';
 
 const clientVersion = require('../../package.json').version;
 
@@ -81,52 +82,6 @@ function uniformRandom(min: number, max: number) {
 }
 
 const tooManyPingsData: Buffer = Buffer.from('too_many_pings', 'ascii');
-
-export interface TcpSubchannelAddress {
-  port: number;
-  host: string;
-}
-
-export interface IpcSubchannelAddress {
-  path: string;
-}
-
-/**
- * This represents a single backend address to connect to. This interface is a
- * subset of net.SocketConnectOpts, i.e. the options described at
- * https://nodejs.org/api/net.html#net_socket_connect_options_connectlistener.
- * Those are in turn a subset of the options that can be passed to http2.connect.
- */
-export type SubchannelAddress = TcpSubchannelAddress | IpcSubchannelAddress;
-
-export function isTcpSubchannelAddress(
-  address: SubchannelAddress
-): address is TcpSubchannelAddress {
-  return 'port' in address;
-}
-
-export function subchannelAddressEqual(
-  address1: SubchannelAddress,
-  address2: SubchannelAddress
-): boolean {
-  if (isTcpSubchannelAddress(address1)) {
-    return (
-      isTcpSubchannelAddress(address2) &&
-      address1.host === address2.host &&
-      address1.port === address2.port
-    );
-  } else {
-    return !isTcpSubchannelAddress(address2) && address1.path === address2.path;
-  }
-}
-
-export function subchannelAddressToString(address: SubchannelAddress): string {
-  if (isTcpSubchannelAddress(address)) {
-    return address.host + ':' + address.port;
-  } else {
-    return address.path;
-  }
-}
 
 export class Subchannel {
   /**

--- a/packages/grpc-js/test/test-client.ts
+++ b/packages/grpc-js/test/test-client.ts
@@ -20,7 +20,7 @@ import * as assert from 'assert';
 import * as grpc from '../src';
 import { Server, ServerCredentials } from '../src';
 import { Client } from '../src';
-import { ConnectivityState } from '../src/channel';
+import { ConnectivityState } from "../src/connectivity-state";
 
 const clientInsecureCreds = grpc.credentials.createInsecure();
 const serverInsecureCreds = ServerCredentials.createInsecure();

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -19,9 +19,11 @@
 // tslint:disable no-any
 import * as assert from 'assert';
 import * as resolverManager from '../src/resolver';
+import * as load_balancer_pick_first from '../src/load-balancer-pick-first';
+import * as load_balancer_round_robin from '../src/load-balancer-round-robin';
 import { ServiceConfig } from '../src/service-config';
 import { StatusObject } from '../src/call-stream';
-import { SubchannelAddress, isTcpSubchannelAddress } from '../src/subchannel';
+import { SubchannelAddress, isTcpSubchannelAddress } from "../src/subchannel-address";
 import { parseUri, GrpcUri } from '../src/uri-parser';
 
 describe('Name Resolver', () => {
@@ -29,7 +31,8 @@ describe('Name Resolver', () => {
     // For some reason DNS queries sometimes take a long time on Windows
     this.timeout(4000);
     before(() => {
-      resolverManager.registerAll();
+      load_balancer_pick_first.setup();
+      load_balancer_round_robin.setup();
     });
     it('Should resolve localhost properly', done => {
       const target = resolverManager.mapUriDefaultScheme(parseUri('localhost:50051')!)!;


### PR DESCRIPTION
The main changes here are moving the `ConnectivityState` enum and `SubchannelAddress` type (plus related definitions) into separate files so that other files can use them without importing `channel.ts` and `subchannel.ts` respectively. The load balancer registry code also makes the default configurable instead of hardcoding it as pick_first, to avoid a dependency cycle between that code and the pick_first code.

This only addresses dependency cycles in the compiled code, because that's what I had a tool to detect. Plus, dependency cycles that include type-only imports shouldn't really be a problem, as long as the types themselves are not cyclically defined.

This addresses #1821.