### PR TITLE
grpc-js: Tighten server.bindAsync creds typecheck

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -237,8 +237,8 @@ export class Server {
       throw new TypeError('port must be a string');
     }
 
-    if (creds === null || typeof creds !== 'object') {
-      throw new TypeError('creds must be an object');
+    if (creds === null || !(creds instanceof ServerCredentials)) {
+      throw new TypeError('creds must be a ServerCredentials object');
     }
 
     if (typeof callback !== 'function') {

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -119,6 +119,10 @@ describe('Server', () => {
       }, /creds must be a ServerCredentials object/);
 
       assert.throws(() => {
+        server.bindAsync('localhost:0', grpc.credentials.createInsecure() as any, noop);
+      }, /creds must be a ServerCredentials object/);
+
+      assert.throws(() => {
         server.bindAsync(
           'localhost:0',
           ServerCredentials.createInsecure(),

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -116,7 +116,7 @@ describe('Server', () => {
 
       assert.throws(() => {
         server.bindAsync('localhost:0', null as any, noop);
-      }, /creds must be an object/);
+      }, /creds must be a ServerCredentials object/);
 
       assert.throws(() => {
         server.bindAsync(


### PR DESCRIPTION
The goal is to give more immediate feedback for errors like the one reported in #1850. Currently if the user passes an object of the wrong type, the error when it is used occurs asynchronously, which loses relevant context and results in a less-helpful error message.