### PR TITLE
grpc-js-xds: Increase interop test timeout to 6 hours in 1.3.x branch (for real this time)

### DIFF
--- a/test/kokoro/xds-interop.cfg
+++ b/test/kokoro/xds-interop.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-node/packages/grpc-js-xds/scripts/xds.sh"
-timeout_mins: 120
+timeout_mins: 360
 action {
   define_artifacts {
     regex: "github/grpc/reports/**"


### PR DESCRIPTION
#1843 but actually point the PR at the 1.3.x branch this time.