### PR TITLE
Increase xDS job timeouts to match Java and Go

### DIFF
--- a/test/kokoro/xds-interop.cfg
+++ b/test/kokoro/xds-interop.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-node/packages/grpc-js-xds/scripts/xds.sh"
-timeout_mins: 180
+timeout_mins: 360
 action {
   define_artifacts {
     regex: "github/grpc/reports/**"

--- a/test/kokoro/xds-v3-interop.cfg
+++ b/test/kokoro/xds-v3-interop.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-node/packages/grpc-js-xds/scripts/xds-v3.sh"
-timeout_mins: 180
+timeout_mins: 360
 action {
   define_artifacts {
     regex: "github/grpc/reports/**"


### PR DESCRIPTION
With the timeout test, these are already average something like 2:40 so this goes ahead and gives the jobs a (hopefully) excessive time limit.

We are seeing lots of failures due to hitting the 120 minute timeout set on the v1.3.x branch, so this should be backported to v1.3.x and v1.2.x as well.

cc @murgatroid99 

b/192479958