### PR TITLE
grpc-js: Add logging for TLS over proxy connection errors

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -244,7 +244,13 @@ export function getProxiedConnection(
               resolve({ socket: cts, realTarget: parsedTarget });
             }
           );
-          cts.on('error', () => {
+          cts.on('error', (error: Error) => {
+            trace('Failed to establish a TLS connection to ' +
+                    options.path +
+                    ' through proxy ' +
+                    proxyAddressString +
+                    ' with error ' +
+                    error.message);
             reject();
           });
         } else {


### PR DESCRIPTION
I think #1841 is hitting this error case, but without this log line it's hard to tell what exactly is happening.