### PR TITLE
grpc-js: Format source files and fix lint errors

### DIFF
--- a/packages/grpc-js/src/call-credentials-filter.ts
+++ b/packages/grpc-js/src/call-credentials-filter.ts
@@ -66,7 +66,9 @@ export class CallCredentialsFilter extends BaseFilter implements Filter {
         Status.INTERNAL,
         '"authorization" metadata cannot have multiple values'
       );
-      return Promise.reject<Metadata>('"authorization" metadata cannot have multiple values');
+      return Promise.reject<Metadata>(
+        '"authorization" metadata cannot have multiple values'
+      );
     }
     return resultMetadata;
   }

--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -57,7 +57,7 @@ interface SystemError extends Error {
  * Should do approximately the same thing as util.getSystemErrorName but the
  * TypeScript types don't have that function for some reason so I just made my
  * own.
- * @param errno 
+ * @param errno
  */
 function getSystemErrorName(errno: number): string {
   for (const [name, num] of Object.entries(os.constants.errno)) {
@@ -71,9 +71,10 @@ function getSystemErrorName(errno: number): string {
 export type Deadline = Date | number;
 
 function getMinDeadline(deadlineList: Deadline[]): Deadline {
-  let minValue: number = Infinity;
+  let minValue = Infinity;
   for (const deadline of deadlineList) {
-    const deadlineMsecs = deadline instanceof Date ? deadline.getTime() : deadline;
+    const deadlineMsecs =
+      deadline instanceof Date ? deadline.getTime() : deadline;
     if (deadlineMsecs < minValue) {
       minValue = deadlineMsecs;
     }
@@ -265,7 +266,10 @@ export class Http2CallStream implements Call {
         metadata: new Metadata(),
       });
     };
-    if (this.options.parentCall && this.options.flags & Propagate.CANCELLATION) {
+    if (
+      this.options.parentCall &&
+      this.options.flags & Propagate.CANCELLATION
+    ) {
       this.options.parentCall.on('cancelled', () => {
         this.cancelWithStatus(Status.CANCELLED, 'Cancelled by parent call');
       });
@@ -464,7 +468,9 @@ export class Http2CallStream implements Call {
     subchannel: Subchannel,
     extraFilters: FilterFactory<Filter>[]
   ): void {
-    this.filterStack.push(extraFilters.map(filterFactory => filterFactory.createFilter(this)));
+    this.filterStack.push(
+      extraFilters.map((filterFactory) => filterFactory.createFilter(this))
+    );
     if (this.finalStatus !== null) {
       stream.close(NGHTTP2_CANCEL);
     } else {
@@ -548,7 +554,7 @@ export class Http2CallStream implements Call {
       stream.on('close', () => {
         /* Use process.next tick to ensure that this code happens after any
          * "error" event that may be emitted at about the same time, so that
-         * we can bubble up the error message from that event. */ 
+         * we can bubble up the error message from that event. */
         process.nextTick(() => {
           this.trace('HTTP/2 stream closed with code ' + stream.rstCode);
           /* If we have a final status with an OK status code, that means that
@@ -629,7 +635,16 @@ export class Http2CallStream implements Call {
          * https://github.com/nodejs/node/blob/8b8620d580314050175983402dfddf2674e8e22a/lib/internal/http2/core.js#L2267
          */
         if (err.code !== 'ERR_HTTP2_STREAM_ERROR') {
-          this.trace('Node error event: message=' + err.message + ' code=' + err.code + ' errno=' + getSystemErrorName(err.errno) + ' syscall=' + err.syscall);
+          this.trace(
+            'Node error event: message=' +
+              err.message +
+              ' code=' +
+              err.code +
+              ' errno=' +
+              getSystemErrorName(err.errno) +
+              ' syscall=' +
+              err.syscall
+          );
           this.internalError = err;
         }
       });

--- a/packages/grpc-js/src/call.ts
+++ b/packages/grpc-js/src/call.ts
@@ -81,7 +81,8 @@ export function callErrorFromStatus(status: StatusObject): ServiceError {
   return Object.assign(new Error(message), status);
 }
 
-export class ClientUnaryCallImpl extends EventEmitter
+export class ClientUnaryCallImpl
+  extends EventEmitter
   implements ClientUnaryCall {
   public call?: InterceptingCallInterface;
   constructor() {
@@ -97,7 +98,8 @@ export class ClientUnaryCallImpl extends EventEmitter
   }
 }
 
-export class ClientReadableStreamImpl<ResponseType> extends Readable
+export class ClientReadableStreamImpl<ResponseType>
+  extends Readable
   implements ClientReadableStream<ResponseType> {
   public call?: InterceptingCallInterface;
   constructor(readonly deserialize: (chunk: Buffer) => ResponseType) {
@@ -117,7 +119,8 @@ export class ClientReadableStreamImpl<ResponseType> extends Readable
   }
 }
 
-export class ClientWritableStreamImpl<RequestType> extends Writable
+export class ClientWritableStreamImpl<RequestType>
+  extends Writable
   implements ClientWritableStream<RequestType> {
   public call?: InterceptingCallInterface;
   constructor(readonly serialize: (value: RequestType) => Buffer) {
@@ -149,7 +152,8 @@ export class ClientWritableStreamImpl<RequestType> extends Writable
   }
 }
 
-export class ClientDuplexStreamImpl<RequestType, ResponseType> extends Duplex
+export class ClientDuplexStreamImpl<RequestType, ResponseType>
+  extends Duplex
   implements ClientDuplexStream<RequestType, ResponseType> {
   public call?: InterceptingCallInterface;
   constructor(

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -37,6 +37,7 @@ export interface ChannelOptions {
   'grpc.http_connect_target'?: string;
   'grpc.http_connect_creds'?: string;
   'grpc-node.max_session_memory'?: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
 

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -33,9 +33,14 @@ import { FilterStackFactory } from './filter-stack';
 import { CallCredentialsFilterFactory } from './call-credentials-filter';
 import { DeadlineFilterFactory } from './deadline-filter';
 import { CompressionFilterFactory } from './compression-filter';
-import { CallConfig, ConfigSelector, getDefaultAuthority, mapUriDefaultScheme } from './resolver';
+import {
+  CallConfig,
+  ConfigSelector,
+  getDefaultAuthority,
+  mapUriDefaultScheme,
+} from './resolver';
 import { trace, log } from './logging';
-import { SubchannelAddress } from "./subchannel-address";
+import { SubchannelAddress } from './subchannel-address';
 import { MaxMessageSizeFilterFactory } from './max-message-size-filter';
 import { mapProxyName } from './http_proxy';
 import { GrpcUri, parseUri, uriToString } from './uri-parser';
@@ -253,8 +258,8 @@ export class ChannelImplementation implements Channel {
         process.nextTick(() => {
           const localQueue = this.configSelectionQueue;
           this.configSelectionQueue = [];
-          this.callRefTimerUnref()
-          for (const {callStream, callMetadata} of localQueue) {
+          this.callRefTimerUnref();
+          for (const { callStream, callMetadata } of localQueue) {
             this.tryGetConfig(callStream, callMetadata);
           }
           this.configSelectionQueue = [];
@@ -262,15 +267,21 @@ export class ChannelImplementation implements Channel {
       },
       (status) => {
         if (this.configSelectionQueue.length > 0) {
-          trace(LogVerbosity.DEBUG, 'channel', 'Name resolution failed for target ' + uriToString(this.target) + ' with calls queued for config selection');
+          trace(
+            LogVerbosity.DEBUG,
+            'channel',
+            'Name resolution failed for target ' +
+              uriToString(this.target) +
+              ' with calls queued for config selection'
+          );
         }
         const localQueue = this.configSelectionQueue;
         this.configSelectionQueue = [];
         this.callRefTimerUnref();
-        for (const {callStream, callMetadata} of localQueue) {
+        for (const { callStream, callMetadata } of localQueue) {
           if (callMetadata.getOptions().waitForReady) {
             this.callRefTimerRef();
-            this.configSelectionQueue.push({callStream, callMetadata});
+            this.configSelectionQueue.push({ callStream, callMetadata });
           } else {
             callStream.cancelWithStatus(status.code, status.details);
           }
@@ -288,20 +299,38 @@ export class ChannelImplementation implements Channel {
   private callRefTimerRef() {
     // If the hasRef function does not exist, always run the code
     if (!this.callRefTimer.hasRef?.()) {
-      trace(LogVerbosity.DEBUG, 'channel', 'callRefTimer.ref | configSelectionQueue.length=' + this.configSelectionQueue.length + ' pickQueue.length=' + this.pickQueue.length);
+      trace(
+        LogVerbosity.DEBUG,
+        'channel',
+        'callRefTimer.ref | configSelectionQueue.length=' +
+          this.configSelectionQueue.length +
+          ' pickQueue.length=' +
+          this.pickQueue.length
+      );
       this.callRefTimer.ref?.();
     }
   }
 
   private callRefTimerUnref() {
     // If the hasRef function does not exist, always run the code
-    if ((!this.callRefTimer.hasRef) || (this.callRefTimer.hasRef())) {
-      trace(LogVerbosity.DEBUG, 'channel', 'callRefTimer.unref | configSelectionQueue.length=' + this.configSelectionQueue.length + ' pickQueue.length=' + this.pickQueue.length);
+    if (!this.callRefTimer.hasRef || this.callRefTimer.hasRef()) {
+      trace(
+        LogVerbosity.DEBUG,
+        'channel',
+        'callRefTimer.unref | configSelectionQueue.length=' +
+          this.configSelectionQueue.length +
+          ' pickQueue.length=' +
+          this.pickQueue.length
+      );
       this.callRefTimer.unref?.();
     }
   }
 
-  private pushPick(callStream: Http2CallStream, callMetadata: Metadata, callConfig: CallConfig) {
+  private pushPick(
+    callStream: Http2CallStream,
+    callMetadata: Metadata,
+    callConfig: CallConfig
+  ) {
     this.pickQueue.push({ callStream, callMetadata, callConfig });
     this.callRefTimerRef();
   }
@@ -313,8 +342,15 @@ export class ChannelImplementation implements Channel {
    * @param callStream
    * @param callMetadata
    */
-  private tryPick(callStream: Http2CallStream, callMetadata: Metadata, callConfig: CallConfig) {
-    const pickResult = this.currentPicker.pick({ metadata: callMetadata, extraPickInfo: callConfig.pickInformation });
+  private tryPick(
+    callStream: Http2CallStream,
+    callMetadata: Metadata,
+    callConfig: CallConfig
+  ) {
+    const pickResult = this.currentPicker.pick({
+      metadata: callMetadata,
+      extraPickInfo: callConfig.pickInformation,
+    });
     trace(
       LogVerbosity.DEBUG,
       'channel',
@@ -412,7 +448,9 @@ export class ChannelImplementation implements Channel {
                       );
                       callStream.cancelWithStatus(
                         Status.INTERNAL,
-                        `Failed to start HTTP/2 stream with error: ${(error as Error).message}`
+                        `Failed to start HTTP/2 stream with error: ${
+                          (error as Error).message
+                        }`
                       );
                     }
                   }
@@ -434,7 +472,7 @@ export class ChannelImplementation implements Channel {
               (error: Error & { code: number }) => {
                 // We assume the error code isn't 0 (Status.OK)
                 callStream.cancelWithStatus(
-                  (typeof error.code === 'number') ? error.code : Status.UNKNOWN,
+                  typeof error.code === 'number' ? error.code : Status.UNKNOWN,
                   `Getting metadata from plugin failed with error: ${error.message}`
                 );
               }
@@ -492,7 +530,7 @@ export class ChannelImplementation implements Channel {
     const watchersCopy = this.connectivityStateWatchers.slice();
     for (const watcherObject of watchersCopy) {
       if (newState !== watcherObject.currentState) {
-        if(watcherObject.timer) {
+        if (watcherObject.timer) {
           clearTimeout(watcherObject.timer);
         }
         this.removeConnectivityStateWatcher(watcherObject);
@@ -513,9 +551,9 @@ export class ChannelImplementation implements Channel {
        * ResolvingLoadBalancer may be idle and if so it needs to be kicked
        * because it now has a pending request. */
       this.resolvingLoadBalancer.exitIdle();
-      this.configSelectionQueue.push({ 
+      this.configSelectionQueue.push({
         callStream: stream,
-        callMetadata: metadata
+        callMetadata: metadata,
       });
       this.callRefTimerRef();
     } else {
@@ -523,15 +561,23 @@ export class ChannelImplementation implements Channel {
       if (callConfig.status === Status.OK) {
         if (callConfig.methodConfig.timeout) {
           const deadline = new Date();
-          deadline.setSeconds(deadline.getSeconds() + callConfig.methodConfig.timeout.seconds);
-          deadline.setMilliseconds(deadline.getMilliseconds() + callConfig.methodConfig.timeout.nanos / 1_000_000);
+          deadline.setSeconds(
+            deadline.getSeconds() + callConfig.methodConfig.timeout.seconds
+          );
+          deadline.setMilliseconds(
+            deadline.getMilliseconds() +
+              callConfig.methodConfig.timeout.nanos / 1_000_000
+          );
           stream.setConfigDeadline(deadline);
           // Refreshing the filters makes the deadline filter pick up the new deadline
           stream.filterStack.refresh();
         }
         this.tryPick(stream, metadata, callConfig);
       } else {
-        stream.cancelWithStatus(callConfig.status, "Failed to route call to method " + stream.getMethod());
+        stream.cancelWithStatus(
+          callConfig.status,
+          'Failed to route call to method ' + stream.getMethod()
+        );
       }
     }
   }
@@ -569,7 +615,7 @@ export class ChannelImplementation implements Channel {
       throw new Error('Channel has been shut down');
     }
     let timer = null;
-    if(deadline !== Infinity) {
+    if (deadline !== Infinity) {
       const deadlineDate: Date =
         deadline instanceof Date ? deadline : new Date(deadline);
       const now = new Date();
@@ -585,12 +631,12 @@ export class ChannelImplementation implements Channel {
         callback(
           new Error('Deadline passed without connectivity state change')
         );
-      }, deadlineDate.getTime() - now.getTime())
+      }, deadlineDate.getTime() - now.getTime());
     }
     const watcherObject = {
       currentState,
       callback,
-      timer
+      timer,
     };
     this.connectivityStateWatchers.push(watcherObject);
   }

--- a/packages/grpc-js/src/client-interceptors.ts
+++ b/packages/grpc-js/src/client-interceptors.ts
@@ -348,7 +348,10 @@ class BaseInterceptingCall implements InterceptingCallInterface {
     try {
       serialized = this.methodDefinition.requestSerialize(message);
     } catch (e) {
-      this.call.cancelWithStatus(Status.INTERNAL, `Request message serialization failure: ${e.message}`);
+      this.call.cancelWithStatus(
+        Status.INTERNAL,
+        `Request message serialization failure: ${e.message}`
+      );
       return;
     }
     this.call.sendMessageWithContext(context, serialized);
@@ -403,7 +406,8 @@ class BaseInterceptingCall implements InterceptingCallInterface {
  * BaseInterceptingCall with special-cased behavior for methods with unary
  * responses.
  */
-class BaseUnaryInterceptingCall extends BaseInterceptingCall
+class BaseUnaryInterceptingCall
+  extends BaseInterceptingCall
   implements InterceptingCallInterface {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(call: Call, methodDefinition: ClientMethodDefinition<any, any>) {
@@ -435,7 +439,8 @@ class BaseUnaryInterceptingCall extends BaseInterceptingCall
  * BaseInterceptingCall with special-cased behavior for methods with streaming
  * responses.
  */
-class BaseStreamingInterceptingCall extends BaseInterceptingCall
+class BaseStreamingInterceptingCall
+  extends BaseInterceptingCall
   implements InterceptingCallInterface {}
 
 function getBottomInterceptingCall(

--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -31,7 +31,7 @@ import {
 import { CallCredentials } from './call-credentials';
 import { Deadline, StatusObject } from './call-stream';
 import { Channel, ChannelImplementation } from './channel';
-import { ConnectivityState } from "./connectivity-state";
+import { ConnectivityState } from './connectivity-state';
 import { ChannelCredentials } from './channel-credentials';
 import { ChannelOptions } from './channel-options';
 import { Status } from './constants';
@@ -56,7 +56,9 @@ const INTERCEPTOR_SYMBOL = Symbol();
 const INTERCEPTOR_PROVIDER_SYMBOL = Symbol();
 const CALL_INVOCATION_TRANSFORMER_SYMBOL = Symbol();
 
-function isFunction<ResponseType>(arg: Metadata | CallOptions | UnaryCallback<ResponseType> | undefined): arg is UnaryCallback<ResponseType>{
+function isFunction<ResponseType>(
+  arg: Metadata | CallOptions | UnaryCallback<ResponseType> | undefined
+): arg is UnaryCallback<ResponseType> {
   return typeof arg === 'function';
 }
 
@@ -266,9 +268,11 @@ export class Client {
     options?: CallOptions | UnaryCallback<ResponseType>,
     callback?: UnaryCallback<ResponseType>
   ): ClientUnaryCall {
-    const checkedArguments = this.checkOptionalUnaryResponseArguments<
-      ResponseType
-    >(metadata, options, callback);
+    const checkedArguments = this.checkOptionalUnaryResponseArguments<ResponseType>(
+      metadata,
+      options,
+      callback
+    );
     const methodDefinition: ClientMethodDefinition<
       RequestType,
       ResponseType
@@ -382,9 +386,11 @@ export class Client {
     options?: CallOptions | UnaryCallback<ResponseType>,
     callback?: UnaryCallback<ResponseType>
   ): ClientWritableStream<RequestType> {
-    const checkedArguments = this.checkOptionalUnaryResponseArguments<
-      ResponseType
-    >(metadata, options, callback);
+    const checkedArguments = this.checkOptionalUnaryResponseArguments<ResponseType>(
+      metadata,
+      options,
+      callback
+    );
     const methodDefinition: ClientMethodDefinition<
       RequestType,
       ResponseType
@@ -408,9 +414,7 @@ export class Client {
         callProperties
       ) as CallProperties<RequestType, ResponseType>;
     }
-    const emitter: ClientWritableStream<RequestType> = callProperties.call as ClientWritableStream<
-      RequestType
-    >;
+    const emitter: ClientWritableStream<RequestType> = callProperties.call as ClientWritableStream<RequestType>;
     const interceptorArgs: InterceptorArguments = {
       clientInterceptors: this[INTERCEPTOR_SYMBOL],
       clientInterceptorProviders: this[INTERCEPTOR_PROVIDER_SYMBOL],
@@ -532,9 +536,7 @@ export class Client {
         callProperties
       ) as CallProperties<RequestType, ResponseType>;
     }
-    const stream: ClientReadableStream<ResponseType> = callProperties.call as ClientReadableStream<
-      ResponseType
-    >;
+    const stream: ClientReadableStream<ResponseType> = callProperties.call as ClientReadableStream<ResponseType>;
     const interceptorArgs: InterceptorArguments = {
       clientInterceptors: this[INTERCEPTOR_SYMBOL],
       clientInterceptorProviders: this[INTERCEPTOR_PROVIDER_SYMBOL],
@@ -659,7 +661,7 @@ export class Client {
         stream.emit('metadata', metadata);
       },
       onReceiveMessage(message: Buffer) {
-        stream.push(message)
+        stream.push(message);
       },
       onReceiveStatus(status: StatusObject) {
         if (receivedStatus) {
@@ -676,4 +678,3 @@ export class Client {
     return stream;
   }
 }
-

--- a/packages/grpc-js/src/connectivity-state.ts
+++ b/packages/grpc-js/src/connectivity-state.ts
@@ -20,5 +20,5 @@ export enum ConnectivityState {
   CONNECTING,
   READY,
   TRANSIENT_FAILURE,
-  SHUTDOWN
+  SHUTDOWN,
 }

--- a/packages/grpc-js/src/constants.ts
+++ b/packages/grpc-js/src/constants.ts
@@ -52,7 +52,11 @@ export enum Propagate {
   CENSUS_TRACING_CONTEXT = 4,
   CANCELLATION = 8,
   // https://github.com/grpc/grpc/blob/master/include/grpc/impl/codegen/propagation_bits.h#L43
-  DEFAULTS = 0xffff | Propagate.DEADLINE | Propagate.CENSUS_STATS_CONTEXT | Propagate.CENSUS_TRACING_CONTEXT | Propagate.CANCELLATION,
+  DEFAULTS = 0xffff |
+    Propagate.DEADLINE |
+    Propagate.CENSUS_STATS_CONTEXT |
+    Propagate.CENSUS_TRACING_CONTEXT |
+    Propagate.CANCELLATION,
 }
 
 // -1 means unlimited

--- a/packages/grpc-js/src/deadline-filter.ts
+++ b/packages/grpc-js/src/deadline-filter.ts
@@ -42,7 +42,7 @@ function getDeadline(deadline: number) {
 
 export class DeadlineFilter extends BaseFilter implements Filter {
   private timer: NodeJS.Timer | null = null;
-  private deadline: number = Infinity;
+  private deadline = Infinity;
   constructor(
     private readonly channel: Channel,
     private readonly callStream: Call
@@ -66,7 +66,7 @@ export class DeadlineFilter extends BaseFilter implements Filter {
       clearTimeout(this.timer);
     }
     const now: number = new Date().getTime();
-    let timeout = this.deadline - now;
+    const timeout = this.deadline - now;
     if (timeout <= 0) {
       process.nextTick(() => {
         this.callStream.cancelWithStatus(

--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -1,12 +1,34 @@
 export { trace } from './logging';
-export { Resolver, ResolverListener, registerResolver, ConfigSelector } from './resolver';
+export {
+  Resolver,
+  ResolverListener,
+  registerResolver,
+  ConfigSelector,
+} from './resolver';
 export { GrpcUri, uriToString } from './uri-parser';
 export { ServiceConfig, Duration } from './service-config';
 export { BackoffTimeout } from './backoff-timeout';
-export { LoadBalancer, LoadBalancingConfig, ChannelControlHelper, registerLoadBalancerType, getFirstUsableConfig, validateLoadBalancingConfig } from './load-balancer';
-export { SubchannelAddress, subchannelAddressToString } from './subchannel-address';
+export {
+  LoadBalancer,
+  LoadBalancingConfig,
+  ChannelControlHelper,
+  registerLoadBalancerType,
+  getFirstUsableConfig,
+  validateLoadBalancingConfig,
+} from './load-balancer';
+export {
+  SubchannelAddress,
+  subchannelAddressToString,
+} from './subchannel-address';
 export { ChildLoadBalancerHandler } from './load-balancer-child-handler';
-export { Picker, UnavailablePicker, QueuePicker, PickResult, PickArgs, PickResultType } from './picker';
+export {
+  Picker,
+  UnavailablePicker,
+  QueuePicker,
+  PickResult,
+  PickArgs,
+  PickResultType,
+} from './picker';
 export { Call as CallStream } from './call-stream';
 export { Filter, BaseFilter, FilterFactory } from './filter';
 export { FilterStackFactory } from './filter-stack';

--- a/packages/grpc-js/src/filter.ts
+++ b/packages/grpc-js/src/filter.ts
@@ -57,8 +57,7 @@ export abstract class BaseFilter implements Filter {
     return status;
   }
 
-  refresh(): void {
-  }
+  refresh(): void {}
 }
 
 export interface FilterFactory<T extends Filter> {

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -25,8 +25,8 @@ import * as logging from './logging';
 import {
   SubchannelAddress,
   isTcpSubchannelAddress,
-  subchannelAddressToString
-} from "./subchannel-address";
+  subchannelAddressToString,
+} from './subchannel-address';
 import { ChannelOptions } from './channel-options';
 import { GrpcUri, parseUri, splitHostPort, uriToString } from './uri-parser';
 import { URL } from 'url';
@@ -93,7 +93,7 @@ function getProxyInfo(): ProxyInfo {
     port = '80';
   }
   const result: ProxyInfo = {
-    address: `${hostname}:${port}`
+    address: `${hostname}:${port}`,
   };
   if (userCred) {
     result.creds = userCred;
@@ -147,7 +147,9 @@ export function mapProxyName(
   const serverHost = hostPort.host;
   for (const host of getNoProxyHostList()) {
     if (host === serverHost) {
-      trace('Not using proxy for target in no_proxy list: ' + uriToString(target));
+      trace(
+        'Not using proxy for target in no_proxy list: ' + uriToString(target)
+      );
       return noProxyResult;
     }
   }
@@ -226,7 +228,7 @@ export function getProxiedConnection(
           const targetPath = getDefaultAuthority(parsedTarget);
           const hostPort = splitHostPort(targetPath);
           const remoteHost = hostPort?.host ?? targetPath;
-          
+
           const cts = tls.connect(
             {
               host: remoteHost,

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -25,7 +25,7 @@ import {
 import { CallCredentials, OAuth2Client } from './call-credentials';
 import { Deadline, StatusObject } from './call-stream';
 import { Channel, ChannelImplementation } from './channel';
-import { ConnectivityState } from "./connectivity-state";
+import { ConnectivityState } from './connectivity-state';
 import { ChannelCredentials } from './channel-credentials';
 import {
   CallOptions,
@@ -183,7 +183,12 @@ export {
 
 /**** Server ****/
 
-export { handleBidiStreamingCall, handleServerStreamingCall, handleUnaryCall, handleClientStreamingCall };
+export {
+  handleBidiStreamingCall,
+  handleServerStreamingCall,
+  handleUnaryCall,
+  handleClientStreamingCall,
+};
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type Call =

--- a/packages/grpc-js/src/load-balancer-child-handler.ts
+++ b/packages/grpc-js/src/load-balancer-child-handler.ts
@@ -19,12 +19,12 @@ import {
   LoadBalancer,
   ChannelControlHelper,
   LoadBalancingConfig,
-  createLoadBalancer
+  createLoadBalancer,
 } from './load-balancer';
 import { Subchannel } from './subchannel';
-import { SubchannelAddress } from "./subchannel-address";
+import { SubchannelAddress } from './subchannel-address';
 import { ChannelOptions } from './channel-options';
-import { ConnectivityState } from "./connectivity-state";
+import { ConnectivityState } from './connectivity-state';
 import { Picker } from './picker';
 
 const TYPE_NAME = 'child_load_balancer_helper';

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -19,10 +19,10 @@ import {
   LoadBalancer,
   ChannelControlHelper,
   LoadBalancingConfig,
-  registerDefaultLoadBalancerType, 
-  registerLoadBalancerType
+  registerDefaultLoadBalancerType,
+  registerLoadBalancerType,
 } from './load-balancer';
-import { ConnectivityState } from "./connectivity-state";
+import { ConnectivityState } from './connectivity-state';
 import {
   QueuePicker,
   Picker,
@@ -31,14 +31,11 @@ import {
   PickResultType,
   UnavailablePicker,
 } from './picker';
-import {
-  Subchannel,
-  ConnectivityStateListener,
-} from './subchannel';
+import { Subchannel, ConnectivityStateListener } from './subchannel';
 import {
   SubchannelAddress,
-  subchannelAddressToString
-} from "./subchannel-address";
+  subchannelAddressToString,
+} from './subchannel-address';
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
 
@@ -65,10 +62,11 @@ export class PickFirstLoadBalancingConfig implements LoadBalancingConfig {
 
   toJsonObject(): object {
     return {
-      [TYPE_NAME]: {}
+      [TYPE_NAME]: {},
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static createFromJson(obj: any) {
     return new PickFirstLoadBalancingConfig();
   }
@@ -460,6 +458,10 @@ export class PickFirstLoadBalancer implements LoadBalancer {
 }
 
 export function setup(): void {
-  registerLoadBalancerType(TYPE_NAME, PickFirstLoadBalancer, PickFirstLoadBalancingConfig);
+  registerLoadBalancerType(
+    TYPE_NAME,
+    PickFirstLoadBalancer,
+    PickFirstLoadBalancingConfig
+  );
   registerDefaultLoadBalancerType(TYPE_NAME);
 }

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -19,9 +19,9 @@ import {
   LoadBalancer,
   ChannelControlHelper,
   LoadBalancingConfig,
-  registerLoadBalancerType
+  registerLoadBalancerType,
 } from './load-balancer';
-import { ConnectivityState } from "./connectivity-state";
+import { ConnectivityState } from './connectivity-state';
 import {
   QueuePicker,
   Picker,
@@ -30,14 +30,11 @@ import {
   PickResultType,
   UnavailablePicker,
 } from './picker';
-import {
-  Subchannel,
-  ConnectivityStateListener,
-} from './subchannel';
+import { Subchannel, ConnectivityStateListener } from './subchannel';
 import {
   SubchannelAddress,
-  subchannelAddressToString
-} from "./subchannel-address";
+  subchannelAddressToString,
+} from './subchannel-address';
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
 
@@ -58,10 +55,11 @@ class RoundRobinLoadBalancingConfig implements LoadBalancingConfig {
 
   toJsonObject(): object {
     return {
-      [TYPE_NAME]: {}
+      [TYPE_NAME]: {},
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static createFromJson(obj: any) {
     return new RoundRobinLoadBalancingConfig();
   }
@@ -130,7 +128,7 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
       this.subchannelStateCounts[previousState] -= 1;
       this.subchannelStateCounts[newState] += 1;
       this.calculateAndUpdateState();
-      
+
       if (
         newState === ConnectivityState.TRANSIENT_FAILURE ||
         newState === ConnectivityState.IDLE
@@ -249,5 +247,9 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
 }
 
 export function setup() {
-  registerLoadBalancerType(TYPE_NAME, RoundRobinLoadBalancer, RoundRobinLoadBalancingConfig);
+  registerLoadBalancerType(
+    TYPE_NAME,
+    RoundRobinLoadBalancer,
+    RoundRobinLoadBalancingConfig
+  );
 }

--- a/packages/grpc-js/src/load-balancer.ts
+++ b/packages/grpc-js/src/load-balancer.ts
@@ -17,8 +17,8 @@
 
 import { ChannelOptions } from './channel-options';
 import { Subchannel } from './subchannel';
-import { SubchannelAddress } from "./subchannel-address";
-import { ConnectivityState } from "./connectivity-state";
+import { SubchannelAddress } from './subchannel-address';
+import { ConnectivityState } from './connectivity-state';
 import { Picker } from './picker';
 
 /**
@@ -101,7 +101,9 @@ export interface LoadBalancingConfig {
 }
 
 export interface LoadBalancingConfigConstructor {
-  new(...args: any): LoadBalancingConfig;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any): LoadBalancingConfig;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createFromJson(obj: any): LoadBalancingConfig;
 }
 
@@ -121,7 +123,7 @@ export function registerLoadBalancerType(
 ) {
   registeredLoadBalancerTypes[typeName] = {
     LoadBalancer: loadBalancerType,
-    LoadBalancingConfig: loadBalancingConfigType
+    LoadBalancingConfig: loadBalancingConfigType,
   };
 }
 
@@ -135,7 +137,9 @@ export function createLoadBalancer(
 ): LoadBalancer | null {
   const typeName = config.getLoadBalancerName();
   if (typeName in registeredLoadBalancerTypes) {
-    return new registeredLoadBalancerTypes[typeName].LoadBalancer(channelControlHelper);
+    return new registeredLoadBalancerTypes[typeName].LoadBalancer(
+      channelControlHelper
+    );
   } else {
     return null;
   }
@@ -145,10 +149,13 @@ export function isLoadBalancerNameRegistered(typeName: string): boolean {
   return typeName in registeredLoadBalancerTypes;
 }
 
-export function getFirstUsableConfig(configs: LoadBalancingConfig[], fallbackTodefault?: true): LoadBalancingConfig;
 export function getFirstUsableConfig(
   configs: LoadBalancingConfig[],
-  fallbackTodefault: boolean = false
+  fallbackTodefault?: true
+): LoadBalancingConfig;
+export function getFirstUsableConfig(
+  configs: LoadBalancingConfig[],
+  fallbackTodefault = false
 ): LoadBalancingConfig | null {
   for (const config of configs) {
     if (config.getLoadBalancerName() in registeredLoadBalancerTypes) {
@@ -157,7 +164,9 @@ export function getFirstUsableConfig(
   }
   if (fallbackTodefault) {
     if (defaultLoadBalancerType) {
-      return new registeredLoadBalancerTypes[defaultLoadBalancerType]!.LoadBalancingConfig();
+      return new registeredLoadBalancerTypes[
+        defaultLoadBalancerType
+      ]!.LoadBalancingConfig();
     } else {
       return null;
     }
@@ -166,17 +175,22 @@ export function getFirstUsableConfig(
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function validateLoadBalancingConfig(obj: any): LoadBalancingConfig {
-  if (!(obj !== null && (typeof obj === 'object'))) {
+  if (!(obj !== null && typeof obj === 'object')) {
     throw new Error('Load balancing config must be an object');
   }
   const keys = Object.keys(obj);
   if (keys.length !== 1) {
-    throw new Error('Provided load balancing config has multiple conflicting entries');
+    throw new Error(
+      'Provided load balancing config has multiple conflicting entries'
+    );
   }
   const typeName = keys[0];
   if (typeName in registeredLoadBalancerTypes) {
-    return registeredLoadBalancerTypes[typeName].LoadBalancingConfig.createFromJson(obj[typeName]);
+    return registeredLoadBalancerTypes[
+      typeName
+    ].LoadBalancingConfig.createFromJson(obj[typeName]);
   } else {
     throw new Error(`Unrecognized load balancing config name ${typeName}`);
   }

--- a/packages/grpc-js/src/logging.ts
+++ b/packages/grpc-js/src/logging.ts
@@ -20,7 +20,8 @@ import { LogVerbosity } from './constants';
 let _logger: Partial<Console> = console;
 let _logVerbosity: LogVerbosity = LogVerbosity.ERROR;
 
-const verbosityString = process.env.GRPC_NODE_VERBOSITY ?? process.env.GRPC_VERBOSITY ?? '';
+const verbosityString =
+  process.env.GRPC_NODE_VERBOSITY ?? process.env.GRPC_VERBOSITY ?? '';
 
 switch (verbosityString.toUpperCase()) {
   case 'DEBUG':
@@ -58,14 +59,15 @@ export const log = (severity: LogVerbosity, ...args: any[]): void => {
   }
 };
 
-const tracersString = process.env.GRPC_NODE_TRACE ?? process.env.GRPC_TRACE ?? '';
+const tracersString =
+  process.env.GRPC_NODE_TRACE ?? process.env.GRPC_TRACE ?? '';
 const enabledTracers = new Set<string>();
 const disabledTracers = new Set<string>();
 for (const tracerName of tracersString.split(',')) {
   if (tracerName.startsWith('-')) {
     disabledTracers.add(tracerName.substring(1));
   } else {
-    enabledTracers.add(tracerName)
+    enabledTracers.add(tracerName);
   }
 }
 const allEnabled = enabledTracers.has('all');
@@ -75,7 +77,10 @@ export function trace(
   tracer: string,
   text: string
 ): void {
-  if (!disabledTracers.has(tracer) && (allEnabled || enabledTracers.has(tracer))) {
+  if (
+    !disabledTracers.has(tracer) &&
+    (allEnabled || enabledTracers.has(tracer))
+  ) {
     log(severity, new Date().toISOString() + ' | ' + tracer + ' | ' + text);
   }
 }

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -98,7 +98,7 @@ export interface ServiceClientConstructor {
  * keys.
  * @param key key for check, string.
  */
-function isPrototypePolluted(key: string): Boolean {
+function isPrototypePolluted(key: string): boolean {
   return ['__proto__', 'prototype', 'constructor'].includes(key);
 }
 

--- a/packages/grpc-js/src/max-message-size-filter.ts
+++ b/packages/grpc-js/src/max-message-size-filter.ts
@@ -15,10 +15,14 @@
  *
  */
 
-import { BaseFilter, Filter, FilterFactory } from "./filter";
-import { Call, WriteObject } from "./call-stream";
-import { Status, DEFAULT_MAX_SEND_MESSAGE_LENGTH, DEFAULT_MAX_RECEIVE_MESSAGE_LENGTH } from "./constants";
-import { ChannelOptions } from "./channel-options";
+import { BaseFilter, Filter, FilterFactory } from './filter';
+import { Call, WriteObject } from './call-stream';
+import {
+  Status,
+  DEFAULT_MAX_SEND_MESSAGE_LENGTH,
+  DEFAULT_MAX_RECEIVE_MESSAGE_LENGTH,
+} from './constants';
+import { ChannelOptions } from './channel-options';
 
 export class MaxMessageSizeFilter extends BaseFilter implements Filter {
   private maxSendMessageSize: number = DEFAULT_MAX_SEND_MESSAGE_LENGTH;
@@ -44,7 +48,10 @@ export class MaxMessageSizeFilter extends BaseFilter implements Filter {
     } else {
       const concreteMessage = await message;
       if (concreteMessage.message.length > this.maxSendMessageSize) {
-        this.callStream.cancelWithStatus(Status.RESOURCE_EXHAUSTED, `Sent message larger than max (${concreteMessage.message.length} vs. ${this.maxSendMessageSize})`);
+        this.callStream.cancelWithStatus(
+          Status.RESOURCE_EXHAUSTED,
+          `Sent message larger than max (${concreteMessage.message.length} vs. ${this.maxSendMessageSize})`
+        );
         return Promise.reject<WriteObject>('Message too large');
       } else {
         return concreteMessage;
@@ -60,7 +67,10 @@ export class MaxMessageSizeFilter extends BaseFilter implements Filter {
     } else {
       const concreteMessage = await message;
       if (concreteMessage.length > this.maxReceiveMessageSize) {
-        this.callStream.cancelWithStatus(Status.RESOURCE_EXHAUSTED, `Received message larger than max (${concreteMessage.length} vs. ${this.maxReceiveMessageSize})`);
+        this.callStream.cancelWithStatus(
+          Status.RESOURCE_EXHAUSTED,
+          `Received message larger than max (${concreteMessage.length} vs. ${this.maxReceiveMessageSize})`
+        );
         return Promise.reject<Buffer>('Message too large');
       } else {
         return concreteMessage;
@@ -69,7 +79,8 @@ export class MaxMessageSizeFilter extends BaseFilter implements Filter {
   }
 }
 
-export class MaxMessageSizeFilterFactory implements FilterFactory<MaxMessageSizeFilter> {
+export class MaxMessageSizeFilterFactory
+  implements FilterFactory<MaxMessageSizeFilter> {
   constructor(private readonly options: ChannelOptions) {}
 
   createFilter(callStream: Call): MaxMessageSizeFilter {

--- a/packages/grpc-js/src/metadata.ts
+++ b/packages/grpc-js/src/metadata.ts
@@ -247,7 +247,7 @@ export class Metadata {
    * representation of the metadata map.
    */
   toJSON() {
-    const result: {[key: string]: MetadataValue[]} = {};
+    const result: { [key: string]: MetadataValue[] } = {};
     for (const [key, values] of this.internalRepr.entries()) {
       result[key] = values;
     }

--- a/packages/grpc-js/src/picker.ts
+++ b/packages/grpc-js/src/picker.ts
@@ -85,7 +85,7 @@ export interface DropCallPickResult extends PickResult {
 
 export interface PickArgs {
   metadata: Metadata;
-  extraPickInfo: {[key: string]: string};
+  extraPickInfo: { [key: string]: string };
 }
 
 /**

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -28,7 +28,7 @@ import { StatusObject } from './call-stream';
 import { Metadata } from './metadata';
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
-import { SubchannelAddress, TcpSubchannelAddress } from "./subchannel-address";
+import { SubchannelAddress, TcpSubchannelAddress } from './subchannel-address';
 import { GrpcUri, uriToString, splitHostPort } from './uri-parser';
 import { isIPv6, isIPv4 } from 'net';
 import { ChannelOptions } from './channel-options';
@@ -129,7 +129,13 @@ class DnsResolver implements Resolver {
     if (this.ipResult !== null) {
       trace('Returning IP address for target ' + uriToString(this.target));
       setImmediate(() => {
-        this.listener.onSuccessfulResolution(this.ipResult!, null, null, null, {});
+        this.listener.onSuccessfulResolution(
+          this.ipResult!,
+          null,
+          null,
+          null,
+          {}
+        );
       });
       return;
     }

--- a/packages/grpc-js/src/resolver-ip.ts
+++ b/packages/grpc-js/src/resolver-ip.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { isIPv4, isIPv6 } from "net";
-import { StatusObject } from "./call-stream";
-import { ChannelOptions } from "./channel-options";
-import { LogVerbosity, Status } from "./constants";
-import { Metadata } from "./metadata";
-import { registerResolver, Resolver, ResolverListener } from "./resolver";
-import { SubchannelAddress } from "./subchannel-address";
-import { GrpcUri, splitHostPort, uriToString } from "./uri-parser";
+import { isIPv4, isIPv6 } from 'net';
+import { StatusObject } from './call-stream';
+import { ChannelOptions } from './channel-options';
+import { LogVerbosity, Status } from './constants';
+import { Metadata } from './metadata';
+import { registerResolver, Resolver, ResolverListener } from './resolver';
+import { SubchannelAddress } from './subchannel-address';
+import { GrpcUri, splitHostPort, uriToString } from './uri-parser';
 import * as logging from './logging';
 
 const TRACER_NAME = 'ip_resolver';
@@ -52,7 +52,7 @@ class IpResolver implements Resolver {
       this.error = {
         code: Status.UNAVAILABLE,
         details: `Unrecognized scheme ${target.scheme} in IP resolver`,
-        metadata: new Metadata()
+        metadata: new Metadata(),
       };
       return;
     }
@@ -63,21 +63,24 @@ class IpResolver implements Resolver {
         this.error = {
           code: Status.UNAVAILABLE,
           details: `Failed to parse ${target.scheme} address ${path}`,
-          metadata: new Metadata()
+          metadata: new Metadata(),
         };
         return;
       }
-      if ((target.scheme === IPV4_SCHEME && !isIPv4(hostPort.host)) || (target.scheme === IPV6_SCHEME && !isIPv6(hostPort.host))) {
+      if (
+        (target.scheme === IPV4_SCHEME && !isIPv4(hostPort.host)) ||
+        (target.scheme === IPV6_SCHEME && !isIPv6(hostPort.host))
+      ) {
         this.error = {
           code: Status.UNAVAILABLE,
           details: `Failed to parse ${target.scheme} address ${path}`,
-          metadata: new Metadata()
+          metadata: new Metadata(),
         };
         return;
       }
       addresses.push({
         host: hostPort.host,
-        port: hostPort.port ?? DEFAULT_PORT
+        port: hostPort.port ?? DEFAULT_PORT,
       });
     }
     this.addresses = addresses;
@@ -86,9 +89,15 @@ class IpResolver implements Resolver {
   updateResolution(): void {
     process.nextTick(() => {
       if (this.error) {
-        this.listener.onError(this.error)
+        this.listener.onError(this.error);
       } else {
-        this.listener.onSuccessfulResolution(this.addresses, null, null, null, {});
+        this.listener.onSuccessfulResolution(
+          this.addresses,
+          null,
+          null,
+          null,
+          {}
+        );
       }
     });
   }

--- a/packages/grpc-js/src/resolver-uds.ts
+++ b/packages/grpc-js/src/resolver-uds.ts
@@ -15,7 +15,7 @@
  */
 
 import { Resolver, ResolverListener, registerResolver } from './resolver';
-import { SubchannelAddress } from "./subchannel-address";
+import { SubchannelAddress } from './subchannel-address';
 import { GrpcUri } from './uri-parser';
 import { ChannelOptions } from './channel-options';
 

--- a/packages/grpc-js/src/resolver.ts
+++ b/packages/grpc-js/src/resolver.ts
@@ -17,7 +17,7 @@
 
 import { MethodConfig, ServiceConfig } from './service-config';
 import { StatusObject } from './call-stream';
-import { SubchannelAddress } from "./subchannel-address";
+import { SubchannelAddress } from './subchannel-address';
 import { GrpcUri, uriToString } from './uri-parser';
 import { ChannelOptions } from './channel-options';
 import { Metadata } from './metadata';
@@ -26,7 +26,7 @@ import { Status } from './constants';
 export interface CallConfig {
   methodConfig: MethodConfig;
   onCommitted?: () => void;
-  pickInformation: {[key: string]: string};
+  pickInformation: { [key: string]: string };
   status: Status;
 }
 
@@ -78,7 +78,7 @@ export interface Resolver {
    * called synchronously with the constructor or updateResolution.
    */
   updateResolution(): void;
-  
+
   /**
    * Destroy the resolver. Should be called when the owning channel shuts down.
    */

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -19,10 +19,10 @@ import {
   ChannelControlHelper,
   LoadBalancer,
   LoadBalancingConfig,
-  getFirstUsableConfig
+  getFirstUsableConfig,
 } from './load-balancer';
 import { ServiceConfig, validateServiceConfig } from './service-config';
-import { ConnectivityState } from "./connectivity-state";
+import { ConnectivityState } from './connectivity-state';
 import { ConfigSelector, createResolver, Resolver } from './resolver';
 import { ServiceError } from './call';
 import { Picker, UnavailablePicker, QueuePicker } from './picker';
@@ -32,7 +32,7 @@ import { StatusObject } from './call-stream';
 import { Metadata } from './metadata';
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
-import { SubchannelAddress } from "./subchannel-address";
+import { SubchannelAddress } from './subchannel-address';
 import { GrpcUri, uriToString } from './uri-parser';
 import { ChildLoadBalancerHandler } from './load-balancer-child-handler';
 import { ChannelOptions } from './channel-options';
@@ -46,30 +46,38 @@ function trace(text: string): void {
 
 const DEFAULT_LOAD_BALANCER_NAME = 'pick_first';
 
-function getDefaultConfigSelector(serviceConfig: ServiceConfig | null): ConfigSelector {
-  return function defaultConfigSelector(methodName: string, metadata: Metadata) {
-    const splitName = methodName.split('/').filter(x => x.length > 0);
+function getDefaultConfigSelector(
+  serviceConfig: ServiceConfig | null
+): ConfigSelector {
+  return function defaultConfigSelector(
+    methodName: string,
+    metadata: Metadata
+  ) {
+    const splitName = methodName.split('/').filter((x) => x.length > 0);
     const service = splitName[0] ?? '';
     const method = splitName[1] ?? '';
     if (serviceConfig && serviceConfig.methodConfig) {
       for (const methodConfig of serviceConfig.methodConfig) {
         for (const name of methodConfig.name) {
-          if (name.service === service && (name.method === undefined || name.method === method)) {
+          if (
+            name.service === service &&
+            (name.method === undefined || name.method === method)
+          ) {
             return {
               methodConfig: methodConfig,
               pickInformation: {},
-              status: Status.OK
+              status: Status.OK,
             };
           }
         }
       }
     }
     return {
-      methodConfig: {name: []},
+      methodConfig: { name: [] },
       pickInformation: {},
-      status: Status.OK
+      status: Status.OK,
     };
-  }
+  };
 }
 
 export interface ResolutionCallback {
@@ -201,7 +209,10 @@ export class ResolvingLoadBalancer implements LoadBalancer {
           }
           const workingConfigList =
             workingServiceConfig?.loadBalancingConfig ?? [];
-          const loadBalancingConfig = getFirstUsableConfig(workingConfigList, true);
+          const loadBalancingConfig = getFirstUsableConfig(
+            workingConfigList,
+            true
+          );
           if (loadBalancingConfig === null) {
             // There were load balancing configs but none are supported. This counts as a resolution failure
             this.handleResolutionFailure({
@@ -217,8 +228,11 @@ export class ResolvingLoadBalancer implements LoadBalancer {
             loadBalancingConfig,
             attributes
           );
-          const finalServiceConfig = workingServiceConfig ?? this.defaultServiceConfig;
-          this.onSuccessfulResolution(configSelector ?? getDefaultConfigSelector(finalServiceConfig));
+          const finalServiceConfig =
+            workingServiceConfig ?? this.defaultServiceConfig;
+          this.onSuccessfulResolution(
+            configSelector ?? getDefaultConfigSelector(finalServiceConfig)
+          );
         },
         onError: (error: StatusObject) => {
           this.handleResolutionFailure(error);

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -100,7 +100,8 @@ export type ServerDuplexStream<RequestType, ResponseType> = ServerSurfaceCall &
   ObjectReadable<RequestType> &
   ObjectWritable<ResponseType> & { end: (metadata?: Metadata) => void };
 
-export class ServerUnaryCallImpl<RequestType, ResponseType> extends EventEmitter
+export class ServerUnaryCallImpl<RequestType, ResponseType>
+  extends EventEmitter
   implements ServerUnaryCall<RequestType, ResponseType> {
   cancelled: boolean;
 
@@ -239,7 +240,8 @@ export class ServerWritableStreamImpl<RequestType, ResponseType>
   }
 }
 
-export class ServerDuplexStreamImpl<RequestType, ResponseType> extends Duplex
+export class ServerDuplexStreamImpl<RequestType, ResponseType>
+  extends Duplex
   implements ServerDuplexStream<RequestType, ResponseType> {
   cancelled: boolean;
   private trailingMetadata: Metadata;

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -55,8 +55,8 @@ import {
   SubchannelAddress,
   TcpSubchannelAddress,
   isTcpSubchannelAddress,
-  subchannelAddressToString
-} from "./subchannel-address";
+  subchannelAddressToString,
+} from './subchannel-address';
 import { parseUri } from './uri-parser';
 
 const TRACER_NAME = 'server';
@@ -209,10 +209,7 @@ export class Server {
   }
 
   removeService(service: ServiceDefinition): void {
-    if (
-      service === null ||
-      typeof service !== 'object'
-    ) {
+    if (service === null || typeof service !== 'object') {
       throw new Error('removeService() requires object as argument');
     }
 
@@ -258,10 +255,12 @@ export class Server {
     }
 
     const serverOptions: http2.ServerOptions = {
-      maxSendHeaderBlockLength: Number.MAX_SAFE_INTEGER
+      maxSendHeaderBlockLength: Number.MAX_SAFE_INTEGER,
     };
     if ('grpc-node.max_session_memory' in this.options) {
-      serverOptions.maxSessionMemory = this.options['grpc-node.max_session_memory'];
+      serverOptions.maxSessionMemory = this.options[
+        'grpc-node.max_session_memory'
+      ];
     }
     if ('grpc.max_concurrent_streams' in this.options) {
       serverOptions.settings = {

--- a/packages/grpc-js/src/service-config.ts
+++ b/packages/grpc-js/src/service-config.ts
@@ -27,7 +27,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import * as os from 'os';
-import { LoadBalancingConfig, validateLoadBalancingConfig } from './load-balancer';
+import {
+  LoadBalancingConfig,
+  validateLoadBalancingConfig,
+} from './load-balancer';
 
 export interface MethodConfigName {
   service: string;
@@ -107,21 +110,30 @@ function validateMethodConfig(obj: any): MethodConfig {
   }
   if ('timeout' in obj) {
     if (typeof obj.timeout === 'object') {
-      if (!('seconds' in obj.timeout) || !(typeof obj.timeout.seconds === 'number')) {
+      if (
+        !('seconds' in obj.timeout) ||
+        !(typeof obj.timeout.seconds === 'number')
+      ) {
         throw new Error('Invalid method config: invalid timeout.seconds');
       }
-      if (!('nanos' in obj.timeout) || !(typeof obj.timeout.nanos === 'number')) {
+      if (
+        !('nanos' in obj.timeout) ||
+        !(typeof obj.timeout.nanos === 'number')
+      ) {
         throw new Error('Invalid method config: invalid timeout.nanos');
       }
       result.timeout = obj.timeout;
     } else if (
-      (typeof obj.timeout === 'string') && TIMEOUT_REGEX.test(obj.timeout)
+      typeof obj.timeout === 'string' &&
+      TIMEOUT_REGEX.test(obj.timeout)
     ) {
-      const timeoutParts = obj.timeout.substring(0, obj.timeout.length - 1).split('.');
+      const timeoutParts = obj.timeout
+        .substring(0, obj.timeout.length - 1)
+        .split('.');
       result.timeout = {
         seconds: timeoutParts[0] | 0,
-        nanos: (timeoutParts[1] ?? 0) | 0
-      }
+        nanos: (timeoutParts[1] ?? 0) | 0,
+      };
     } else {
       throw new Error('Invalid method config: invalid timeout');
     }

--- a/packages/grpc-js/src/subchannel-pool.ts
+++ b/packages/grpc-js/src/subchannel-pool.ts
@@ -16,13 +16,11 @@
  */
 
 import { ChannelOptions, channelOptionsEqual } from './channel-options';
-import {
-  Subchannel,
-} from './subchannel';
+import { Subchannel } from './subchannel';
 import {
   SubchannelAddress,
-  subchannelAddressEqual
-} from "./subchannel-address";
+  subchannelAddressEqual,
+} from './subchannel-address';
 import { ChannelCredentials } from './channel-credentials';
 import { GrpcUri, uriToString } from './uri-parser';
 

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -21,7 +21,7 @@ import { Metadata } from './metadata';
 import { Http2CallStream } from './call-stream';
 import { ChannelOptions } from './channel-options';
 import { PeerCertificate, checkServerIdentity } from 'tls';
-import { ConnectivityState } from "./connectivity-state";
+import { ConnectivityState } from './connectivity-state';
 import { BackoffTimeout, BackoffOptions } from './backoff-timeout';
 import { getDefaultAuthority } from './resolver';
 import * as logging from './logging';
@@ -31,7 +31,10 @@ import * as net from 'net';
 import { GrpcUri, parseUri, splitHostPort, uriToString } from './uri-parser';
 import { ConnectionOptions } from 'tls';
 import { FilterFactory, Filter } from './filter';
-import { SubchannelAddress, subchannelAddressToString } from './subchannel-address';
+import {
+  SubchannelAddress,
+  subchannelAddressToString,
+} from './subchannel-address';
 
 const clientVersion = require('../../package.json').version;
 
@@ -138,7 +141,7 @@ export class Subchannel {
   /**
    * Indicates whether keepalive pings should be sent without any active calls
    */
-  private keepaliveWithoutCalls: boolean = false;
+  private keepaliveWithoutCalls = false;
 
   /**
    * Tracks calls with references to this subchannel
@@ -186,7 +189,8 @@ export class Subchannel {
       this.keepaliveTimeoutMs = options['grpc.keepalive_timeout_ms']!;
     }
     if ('grpc.keepalive_permit_without_calls' in options) {
-      this.keepaliveWithoutCalls = options['grpc.keepalive_permit_without_calls'] === 1;
+      this.keepaliveWithoutCalls =
+        options['grpc.keepalive_permit_without_calls'] === 1;
     } else {
       this.keepaliveWithoutCalls = false;
     }
@@ -231,7 +235,11 @@ export class Subchannel {
   }
 
   private sendPing() {
-    logging.trace(LogVerbosity.DEBUG, 'keepalive', 'Sending ping to ' + this.subchannelAddressString);
+    logging.trace(
+      LogVerbosity.DEBUG,
+      'keepalive',
+      'Sending ping to ' + this.subchannelAddressString
+    );
     this.keepaliveTimeoutId = setTimeout(() => {
       this.transitionToState([ConnectivityState.READY], ConnectivityState.IDLE);
     }, this.keepaliveTimeoutMs);
@@ -247,7 +255,7 @@ export class Subchannel {
     this.keepaliveIntervalId = setInterval(() => {
       this.sendPing();
     }, this.keepaliveTimeMs);
-    this.keepaliveIntervalId.unref?.()
+    this.keepaliveIntervalId.unref?.();
     /* Don't send a ping immediately because whatever caused us to start
      * sending pings should also involve some network activity. */
   }
@@ -265,7 +273,9 @@ export class Subchannel {
       this.credentials._getConnectionOptions() || {};
     connectionOptions.maxSendHeaderBlockLength = Number.MAX_SAFE_INTEGER;
     if ('grpc-node.max_session_memory' in this.options) {
-      connectionOptions.maxSessionMemory = this.options['grpc-node.max_session_memory'];
+      connectionOptions.maxSessionMemory = this.options[
+        'grpc-node.max_session_memory'
+      ];
     }
     let addressScheme = 'http://';
     if ('secureContext' in connectionOptions) {
@@ -387,7 +397,11 @@ export class Subchannel {
             );
             logging.log(
               LogVerbosity.ERROR,
-              `Connection to ${uriToString(this.channelTarget)} at ${this.subchannelAddressString} rejected by server because of excess pings. Increasing ping interval to ${this.keepaliveTimeMs} ms`
+              `Connection to ${uriToString(this.channelTarget)} at ${
+                this.subchannelAddressString
+              } rejected by server because of excess pings. Increasing ping interval to ${
+                this.keepaliveTimeMs
+              } ms`
             );
           }
           trace(
@@ -553,10 +567,7 @@ export class Subchannel {
      * this subchannel, we can be sure it will never be used again. */
     if (this.callRefcount === 0 && this.refcount === 0) {
       this.transitionToState(
-        [
-          ConnectivityState.CONNECTING,
-          ConnectivityState.READY,
-        ],
+        [ConnectivityState.CONNECTING, ConnectivityState.READY],
         ConnectivityState.TRANSIENT_FAILURE
       );
     }
@@ -675,7 +686,14 @@ export class Subchannel {
     for (const header of Object.keys(headers)) {
       headersString += '\t\t' + header + ': ' + headers[header] + '\n';
     }
-    logging.trace(LogVerbosity.DEBUG, 'call_stream', 'Starting stream on subchannel ' + this.subchannelAddressString + ' with headers\n' + headersString);
+    logging.trace(
+      LogVerbosity.DEBUG,
+      'call_stream',
+      'Starting stream on subchannel ' +
+        this.subchannelAddressString +
+        ' with headers\n' +
+        headersString
+    );
     callStream.attachHttp2Stream(http2Stream, this, extraFilterFactories);
   }
 


### PR DESCRIPTION
Following up to #1829. The lint errors were all instances of using the `any` type, and all of the fixes were adding a comment indicating that the linter should ignore it because those uses were all intentional.