### PR TITLE
grpc-js: support grpc+json content type

### DIFF
--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -37,6 +37,7 @@ export interface ChannelOptions {
   'grpc.http_connect_target'?: string;
   'grpc.http_connect_creds'?: string;
   'grpc-node.max_session_memory'?: number;
+  'grpc.http_content_type'?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -402,7 +402,8 @@ export class ChannelImplementation implements Channel {
                     pickResult.subchannel!.startCallStream(
                       finalMetadata,
                       callStream,
-                      pickResult.extraFilterFactories
+                      pickResult.extraFilterFactories,
+                      this.options
                     );
                     /* If we reach this point, the call stream has started
                      * successfully */

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -655,14 +655,15 @@ export class Subchannel {
   startCallStream(
     metadata: Metadata,
     callStream: Http2CallStream,
-    extraFilterFactories: FilterFactory<Filter>[]
+    extraFilterFactories: FilterFactory<Filter>[],
+    options: ChannelOptions
   ) {
     const headers = metadata.toHttp2Headers();
     headers[HTTP2_HEADER_AUTHORITY] = callStream.getHost();
     headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;
     headers[HTTP2_HEADER_CONTENT_TYPE] = 'application/grpc';
     headers[HTTP2_HEADER_METHOD] = 'POST';
-    headers[HTTP2_HEADER_PATH] = callStream.getMethod();
+    headers[HTTP2_HEADER_PATH] = options['grpc.http_content_type'] || callStream.getMethod();
     headers[HTTP2_HEADER_TE] = 'trailers';
     let http2Stream: http2.ClientHttp2Stream;
     /* In theory, if an error is thrown by session.request because session has


### PR DESCRIPTION
Golang has a library called jsonpb, which can support grpc requests using json format data. The example library is as follows: 
[https://github.com/johanbrandhorst/grpc-json-example](https://github.com/johanbrandhorst/grpc-json-example)

In order to support back-end development using this library, we need to support the grpc+json content type when we initiate a grpc request

At the same time, if I merge this pr, it can also support other forms of custom codec.

For more information about custom codec, please refer to: [https://pkg.go.dev/google.golang.org/grpc/encoding#Codec](https://pkg.go.dev/google.golang.org/grpc/encoding#Codec)

For more information about jsonpb, please refer to: [https://pkg.go.dev/github.com/golang/protobuf/jsonpb](https://pkg.go.dev/github.com/golang/protobuf/jsonpb)
