### PR TITLE
grpc-js: Split out logs for different severity levels

### DIFF
--- a/packages/grpc-js/test/test-logging.ts
+++ b/packages/grpc-js/test/test-logging.ts
@@ -27,10 +27,6 @@ describe('Logging', () => {
     grpc.setLogVerbosity(grpc.logVerbosity.DEBUG);
   });
 
-  it('logger defaults to console', () => {
-    assert.strictEqual(logging.getLogger(), console);
-  });
-
   it('sets the logger to a new value', () => {
     const logger: Partial<Console> = {};
 


### PR DESCRIPTION
This is an evolution of the change proposed in #1811. With this change, logs at different severity levels are passed to different logger methods, but the default logger still sends them all to `stderr` to preserve the current behavior (though I added severity letters at the beginning of the log lines as core does, to take advantage of the split). This change also falls back to `_logger.error` when other methods are not available, to avoid dropping log messages when using older custom loggers that only implement `error`.

This fixes #1835.