### PR TITLE
grpc-js-xds: Increase interop test timeout

### DIFF
--- a/test/kokoro/xds-interop.cfg
+++ b/test/kokoro/xds-interop.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-node/packages/grpc-js-xds/scripts/xds.sh"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "github/grpc/reports/**"


### PR DESCRIPTION
Recent test runs have been running up against the current limit and failing. This increase matches a previous increase on master.