### PR TITLE
grpc-js-xds: case_sensitive flag should not affect regex matcher

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {

--- a/packages/grpc-js-xds/src/matcher.ts
+++ b/packages/grpc-js-xds/src/matcher.ts
@@ -197,8 +197,8 @@ export class PathExactValueMatcher {
 
 export class PathSafeRegexValueMatcher {
   private targetRegexImpl: RE2;
-  constructor(targetRegex: string, caseInsensitive: boolean) {
-    this.targetRegexImpl = new RE2(`^${targetRegex}$`, caseInsensitive ? 'iu' : 'u');
+  constructor(targetRegex: string) {
+    this.targetRegexImpl = new RE2(`^${targetRegex}$`, 'u');
   }
 
   apply(value: string) {

--- a/packages/grpc-js-xds/src/resolver-xds.ts
+++ b/packages/grpc-js-xds/src/resolver-xds.ts
@@ -169,7 +169,7 @@ function getPredicateForMatcher(routeMatch: RouteMatch__Output): Matcher {
       pathMatcher = new PathExactValueMatcher(routeMatch.path!, caseInsensitive);
       break;
     case 'safe_regex':
-      pathMatcher = new PathSafeRegexValueMatcher(routeMatch.safe_regex!.regex, caseInsensitive);
+      pathMatcher = new PathSafeRegexValueMatcher(routeMatch.safe_regex!.regex);
       break;
     default:
       pathMatcher = new RejectValueMatcher();


### PR DESCRIPTION
This is a correction to existing functionality, according to a conversation in the internal xDS chat room.