### PR TITLE
Prevent early return in proto-loader containsDefinition

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -583,8 +583,8 @@ function containsDefinition(definitionType: typeof Protobuf.Type | typeof Protob
   for (const nested of namespace.nestedArray.sort(compareName)) {
     if (nested instanceof definitionType) {
       return true;
-    } else if (isNamespaceBase(nested) && !(nested instanceof Protobuf.Type) && !(nested instanceof Protobuf.Enum)) {
-      return containsDefinition(definitionType, nested);
+    } else if (isNamespaceBase(nested) && !(nested instanceof Protobuf.Type) && !(nested instanceof Protobuf.Enum) && containsDefinition(definitionType, nested)) {
+      return true;
     }
   }
 


### PR DESCRIPTION
Closes #1830.

f289c343b3393aad73795c0657415f4160bcdcb5 introduced a bug - the recursive for-loop descended into the first element's nested array and returned that value without iterating over the other members of the array. This means that the code would only work correctly when the protofile contained a definition whose name was alphabetically before the first  first amongst its siblings.

This commit fixes the issue by only returning early when `containsDefinition` returns true.

This change results in no effect on the output of `yarn generate-golden` - it seems that the echo.proto file used to generate the test output has enough cases where the target type appears before a namespace base sibling that the bug is not exposed.