### PR TITLE
Set defaults to false for loader definitions

### DIFF
--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -148,7 +148,7 @@ const descriptorOptions: Protobuf.IConversionOptions = {
   longs: String,
   enums: String,
   bytes: String,
-  defaults: true,
+  defaults: false,
   oneofs: true,
   json: true,
 };


### PR DESCRIPTION
This usage of defaults causes issues when using descriptors with protobufjs. Descriptors that default to oneofIndex: 0 cause issues when they aren't actually part of a oneof. Specifically here:

https://github.com/protobufjs/protobuf.js/blob/95b56817ef6fb9bdcb14d956c159da49d0889bff/ext/descriptor/index.js#L218-L219

where it assumes that if there's a `oneofIndex` then that is a valid index into the `oneofDecl` array. I could have changed the logic there but this feels more "upstream" and there doesn't seem to be a need for `defaults` to be `true` regardless of this issue with `protobufjs`.