### PR TITLE
grpc: Make ServiceDefinition type argument optional

### DIFF
--- a/packages/grpc-native-core/index.d.ts
+++ b/packages/grpc-native-core/index.d.ts
@@ -312,7 +312,7 @@ declare module "grpc" {
   /**
    * An object that completely defines a service.
    */
-  export type ServiceDefinition<ImplementationType> = {
+  export type ServiceDefinition<ImplementationType = UntypedServiceImplementation> = {
     readonly [I in keyof ImplementationType]: MethodDefinition<any, any>;
   }
 


### PR DESCRIPTION
This is for compatibility with grpc-js, which does not have a type argument in its `ServiceDefinition`. Making the argument optional shouldn't break any existing code.

I think this is the simplest way to fix #1766, and since we need to do another release anyway this seems like the best time to do it.