### PR TITLE
Change certificate in callback

### DIFF
--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -28,16 +28,6 @@ function verifyIsBufferOrNull(obj: any, friendlyName: string): void {
 }
 
 /**
- * A certificate as received by the checkServerIdentity callback.
- */
-export interface Certificate {
-  /**
-   * The raw certificate in DER form.
-   */
-  raw: Buffer;
-}
-
-/**
  * A callback that will receive the expected hostname and presented peer
  * certificate as parameters. The callback should return an error to
  * indicate that the presented certificate is considered invalid and
@@ -45,7 +35,7 @@ export interface Certificate {
  */
 export type CheckServerIdentityCallback = (
   hostname: string,
-  cert: Certificate
+  cert: PeerCertificate
 ) => Error | undefined;
 
 function bufferOrNullEqual(buf1: Buffer | null, buf2: Buffer | null) {
@@ -198,7 +188,7 @@ class SecureChannelCredentialsImpl extends ChannelCredentials {
         host: string,
         cert: PeerCertificate
       ) => {
-        return verifyOptions.checkServerIdentity!(host, { raw: cert.raw });
+        return verifyOptions.checkServerIdentity!(host, cert);
       };
     }
   }


### PR DESCRIPTION
On communicate module we need to verifity certificate on server.
For verifity we use fingerprint, subjectaltname.
But this grpc version callback only raw data. 

For this way we use nodejs doc:
https://nodejs.org/api/tls.html#tls_certificate_object

I'm change file for coorect. Please apply pull request, so we can use them through npm. Thnk's.