### PR TITLE
grpc-js: Add trace log with library version

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -247,7 +247,10 @@ export { experimental };
 import * as resolver from './resolver';
 import * as load_balancer from './load-balancer';
 
+const clientVersion = require('../../package.json').version;
+
 (() => {
+  logging.trace(LogVerbosity.DEBUG, 'index', 'Loading @grpc/grpc-js version ' + clientVersion);
   resolver.registerAll();
   load_balancer.registerAll();
 })();


### PR DESCRIPTION
I want to have a way to proactively answer the question "Are you sure you're using the right version of the library?"