### PR TITLE
grpc-js: Add more trace logging around establishing connections

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -254,6 +254,12 @@ export function getProxiedConnection(
             reject();
           });
         } else {
+          trace(
+            'Successfully established a plaintext connection to ' +
+              options.path +
+              ' through proxy ' +
+              proxyAddressString
+          );
           resolve({
             socket,
             realTarget: parsedTarget,

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -303,6 +303,11 @@ export class Subchannel {
   }
 
   private createSession(proxyConnectionResult: ProxyConnectionResult) {
+    if (proxyConnectionResult.realTarget) {
+      trace(this.subchannelAddressString + ' creating HTTP/2 session through proxy to ' + proxyConnectionResult.realTarget);
+    } else {
+      trace(this.subchannelAddressString + ' creating HTTP/2 session');
+    }
     const targetAuthority = getDefaultAuthority(
       proxyConnectionResult.realTarget ?? this.channelTarget
     );
@@ -403,6 +408,7 @@ export class Subchannel {
     });
     session.once('close', () => {
       if (this.session === session) {
+        trace(this.subchannelAddressString + ' connection closed');
         this.transitionToState(
           [ConnectivityState.CONNECTING],
           ConnectivityState.TRANSIENT_FAILURE


### PR DESCRIPTION
Apparently #1842 somehow failed to add any new logs to the trace output for the error reported in #1841. These new logs should guarantee that we see at least one new log line. In particular, in `http_proxy.ts`, in `getProxiedConnection`, every `reject` and `resolve` now has a corresponding log or trace log line, so we should always be able to see how that function finished.