### PR TITLE
grpc-js-xds: Add fault injection HTTP filter

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -12,7 +12,7 @@
     "prepare": "npm run compile",
     "pretest": "npm run compile",
     "posttest": "npm run check",
-    "generate-types": "proto-loader-gen-types --keepCase --longs String --enums String --defaults --oneofs --includeComments --includeDirs deps/envoy-api/ deps/udpa/ deps/googleapis/ deps/protoc-gen-validate/ -O src/generated/ --grpcLib @grpc/grpc-js envoy/service/discovery/v2/ads.proto envoy/service/load_stats/v2/lrs.proto envoy/service/discovery/v3/ads.proto envoy/service/load_stats/v3/lrs.proto envoy/config/listener/v3/listener.proto envoy/config/route/v3/route.proto envoy/config/cluster/v3/cluster.proto envoy/config/endpoint/v3/endpoint.proto envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto udpa/type/v1/typed_struct.proto",
+    "generate-types": "proto-loader-gen-types --keepCase --longs String --enums String --defaults --oneofs --includeComments --includeDirs deps/envoy-api/ deps/udpa/ deps/googleapis/ deps/protoc-gen-validate/ -O src/generated/ --grpcLib @grpc/grpc-js envoy/service/discovery/v2/ads.proto envoy/service/load_stats/v2/lrs.proto envoy/service/discovery/v3/ads.proto envoy/service/load_stats/v3/lrs.proto envoy/config/listener/v3/listener.proto envoy/config/route/v3/route.proto envoy/config/cluster/v3/cluster.proto envoy/config/endpoint/v3/endpoint.proto envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto udpa/type/v1/typed_struct.proto envoy/extensions/filters/http/fault/v3/fault.proto",
     "generate-interop-types": "proto-loader-gen-types --keep-case --longs String --enums String --defaults --oneofs --json --includeComments --includeDirs proto/ -O interop/generated --grpcLib @grpc/grpc-js grpc/testing/test.proto"
   },
   "repository": {

--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -48,7 +48,7 @@ git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 
-GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver \
+GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver,fault_injection,http_filter \
   GRPC_NODE_VERBOSITY=DEBUG \
   NODE_XDS_INTEROP_VERBOSITY=1 \
   GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION=1 \

--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -51,8 +51,9 @@ grpc/tools/run_tests/helper_scripts/prep_xds.sh
 GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver \
   GRPC_NODE_VERBOSITY=DEBUG \
   NODE_XDS_INTEROP_VERBOSITY=1 \
+  GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION=1 \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case="all,timeout,circuit_breaking" \
+    --test_case="all,timeout,circuit_breaking,fault_injection" \
     --project_id=grpc-testing \
     --source_image=projects/grpc-testing/global/images/xds-test-server-4 \
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \

--- a/packages/grpc-js-xds/src/fraction.ts
+++ b/packages/grpc-js-xds/src/fraction.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FractionalPercent__Output } from "./generated/envoy/type/v3/FractionalPercent";
+
+export interface Fraction {
+  numerator: number;
+  denominator: number;
+}
+
+export function fractionToString(fraction: Fraction): string {
+  return `${fraction.numerator}/${fraction.denominator}`;
+}
+
+const RUNTIME_FRACTION_DENOMINATOR_VALUES = {
+  HUNDRED: 100,
+  TEN_THOUSAND: 10_000,
+  MILLION: 1_000_000
+}
+
+export function envoyFractionToFraction(envoyFraction: FractionalPercent__Output): Fraction {
+  return {
+    numerator: envoyFraction.numerator,
+    denominator: RUNTIME_FRACTION_DENOMINATOR_VALUES[envoyFraction.denominator]
+  };
+}

--- a/packages/grpc-js-xds/src/generated/ads.ts
+++ b/packages/grpc-js-xds/src/generated/ads.ts
@@ -1,8 +1,8 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { ServiceDefinition, EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
+import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
-import type { AggregatedDiscoveryServiceClient as _envoy_service_discovery_v2_AggregatedDiscoveryServiceClient } from './envoy/service/discovery/v2/AggregatedDiscoveryService';
-import type { AggregatedDiscoveryServiceClient as _envoy_service_discovery_v3_AggregatedDiscoveryServiceClient } from './envoy/service/discovery/v3/AggregatedDiscoveryService';
+import type { AggregatedDiscoveryServiceClient as _envoy_service_discovery_v2_AggregatedDiscoveryServiceClient, AggregatedDiscoveryServiceDefinition as _envoy_service_discovery_v2_AggregatedDiscoveryServiceDefinition } from './envoy/service/discovery/v2/AggregatedDiscoveryService';
+import type { AggregatedDiscoveryServiceClient as _envoy_service_discovery_v3_AggregatedDiscoveryServiceClient, AggregatedDiscoveryServiceDefinition as _envoy_service_discovery_v3_AggregatedDiscoveryServiceDefinition } from './envoy/service/discovery/v3/AggregatedDiscoveryService';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -102,7 +102,7 @@ export interface ProtoGrpcType {
            * DiscoveryRequest/DiscoveryResponse provides sufficient information to recover
            * the multiplexed singleton APIs at the Envoy instance and management server.
            */
-          AggregatedDiscoveryService: SubtypeConstructor<typeof grpc.Client, _envoy_service_discovery_v2_AggregatedDiscoveryServiceClient> & { service: ServiceDefinition }
+          AggregatedDiscoveryService: SubtypeConstructor<typeof grpc.Client, _envoy_service_discovery_v2_AggregatedDiscoveryServiceClient> & { service: _envoy_service_discovery_v2_AggregatedDiscoveryServiceDefinition }
         }
         v3: {
           AdsDummy: MessageTypeDefinition
@@ -114,7 +114,7 @@ export interface ProtoGrpcType {
            * DiscoveryRequest/DiscoveryResponse provides sufficient information to recover
            * the multiplexed singleton APIs at the Envoy instance and management server.
            */
-          AggregatedDiscoveryService: SubtypeConstructor<typeof grpc.Client, _envoy_service_discovery_v3_AggregatedDiscoveryServiceClient> & { service: ServiceDefinition }
+          AggregatedDiscoveryService: SubtypeConstructor<typeof grpc.Client, _envoy_service_discovery_v3_AggregatedDiscoveryServiceClient> & { service: _envoy_service_discovery_v3_AggregatedDiscoveryServiceDefinition }
           DeltaDiscoveryRequest: MessageTypeDefinition
           DeltaDiscoveryResponse: MessageTypeDefinition
           DiscoveryRequest: MessageTypeDefinition

--- a/packages/grpc-js-xds/src/generated/cluster.ts
+++ b/packages/grpc-js-xds/src/generated/cluster.ts
@@ -1,5 +1,5 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { ServiceDefinition, EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
+import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {

--- a/packages/grpc-js-xds/src/generated/endpoint.ts
+++ b/packages/grpc-js-xds/src/generated/endpoint.ts
@@ -1,5 +1,5 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { ServiceDefinition, EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
+import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/DeltaDiscoveryRequest.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/DeltaDiscoveryRequest.ts
@@ -42,7 +42,7 @@ export interface DeltaDiscoveryRequest {
   /**
    * The node making the request.
    */
-  'node'?: (_envoy_api_v2_core_Node);
+  'node'?: (_envoy_api_v2_core_Node | null);
   /**
    * Type of the resource that is being requested, e.g.
    * "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment".
@@ -99,7 +99,7 @@ export interface DeltaDiscoveryRequest {
    * failed to update configuration. The *message* field in *error_details*
    * provides the Envoy internal exception related to the failure.
    */
-  'error_detail'?: (_google_rpc_Status);
+  'error_detail'?: (_google_rpc_Status | null);
 }
 
 /**
@@ -141,7 +141,7 @@ export interface DeltaDiscoveryRequest__Output {
   /**
    * The node making the request.
    */
-  'node'?: (_envoy_api_v2_core_Node__Output);
+  'node': (_envoy_api_v2_core_Node__Output | null);
   /**
    * Type of the resource that is being requested, e.g.
    * "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment".
@@ -198,5 +198,5 @@ export interface DeltaDiscoveryRequest__Output {
    * failed to update configuration. The *message* field in *error_details*
    * provides the Envoy internal exception related to the failure.
    */
-  'error_detail'?: (_google_rpc_Status__Output);
+  'error_detail': (_google_rpc_Status__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/DiscoveryRequest.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/DiscoveryRequest.ts
@@ -22,7 +22,7 @@ export interface DiscoveryRequest {
   /**
    * The node making the request.
    */
-  'node'?: (_envoy_api_v2_core_Node);
+  'node'?: (_envoy_api_v2_core_Node | null);
   /**
    * List of resources to subscribe to, e.g. list of cluster names or a route
    * configuration name. If this is empty, all resources for the API are
@@ -53,7 +53,7 @@ export interface DiscoveryRequest {
    * internal exception related to the failure. It is only intended for consumption during manual
    * debugging, the string provided is not guaranteed to be stable across Envoy versions.
    */
-  'error_detail'?: (_google_rpc_Status);
+  'error_detail'?: (_google_rpc_Status | null);
 }
 
 /**
@@ -75,7 +75,7 @@ export interface DiscoveryRequest__Output {
   /**
    * The node making the request.
    */
-  'node'?: (_envoy_api_v2_core_Node__Output);
+  'node': (_envoy_api_v2_core_Node__Output | null);
   /**
    * List of resources to subscribe to, e.g. list of cluster names or a route
    * configuration name. If this is empty, all resources for the API are
@@ -106,5 +106,5 @@ export interface DiscoveryRequest__Output {
    * internal exception related to the failure. It is only intended for consumption during manual
    * debugging, the string provided is not guaranteed to be stable across Envoy versions.
    */
-  'error_detail'?: (_google_rpc_Status__Output);
+  'error_detail': (_google_rpc_Status__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/DiscoveryResponse.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/DiscoveryResponse.ts
@@ -52,7 +52,7 @@ export interface DiscoveryResponse {
    * [#not-implemented-hide:]
    * The control plane instance that sent the response.
    */
-  'control_plane'?: (_envoy_api_v2_core_ControlPlane);
+  'control_plane'?: (_envoy_api_v2_core_ControlPlane | null);
 }
 
 /**
@@ -104,5 +104,5 @@ export interface DiscoveryResponse__Output {
    * [#not-implemented-hide:]
    * The control plane instance that sent the response.
    */
-  'control_plane'?: (_envoy_api_v2_core_ControlPlane__Output);
+  'control_plane': (_envoy_api_v2_core_ControlPlane__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/Resource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/Resource.ts
@@ -11,7 +11,7 @@ export interface Resource {
   /**
    * The resource being tracked.
    */
-  'resource'?: (_google_protobuf_Any);
+  'resource'?: (_google_protobuf_Any | null);
   /**
    * The resource's name, to distinguish it from others of the same type of resource.
    */
@@ -31,7 +31,7 @@ export interface Resource__Output {
   /**
    * The resource being tracked.
    */
-  'resource'?: (_google_protobuf_Any__Output);
+  'resource': (_google_protobuf_Any__Output | null);
   /**
    * The resource's name, to distinguish it from others of the same type of resource.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/Address.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/Address.ts
@@ -9,8 +9,8 @@ import type { Pipe as _envoy_api_v2_core_Pipe, Pipe__Output as _envoy_api_v2_cor
  * management servers.
  */
 export interface Address {
-  'socket_address'?: (_envoy_api_v2_core_SocketAddress);
-  'pipe'?: (_envoy_api_v2_core_Pipe);
+  'socket_address'?: (_envoy_api_v2_core_SocketAddress | null);
+  'pipe'?: (_envoy_api_v2_core_Pipe | null);
   'address'?: "socket_address"|"pipe";
 }
 
@@ -20,7 +20,7 @@ export interface Address {
  * management servers.
  */
 export interface Address__Output {
-  'socket_address'?: (_envoy_api_v2_core_SocketAddress__Output);
-  'pipe'?: (_envoy_api_v2_core_Pipe__Output);
+  'socket_address'?: (_envoy_api_v2_core_SocketAddress__Output | null);
+  'pipe'?: (_envoy_api_v2_core_Pipe__Output | null);
   'address': "socket_address"|"pipe";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/AsyncDataSource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/AsyncDataSource.ts
@@ -10,11 +10,11 @@ export interface AsyncDataSource {
   /**
    * Local async data source.
    */
-  'local'?: (_envoy_api_v2_core_DataSource);
+  'local'?: (_envoy_api_v2_core_DataSource | null);
   /**
    * Remote async data source.
    */
-  'remote'?: (_envoy_api_v2_core_RemoteDataSource);
+  'remote'?: (_envoy_api_v2_core_RemoteDataSource | null);
   'specifier'?: "local"|"remote";
 }
 
@@ -25,10 +25,10 @@ export interface AsyncDataSource__Output {
   /**
    * Local async data source.
    */
-  'local'?: (_envoy_api_v2_core_DataSource__Output);
+  'local'?: (_envoy_api_v2_core_DataSource__Output | null);
   /**
    * Remote async data source.
    */
-  'remote'?: (_envoy_api_v2_core_RemoteDataSource__Output);
+  'remote'?: (_envoy_api_v2_core_RemoteDataSource__Output | null);
   'specifier': "local"|"remote";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/BackoffStrategy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/BackoffStrategy.ts
@@ -11,7 +11,7 @@ export interface BackoffStrategy {
    * be greater than zero and less than or equal to :ref:`max_interval
    * <envoy_api_field_core.BackoffStrategy.max_interval>`.
    */
-  'base_interval'?: (_google_protobuf_Duration);
+  'base_interval'?: (_google_protobuf_Duration | null);
   /**
    * Specifies the maximum interval between retries. This parameter is optional,
    * but must be greater than or equal to the :ref:`base_interval
@@ -19,7 +19,7 @@ export interface BackoffStrategy {
    * is 10 times the :ref:`base_interval
    * <envoy_api_field_core.BackoffStrategy.base_interval>`.
    */
-  'max_interval'?: (_google_protobuf_Duration);
+  'max_interval'?: (_google_protobuf_Duration | null);
 }
 
 /**
@@ -31,7 +31,7 @@ export interface BackoffStrategy__Output {
    * be greater than zero and less than or equal to :ref:`max_interval
    * <envoy_api_field_core.BackoffStrategy.max_interval>`.
    */
-  'base_interval'?: (_google_protobuf_Duration__Output);
+  'base_interval': (_google_protobuf_Duration__Output | null);
   /**
    * Specifies the maximum interval between retries. This parameter is optional,
    * but must be greater than or equal to the :ref:`base_interval
@@ -39,5 +39,5 @@ export interface BackoffStrategy__Output {
    * is 10 times the :ref:`base_interval
    * <envoy_api_field_core.BackoffStrategy.base_interval>`.
    */
-  'max_interval'?: (_google_protobuf_Duration__Output);
+  'max_interval': (_google_protobuf_Duration__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/BindConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/BindConfig.ts
@@ -8,7 +8,7 @@ export interface BindConfig {
   /**
    * The address to bind to when creating a socket.
    */
-  'source_address'?: (_envoy_api_v2_core_SocketAddress);
+  'source_address'?: (_envoy_api_v2_core_SocketAddress | null);
   /**
    * Whether to set the *IP_FREEBIND* option when creating the socket. When this
    * flag is set to true, allows the :ref:`source_address
@@ -18,7 +18,7 @@ export interface BindConfig {
    * flag is not set (default), the socket is not modified, i.e. the option is
    * neither enabled nor disabled.
    */
-  'freebind'?: (_google_protobuf_BoolValue);
+  'freebind'?: (_google_protobuf_BoolValue | null);
   /**
    * Additional socket options that may not be present in Envoy source code or
    * precompiled binaries.
@@ -30,7 +30,7 @@ export interface BindConfig__Output {
   /**
    * The address to bind to when creating a socket.
    */
-  'source_address'?: (_envoy_api_v2_core_SocketAddress__Output);
+  'source_address': (_envoy_api_v2_core_SocketAddress__Output | null);
   /**
    * Whether to set the *IP_FREEBIND* option when creating the socket. When this
    * flag is set to true, allows the :ref:`source_address
@@ -40,7 +40,7 @@ export interface BindConfig__Output {
    * flag is not set (default), the socket is not modified, i.e. the option is
    * neither enabled nor disabled.
    */
-  'freebind'?: (_google_protobuf_BoolValue__Output);
+  'freebind': (_google_protobuf_BoolValue__Output | null);
   /**
    * Additional socket options that may not be present in Envoy source code or
    * precompiled binaries.

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/BuildVersion.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/BuildVersion.ts
@@ -11,12 +11,12 @@ export interface BuildVersion {
   /**
    * SemVer version of extension.
    */
-  'version'?: (_envoy_type_SemanticVersion);
+  'version'?: (_envoy_type_SemanticVersion | null);
   /**
    * Free-form build information.
    * Envoy defines several well known keys in the source/common/version/version.h file
    */
-  'metadata'?: (_google_protobuf_Struct);
+  'metadata'?: (_google_protobuf_Struct | null);
 }
 
 /**
@@ -27,10 +27,10 @@ export interface BuildVersion__Output {
   /**
    * SemVer version of extension.
    */
-  'version'?: (_envoy_type_SemanticVersion__Output);
+  'version': (_envoy_type_SemanticVersion__Output | null);
   /**
    * Free-form build information.
    * Envoy defines several well known keys in the source/common/version/version.h file
    */
-  'metadata'?: (_google_protobuf_Struct__Output);
+  'metadata': (_google_protobuf_Struct__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/CidrRange.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/CidrRange.ts
@@ -14,7 +14,7 @@ export interface CidrRange {
   /**
    * Length of prefix, e.g. 0, 32.
    */
-  'prefix_len'?: (_google_protobuf_UInt32Value);
+  'prefix_len'?: (_google_protobuf_UInt32Value | null);
 }
 
 /**
@@ -29,5 +29,5 @@ export interface CidrRange__Output {
   /**
    * Length of prefix, e.g. 0, 32.
    */
-  'prefix_len'?: (_google_protobuf_UInt32Value__Output);
+  'prefix_len': (_google_protobuf_UInt32Value__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/Extension.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/Extension.ts
@@ -31,7 +31,7 @@ export interface Extension {
    * of other extensions and the Envoy API.
    * This field is not set when extension did not provide version information.
    */
-  'version'?: (_envoy_api_v2_core_BuildVersion);
+  'version'?: (_envoy_api_v2_core_BuildVersion | null);
   /**
    * Indicates that the extension is present but was disabled via dynamic configuration.
    */
@@ -67,7 +67,7 @@ export interface Extension__Output {
    * of other extensions and the Envoy API.
    * This field is not set when extension did not provide version information.
    */
-  'version'?: (_envoy_api_v2_core_BuildVersion__Output);
+  'version': (_envoy_api_v2_core_BuildVersion__Output | null);
   /**
    * Indicates that the extension is present but was disabled via dynamic configuration.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/HeaderValueOption.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/HeaderValueOption.ts
@@ -10,12 +10,12 @@ export interface HeaderValueOption {
   /**
    * Header name/value pair that this option applies to.
    */
-  'header'?: (_envoy_api_v2_core_HeaderValue);
+  'header'?: (_envoy_api_v2_core_HeaderValue | null);
   /**
    * Should the value be appended? If true (default), the value is appended to
    * existing values.
    */
-  'append'?: (_google_protobuf_BoolValue);
+  'append'?: (_google_protobuf_BoolValue | null);
 }
 
 /**
@@ -25,10 +25,10 @@ export interface HeaderValueOption__Output {
   /**
    * Header name/value pair that this option applies to.
    */
-  'header'?: (_envoy_api_v2_core_HeaderValue__Output);
+  'header': (_envoy_api_v2_core_HeaderValue__Output | null);
   /**
    * Should the value be appended? If true (default), the value is appended to
    * existing values.
    */
-  'append'?: (_google_protobuf_BoolValue__Output);
+  'append': (_google_protobuf_BoolValue__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/HttpUri.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/HttpUri.ts
@@ -30,7 +30,7 @@ export interface HttpUri {
   /**
    * Sets the maximum duration in milliseconds that a response can take to arrive upon request.
    */
-  'timeout'?: (_google_protobuf_Duration);
+  'timeout'?: (_google_protobuf_Duration | null);
   /**
    * Specify how `uri` is to be fetched. Today, this requires an explicit
    * cluster, but in the future we may support dynamic cluster creation or
@@ -68,7 +68,7 @@ export interface HttpUri__Output {
   /**
    * Sets the maximum duration in milliseconds that a response can take to arrive upon request.
    */
-  'timeout'?: (_google_protobuf_Duration__Output);
+  'timeout': (_google_protobuf_Duration__Output | null);
   /**
    * Specify how `uri` is to be fetched. Today, this requires an explicit
    * cluster, but in the future we may support dynamic cluster creation or

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/Metadata.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/Metadata.ts
@@ -63,5 +63,5 @@ export interface Metadata__Output {
    * Key is the reverse DNS filter name, e.g. com.acme.widget. The envoy.*
    * namespace is reserved for Envoy's built-in filters.
    */
-  'filter_metadata'?: ({[key: string]: _google_protobuf_Struct__Output});
+  'filter_metadata': ({[key: string]: _google_protobuf_Struct__Output});
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/Node.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/Node.ts
@@ -41,11 +41,11 @@ export interface Node {
    * Opaque metadata extending the node identifier. Envoy will pass this
    * directly to the management server.
    */
-  'metadata'?: (_google_protobuf_Struct);
+  'metadata'?: (_google_protobuf_Struct | null);
   /**
    * Locality specifying where the Envoy instance is running.
    */
-  'locality'?: (_envoy_api_v2_core_Locality);
+  'locality'?: (_envoy_api_v2_core_Locality | null);
   /**
    * This is motivated by informing a management server during canary which
    * version of Envoy is being tested in a heterogeneous fleet. This will be set
@@ -66,7 +66,7 @@ export interface Node {
   /**
    * Structured version of the entity requesting config.
    */
-  'user_agent_build_version'?: (_envoy_api_v2_core_BuildVersion);
+  'user_agent_build_version'?: (_envoy_api_v2_core_BuildVersion | null);
   /**
    * List of extensions and their versions supported by the node.
    */
@@ -124,11 +124,11 @@ export interface Node__Output {
    * Opaque metadata extending the node identifier. Envoy will pass this
    * directly to the management server.
    */
-  'metadata'?: (_google_protobuf_Struct__Output);
+  'metadata': (_google_protobuf_Struct__Output | null);
   /**
    * Locality specifying where the Envoy instance is running.
    */
-  'locality'?: (_envoy_api_v2_core_Locality__Output);
+  'locality': (_envoy_api_v2_core_Locality__Output | null);
   /**
    * This is motivated by informing a management server during canary which
    * version of Envoy is being tested in a heterogeneous fleet. This will be set
@@ -149,7 +149,7 @@ export interface Node__Output {
   /**
    * Structured version of the entity requesting config.
    */
-  'user_agent_build_version'?: (_envoy_api_v2_core_BuildVersion__Output);
+  'user_agent_build_version'?: (_envoy_api_v2_core_BuildVersion__Output | null);
   /**
    * List of extensions and their versions supported by the node.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/RemoteDataSource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/RemoteDataSource.ts
@@ -10,7 +10,7 @@ export interface RemoteDataSource {
   /**
    * The HTTP URI to fetch the remote data.
    */
-  'http_uri'?: (_envoy_api_v2_core_HttpUri);
+  'http_uri'?: (_envoy_api_v2_core_HttpUri | null);
   /**
    * SHA256 string for verifying data.
    */
@@ -18,7 +18,7 @@ export interface RemoteDataSource {
   /**
    * Retry policy for fetching remote data.
    */
-  'retry_policy'?: (_envoy_api_v2_core_RetryPolicy);
+  'retry_policy'?: (_envoy_api_v2_core_RetryPolicy | null);
 }
 
 /**
@@ -28,7 +28,7 @@ export interface RemoteDataSource__Output {
   /**
    * The HTTP URI to fetch the remote data.
    */
-  'http_uri'?: (_envoy_api_v2_core_HttpUri__Output);
+  'http_uri': (_envoy_api_v2_core_HttpUri__Output | null);
   /**
    * SHA256 string for verifying data.
    */
@@ -36,5 +36,5 @@ export interface RemoteDataSource__Output {
   /**
    * Retry policy for fetching remote data.
    */
-  'retry_policy'?: (_envoy_api_v2_core_RetryPolicy__Output);
+  'retry_policy': (_envoy_api_v2_core_RetryPolicy__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/RetryPolicy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/RetryPolicy.ts
@@ -12,12 +12,12 @@ export interface RetryPolicy {
    * This parameter is optional, in which case the default base interval is 1000 milliseconds. The
    * default maximum interval is 10 times the base interval.
    */
-  'retry_back_off'?: (_envoy_api_v2_core_BackoffStrategy);
+  'retry_back_off'?: (_envoy_api_v2_core_BackoffStrategy | null);
   /**
    * Specifies the allowed number of retries. This parameter is optional and
    * defaults to 1.
    */
-  'num_retries'?: (_google_protobuf_UInt32Value);
+  'num_retries'?: (_google_protobuf_UInt32Value | null);
 }
 
 /**
@@ -29,10 +29,10 @@ export interface RetryPolicy__Output {
    * This parameter is optional, in which case the default base interval is 1000 milliseconds. The
    * default maximum interval is 10 times the base interval.
    */
-  'retry_back_off'?: (_envoy_api_v2_core_BackoffStrategy__Output);
+  'retry_back_off': (_envoy_api_v2_core_BackoffStrategy__Output | null);
   /**
    * Specifies the allowed number of retries. This parameter is optional and
    * defaults to 1.
    */
-  'num_retries'?: (_google_protobuf_UInt32Value__Output);
+  'num_retries': (_google_protobuf_UInt32Value__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/RuntimeFeatureFlag.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/RuntimeFeatureFlag.ts
@@ -9,7 +9,7 @@ export interface RuntimeFeatureFlag {
   /**
    * Default value if runtime value is not available.
    */
-  'default_value'?: (_google_protobuf_BoolValue);
+  'default_value'?: (_google_protobuf_BoolValue | null);
   /**
    * Runtime key to get value for comparison. This value is used if defined. The boolean value must
    * be represented via its
@@ -25,7 +25,7 @@ export interface RuntimeFeatureFlag__Output {
   /**
    * Default value if runtime value is not available.
    */
-  'default_value'?: (_google_protobuf_BoolValue__Output);
+  'default_value': (_google_protobuf_BoolValue__Output | null);
   /**
    * Runtime key to get value for comparison. This value is used if defined. The boolean value must
    * be represented via its

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/RuntimeFractionalPercent.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/RuntimeFractionalPercent.ts
@@ -18,7 +18,7 @@ export interface RuntimeFractionalPercent {
   /**
    * Default value if the runtime value's for the numerator/denominator keys are not available.
    */
-  'default_value'?: (_envoy_type_FractionalPercent);
+  'default_value'?: (_envoy_type_FractionalPercent | null);
   /**
    * Runtime key for a YAML representation of a FractionalPercent.
    */
@@ -41,7 +41,7 @@ export interface RuntimeFractionalPercent__Output {
   /**
    * Default value if the runtime value's for the numerator/denominator keys are not available.
    */
-  'default_value'?: (_envoy_type_FractionalPercent__Output);
+  'default_value': (_envoy_type_FractionalPercent__Output | null);
   /**
    * Runtime key for a YAML representation of a FractionalPercent.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/TcpKeepalive.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/TcpKeepalive.ts
@@ -8,18 +8,18 @@ export interface TcpKeepalive {
    * the connection is dead. Default is to use the OS level configuration (unless
    * overridden, Linux defaults to 9.)
    */
-  'keepalive_probes'?: (_google_protobuf_UInt32Value);
+  'keepalive_probes'?: (_google_protobuf_UInt32Value | null);
   /**
    * The number of seconds a connection needs to be idle before keep-alive probes
    * start being sent. Default is to use the OS level configuration (unless
    * overridden, Linux defaults to 7200s (i.e., 2 hours.)
    */
-  'keepalive_time'?: (_google_protobuf_UInt32Value);
+  'keepalive_time'?: (_google_protobuf_UInt32Value | null);
   /**
    * The number of seconds between keep-alive probes. Default is to use the OS
    * level configuration (unless overridden, Linux defaults to 75s.)
    */
-  'keepalive_interval'?: (_google_protobuf_UInt32Value);
+  'keepalive_interval'?: (_google_protobuf_UInt32Value | null);
 }
 
 export interface TcpKeepalive__Output {
@@ -28,16 +28,16 @@ export interface TcpKeepalive__Output {
    * the connection is dead. Default is to use the OS level configuration (unless
    * overridden, Linux defaults to 9.)
    */
-  'keepalive_probes'?: (_google_protobuf_UInt32Value__Output);
+  'keepalive_probes': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The number of seconds a connection needs to be idle before keep-alive probes
    * start being sent. Default is to use the OS level configuration (unless
    * overridden, Linux defaults to 7200s (i.e., 2 hours.)
    */
-  'keepalive_time'?: (_google_protobuf_UInt32Value__Output);
+  'keepalive_time': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The number of seconds between keep-alive probes. Default is to use the OS
    * level configuration (unless overridden, Linux defaults to 75s.)
    */
-  'keepalive_interval'?: (_google_protobuf_UInt32Value__Output);
+  'keepalive_interval': (_google_protobuf_UInt32Value__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/core/TransportSocket.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/core/TransportSocket.ts
@@ -15,8 +15,8 @@ export interface TransportSocket {
    * socket implementation.
    */
   'name'?: (string);
-  'config'?: (_google_protobuf_Struct);
-  'typed_config'?: (_google_protobuf_Any);
+  'config'?: (_google_protobuf_Struct | null);
+  'typed_config'?: (_google_protobuf_Any | null);
   /**
    * Implementation specific configuration which depends on the implementation being instantiated.
    * See the supported transport socket implementations for further documentation.
@@ -36,8 +36,8 @@ export interface TransportSocket__Output {
    * socket implementation.
    */
   'name': (string);
-  'config'?: (_google_protobuf_Struct__Output);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'config'?: (_google_protobuf_Struct__Output | null);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   /**
    * Implementation specific configuration which depends on the implementation being instantiated.
    * See the supported transport socket implementations for further documentation.

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/endpoint/ClusterStats.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/endpoint/ClusterStats.ts
@@ -57,7 +57,7 @@ export interface ClusterStats {
    * and the *LoadStatsResponse* message sent from the management server, this may be longer than
    * the requested load reporting interval in the *LoadStatsResponse*.
    */
-  'load_report_interval'?: (_google_protobuf_Duration);
+  'load_report_interval'?: (_google_protobuf_Duration | null);
   /**
    * Information about deliberately dropped requests for each category specified
    * in the DropOverload policy.
@@ -102,7 +102,7 @@ export interface ClusterStats__Output {
    * and the *LoadStatsResponse* message sent from the management server, this may be longer than
    * the requested load reporting interval in the *LoadStatsResponse*.
    */
-  'load_report_interval'?: (_google_protobuf_Duration__Output);
+  'load_report_interval': (_google_protobuf_Duration__Output | null);
   /**
    * Information about deliberately dropped requests for each category specified
    * in the DropOverload policy.

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/endpoint/UpstreamEndpointStats.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/endpoint/UpstreamEndpointStats.ts
@@ -13,7 +13,7 @@ export interface UpstreamEndpointStats {
   /**
    * Upstream host address.
    */
-  'address'?: (_envoy_api_v2_core_Address);
+  'address'?: (_envoy_api_v2_core_Address | null);
   /**
    * The total number of requests successfully completed by the endpoints in the
    * locality. These include non-5xx responses for HTTP, where errors
@@ -46,7 +46,7 @@ export interface UpstreamEndpointStats {
    * Opaque and implementation dependent metadata of the
    * endpoint. Envoy will pass this directly to the management server.
    */
-  'metadata'?: (_google_protobuf_Struct);
+  'metadata'?: (_google_protobuf_Struct | null);
   /**
    * The total number of requests that were issued to this endpoint
    * since the last report. A single TCP connection, HTTP or gRPC
@@ -63,7 +63,7 @@ export interface UpstreamEndpointStats__Output {
   /**
    * Upstream host address.
    */
-  'address'?: (_envoy_api_v2_core_Address__Output);
+  'address': (_envoy_api_v2_core_Address__Output | null);
   /**
    * The total number of requests successfully completed by the endpoints in the
    * locality. These include non-5xx responses for HTTP, where errors
@@ -96,7 +96,7 @@ export interface UpstreamEndpointStats__Output {
    * Opaque and implementation dependent metadata of the
    * endpoint. Envoy will pass this directly to the management server.
    */
-  'metadata'?: (_google_protobuf_Struct__Output);
+  'metadata': (_google_protobuf_Struct__Output | null);
   /**
    * The total number of requests that were issued to this endpoint
    * since the last report. A single TCP connection, HTTP or gRPC

--- a/packages/grpc-js-xds/src/generated/envoy/api/v2/endpoint/UpstreamLocalityStats.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/api/v2/endpoint/UpstreamLocalityStats.ts
@@ -18,7 +18,7 @@ export interface UpstreamLocalityStats {
    * Name of zone, region and optionally endpoint group these metrics were
    * collected from. Zone and region names could be empty if unknown.
    */
-  'locality'?: (_envoy_api_v2_core_Locality);
+  'locality'?: (_envoy_api_v2_core_Locality | null);
   /**
    * The total number of requests successfully completed by the endpoints in the
    * locality.
@@ -69,7 +69,7 @@ export interface UpstreamLocalityStats__Output {
    * Name of zone, region and optionally endpoint group these metrics were
    * collected from. Zone and region names could be empty if unknown.
    */
-  'locality'?: (_envoy_api_v2_core_Locality__Output);
+  'locality': (_envoy_api_v2_core_Locality__Output | null);
   /**
    * The total number of requests successfully completed by the endpoints in the
    * locality.

--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/AccessLog.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/AccessLog.ts
@@ -16,8 +16,8 @@ export interface AccessLog {
   /**
    * Filter which is used to determine if the access log needs to be written.
    */
-  'filter'?: (_envoy_config_accesslog_v3_AccessLogFilter);
-  'typed_config'?: (_google_protobuf_Any);
+  'filter'?: (_envoy_config_accesslog_v3_AccessLogFilter | null);
+  'typed_config'?: (_google_protobuf_Any | null);
   /**
    * Custom configuration that depends on the access log being instantiated.
    * Built-in configurations include:
@@ -45,8 +45,8 @@ export interface AccessLog__Output {
   /**
    * Filter which is used to determine if the access log needs to be written.
    */
-  'filter'?: (_envoy_config_accesslog_v3_AccessLogFilter__Output);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'filter': (_envoy_config_accesslog_v3_AccessLogFilter__Output | null);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   /**
    * Custom configuration that depends on the access log being instantiated.
    * Built-in configurations include:

--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/AccessLogFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/AccessLogFilter.ts
@@ -20,51 +20,51 @@ export interface AccessLogFilter {
   /**
    * Status code filter.
    */
-  'status_code_filter'?: (_envoy_config_accesslog_v3_StatusCodeFilter);
+  'status_code_filter'?: (_envoy_config_accesslog_v3_StatusCodeFilter | null);
   /**
    * Duration filter.
    */
-  'duration_filter'?: (_envoy_config_accesslog_v3_DurationFilter);
+  'duration_filter'?: (_envoy_config_accesslog_v3_DurationFilter | null);
   /**
    * Not health check filter.
    */
-  'not_health_check_filter'?: (_envoy_config_accesslog_v3_NotHealthCheckFilter);
+  'not_health_check_filter'?: (_envoy_config_accesslog_v3_NotHealthCheckFilter | null);
   /**
    * Traceable filter.
    */
-  'traceable_filter'?: (_envoy_config_accesslog_v3_TraceableFilter);
+  'traceable_filter'?: (_envoy_config_accesslog_v3_TraceableFilter | null);
   /**
    * Runtime filter.
    */
-  'runtime_filter'?: (_envoy_config_accesslog_v3_RuntimeFilter);
+  'runtime_filter'?: (_envoy_config_accesslog_v3_RuntimeFilter | null);
   /**
    * And filter.
    */
-  'and_filter'?: (_envoy_config_accesslog_v3_AndFilter);
+  'and_filter'?: (_envoy_config_accesslog_v3_AndFilter | null);
   /**
    * Or filter.
    */
-  'or_filter'?: (_envoy_config_accesslog_v3_OrFilter);
+  'or_filter'?: (_envoy_config_accesslog_v3_OrFilter | null);
   /**
    * Header filter.
    */
-  'header_filter'?: (_envoy_config_accesslog_v3_HeaderFilter);
+  'header_filter'?: (_envoy_config_accesslog_v3_HeaderFilter | null);
   /**
    * Response flag filter.
    */
-  'response_flag_filter'?: (_envoy_config_accesslog_v3_ResponseFlagFilter);
+  'response_flag_filter'?: (_envoy_config_accesslog_v3_ResponseFlagFilter | null);
   /**
    * gRPC status filter.
    */
-  'grpc_status_filter'?: (_envoy_config_accesslog_v3_GrpcStatusFilter);
+  'grpc_status_filter'?: (_envoy_config_accesslog_v3_GrpcStatusFilter | null);
   /**
    * Extension filter.
    */
-  'extension_filter'?: (_envoy_config_accesslog_v3_ExtensionFilter);
+  'extension_filter'?: (_envoy_config_accesslog_v3_ExtensionFilter | null);
   /**
    * Metadata Filter
    */
-  'metadata_filter'?: (_envoy_config_accesslog_v3_MetadataFilter);
+  'metadata_filter'?: (_envoy_config_accesslog_v3_MetadataFilter | null);
   'filter_specifier'?: "status_code_filter"|"duration_filter"|"not_health_check_filter"|"traceable_filter"|"runtime_filter"|"and_filter"|"or_filter"|"header_filter"|"response_flag_filter"|"grpc_status_filter"|"extension_filter"|"metadata_filter";
 }
 
@@ -75,50 +75,50 @@ export interface AccessLogFilter__Output {
   /**
    * Status code filter.
    */
-  'status_code_filter'?: (_envoy_config_accesslog_v3_StatusCodeFilter__Output);
+  'status_code_filter'?: (_envoy_config_accesslog_v3_StatusCodeFilter__Output | null);
   /**
    * Duration filter.
    */
-  'duration_filter'?: (_envoy_config_accesslog_v3_DurationFilter__Output);
+  'duration_filter'?: (_envoy_config_accesslog_v3_DurationFilter__Output | null);
   /**
    * Not health check filter.
    */
-  'not_health_check_filter'?: (_envoy_config_accesslog_v3_NotHealthCheckFilter__Output);
+  'not_health_check_filter'?: (_envoy_config_accesslog_v3_NotHealthCheckFilter__Output | null);
   /**
    * Traceable filter.
    */
-  'traceable_filter'?: (_envoy_config_accesslog_v3_TraceableFilter__Output);
+  'traceable_filter'?: (_envoy_config_accesslog_v3_TraceableFilter__Output | null);
   /**
    * Runtime filter.
    */
-  'runtime_filter'?: (_envoy_config_accesslog_v3_RuntimeFilter__Output);
+  'runtime_filter'?: (_envoy_config_accesslog_v3_RuntimeFilter__Output | null);
   /**
    * And filter.
    */
-  'and_filter'?: (_envoy_config_accesslog_v3_AndFilter__Output);
+  'and_filter'?: (_envoy_config_accesslog_v3_AndFilter__Output | null);
   /**
    * Or filter.
    */
-  'or_filter'?: (_envoy_config_accesslog_v3_OrFilter__Output);
+  'or_filter'?: (_envoy_config_accesslog_v3_OrFilter__Output | null);
   /**
    * Header filter.
    */
-  'header_filter'?: (_envoy_config_accesslog_v3_HeaderFilter__Output);
+  'header_filter'?: (_envoy_config_accesslog_v3_HeaderFilter__Output | null);
   /**
    * Response flag filter.
    */
-  'response_flag_filter'?: (_envoy_config_accesslog_v3_ResponseFlagFilter__Output);
+  'response_flag_filter'?: (_envoy_config_accesslog_v3_ResponseFlagFilter__Output | null);
   /**
    * gRPC status filter.
    */
-  'grpc_status_filter'?: (_envoy_config_accesslog_v3_GrpcStatusFilter__Output);
+  'grpc_status_filter'?: (_envoy_config_accesslog_v3_GrpcStatusFilter__Output | null);
   /**
    * Extension filter.
    */
-  'extension_filter'?: (_envoy_config_accesslog_v3_ExtensionFilter__Output);
+  'extension_filter'?: (_envoy_config_accesslog_v3_ExtensionFilter__Output | null);
   /**
    * Metadata Filter
    */
-  'metadata_filter'?: (_envoy_config_accesslog_v3_MetadataFilter__Output);
+  'metadata_filter'?: (_envoy_config_accesslog_v3_MetadataFilter__Output | null);
   'filter_specifier': "status_code_filter"|"duration_filter"|"not_health_check_filter"|"traceable_filter"|"runtime_filter"|"and_filter"|"or_filter"|"header_filter"|"response_flag_filter"|"grpc_status_filter"|"extension_filter"|"metadata_filter";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/ComparisonFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/ComparisonFilter.ts
@@ -30,7 +30,7 @@ export interface ComparisonFilter {
   /**
    * Value to compare against.
    */
-  'value'?: (_envoy_config_core_v3_RuntimeUInt32);
+  'value'?: (_envoy_config_core_v3_RuntimeUInt32 | null);
 }
 
 /**
@@ -44,5 +44,5 @@ export interface ComparisonFilter__Output {
   /**
    * Value to compare against.
    */
-  'value'?: (_envoy_config_core_v3_RuntimeUInt32__Output);
+  'value': (_envoy_config_core_v3_RuntimeUInt32__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/DurationFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/DurationFilter.ts
@@ -9,7 +9,7 @@ export interface DurationFilter {
   /**
    * Comparison.
    */
-  'comparison'?: (_envoy_config_accesslog_v3_ComparisonFilter);
+  'comparison'?: (_envoy_config_accesslog_v3_ComparisonFilter | null);
 }
 
 /**
@@ -19,5 +19,5 @@ export interface DurationFilter__Output {
   /**
    * Comparison.
    */
-  'comparison'?: (_envoy_config_accesslog_v3_ComparisonFilter__Output);
+  'comparison': (_envoy_config_accesslog_v3_ComparisonFilter__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/ExtensionFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/ExtensionFilter.ts
@@ -11,7 +11,7 @@ export interface ExtensionFilter {
    * match a statically registered filter.
    */
   'name'?: (string);
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
   /**
    * Custom configuration that depends on the filter being instantiated.
    */
@@ -27,7 +27,7 @@ export interface ExtensionFilter__Output {
    * match a statically registered filter.
    */
   'name': (string);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   /**
    * Custom configuration that depends on the filter being instantiated.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/HeaderFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/HeaderFilter.ts
@@ -10,7 +10,7 @@ export interface HeaderFilter {
    * Only requests with a header which matches the specified HeaderMatcher will
    * pass the filter check.
    */
-  'header'?: (_envoy_config_route_v3_HeaderMatcher);
+  'header'?: (_envoy_config_route_v3_HeaderMatcher | null);
 }
 
 /**
@@ -21,5 +21,5 @@ export interface HeaderFilter__Output {
    * Only requests with a header which matches the specified HeaderMatcher will
    * pass the filter check.
    */
-  'header'?: (_envoy_config_route_v3_HeaderMatcher__Output);
+  'header': (_envoy_config_route_v3_HeaderMatcher__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/MetadataFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/MetadataFilter.ts
@@ -17,12 +17,12 @@ export interface MetadataFilter {
    * access_log_hint metadata, set the filter to "envoy.common" and the path to
    * "access_log_hint", and the value to "true".
    */
-  'matcher'?: (_envoy_type_matcher_v3_MetadataMatcher);
+  'matcher'?: (_envoy_type_matcher_v3_MetadataMatcher | null);
   /**
    * Default result if the key does not exist in dynamic metadata: if unset or
    * true, then log; if false, then don't log.
    */
-  'match_if_key_not_found'?: (_google_protobuf_BoolValue);
+  'match_if_key_not_found'?: (_google_protobuf_BoolValue | null);
 }
 
 /**
@@ -39,10 +39,10 @@ export interface MetadataFilter__Output {
    * access_log_hint metadata, set the filter to "envoy.common" and the path to
    * "access_log_hint", and the value to "true".
    */
-  'matcher'?: (_envoy_type_matcher_v3_MetadataMatcher__Output);
+  'matcher': (_envoy_type_matcher_v3_MetadataMatcher__Output | null);
   /**
    * Default result if the key does not exist in dynamic metadata: if unset or
    * true, then log; if false, then don't log.
    */
-  'match_if_key_not_found'?: (_google_protobuf_BoolValue__Output);
+  'match_if_key_not_found': (_google_protobuf_BoolValue__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/RuntimeFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/RuntimeFilter.ts
@@ -16,7 +16,7 @@ export interface RuntimeFilter {
    * The default sampling percentage. If not specified, defaults to 0% with
    * denominator of 100.
    */
-  'percent_sampled'?: (_envoy_type_v3_FractionalPercent);
+  'percent_sampled'?: (_envoy_type_v3_FractionalPercent | null);
   /**
    * By default, sampling pivots on the header
    * :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` being
@@ -51,7 +51,7 @@ export interface RuntimeFilter__Output {
    * The default sampling percentage. If not specified, defaults to 0% with
    * denominator of 100.
    */
-  'percent_sampled'?: (_envoy_type_v3_FractionalPercent__Output);
+  'percent_sampled': (_envoy_type_v3_FractionalPercent__Output | null);
   /**
    * By default, sampling pivots on the header
    * :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` being

--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/StatusCodeFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/StatusCodeFilter.ts
@@ -9,7 +9,7 @@ export interface StatusCodeFilter {
   /**
    * Comparison.
    */
-  'comparison'?: (_envoy_config_accesslog_v3_ComparisonFilter);
+  'comparison'?: (_envoy_config_accesslog_v3_ComparisonFilter | null);
 }
 
 /**
@@ -19,5 +19,5 @@ export interface StatusCodeFilter__Output {
   /**
    * Comparison.
    */
-  'comparison'?: (_envoy_config_accesslog_v3_ComparisonFilter__Output);
+  'comparison': (_envoy_config_accesslog_v3_ComparisonFilter__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/CircuitBreakers.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/CircuitBreakers.ts
@@ -12,14 +12,14 @@ export interface _envoy_config_cluster_v3_CircuitBreakers_Thresholds_RetryBudget
    * 
    * This parameter is optional. Defaults to 20%.
    */
-  'budget_percent'?: (_envoy_type_v3_Percent);
+  'budget_percent'?: (_envoy_type_v3_Percent | null);
   /**
    * Specifies the minimum retry concurrency allowed for the retry budget. The limit on the
    * number of active retries may never go below this number.
    * 
    * This parameter is optional. Defaults to 3.
    */
-  'min_retry_concurrency'?: (_google_protobuf_UInt32Value);
+  'min_retry_concurrency'?: (_google_protobuf_UInt32Value | null);
 }
 
 export interface _envoy_config_cluster_v3_CircuitBreakers_Thresholds_RetryBudget__Output {
@@ -30,14 +30,14 @@ export interface _envoy_config_cluster_v3_CircuitBreakers_Thresholds_RetryBudget
    * 
    * This parameter is optional. Defaults to 20%.
    */
-  'budget_percent'?: (_envoy_type_v3_Percent__Output);
+  'budget_percent': (_envoy_type_v3_Percent__Output | null);
   /**
    * Specifies the minimum retry concurrency allowed for the retry budget. The limit on the
    * number of active retries may never go below this number.
    * 
    * This parameter is optional. Defaults to 3.
    */
-  'min_retry_concurrency'?: (_google_protobuf_UInt32Value__Output);
+  'min_retry_concurrency': (_google_protobuf_UInt32Value__Output | null);
 }
 
 /**
@@ -55,22 +55,22 @@ export interface _envoy_config_cluster_v3_CircuitBreakers_Thresholds {
    * The maximum number of connections that Envoy will make to the upstream
    * cluster. If not specified, the default is 1024.
    */
-  'max_connections'?: (_google_protobuf_UInt32Value);
+  'max_connections'?: (_google_protobuf_UInt32Value | null);
   /**
    * The maximum number of pending requests that Envoy will allow to the
    * upstream cluster. If not specified, the default is 1024.
    */
-  'max_pending_requests'?: (_google_protobuf_UInt32Value);
+  'max_pending_requests'?: (_google_protobuf_UInt32Value | null);
   /**
    * The maximum number of parallel requests that Envoy will make to the
    * upstream cluster. If not specified, the default is 1024.
    */
-  'max_requests'?: (_google_protobuf_UInt32Value);
+  'max_requests'?: (_google_protobuf_UInt32Value | null);
   /**
    * The maximum number of parallel retries that Envoy will allow to the
    * upstream cluster. If not specified, the default is 3.
    */
-  'max_retries'?: (_google_protobuf_UInt32Value);
+  'max_retries'?: (_google_protobuf_UInt32Value | null);
   /**
    * Specifies a limit on concurrent retries in relation to the number of active requests. This
    * parameter is optional.
@@ -80,7 +80,7 @@ export interface _envoy_config_cluster_v3_CircuitBreakers_Thresholds {
    * If this field is set, the retry budget will override any configured retry circuit
    * breaker.
    */
-  'retry_budget'?: (_envoy_config_cluster_v3_CircuitBreakers_Thresholds_RetryBudget);
+  'retry_budget'?: (_envoy_config_cluster_v3_CircuitBreakers_Thresholds_RetryBudget | null);
   /**
    * If track_remaining is true, then stats will be published that expose
    * the number of resources remaining until the circuit breakers open. If
@@ -99,7 +99,7 @@ export interface _envoy_config_cluster_v3_CircuitBreakers_Thresholds {
    * :ref:`Circuit Breaking <arch_overview_circuit_break_cluster_maximum_connection_pools>` for
    * more details.
    */
-  'max_connection_pools'?: (_google_protobuf_UInt32Value);
+  'max_connection_pools'?: (_google_protobuf_UInt32Value | null);
 }
 
 /**
@@ -117,22 +117,22 @@ export interface _envoy_config_cluster_v3_CircuitBreakers_Thresholds__Output {
    * The maximum number of connections that Envoy will make to the upstream
    * cluster. If not specified, the default is 1024.
    */
-  'max_connections'?: (_google_protobuf_UInt32Value__Output);
+  'max_connections': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The maximum number of pending requests that Envoy will allow to the
    * upstream cluster. If not specified, the default is 1024.
    */
-  'max_pending_requests'?: (_google_protobuf_UInt32Value__Output);
+  'max_pending_requests': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The maximum number of parallel requests that Envoy will make to the
    * upstream cluster. If not specified, the default is 1024.
    */
-  'max_requests'?: (_google_protobuf_UInt32Value__Output);
+  'max_requests': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The maximum number of parallel retries that Envoy will allow to the
    * upstream cluster. If not specified, the default is 3.
    */
-  'max_retries'?: (_google_protobuf_UInt32Value__Output);
+  'max_retries': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Specifies a limit on concurrent retries in relation to the number of active requests. This
    * parameter is optional.
@@ -142,7 +142,7 @@ export interface _envoy_config_cluster_v3_CircuitBreakers_Thresholds__Output {
    * If this field is set, the retry budget will override any configured retry circuit
    * breaker.
    */
-  'retry_budget'?: (_envoy_config_cluster_v3_CircuitBreakers_Thresholds_RetryBudget__Output);
+  'retry_budget': (_envoy_config_cluster_v3_CircuitBreakers_Thresholds_RetryBudget__Output | null);
   /**
    * If track_remaining is true, then stats will be published that expose
    * the number of resources remaining until the circuit breakers open. If
@@ -161,7 +161,7 @@ export interface _envoy_config_cluster_v3_CircuitBreakers_Thresholds__Output {
    * :ref:`Circuit Breaking <arch_overview_circuit_break_cluster_maximum_connection_pools>` for
    * more details.
    */
-  'max_connection_pools'?: (_google_protobuf_UInt32Value__Output);
+  'max_connection_pools': (_google_protobuf_UInt32Value__Output | null);
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/Cluster.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/Cluster.ts
@@ -56,9 +56,9 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig {
    * .. note::
    * The specified percent will be truncated to the nearest 1%.
    */
-  'healthy_panic_threshold'?: (_envoy_type_v3_Percent);
-  'zone_aware_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig_ZoneAwareLbConfig);
-  'locality_weighted_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig_LocalityWeightedLbConfig);
+  'healthy_panic_threshold'?: (_envoy_type_v3_Percent | null);
+  'zone_aware_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig_ZoneAwareLbConfig | null);
+  'locality_weighted_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig_LocalityWeightedLbConfig | null);
   /**
    * If set, all health check/weight/metadata updates that happen within this duration will be
    * merged and delivered in one shot when the duration expires. The start of the duration is when
@@ -75,7 +75,7 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig {
    * because merging those updates isn't currently safe. See
    * https://github.com/envoyproxy/envoy/pull/3941.
    */
-  'update_merge_window'?: (_google_protobuf_Duration);
+  'update_merge_window'?: (_google_protobuf_Duration | null);
   /**
    * If set to true, Envoy will :ref:`exclude <arch_overview_load_balancing_excluded>` new hosts
    * when computing load balancing weights until they have been health checked for the first time.
@@ -90,7 +90,7 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig {
   /**
    * Common Configuration for all consistent hashing load balancers (MaglevLb, RingHashLb, etc.)
    */
-  'consistent_hashing_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig_ConsistentHashingLbConfig);
+  'consistent_hashing_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig_ConsistentHashingLbConfig | null);
   'locality_config_specifier'?: "zone_aware_lb_config"|"locality_weighted_lb_config";
 }
 
@@ -107,9 +107,9 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig__Output {
    * .. note::
    * The specified percent will be truncated to the nearest 1%.
    */
-  'healthy_panic_threshold'?: (_envoy_type_v3_Percent__Output);
-  'zone_aware_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig_ZoneAwareLbConfig__Output);
-  'locality_weighted_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig_LocalityWeightedLbConfig__Output);
+  'healthy_panic_threshold': (_envoy_type_v3_Percent__Output | null);
+  'zone_aware_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig_ZoneAwareLbConfig__Output | null);
+  'locality_weighted_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig_LocalityWeightedLbConfig__Output | null);
   /**
    * If set, all health check/weight/metadata updates that happen within this duration will be
    * merged and delivered in one shot when the duration expires. The start of the duration is when
@@ -126,7 +126,7 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig__Output {
    * because merging those updates isn't currently safe. See
    * https://github.com/envoyproxy/envoy/pull/3941.
    */
-  'update_merge_window'?: (_google_protobuf_Duration__Output);
+  'update_merge_window': (_google_protobuf_Duration__Output | null);
   /**
    * If set to true, Envoy will :ref:`exclude <arch_overview_load_balancing_excluded>` new hosts
    * when computing load balancing weights until they have been health checked for the first time.
@@ -141,7 +141,7 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig__Output {
   /**
    * Common Configuration for all consistent hashing load balancers (MaglevLb, RingHashLb, etc.)
    */
-  'consistent_hashing_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig_ConsistentHashingLbConfig__Output);
+  'consistent_hashing_lb_config': (_envoy_config_cluster_v3_Cluster_CommonLbConfig_ConsistentHashingLbConfig__Output | null);
   'locality_config_specifier': "zone_aware_lb_config"|"locality_weighted_lb_config";
 }
 
@@ -174,7 +174,7 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig_ConsistentHashi
    * This is an O(N) algorithm, unlike other load balancers. Using a lower `hash_balance_factor` results in more hosts
    * being probed, so use a higher value if you require better performance.
    */
-  'hash_balance_factor'?: (_google_protobuf_UInt32Value);
+  'hash_balance_factor'?: (_google_protobuf_UInt32Value | null);
 }
 
 /**
@@ -206,7 +206,7 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig_ConsistentHashi
    * This is an O(N) algorithm, unlike other load balancers. Using a lower `hash_balance_factor` results in more hosts
    * being probed, so use a higher value if you require better performance.
    */
-  'hash_balance_factor'?: (_google_protobuf_UInt32Value__Output);
+  'hash_balance_factor': (_google_protobuf_UInt32Value__Output | null);
 }
 
 /**
@@ -221,7 +221,7 @@ export interface _envoy_config_cluster_v3_Cluster_CustomClusterType {
    * Cluster specific configuration which depends on the cluster being instantiated.
    * See the supported cluster for further documentation.
    */
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
 }
 
 /**
@@ -236,7 +236,7 @@ export interface _envoy_config_cluster_v3_Cluster_CustomClusterType__Output {
    * Cluster specific configuration which depends on the cluster being instantiated.
    * See the supported cluster for further documentation.
    */
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config': (_google_protobuf_Any__Output | null);
 }
 
 // Original file: deps/envoy-api/envoy/config/cluster/v3/cluster.proto
@@ -303,7 +303,7 @@ export interface _envoy_config_cluster_v3_Cluster_EdsClusterConfig {
   /**
    * Configuration for the source of EDS updates for this Cluster.
    */
-  'eds_config'?: (_envoy_config_core_v3_ConfigSource);
+  'eds_config'?: (_envoy_config_core_v3_ConfigSource | null);
   /**
    * Optional alternative to cluster name to present to EDS. This does not
    * have the same restrictions as cluster name, i.e. it may be arbitrary
@@ -319,7 +319,7 @@ export interface _envoy_config_cluster_v3_Cluster_EdsClusterConfig__Output {
   /**
    * Configuration for the source of EDS updates for this Cluster.
    */
-  'eds_config'?: (_envoy_config_core_v3_ConfigSource__Output);
+  'eds_config': (_envoy_config_core_v3_ConfigSource__Output | null);
   /**
    * Optional alternative to cluster name to present to EDS. This does not
    * have the same restrictions as cluster name, i.e. it may be arbitrary
@@ -420,7 +420,7 @@ export interface _envoy_config_cluster_v3_Cluster_LbSubsetConfig {
    * is the same as a fallback_policy of
    * :ref:`NO_FALLBACK<envoy_api_enum_value_config.cluster.v3.Cluster.LbSubsetConfig.LbSubsetFallbackPolicy.NO_FALLBACK>`.
    */
-  'default_subset'?: (_google_protobuf_Struct);
+  'default_subset'?: (_google_protobuf_Struct | null);
   /**
    * For each entry, LbEndpoint.Metadata's
    * *envoy.lb* namespace is traversed and a subset is created for each unique
@@ -497,7 +497,7 @@ export interface _envoy_config_cluster_v3_Cluster_LbSubsetConfig__Output {
    * is the same as a fallback_policy of
    * :ref:`NO_FALLBACK<envoy_api_enum_value_config.cluster.v3.Cluster.LbSubsetConfig.LbSubsetFallbackPolicy.NO_FALLBACK>`.
    */
-  'default_subset'?: (_google_protobuf_Struct__Output);
+  'default_subset': (_google_protobuf_Struct__Output | null);
   /**
    * For each entry, LbEndpoint.Metadata's
    * *envoy.lb* namespace is traversed and a subset is created for each unique
@@ -693,7 +693,7 @@ export interface _envoy_config_cluster_v3_Cluster_LeastRequestLbConfig {
    * The number of random healthy hosts from which the host with the fewest active requests will
    * be chosen. Defaults to 2 so that we perform two-choice selection if the field is not set.
    */
-  'choice_count'?: (_google_protobuf_UInt32Value);
+  'choice_count'?: (_google_protobuf_UInt32Value | null);
   /**
    * The following formula is used to calculate the dynamic weights when hosts have different load
    * balancing weights:
@@ -719,7 +719,7 @@ export interface _envoy_config_cluster_v3_Cluster_LeastRequestLbConfig {
    * .. note::
    * This setting only takes effect if all host weights are not equal.
    */
-  'active_request_bias'?: (_envoy_config_core_v3_RuntimeDouble);
+  'active_request_bias'?: (_envoy_config_core_v3_RuntimeDouble | null);
 }
 
 /**
@@ -730,7 +730,7 @@ export interface _envoy_config_cluster_v3_Cluster_LeastRequestLbConfig__Output {
    * The number of random healthy hosts from which the host with the fewest active requests will
    * be chosen. Defaults to 2 so that we perform two-choice selection if the field is not set.
    */
-  'choice_count'?: (_google_protobuf_UInt32Value__Output);
+  'choice_count': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The following formula is used to calculate the dynamic weights when hosts have different load
    * balancing weights:
@@ -756,7 +756,7 @@ export interface _envoy_config_cluster_v3_Cluster_LeastRequestLbConfig__Output {
    * .. note::
    * This setting only takes effect if all host weights are not equal.
    */
-  'active_request_bias'?: (_envoy_config_core_v3_RuntimeDouble__Output);
+  'active_request_bias': (_envoy_config_core_v3_RuntimeDouble__Output | null);
 }
 
 /**
@@ -784,7 +784,7 @@ export interface _envoy_config_cluster_v3_Cluster_MaglevLbConfig {
    * upstream as it was before. Increasing the table size reduces the amount of disruption.
    * The table size must be prime number. If it is not specified, the default is 65537.
    */
-  'table_size'?: (_google_protobuf_UInt64Value);
+  'table_size'?: (_google_protobuf_UInt64Value | null);
 }
 
 /**
@@ -798,7 +798,7 @@ export interface _envoy_config_cluster_v3_Cluster_MaglevLbConfig__Output {
    * upstream as it was before. Increasing the table size reduces the amount of disruption.
    * The table size must be prime number. If it is not specified, the default is 65537.
    */
-  'table_size'?: (_google_protobuf_UInt64Value__Output);
+  'table_size': (_google_protobuf_UInt64Value__Output | null);
 }
 
 /**
@@ -876,7 +876,7 @@ export interface _envoy_config_cluster_v3_Cluster_PreconnectPolicy {
    * This is limited somewhat arbitrarily to 3 because preconnecting too aggressively can
    * harm latency more than the preconnecting helps.
    */
-  'per_upstream_preconnect_ratio'?: (_google_protobuf_DoubleValue);
+  'per_upstream_preconnect_ratio'?: (_google_protobuf_DoubleValue | null);
   /**
    * Indicates how many many streams (rounded up) can be anticipated across a cluster for each
    * stream, useful for low QPS services. This is currently supported for a subset of
@@ -901,7 +901,7 @@ export interface _envoy_config_cluster_v3_Cluster_PreconnectPolicy {
    * basically preconnecting max(predictive-preconnect, per-upstream-preconnect), for each
    * upstream.
    */
-  'predictive_preconnect_ratio'?: (_google_protobuf_DoubleValue);
+  'predictive_preconnect_ratio'?: (_google_protobuf_DoubleValue | null);
 }
 
 export interface _envoy_config_cluster_v3_Cluster_PreconnectPolicy__Output {
@@ -931,7 +931,7 @@ export interface _envoy_config_cluster_v3_Cluster_PreconnectPolicy__Output {
    * This is limited somewhat arbitrarily to 3 because preconnecting too aggressively can
    * harm latency more than the preconnecting helps.
    */
-  'per_upstream_preconnect_ratio'?: (_google_protobuf_DoubleValue__Output);
+  'per_upstream_preconnect_ratio': (_google_protobuf_DoubleValue__Output | null);
   /**
    * Indicates how many many streams (rounded up) can be anticipated across a cluster for each
    * stream, useful for low QPS services. This is currently supported for a subset of
@@ -956,7 +956,7 @@ export interface _envoy_config_cluster_v3_Cluster_PreconnectPolicy__Output {
    * basically preconnecting max(predictive-preconnect, per-upstream-preconnect), for each
    * upstream.
    */
-  'predictive_preconnect_ratio'?: (_google_protobuf_DoubleValue__Output);
+  'predictive_preconnect_ratio': (_google_protobuf_DoubleValue__Output | null);
 }
 
 export interface _envoy_config_cluster_v3_Cluster_RefreshRate {
@@ -965,14 +965,14 @@ export interface _envoy_config_cluster_v3_Cluster_RefreshRate {
    * than zero and less than
    * :ref:`max_interval <envoy_api_field_config.cluster.v3.Cluster.RefreshRate.max_interval>`.
    */
-  'base_interval'?: (_google_protobuf_Duration);
+  'base_interval'?: (_google_protobuf_Duration | null);
   /**
    * Specifies the maximum interval between refreshes. This parameter is optional, but must be
    * greater than or equal to the
    * :ref:`base_interval <envoy_api_field_config.cluster.v3.Cluster.RefreshRate.base_interval>`  if set. The default
    * is 10 times the :ref:`base_interval <envoy_api_field_config.cluster.v3.Cluster.RefreshRate.base_interval>`.
    */
-  'max_interval'?: (_google_protobuf_Duration);
+  'max_interval'?: (_google_protobuf_Duration | null);
 }
 
 export interface _envoy_config_cluster_v3_Cluster_RefreshRate__Output {
@@ -981,14 +981,14 @@ export interface _envoy_config_cluster_v3_Cluster_RefreshRate__Output {
    * than zero and less than
    * :ref:`max_interval <envoy_api_field_config.cluster.v3.Cluster.RefreshRate.max_interval>`.
    */
-  'base_interval'?: (_google_protobuf_Duration__Output);
+  'base_interval': (_google_protobuf_Duration__Output | null);
   /**
    * Specifies the maximum interval between refreshes. This parameter is optional, but must be
    * greater than or equal to the
    * :ref:`base_interval <envoy_api_field_config.cluster.v3.Cluster.RefreshRate.base_interval>`  if set. The default
    * is 10 times the :ref:`base_interval <envoy_api_field_config.cluster.v3.Cluster.RefreshRate.base_interval>`.
    */
-  'max_interval'?: (_google_protobuf_Duration__Output);
+  'max_interval': (_google_protobuf_Duration__Output | null);
 }
 
 /**
@@ -1002,7 +1002,7 @@ export interface _envoy_config_cluster_v3_Cluster_RingHashLbConfig {
    * to 1024 entries, and limited to 8M entries. See also
    * :ref:`maximum_ring_size<envoy_api_field_config.cluster.v3.Cluster.RingHashLbConfig.maximum_ring_size>`.
    */
-  'minimum_ring_size'?: (_google_protobuf_UInt64Value);
+  'minimum_ring_size'?: (_google_protobuf_UInt64Value | null);
   /**
    * The hash function used to hash hosts onto the ketama ring. The value defaults to
    * :ref:`XX_HASH<envoy_api_enum_value_config.cluster.v3.Cluster.RingHashLbConfig.HashFunction.XX_HASH>`.
@@ -1013,7 +1013,7 @@ export interface _envoy_config_cluster_v3_Cluster_RingHashLbConfig {
    * to further constrain resource use. See also
    * :ref:`minimum_ring_size<envoy_api_field_config.cluster.v3.Cluster.RingHashLbConfig.minimum_ring_size>`.
    */
-  'maximum_ring_size'?: (_google_protobuf_UInt64Value);
+  'maximum_ring_size'?: (_google_protobuf_UInt64Value | null);
 }
 
 /**
@@ -1027,7 +1027,7 @@ export interface _envoy_config_cluster_v3_Cluster_RingHashLbConfig__Output {
    * to 1024 entries, and limited to 8M entries. See also
    * :ref:`maximum_ring_size<envoy_api_field_config.cluster.v3.Cluster.RingHashLbConfig.maximum_ring_size>`.
    */
-  'minimum_ring_size'?: (_google_protobuf_UInt64Value__Output);
+  'minimum_ring_size': (_google_protobuf_UInt64Value__Output | null);
   /**
    * The hash function used to hash hosts onto the ketama ring. The value defaults to
    * :ref:`XX_HASH<envoy_api_enum_value_config.cluster.v3.Cluster.RingHashLbConfig.HashFunction.XX_HASH>`.
@@ -1038,7 +1038,7 @@ export interface _envoy_config_cluster_v3_Cluster_RingHashLbConfig__Output {
    * to further constrain resource use. See also
    * :ref:`minimum_ring_size<envoy_api_field_config.cluster.v3.Cluster.RingHashLbConfig.minimum_ring_size>`.
    */
-  'maximum_ring_size'?: (_google_protobuf_UInt64Value__Output);
+  'maximum_ring_size': (_google_protobuf_UInt64Value__Output | null);
 }
 
 /**
@@ -1057,11 +1057,11 @@ export interface _envoy_config_cluster_v3_Cluster_TransportSocketMatch {
    * The endpoint's metadata entry in *envoy.transport_socket_match* is used to match
    * against the values specified in this field.
    */
-  'match'?: (_google_protobuf_Struct);
+  'match'?: (_google_protobuf_Struct | null);
   /**
    * The configuration of the transport socket.
    */
-  'transport_socket'?: (_envoy_config_core_v3_TransportSocket);
+  'transport_socket'?: (_envoy_config_core_v3_TransportSocket | null);
 }
 
 /**
@@ -1080,11 +1080,11 @@ export interface _envoy_config_cluster_v3_Cluster_TransportSocketMatch__Output {
    * The endpoint's metadata entry in *envoy.transport_socket_match* is used to match
    * against the values specified in this field.
    */
-  'match'?: (_google_protobuf_Struct__Output);
+  'match': (_google_protobuf_Struct__Output | null);
   /**
    * The configuration of the transport socket.
    */
-  'transport_socket'?: (_envoy_config_core_v3_TransportSocket__Output);
+  'transport_socket': (_envoy_config_core_v3_TransportSocket__Output | null);
 }
 
 /**
@@ -1098,7 +1098,7 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig_ZoneAwareLbConf
    * * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
    * * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
    */
-  'routing_enabled'?: (_envoy_type_v3_Percent);
+  'routing_enabled'?: (_envoy_type_v3_Percent | null);
   /**
    * Configures minimum upstream cluster size required for zone aware routing
    * If upstream cluster size is less than specified, zone aware routing is not performed
@@ -1106,7 +1106,7 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig_ZoneAwareLbConf
    * * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
    * * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
    */
-  'min_cluster_size'?: (_google_protobuf_UInt64Value);
+  'min_cluster_size'?: (_google_protobuf_UInt64Value | null);
   /**
    * If set to true, Envoy will not consider any hosts when the cluster is in :ref:`panic
    * mode<arch_overview_load_balancing_panic_threshold>`. Instead, the cluster will fail all
@@ -1127,7 +1127,7 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig_ZoneAwareLbConf
    * * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
    * * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
    */
-  'routing_enabled'?: (_envoy_type_v3_Percent__Output);
+  'routing_enabled': (_envoy_type_v3_Percent__Output | null);
   /**
    * Configures minimum upstream cluster size required for zone aware routing
    * If upstream cluster size is less than specified, zone aware routing is not performed
@@ -1135,7 +1135,7 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig_ZoneAwareLbConf
    * * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
    * * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
    */
-  'min_cluster_size'?: (_google_protobuf_UInt64Value__Output);
+  'min_cluster_size': (_google_protobuf_UInt64Value__Output | null);
   /**
    * If set to true, Envoy will not consider any hosts when the cluster is in :ref:`panic
    * mode<arch_overview_load_balancing_panic_threshold>`. Instead, the cluster will fail all
@@ -1166,16 +1166,16 @@ export interface Cluster {
   /**
    * Configuration to use for EDS updates for the Cluster.
    */
-  'eds_cluster_config'?: (_envoy_config_cluster_v3_Cluster_EdsClusterConfig);
+  'eds_cluster_config'?: (_envoy_config_cluster_v3_Cluster_EdsClusterConfig | null);
   /**
    * The timeout for new network connections to hosts in the cluster.
    */
-  'connect_timeout'?: (_google_protobuf_Duration);
+  'connect_timeout'?: (_google_protobuf_Duration | null);
   /**
    * Soft limit on size of the cluster’s connections read and write buffers. If
    * unspecified, an implementation defined default is applied (1MiB).
    */
-  'per_connection_buffer_limit_bytes'?: (_google_protobuf_UInt32Value);
+  'per_connection_buffer_limit_bytes'?: (_google_protobuf_UInt32Value | null);
   /**
    * The :ref:`load balancer type <arch_overview_load_balancing_types>` to use
    * when picking a host in the cluster.
@@ -1195,11 +1195,11 @@ export interface Cluster {
    * implementations. If not specified, there is no limit. Setting this
    * parameter to 1 will effectively disable keep alive.
    */
-  'max_requests_per_connection'?: (_google_protobuf_UInt32Value);
+  'max_requests_per_connection'?: (_google_protobuf_UInt32Value | null);
   /**
    * Optional :ref:`circuit breaking <arch_overview_circuit_break>` for the cluster.
    */
-  'circuit_breakers'?: (_envoy_config_cluster_v3_CircuitBreakers);
+  'circuit_breakers'?: (_envoy_config_cluster_v3_CircuitBreakers | null);
   /**
    * Additional options when handling HTTP1 requests.
    * This has been deprecated in favor of http_protocol_options fields in the in the
@@ -1210,7 +1210,7 @@ export interface Cluster {
    * <envoy_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.upstream_http_protocol_options>`
    * for example usage.
    */
-  'http_protocol_options'?: (_envoy_config_core_v3_Http1ProtocolOptions);
+  'http_protocol_options'?: (_envoy_config_core_v3_Http1ProtocolOptions | null);
   /**
    * Even if default HTTP2 protocol options are desired, this field must be
    * set so that Envoy will assume that the upstream supports HTTP/2 when
@@ -1226,7 +1226,7 @@ export interface Cluster {
    * <envoy_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.upstream_http_protocol_options>`
    * for example usage.
    */
-  'http2_protocol_options'?: (_envoy_config_core_v3_Http2ProtocolOptions);
+  'http2_protocol_options'?: (_envoy_config_core_v3_Http2ProtocolOptions | null);
   /**
    * If the DNS refresh rate is specified and the cluster type is either
    * :ref:`STRICT_DNS<envoy_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`,
@@ -1238,7 +1238,7 @@ export interface Cluster {
    * and :ref:`LOGICAL_DNS<envoy_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`
    * this setting is ignored.
    */
-  'dns_refresh_rate'?: (_google_protobuf_Duration);
+  'dns_refresh_rate'?: (_google_protobuf_Duration | null);
   /**
    * The DNS IP address resolution policy. If this setting is not specified, the
    * value defaults to
@@ -1266,7 +1266,7 @@ export interface Cluster {
    * Each of the configuration values can be overridden via
    * :ref:`runtime values <config_cluster_manager_cluster_runtime_outlier_detection>`.
    */
-  'outlier_detection'?: (_envoy_config_cluster_v3_OutlierDetection);
+  'outlier_detection'?: (_envoy_config_cluster_v3_OutlierDetection | null);
   /**
    * The interval for removing stale hosts from a cluster type
    * :ref:`ORIGINAL_DST<envoy_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.ORIGINAL_DST>`.
@@ -1282,21 +1282,21 @@ export interface Cluster {
    * :ref:`ORIGINAL_DST<envoy_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.ORIGINAL_DST>`
    * this setting is ignored.
    */
-  'cleanup_interval'?: (_google_protobuf_Duration);
+  'cleanup_interval'?: (_google_protobuf_Duration | null);
   /**
    * Optional configuration used to bind newly established upstream connections.
    * This overrides any bind_config specified in the bootstrap proto.
    * If the address and port are empty, no bind will be performed.
    */
-  'upstream_bind_config'?: (_envoy_config_core_v3_BindConfig);
+  'upstream_bind_config'?: (_envoy_config_core_v3_BindConfig | null);
   /**
    * Configuration for load balancing subsetting.
    */
-  'lb_subset_config'?: (_envoy_config_cluster_v3_Cluster_LbSubsetConfig);
+  'lb_subset_config'?: (_envoy_config_cluster_v3_Cluster_LbSubsetConfig | null);
   /**
    * Optional configuration for the Ring Hash load balancing policy.
    */
-  'ring_hash_lb_config'?: (_envoy_config_cluster_v3_Cluster_RingHashLbConfig);
+  'ring_hash_lb_config'?: (_envoy_config_cluster_v3_Cluster_RingHashLbConfig | null);
   /**
    * Optional custom transport socket implementation to use for upstream connections.
    * To setup TLS, set a transport socket with name `tls` and
@@ -1304,7 +1304,7 @@ export interface Cluster {
    * If no transport socket configuration is specified, new connections
    * will be set up with plaintext.
    */
-  'transport_socket'?: (_envoy_config_core_v3_TransportSocket);
+  'transport_socket'?: (_envoy_config_core_v3_TransportSocket | null);
   /**
    * The Metadata field can be used to provide additional information about the
    * cluster. It can be used for stats, logging, and varying filter behavior.
@@ -1312,7 +1312,7 @@ export interface Cluster {
    * will need the information. For instance, if the metadata is intended for
    * the Router filter, the filter name should be specified as *envoy.filters.http.router*.
    */
-  'metadata'?: (_envoy_config_core_v3_Metadata);
+  'metadata'?: (_envoy_config_core_v3_Metadata | null);
   /**
    * Determines how Envoy selects the protocol used to speak to upstream hosts.
    * This has been deprecated in favor of setting explicit protocol selection
@@ -1325,7 +1325,7 @@ export interface Cluster {
   /**
    * Common configuration for all load balancer implementations.
    */
-  'common_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig);
+  'common_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig | null);
   /**
    * An optional alternative to the cluster name to be used while emitting stats.
    * Any ``:`` in the name will be converted to ``_`` when emitting statistics. This should not be
@@ -1345,11 +1345,11 @@ export interface Cluster {
    * <envoy_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.upstream_http_protocol_options>`
    * for example usage.
    */
-  'common_http_protocol_options'?: (_envoy_config_core_v3_HttpProtocolOptions);
+  'common_http_protocol_options'?: (_envoy_config_core_v3_HttpProtocolOptions | null);
   /**
    * Optional options for upstream connections.
    */
-  'upstream_connection_options'?: (_envoy_config_cluster_v3_UpstreamConnectionOptions);
+  'upstream_connection_options'?: (_envoy_config_cluster_v3_UpstreamConnectionOptions | null);
   /**
    * If an upstream host becomes unhealthy (as determined by the configured health checks
    * or outlier detection), immediately close all connections to the failed host.
@@ -1384,11 +1384,11 @@ export interface Cluster {
    * Setting this allows non-EDS cluster types to contain embedded EDS equivalent
    * :ref:`endpoint assignments<envoy_api_msg_config.endpoint.v3.ClusterLoadAssignment>`.
    */
-  'load_assignment'?: (_envoy_config_endpoint_v3_ClusterLoadAssignment);
+  'load_assignment'?: (_envoy_config_endpoint_v3_ClusterLoadAssignment | null);
   /**
    * Optional configuration for the Original Destination load balancing policy.
    */
-  'original_dst_lb_config'?: (_envoy_config_cluster_v3_Cluster_OriginalDstLbConfig);
+  'original_dst_lb_config'?: (_envoy_config_cluster_v3_Cluster_OriginalDstLbConfig | null);
   /**
    * The extension_protocol_options field is used to provide extension-specific protocol options
    * for upstream connections. The key should match the extension filter name, such as
@@ -1400,11 +1400,11 @@ export interface Cluster {
   /**
    * Optional configuration for the LeastRequest load balancing policy.
    */
-  'least_request_lb_config'?: (_envoy_config_cluster_v3_Cluster_LeastRequestLbConfig);
+  'least_request_lb_config'?: (_envoy_config_cluster_v3_Cluster_LeastRequestLbConfig | null);
   /**
    * The custom cluster type.
    */
-  'cluster_type'?: (_envoy_config_cluster_v3_Cluster_CustomClusterType);
+  'cluster_type'?: (_envoy_config_cluster_v3_Cluster_CustomClusterType | null);
   /**
    * Optional configuration for setting cluster's DNS refresh rate. If the value is set to true,
    * cluster's DNS refresh rate will be set to resource record's TTL which comes from DNS
@@ -1422,7 +1422,7 @@ export interface Cluster {
    * :ref:`lb_policy<envoy_api_field_config.cluster.v3.Cluster.lb_policy>` field has the value
    * :ref:`LOAD_BALANCING_POLICY_CONFIG<envoy_api_enum_value_config.cluster.v3.Cluster.LbPolicy.LOAD_BALANCING_POLICY_CONFIG>`.
    */
-  'load_balancing_policy'?: (_envoy_config_cluster_v3_LoadBalancingPolicy);
+  'load_balancing_policy'?: (_envoy_config_cluster_v3_LoadBalancingPolicy | null);
   /**
    * [#not-implemented-hide:]
    * If present, tells the client where to send load reports via LRS. If not present, the
@@ -1439,7 +1439,7 @@ export interface Cluster {
    * maybe by allowing LRS to go on the ADS stream, or maybe by moving some of the negotiation
    * from the LRS stream here.]
    */
-  'lrs_server'?: (_envoy_config_core_v3_ConfigSource);
+  'lrs_server'?: (_envoy_config_core_v3_ConfigSource | null);
   /**
    * Configuration to use different transport sockets for different endpoints.
    * The entry of *envoy.transport_socket_match* in the
@@ -1502,7 +1502,7 @@ export interface Cluster {
    * :ref:`LOGICAL_DNS<envoy_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>` this setting is
    * ignored.
    */
-  'dns_failure_refresh_rate'?: (_envoy_config_cluster_v3_Cluster_RefreshRate);
+  'dns_failure_refresh_rate'?: (_envoy_config_cluster_v3_Cluster_RefreshRate | null);
   /**
    * [#next-major-version: Reconcile DNS options in a single message.]
    * Always use TCP queries instead of UDP queries for DNS lookups.
@@ -1523,7 +1523,7 @@ export interface Cluster {
    * <envoy_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.upstream_http_protocol_options>`
    * for example usage.
    */
-  'upstream_http_protocol_options'?: (_envoy_config_core_v3_UpstreamHttpProtocolOptions);
+  'upstream_http_protocol_options'?: (_envoy_config_core_v3_UpstreamHttpProtocolOptions | null);
   /**
    * If track_timeout_budgets is true, the :ref:`timeout budget histograms
    * <config_cluster_manager_cluster_stats_timeout_budgets>` will be published for each
@@ -1556,15 +1556,15 @@ export interface Cluster {
    * CONNECT only if a custom filter indicates it is appropriate, the custom factories
    * can be registered and configured here.
    */
-  'upstream_config'?: (_envoy_config_core_v3_TypedExtensionConfig);
+  'upstream_config'?: (_envoy_config_core_v3_TypedExtensionConfig | null);
   /**
    * Configuration to track optional cluster stats.
    */
-  'track_cluster_stats'?: (_envoy_config_cluster_v3_TrackClusterStats);
+  'track_cluster_stats'?: (_envoy_config_cluster_v3_TrackClusterStats | null);
   /**
    * Preconnect configuration for this cluster.
    */
-  'preconnect_policy'?: (_envoy_config_cluster_v3_Cluster_PreconnectPolicy);
+  'preconnect_policy'?: (_envoy_config_cluster_v3_Cluster_PreconnectPolicy | null);
   /**
    * If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
    * connection pool for every downstream connection
@@ -1573,7 +1573,7 @@ export interface Cluster {
   /**
    * Optional configuration for the Maglev load balancing policy.
    */
-  'maglev_lb_config'?: (_envoy_config_cluster_v3_Cluster_MaglevLbConfig);
+  'maglev_lb_config'?: (_envoy_config_cluster_v3_Cluster_MaglevLbConfig | null);
   'cluster_discovery_type'?: "type"|"cluster_type";
   /**
    * Optional configuration for the load balancing algorithm selected by
@@ -1609,16 +1609,16 @@ export interface Cluster__Output {
   /**
    * Configuration to use for EDS updates for the Cluster.
    */
-  'eds_cluster_config'?: (_envoy_config_cluster_v3_Cluster_EdsClusterConfig__Output);
+  'eds_cluster_config': (_envoy_config_cluster_v3_Cluster_EdsClusterConfig__Output | null);
   /**
    * The timeout for new network connections to hosts in the cluster.
    */
-  'connect_timeout'?: (_google_protobuf_Duration__Output);
+  'connect_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * Soft limit on size of the cluster’s connections read and write buffers. If
    * unspecified, an implementation defined default is applied (1MiB).
    */
-  'per_connection_buffer_limit_bytes'?: (_google_protobuf_UInt32Value__Output);
+  'per_connection_buffer_limit_bytes': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The :ref:`load balancer type <arch_overview_load_balancing_types>` to use
    * when picking a host in the cluster.
@@ -1638,11 +1638,11 @@ export interface Cluster__Output {
    * implementations. If not specified, there is no limit. Setting this
    * parameter to 1 will effectively disable keep alive.
    */
-  'max_requests_per_connection'?: (_google_protobuf_UInt32Value__Output);
+  'max_requests_per_connection': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Optional :ref:`circuit breaking <arch_overview_circuit_break>` for the cluster.
    */
-  'circuit_breakers'?: (_envoy_config_cluster_v3_CircuitBreakers__Output);
+  'circuit_breakers': (_envoy_config_cluster_v3_CircuitBreakers__Output | null);
   /**
    * Additional options when handling HTTP1 requests.
    * This has been deprecated in favor of http_protocol_options fields in the in the
@@ -1653,7 +1653,7 @@ export interface Cluster__Output {
    * <envoy_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.upstream_http_protocol_options>`
    * for example usage.
    */
-  'http_protocol_options'?: (_envoy_config_core_v3_Http1ProtocolOptions__Output);
+  'http_protocol_options': (_envoy_config_core_v3_Http1ProtocolOptions__Output | null);
   /**
    * Even if default HTTP2 protocol options are desired, this field must be
    * set so that Envoy will assume that the upstream supports HTTP/2 when
@@ -1669,7 +1669,7 @@ export interface Cluster__Output {
    * <envoy_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.upstream_http_protocol_options>`
    * for example usage.
    */
-  'http2_protocol_options'?: (_envoy_config_core_v3_Http2ProtocolOptions__Output);
+  'http2_protocol_options': (_envoy_config_core_v3_Http2ProtocolOptions__Output | null);
   /**
    * If the DNS refresh rate is specified and the cluster type is either
    * :ref:`STRICT_DNS<envoy_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`,
@@ -1681,7 +1681,7 @@ export interface Cluster__Output {
    * and :ref:`LOGICAL_DNS<envoy_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`
    * this setting is ignored.
    */
-  'dns_refresh_rate'?: (_google_protobuf_Duration__Output);
+  'dns_refresh_rate': (_google_protobuf_Duration__Output | null);
   /**
    * The DNS IP address resolution policy. If this setting is not specified, the
    * value defaults to
@@ -1709,7 +1709,7 @@ export interface Cluster__Output {
    * Each of the configuration values can be overridden via
    * :ref:`runtime values <config_cluster_manager_cluster_runtime_outlier_detection>`.
    */
-  'outlier_detection'?: (_envoy_config_cluster_v3_OutlierDetection__Output);
+  'outlier_detection': (_envoy_config_cluster_v3_OutlierDetection__Output | null);
   /**
    * The interval for removing stale hosts from a cluster type
    * :ref:`ORIGINAL_DST<envoy_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.ORIGINAL_DST>`.
@@ -1725,21 +1725,21 @@ export interface Cluster__Output {
    * :ref:`ORIGINAL_DST<envoy_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.ORIGINAL_DST>`
    * this setting is ignored.
    */
-  'cleanup_interval'?: (_google_protobuf_Duration__Output);
+  'cleanup_interval': (_google_protobuf_Duration__Output | null);
   /**
    * Optional configuration used to bind newly established upstream connections.
    * This overrides any bind_config specified in the bootstrap proto.
    * If the address and port are empty, no bind will be performed.
    */
-  'upstream_bind_config'?: (_envoy_config_core_v3_BindConfig__Output);
+  'upstream_bind_config': (_envoy_config_core_v3_BindConfig__Output | null);
   /**
    * Configuration for load balancing subsetting.
    */
-  'lb_subset_config'?: (_envoy_config_cluster_v3_Cluster_LbSubsetConfig__Output);
+  'lb_subset_config': (_envoy_config_cluster_v3_Cluster_LbSubsetConfig__Output | null);
   /**
    * Optional configuration for the Ring Hash load balancing policy.
    */
-  'ring_hash_lb_config'?: (_envoy_config_cluster_v3_Cluster_RingHashLbConfig__Output);
+  'ring_hash_lb_config'?: (_envoy_config_cluster_v3_Cluster_RingHashLbConfig__Output | null);
   /**
    * Optional custom transport socket implementation to use for upstream connections.
    * To setup TLS, set a transport socket with name `tls` and
@@ -1747,7 +1747,7 @@ export interface Cluster__Output {
    * If no transport socket configuration is specified, new connections
    * will be set up with plaintext.
    */
-  'transport_socket'?: (_envoy_config_core_v3_TransportSocket__Output);
+  'transport_socket': (_envoy_config_core_v3_TransportSocket__Output | null);
   /**
    * The Metadata field can be used to provide additional information about the
    * cluster. It can be used for stats, logging, and varying filter behavior.
@@ -1755,7 +1755,7 @@ export interface Cluster__Output {
    * will need the information. For instance, if the metadata is intended for
    * the Router filter, the filter name should be specified as *envoy.filters.http.router*.
    */
-  'metadata'?: (_envoy_config_core_v3_Metadata__Output);
+  'metadata': (_envoy_config_core_v3_Metadata__Output | null);
   /**
    * Determines how Envoy selects the protocol used to speak to upstream hosts.
    * This has been deprecated in favor of setting explicit protocol selection
@@ -1768,7 +1768,7 @@ export interface Cluster__Output {
   /**
    * Common configuration for all load balancer implementations.
    */
-  'common_lb_config'?: (_envoy_config_cluster_v3_Cluster_CommonLbConfig__Output);
+  'common_lb_config': (_envoy_config_cluster_v3_Cluster_CommonLbConfig__Output | null);
   /**
    * An optional alternative to the cluster name to be used while emitting stats.
    * Any ``:`` in the name will be converted to ``_`` when emitting statistics. This should not be
@@ -1788,11 +1788,11 @@ export interface Cluster__Output {
    * <envoy_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.upstream_http_protocol_options>`
    * for example usage.
    */
-  'common_http_protocol_options'?: (_envoy_config_core_v3_HttpProtocolOptions__Output);
+  'common_http_protocol_options': (_envoy_config_core_v3_HttpProtocolOptions__Output | null);
   /**
    * Optional options for upstream connections.
    */
-  'upstream_connection_options'?: (_envoy_config_cluster_v3_UpstreamConnectionOptions__Output);
+  'upstream_connection_options': (_envoy_config_cluster_v3_UpstreamConnectionOptions__Output | null);
   /**
    * If an upstream host becomes unhealthy (as determined by the configured health checks
    * or outlier detection), immediately close all connections to the failed host.
@@ -1827,11 +1827,11 @@ export interface Cluster__Output {
    * Setting this allows non-EDS cluster types to contain embedded EDS equivalent
    * :ref:`endpoint assignments<envoy_api_msg_config.endpoint.v3.ClusterLoadAssignment>`.
    */
-  'load_assignment'?: (_envoy_config_endpoint_v3_ClusterLoadAssignment__Output);
+  'load_assignment': (_envoy_config_endpoint_v3_ClusterLoadAssignment__Output | null);
   /**
    * Optional configuration for the Original Destination load balancing policy.
    */
-  'original_dst_lb_config'?: (_envoy_config_cluster_v3_Cluster_OriginalDstLbConfig__Output);
+  'original_dst_lb_config'?: (_envoy_config_cluster_v3_Cluster_OriginalDstLbConfig__Output | null);
   /**
    * The extension_protocol_options field is used to provide extension-specific protocol options
    * for upstream connections. The key should match the extension filter name, such as
@@ -1839,15 +1839,15 @@ export interface Cluster__Output {
    * specific options.
    * [#next-major-version: make this a list of typed extensions.]
    */
-  'typed_extension_protocol_options'?: ({[key: string]: _google_protobuf_Any__Output});
+  'typed_extension_protocol_options': ({[key: string]: _google_protobuf_Any__Output});
   /**
    * Optional configuration for the LeastRequest load balancing policy.
    */
-  'least_request_lb_config'?: (_envoy_config_cluster_v3_Cluster_LeastRequestLbConfig__Output);
+  'least_request_lb_config'?: (_envoy_config_cluster_v3_Cluster_LeastRequestLbConfig__Output | null);
   /**
    * The custom cluster type.
    */
-  'cluster_type'?: (_envoy_config_cluster_v3_Cluster_CustomClusterType__Output);
+  'cluster_type'?: (_envoy_config_cluster_v3_Cluster_CustomClusterType__Output | null);
   /**
    * Optional configuration for setting cluster's DNS refresh rate. If the value is set to true,
    * cluster's DNS refresh rate will be set to resource record's TTL which comes from DNS
@@ -1865,7 +1865,7 @@ export interface Cluster__Output {
    * :ref:`lb_policy<envoy_api_field_config.cluster.v3.Cluster.lb_policy>` field has the value
    * :ref:`LOAD_BALANCING_POLICY_CONFIG<envoy_api_enum_value_config.cluster.v3.Cluster.LbPolicy.LOAD_BALANCING_POLICY_CONFIG>`.
    */
-  'load_balancing_policy'?: (_envoy_config_cluster_v3_LoadBalancingPolicy__Output);
+  'load_balancing_policy': (_envoy_config_cluster_v3_LoadBalancingPolicy__Output | null);
   /**
    * [#not-implemented-hide:]
    * If present, tells the client where to send load reports via LRS. If not present, the
@@ -1882,7 +1882,7 @@ export interface Cluster__Output {
    * maybe by allowing LRS to go on the ADS stream, or maybe by moving some of the negotiation
    * from the LRS stream here.]
    */
-  'lrs_server'?: (_envoy_config_core_v3_ConfigSource__Output);
+  'lrs_server': (_envoy_config_core_v3_ConfigSource__Output | null);
   /**
    * Configuration to use different transport sockets for different endpoints.
    * The entry of *envoy.transport_socket_match* in the
@@ -1945,7 +1945,7 @@ export interface Cluster__Output {
    * :ref:`LOGICAL_DNS<envoy_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>` this setting is
    * ignored.
    */
-  'dns_failure_refresh_rate'?: (_envoy_config_cluster_v3_Cluster_RefreshRate__Output);
+  'dns_failure_refresh_rate': (_envoy_config_cluster_v3_Cluster_RefreshRate__Output | null);
   /**
    * [#next-major-version: Reconcile DNS options in a single message.]
    * Always use TCP queries instead of UDP queries for DNS lookups.
@@ -1966,7 +1966,7 @@ export interface Cluster__Output {
    * <envoy_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.upstream_http_protocol_options>`
    * for example usage.
    */
-  'upstream_http_protocol_options'?: (_envoy_config_core_v3_UpstreamHttpProtocolOptions__Output);
+  'upstream_http_protocol_options': (_envoy_config_core_v3_UpstreamHttpProtocolOptions__Output | null);
   /**
    * If track_timeout_budgets is true, the :ref:`timeout budget histograms
    * <config_cluster_manager_cluster_stats_timeout_budgets>` will be published for each
@@ -1999,15 +1999,15 @@ export interface Cluster__Output {
    * CONNECT only if a custom filter indicates it is appropriate, the custom factories
    * can be registered and configured here.
    */
-  'upstream_config'?: (_envoy_config_core_v3_TypedExtensionConfig__Output);
+  'upstream_config': (_envoy_config_core_v3_TypedExtensionConfig__Output | null);
   /**
    * Configuration to track optional cluster stats.
    */
-  'track_cluster_stats'?: (_envoy_config_cluster_v3_TrackClusterStats__Output);
+  'track_cluster_stats': (_envoy_config_cluster_v3_TrackClusterStats__Output | null);
   /**
    * Preconnect configuration for this cluster.
    */
-  'preconnect_policy'?: (_envoy_config_cluster_v3_Cluster_PreconnectPolicy__Output);
+  'preconnect_policy': (_envoy_config_cluster_v3_Cluster_PreconnectPolicy__Output | null);
   /**
    * If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
    * connection pool for every downstream connection
@@ -2016,7 +2016,7 @@ export interface Cluster__Output {
   /**
    * Optional configuration for the Maglev load balancing policy.
    */
-  'maglev_lb_config'?: (_envoy_config_cluster_v3_Cluster_MaglevLbConfig__Output);
+  'maglev_lb_config'?: (_envoy_config_cluster_v3_Cluster_MaglevLbConfig__Output | null);
   'cluster_discovery_type': "type"|"cluster_type";
   /**
    * Optional configuration for the load balancing algorithm selected by

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/ClusterCollection.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/ClusterCollection.ts
@@ -7,7 +7,7 @@ import type { CollectionEntry as _xds_core_v3_CollectionEntry, CollectionEntry__
  * [#not-implemented-hide:]
  */
 export interface ClusterCollection {
-  'entries'?: (_xds_core_v3_CollectionEntry);
+  'entries'?: (_xds_core_v3_CollectionEntry | null);
 }
 
 /**
@@ -15,5 +15,5 @@ export interface ClusterCollection {
  * [#not-implemented-hide:]
  */
 export interface ClusterCollection__Output {
-  'entries'?: (_xds_core_v3_CollectionEntry__Output);
+  'entries': (_xds_core_v3_CollectionEntry__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/Filter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/Filter.ts
@@ -12,7 +12,7 @@ export interface Filter {
    * Filter specific configuration which depends on the filter being
    * instantiated. See the supported filters for further documentation.
    */
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
 }
 
 export interface Filter__Output {
@@ -25,5 +25,5 @@ export interface Filter__Output {
    * Filter specific configuration which depends on the filter being
    * instantiated. See the supported filters for further documentation.
    */
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config': (_google_protobuf_Any__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/LoadBalancingPolicy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/LoadBalancingPolicy.ts
@@ -7,7 +7,7 @@ export interface _envoy_config_cluster_v3_LoadBalancingPolicy_Policy {
    * Required. The name of the LB policy.
    */
   'name'?: (string);
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
 }
 
 export interface _envoy_config_cluster_v3_LoadBalancingPolicy_Policy__Output {
@@ -15,7 +15,7 @@ export interface _envoy_config_cluster_v3_LoadBalancingPolicy_Policy__Output {
    * Required. The name of the LB policy.
    */
   'name': (string);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config': (_google_protobuf_Any__Output | null);
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/OutlierDetection.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/OutlierDetection.ts
@@ -14,44 +14,44 @@ export interface OutlierDetection {
    * to 5xx error codes before a consecutive 5xx ejection
    * occurs. Defaults to 5.
    */
-  'consecutive_5xx'?: (_google_protobuf_UInt32Value);
+  'consecutive_5xx'?: (_google_protobuf_UInt32Value | null);
   /**
    * The time interval between ejection analysis sweeps. This can result in
    * both new ejections as well as hosts being returned to service. Defaults
    * to 10000ms or 10s.
    */
-  'interval'?: (_google_protobuf_Duration);
+  'interval'?: (_google_protobuf_Duration | null);
   /**
    * The base time that a host is ejected for. The real time is equal to the
    * base time multiplied by the number of times the host has been ejected and is
    * capped by :ref:`max_ejection_time<envoy_api_field_config.cluster.v3.OutlierDetection.max_ejection_time>`.
    * Defaults to 30000ms or 30s.
    */
-  'base_ejection_time'?: (_google_protobuf_Duration);
+  'base_ejection_time'?: (_google_protobuf_Duration | null);
   /**
    * The maximum % of an upstream cluster that can be ejected due to outlier
    * detection. Defaults to 10% but will eject at least one host regardless of the value.
    */
-  'max_ejection_percent'?: (_google_protobuf_UInt32Value);
+  'max_ejection_percent'?: (_google_protobuf_UInt32Value | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status
    * is detected through consecutive 5xx. This setting can be used to disable
    * ejection or to ramp it up slowly. Defaults to 100.
    */
-  'enforcing_consecutive_5xx'?: (_google_protobuf_UInt32Value);
+  'enforcing_consecutive_5xx'?: (_google_protobuf_UInt32Value | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status
    * is detected through success rate statistics. This setting can be used to
    * disable ejection or to ramp it up slowly. Defaults to 100.
    */
-  'enforcing_success_rate'?: (_google_protobuf_UInt32Value);
+  'enforcing_success_rate'?: (_google_protobuf_UInt32Value | null);
   /**
    * The number of hosts in a cluster that must have enough request volume to
    * detect success rate outliers. If the number of hosts is less than this
    * setting, outlier detection via success rate statistics is not performed
    * for any host in the cluster. Defaults to 5.
    */
-  'success_rate_minimum_hosts'?: (_google_protobuf_UInt32Value);
+  'success_rate_minimum_hosts'?: (_google_protobuf_UInt32Value | null);
   /**
    * The minimum number of total requests that must be collected in one
    * interval (as defined by the interval duration above) to include this host
@@ -59,7 +59,7 @@ export interface OutlierDetection {
    * setting, outlier detection via success rate statistics is not performed
    * for that host. Defaults to 100.
    */
-  'success_rate_request_volume'?: (_google_protobuf_UInt32Value);
+  'success_rate_request_volume'?: (_google_protobuf_UInt32Value | null);
   /**
    * This factor is used to determine the ejection threshold for success rate
    * outlier ejection. The ejection threshold is the difference between the
@@ -69,18 +69,18 @@ export interface OutlierDetection {
    * double. That is, if the desired factor is 1.9, the runtime value should
    * be 1900. Defaults to 1900.
    */
-  'success_rate_stdev_factor'?: (_google_protobuf_UInt32Value);
+  'success_rate_stdev_factor'?: (_google_protobuf_UInt32Value | null);
   /**
    * The number of consecutive gateway failures (502, 503, 504 status codes)
    * before a consecutive gateway failure ejection occurs. Defaults to 5.
    */
-  'consecutive_gateway_failure'?: (_google_protobuf_UInt32Value);
+  'consecutive_gateway_failure'?: (_google_protobuf_UInt32Value | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status
    * is detected through consecutive gateway failures. This setting can be
    * used to disable ejection or to ramp it up slowly. Defaults to 0.
    */
-  'enforcing_consecutive_gateway_failure'?: (_google_protobuf_UInt32Value);
+  'enforcing_consecutive_gateway_failure'?: (_google_protobuf_UInt32Value | null);
   /**
    * Determines whether to distinguish local origin failures from external errors. If set to true
    * the following configuration parameters are taken into account:
@@ -97,7 +97,7 @@ export interface OutlierDetection {
    * :ref:`split_external_local_origin_errors<envoy_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
    * is set to true.
    */
-  'consecutive_local_origin_failure'?: (_google_protobuf_UInt32Value);
+  'consecutive_local_origin_failure'?: (_google_protobuf_UInt32Value | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status
    * is detected through consecutive locally originated failures. This setting can be
@@ -106,7 +106,7 @@ export interface OutlierDetection {
    * :ref:`split_external_local_origin_errors<envoy_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
    * is set to true.
    */
-  'enforcing_consecutive_local_origin_failure'?: (_google_protobuf_UInt32Value);
+  'enforcing_consecutive_local_origin_failure'?: (_google_protobuf_UInt32Value | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status
    * is detected through success rate statistics for locally originated errors.
@@ -115,13 +115,13 @@ export interface OutlierDetection {
    * :ref:`split_external_local_origin_errors<envoy_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
    * is set to true.
    */
-  'enforcing_local_origin_success_rate'?: (_google_protobuf_UInt32Value);
+  'enforcing_local_origin_success_rate'?: (_google_protobuf_UInt32Value | null);
   /**
    * The failure percentage to use when determining failure percentage-based outlier detection. If
    * the failure percentage of a given host is greater than or equal to this value, it will be
    * ejected. Defaults to 85.
    */
-  'failure_percentage_threshold'?: (_google_protobuf_UInt32Value);
+  'failure_percentage_threshold'?: (_google_protobuf_UInt32Value | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status is detected through
    * failure percentage statistics. This setting can be used to disable ejection or to ramp it up
@@ -130,32 +130,32 @@ export interface OutlierDetection {
    * [#next-major-version: setting this without setting failure_percentage_threshold should be
    * invalid in v4.]
    */
-  'enforcing_failure_percentage'?: (_google_protobuf_UInt32Value);
+  'enforcing_failure_percentage'?: (_google_protobuf_UInt32Value | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status is detected through
    * local-origin failure percentage statistics. This setting can be used to disable ejection or to
    * ramp it up slowly. Defaults to 0.
    */
-  'enforcing_failure_percentage_local_origin'?: (_google_protobuf_UInt32Value);
+  'enforcing_failure_percentage_local_origin'?: (_google_protobuf_UInt32Value | null);
   /**
    * The minimum number of hosts in a cluster in order to perform failure percentage-based ejection.
    * If the total number of hosts in the cluster is less than this value, failure percentage-based
    * ejection will not be performed. Defaults to 5.
    */
-  'failure_percentage_minimum_hosts'?: (_google_protobuf_UInt32Value);
+  'failure_percentage_minimum_hosts'?: (_google_protobuf_UInt32Value | null);
   /**
    * The minimum number of total requests that must be collected in one interval (as defined by the
    * interval duration above) to perform failure percentage-based ejection for this host. If the
    * volume is lower than this setting, failure percentage-based ejection will not be performed for
    * this host. Defaults to 50.
    */
-  'failure_percentage_request_volume'?: (_google_protobuf_UInt32Value);
+  'failure_percentage_request_volume'?: (_google_protobuf_UInt32Value | null);
   /**
    * The maximum time that a host is ejected for. See :ref:`base_ejection_time<envoy_api_field_config.cluster.v3.OutlierDetection.base_ejection_time>`
    * for more information.
    * Defaults to 300000ms or 300s.
    */
-  'max_ejection_time'?: (_google_protobuf_Duration);
+  'max_ejection_time'?: (_google_protobuf_Duration | null);
 }
 
 /**
@@ -169,44 +169,44 @@ export interface OutlierDetection__Output {
    * to 5xx error codes before a consecutive 5xx ejection
    * occurs. Defaults to 5.
    */
-  'consecutive_5xx'?: (_google_protobuf_UInt32Value__Output);
+  'consecutive_5xx': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The time interval between ejection analysis sweeps. This can result in
    * both new ejections as well as hosts being returned to service. Defaults
    * to 10000ms or 10s.
    */
-  'interval'?: (_google_protobuf_Duration__Output);
+  'interval': (_google_protobuf_Duration__Output | null);
   /**
    * The base time that a host is ejected for. The real time is equal to the
    * base time multiplied by the number of times the host has been ejected and is
    * capped by :ref:`max_ejection_time<envoy_api_field_config.cluster.v3.OutlierDetection.max_ejection_time>`.
    * Defaults to 30000ms or 30s.
    */
-  'base_ejection_time'?: (_google_protobuf_Duration__Output);
+  'base_ejection_time': (_google_protobuf_Duration__Output | null);
   /**
    * The maximum % of an upstream cluster that can be ejected due to outlier
    * detection. Defaults to 10% but will eject at least one host regardless of the value.
    */
-  'max_ejection_percent'?: (_google_protobuf_UInt32Value__Output);
+  'max_ejection_percent': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status
    * is detected through consecutive 5xx. This setting can be used to disable
    * ejection or to ramp it up slowly. Defaults to 100.
    */
-  'enforcing_consecutive_5xx'?: (_google_protobuf_UInt32Value__Output);
+  'enforcing_consecutive_5xx': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status
    * is detected through success rate statistics. This setting can be used to
    * disable ejection or to ramp it up slowly. Defaults to 100.
    */
-  'enforcing_success_rate'?: (_google_protobuf_UInt32Value__Output);
+  'enforcing_success_rate': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The number of hosts in a cluster that must have enough request volume to
    * detect success rate outliers. If the number of hosts is less than this
    * setting, outlier detection via success rate statistics is not performed
    * for any host in the cluster. Defaults to 5.
    */
-  'success_rate_minimum_hosts'?: (_google_protobuf_UInt32Value__Output);
+  'success_rate_minimum_hosts': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The minimum number of total requests that must be collected in one
    * interval (as defined by the interval duration above) to include this host
@@ -214,7 +214,7 @@ export interface OutlierDetection__Output {
    * setting, outlier detection via success rate statistics is not performed
    * for that host. Defaults to 100.
    */
-  'success_rate_request_volume'?: (_google_protobuf_UInt32Value__Output);
+  'success_rate_request_volume': (_google_protobuf_UInt32Value__Output | null);
   /**
    * This factor is used to determine the ejection threshold for success rate
    * outlier ejection. The ejection threshold is the difference between the
@@ -224,18 +224,18 @@ export interface OutlierDetection__Output {
    * double. That is, if the desired factor is 1.9, the runtime value should
    * be 1900. Defaults to 1900.
    */
-  'success_rate_stdev_factor'?: (_google_protobuf_UInt32Value__Output);
+  'success_rate_stdev_factor': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The number of consecutive gateway failures (502, 503, 504 status codes)
    * before a consecutive gateway failure ejection occurs. Defaults to 5.
    */
-  'consecutive_gateway_failure'?: (_google_protobuf_UInt32Value__Output);
+  'consecutive_gateway_failure': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status
    * is detected through consecutive gateway failures. This setting can be
    * used to disable ejection or to ramp it up slowly. Defaults to 0.
    */
-  'enforcing_consecutive_gateway_failure'?: (_google_protobuf_UInt32Value__Output);
+  'enforcing_consecutive_gateway_failure': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Determines whether to distinguish local origin failures from external errors. If set to true
    * the following configuration parameters are taken into account:
@@ -252,7 +252,7 @@ export interface OutlierDetection__Output {
    * :ref:`split_external_local_origin_errors<envoy_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
    * is set to true.
    */
-  'consecutive_local_origin_failure'?: (_google_protobuf_UInt32Value__Output);
+  'consecutive_local_origin_failure': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status
    * is detected through consecutive locally originated failures. This setting can be
@@ -261,7 +261,7 @@ export interface OutlierDetection__Output {
    * :ref:`split_external_local_origin_errors<envoy_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
    * is set to true.
    */
-  'enforcing_consecutive_local_origin_failure'?: (_google_protobuf_UInt32Value__Output);
+  'enforcing_consecutive_local_origin_failure': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status
    * is detected through success rate statistics for locally originated errors.
@@ -270,13 +270,13 @@ export interface OutlierDetection__Output {
    * :ref:`split_external_local_origin_errors<envoy_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>`
    * is set to true.
    */
-  'enforcing_local_origin_success_rate'?: (_google_protobuf_UInt32Value__Output);
+  'enforcing_local_origin_success_rate': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The failure percentage to use when determining failure percentage-based outlier detection. If
    * the failure percentage of a given host is greater than or equal to this value, it will be
    * ejected. Defaults to 85.
    */
-  'failure_percentage_threshold'?: (_google_protobuf_UInt32Value__Output);
+  'failure_percentage_threshold': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status is detected through
    * failure percentage statistics. This setting can be used to disable ejection or to ramp it up
@@ -285,30 +285,30 @@ export interface OutlierDetection__Output {
    * [#next-major-version: setting this without setting failure_percentage_threshold should be
    * invalid in v4.]
    */
-  'enforcing_failure_percentage'?: (_google_protobuf_UInt32Value__Output);
+  'enforcing_failure_percentage': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The % chance that a host will be actually ejected when an outlier status is detected through
    * local-origin failure percentage statistics. This setting can be used to disable ejection or to
    * ramp it up slowly. Defaults to 0.
    */
-  'enforcing_failure_percentage_local_origin'?: (_google_protobuf_UInt32Value__Output);
+  'enforcing_failure_percentage_local_origin': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The minimum number of hosts in a cluster in order to perform failure percentage-based ejection.
    * If the total number of hosts in the cluster is less than this value, failure percentage-based
    * ejection will not be performed. Defaults to 5.
    */
-  'failure_percentage_minimum_hosts'?: (_google_protobuf_UInt32Value__Output);
+  'failure_percentage_minimum_hosts': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The minimum number of total requests that must be collected in one interval (as defined by the
    * interval duration above) to perform failure percentage-based ejection for this host. If the
    * volume is lower than this setting, failure percentage-based ejection will not be performed for
    * this host. Defaults to 50.
    */
-  'failure_percentage_request_volume'?: (_google_protobuf_UInt32Value__Output);
+  'failure_percentage_request_volume': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The maximum time that a host is ejected for. See :ref:`base_ejection_time<envoy_api_field_config.cluster.v3.OutlierDetection.base_ejection_time>`
    * for more information.
    * Defaults to 300000ms or 300s.
    */
-  'max_ejection_time'?: (_google_protobuf_Duration__Output);
+  'max_ejection_time': (_google_protobuf_Duration__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/UpstreamBindConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/UpstreamBindConfig.ts
@@ -10,7 +10,7 @@ export interface UpstreamBindConfig {
   /**
    * The address Envoy should bind to when establishing upstream connections.
    */
-  'source_address'?: (_envoy_config_core_v3_Address);
+  'source_address'?: (_envoy_config_core_v3_Address | null);
 }
 
 /**
@@ -21,5 +21,5 @@ export interface UpstreamBindConfig__Output {
   /**
    * The address Envoy should bind to when establishing upstream connections.
    */
-  'source_address'?: (_envoy_config_core_v3_Address__Output);
+  'source_address': (_envoy_config_core_v3_Address__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/UpstreamConnectionOptions.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/UpstreamConnectionOptions.ts
@@ -6,12 +6,12 @@ export interface UpstreamConnectionOptions {
   /**
    * If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
    */
-  'tcp_keepalive'?: (_envoy_config_core_v3_TcpKeepalive);
+  'tcp_keepalive'?: (_envoy_config_core_v3_TcpKeepalive | null);
 }
 
 export interface UpstreamConnectionOptions__Output {
   /**
    * If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
    */
-  'tcp_keepalive'?: (_envoy_config_core_v3_TcpKeepalive__Output);
+  'tcp_keepalive': (_envoy_config_core_v3_TcpKeepalive__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Address.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Address.ts
@@ -10,12 +10,12 @@ import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress
  * management servers.
  */
 export interface Address {
-  'socket_address'?: (_envoy_config_core_v3_SocketAddress);
-  'pipe'?: (_envoy_config_core_v3_Pipe);
+  'socket_address'?: (_envoy_config_core_v3_SocketAddress | null);
+  'pipe'?: (_envoy_config_core_v3_Pipe | null);
   /**
    * [#not-implemented-hide:]
    */
-  'envoy_internal_address'?: (_envoy_config_core_v3_EnvoyInternalAddress);
+  'envoy_internal_address'?: (_envoy_config_core_v3_EnvoyInternalAddress | null);
   'address'?: "socket_address"|"pipe"|"envoy_internal_address";
 }
 
@@ -25,11 +25,11 @@ export interface Address {
  * management servers.
  */
 export interface Address__Output {
-  'socket_address'?: (_envoy_config_core_v3_SocketAddress__Output);
-  'pipe'?: (_envoy_config_core_v3_Pipe__Output);
+  'socket_address'?: (_envoy_config_core_v3_SocketAddress__Output | null);
+  'pipe'?: (_envoy_config_core_v3_Pipe__Output | null);
   /**
    * [#not-implemented-hide:]
    */
-  'envoy_internal_address'?: (_envoy_config_core_v3_EnvoyInternalAddress__Output);
+  'envoy_internal_address'?: (_envoy_config_core_v3_EnvoyInternalAddress__Output | null);
   'address': "socket_address"|"pipe"|"envoy_internal_address";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/ApiConfigSource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/ApiConfigSource.ts
@@ -70,7 +70,7 @@ export interface ApiConfigSource {
   /**
    * For REST APIs, the delay between successive polls.
    */
-  'refresh_delay'?: (_google_protobuf_Duration);
+  'refresh_delay'?: (_google_protobuf_Duration | null);
   /**
    * Multiple gRPC services be provided for GRPC. If > 1 cluster is defined,
    * services will be cycled through if any kind of failure occurs.
@@ -79,12 +79,12 @@ export interface ApiConfigSource {
   /**
    * For REST APIs, the request timeout. If not set, a default value of 1s will be used.
    */
-  'request_timeout'?: (_google_protobuf_Duration);
+  'request_timeout'?: (_google_protobuf_Duration | null);
   /**
    * For GRPC APIs, the rate limit settings. If present, discovery requests made by Envoy will be
    * rate limited.
    */
-  'rate_limit_settings'?: (_envoy_config_core_v3_RateLimitSettings);
+  'rate_limit_settings'?: (_envoy_config_core_v3_RateLimitSettings | null);
   /**
    * Skip the node identifier in subsequent discovery requests for streaming gRPC config types.
    */
@@ -120,7 +120,7 @@ export interface ApiConfigSource__Output {
   /**
    * For REST APIs, the delay between successive polls.
    */
-  'refresh_delay'?: (_google_protobuf_Duration__Output);
+  'refresh_delay': (_google_protobuf_Duration__Output | null);
   /**
    * Multiple gRPC services be provided for GRPC. If > 1 cluster is defined,
    * services will be cycled through if any kind of failure occurs.
@@ -129,12 +129,12 @@ export interface ApiConfigSource__Output {
   /**
    * For REST APIs, the request timeout. If not set, a default value of 1s will be used.
    */
-  'request_timeout'?: (_google_protobuf_Duration__Output);
+  'request_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * For GRPC APIs, the rate limit settings. If present, discovery requests made by Envoy will be
    * rate limited.
    */
-  'rate_limit_settings'?: (_envoy_config_core_v3_RateLimitSettings__Output);
+  'rate_limit_settings': (_envoy_config_core_v3_RateLimitSettings__Output | null);
   /**
    * Skip the node identifier in subsequent discovery requests for streaming gRPC config types.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/AsyncDataSource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/AsyncDataSource.ts
@@ -10,11 +10,11 @@ export interface AsyncDataSource {
   /**
    * Local async data source.
    */
-  'local'?: (_envoy_config_core_v3_DataSource);
+  'local'?: (_envoy_config_core_v3_DataSource | null);
   /**
    * Remote async data source.
    */
-  'remote'?: (_envoy_config_core_v3_RemoteDataSource);
+  'remote'?: (_envoy_config_core_v3_RemoteDataSource | null);
   'specifier'?: "local"|"remote";
 }
 
@@ -25,10 +25,10 @@ export interface AsyncDataSource__Output {
   /**
    * Local async data source.
    */
-  'local'?: (_envoy_config_core_v3_DataSource__Output);
+  'local'?: (_envoy_config_core_v3_DataSource__Output | null);
   /**
    * Remote async data source.
    */
-  'remote'?: (_envoy_config_core_v3_RemoteDataSource__Output);
+  'remote'?: (_envoy_config_core_v3_RemoteDataSource__Output | null);
   'specifier': "local"|"remote";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/BackoffStrategy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/BackoffStrategy.ts
@@ -11,7 +11,7 @@ export interface BackoffStrategy {
    * be greater than zero and less than or equal to :ref:`max_interval
    * <envoy_api_field_config.core.v3.BackoffStrategy.max_interval>`.
    */
-  'base_interval'?: (_google_protobuf_Duration);
+  'base_interval'?: (_google_protobuf_Duration | null);
   /**
    * Specifies the maximum interval between retries. This parameter is optional,
    * but must be greater than or equal to the :ref:`base_interval
@@ -19,7 +19,7 @@ export interface BackoffStrategy {
    * is 10 times the :ref:`base_interval
    * <envoy_api_field_config.core.v3.BackoffStrategy.base_interval>`.
    */
-  'max_interval'?: (_google_protobuf_Duration);
+  'max_interval'?: (_google_protobuf_Duration | null);
 }
 
 /**
@@ -31,7 +31,7 @@ export interface BackoffStrategy__Output {
    * be greater than zero and less than or equal to :ref:`max_interval
    * <envoy_api_field_config.core.v3.BackoffStrategy.max_interval>`.
    */
-  'base_interval'?: (_google_protobuf_Duration__Output);
+  'base_interval': (_google_protobuf_Duration__Output | null);
   /**
    * Specifies the maximum interval between retries. This parameter is optional,
    * but must be greater than or equal to the :ref:`base_interval
@@ -39,5 +39,5 @@ export interface BackoffStrategy__Output {
    * is 10 times the :ref:`base_interval
    * <envoy_api_field_config.core.v3.BackoffStrategy.base_interval>`.
    */
-  'max_interval'?: (_google_protobuf_Duration__Output);
+  'max_interval': (_google_protobuf_Duration__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/BindConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/BindConfig.ts
@@ -8,7 +8,7 @@ export interface BindConfig {
   /**
    * The address to bind to when creating a socket.
    */
-  'source_address'?: (_envoy_config_core_v3_SocketAddress);
+  'source_address'?: (_envoy_config_core_v3_SocketAddress | null);
   /**
    * Whether to set the *IP_FREEBIND* option when creating the socket. When this
    * flag is set to true, allows the :ref:`source_address
@@ -18,7 +18,7 @@ export interface BindConfig {
    * flag is not set (default), the socket is not modified, i.e. the option is
    * neither enabled nor disabled.
    */
-  'freebind'?: (_google_protobuf_BoolValue);
+  'freebind'?: (_google_protobuf_BoolValue | null);
   /**
    * Additional socket options that may not be present in Envoy source code or
    * precompiled binaries.
@@ -30,7 +30,7 @@ export interface BindConfig__Output {
   /**
    * The address to bind to when creating a socket.
    */
-  'source_address'?: (_envoy_config_core_v3_SocketAddress__Output);
+  'source_address': (_envoy_config_core_v3_SocketAddress__Output | null);
   /**
    * Whether to set the *IP_FREEBIND* option when creating the socket. When this
    * flag is set to true, allows the :ref:`source_address
@@ -40,7 +40,7 @@ export interface BindConfig__Output {
    * flag is not set (default), the socket is not modified, i.e. the option is
    * neither enabled nor disabled.
    */
-  'freebind'?: (_google_protobuf_BoolValue__Output);
+  'freebind': (_google_protobuf_BoolValue__Output | null);
   /**
    * Additional socket options that may not be present in Envoy source code or
    * precompiled binaries.

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/BuildVersion.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/BuildVersion.ts
@@ -11,12 +11,12 @@ export interface BuildVersion {
   /**
    * SemVer version of extension.
    */
-  'version'?: (_envoy_type_v3_SemanticVersion);
+  'version'?: (_envoy_type_v3_SemanticVersion | null);
   /**
    * Free-form build information.
    * Envoy defines several well known keys in the source/common/version/version.h file
    */
-  'metadata'?: (_google_protobuf_Struct);
+  'metadata'?: (_google_protobuf_Struct | null);
 }
 
 /**
@@ -27,10 +27,10 @@ export interface BuildVersion__Output {
   /**
    * SemVer version of extension.
    */
-  'version'?: (_envoy_type_v3_SemanticVersion__Output);
+  'version': (_envoy_type_v3_SemanticVersion__Output | null);
   /**
    * Free-form build information.
    * Envoy defines several well known keys in the source/common/version/version.h file
    */
-  'metadata'?: (_google_protobuf_Struct__Output);
+  'metadata': (_google_protobuf_Struct__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/CidrRange.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/CidrRange.ts
@@ -14,7 +14,7 @@ export interface CidrRange {
   /**
    * Length of prefix, e.g. 0, 32.
    */
-  'prefix_len'?: (_google_protobuf_UInt32Value);
+  'prefix_len'?: (_google_protobuf_UInt32Value | null);
 }
 
 /**
@@ -29,5 +29,5 @@ export interface CidrRange__Output {
   /**
    * Length of prefix, e.g. 0, 32.
    */
-  'prefix_len'?: (_google_protobuf_UInt32Value__Output);
+  'prefix_len': (_google_protobuf_UInt32Value__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/ConfigSource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/ConfigSource.ts
@@ -36,12 +36,12 @@ export interface ConfigSource {
   /**
    * API configuration source.
    */
-  'api_config_source'?: (_envoy_config_core_v3_ApiConfigSource);
+  'api_config_source'?: (_envoy_config_core_v3_ApiConfigSource | null);
   /**
    * When set, ADS will be used to fetch resources. The ADS API configuration
    * source in the bootstrap configuration is used.
    */
-  'ads'?: (_envoy_config_core_v3_AggregatedConfigSource);
+  'ads'?: (_envoy_config_core_v3_AggregatedConfigSource | null);
   /**
    * When this timeout is specified, Envoy will wait no longer than the specified time for first
    * config response on this xDS subscription during the :ref:`initialization process
@@ -51,7 +51,7 @@ export interface ConfigSource {
    * means no timeout - Envoy will wait indefinitely for the first xDS config (unless another
    * timeout applies). The default is 15s.
    */
-  'initial_fetch_timeout'?: (_google_protobuf_Duration);
+  'initial_fetch_timeout'?: (_google_protobuf_Duration | null);
   /**
    * [#not-implemented-hide:]
    * When set, the client will access the resources from the same server it got the
@@ -65,7 +65,7 @@ export interface ConfigSource {
    * this field can implicitly mean to use the same stream in the case where the ConfigSource
    * is provided via ADS and the specified data can also be obtained via ADS.]
    */
-  'self'?: (_envoy_config_core_v3_SelfConfigSource);
+  'self'?: (_envoy_config_core_v3_SelfConfigSource | null);
   /**
    * API version for xDS resources. This implies the type URLs that the client
    * will request for resources and the resource type that the client will in
@@ -111,12 +111,12 @@ export interface ConfigSource__Output {
   /**
    * API configuration source.
    */
-  'api_config_source'?: (_envoy_config_core_v3_ApiConfigSource__Output);
+  'api_config_source'?: (_envoy_config_core_v3_ApiConfigSource__Output | null);
   /**
    * When set, ADS will be used to fetch resources. The ADS API configuration
    * source in the bootstrap configuration is used.
    */
-  'ads'?: (_envoy_config_core_v3_AggregatedConfigSource__Output);
+  'ads'?: (_envoy_config_core_v3_AggregatedConfigSource__Output | null);
   /**
    * When this timeout is specified, Envoy will wait no longer than the specified time for first
    * config response on this xDS subscription during the :ref:`initialization process
@@ -126,7 +126,7 @@ export interface ConfigSource__Output {
    * means no timeout - Envoy will wait indefinitely for the first xDS config (unless another
    * timeout applies). The default is 15s.
    */
-  'initial_fetch_timeout'?: (_google_protobuf_Duration__Output);
+  'initial_fetch_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * [#not-implemented-hide:]
    * When set, the client will access the resources from the same server it got the
@@ -140,7 +140,7 @@ export interface ConfigSource__Output {
    * this field can implicitly mean to use the same stream in the case where the ConfigSource
    * is provided via ADS and the specified data can also be obtained via ADS.]
    */
-  'self'?: (_envoy_config_core_v3_SelfConfigSource__Output);
+  'self'?: (_envoy_config_core_v3_SelfConfigSource__Output | null);
   /**
    * API version for xDS resources. This implies the type URLs that the client
    * will request for resources and the resource type that the client will in

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/EventServiceConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/EventServiceConfig.ts
@@ -10,7 +10,7 @@ export interface EventServiceConfig {
   /**
    * Specifies the gRPC service that hosts the event reporting service.
    */
-  'grpc_service'?: (_envoy_config_core_v3_GrpcService);
+  'grpc_service'?: (_envoy_config_core_v3_GrpcService | null);
   'config_source_specifier'?: "grpc_service";
 }
 
@@ -22,6 +22,6 @@ export interface EventServiceConfig__Output {
   /**
    * Specifies the gRPC service that hosts the event reporting service.
    */
-  'grpc_service'?: (_envoy_config_core_v3_GrpcService__Output);
+  'grpc_service'?: (_envoy_config_core_v3_GrpcService__Output | null);
   'config_source_specifier': "grpc_service";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Extension.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Extension.ts
@@ -31,7 +31,7 @@ export interface Extension {
    * of other extensions and the Envoy API.
    * This field is not set when extension did not provide version information.
    */
-  'version'?: (_envoy_config_core_v3_BuildVersion);
+  'version'?: (_envoy_config_core_v3_BuildVersion | null);
   /**
    * Indicates that the extension is present but was disabled via dynamic configuration.
    */
@@ -67,7 +67,7 @@ export interface Extension__Output {
    * of other extensions and the Envoy API.
    * This field is not set when extension did not provide version information.
    */
-  'version'?: (_envoy_config_core_v3_BuildVersion__Output);
+  'version': (_envoy_config_core_v3_BuildVersion__Output | null);
   /**
    * Indicates that the extension is present but was disabled via dynamic configuration.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/ExtensionConfigSource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/ExtensionConfigSource.ts
@@ -17,13 +17,13 @@ import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__
  * filter chain with a disabled extension filter rejects all incoming streams.
  */
 export interface ExtensionConfigSource {
-  'config_source'?: (_envoy_config_core_v3_ConfigSource);
+  'config_source'?: (_envoy_config_core_v3_ConfigSource | null);
   /**
    * Optional default configuration to use as the initial configuration if
    * there is a failure to receive the initial extension configuration or if
    * `apply_default_config_without_warming` flag is set.
    */
-  'default_config'?: (_google_protobuf_Any);
+  'default_config'?: (_google_protobuf_Any | null);
   /**
    * Use the default config as the initial configuration without warming and
    * waiting for the first discovery response. Requires the default configuration
@@ -51,13 +51,13 @@ export interface ExtensionConfigSource {
  * filter chain with a disabled extension filter rejects all incoming streams.
  */
 export interface ExtensionConfigSource__Output {
-  'config_source'?: (_envoy_config_core_v3_ConfigSource__Output);
+  'config_source': (_envoy_config_core_v3_ConfigSource__Output | null);
   /**
    * Optional default configuration to use as the initial configuration if
    * there is a failure to receive the initial extension configuration or if
    * `apply_default_config_without_warming` flag is set.
    */
-  'default_config'?: (_google_protobuf_Any__Output);
+  'default_config': (_google_protobuf_Any__Output | null);
   /**
    * Use the default config as the initial configuration without warming and
    * waiting for the first discovery response. Requires the default configuration

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/GrpcProtocolOptions.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/GrpcProtocolOptions.ts
@@ -6,12 +6,12 @@ import type { Http2ProtocolOptions as _envoy_config_core_v3_Http2ProtocolOptions
  * [#not-implemented-hide:]
  */
 export interface GrpcProtocolOptions {
-  'http2_protocol_options'?: (_envoy_config_core_v3_Http2ProtocolOptions);
+  'http2_protocol_options'?: (_envoy_config_core_v3_Http2ProtocolOptions | null);
 }
 
 /**
  * [#not-implemented-hide:]
  */
 export interface GrpcProtocolOptions__Output {
-  'http2_protocol_options'?: (_envoy_config_core_v3_Http2ProtocolOptions__Output);
+  'http2_protocol_options': (_envoy_config_core_v3_Http2ProtocolOptions__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/GrpcService.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/GrpcService.ts
@@ -22,7 +22,7 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials {
    * Google Compute Engine credentials.
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a6beb3ac70ff94bd2ebbd89b8f21d1f61
    */
-  'google_compute_engine'?: (_google_protobuf_Empty);
+  'google_compute_engine'?: (_google_protobuf_Empty | null);
   /**
    * Google refresh token credentials.
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a96901c997b91bc6513b08491e0dca37c.
@@ -32,24 +32,24 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials {
    * Service Account JWT Access credentials.
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a92a9f959d6102461f66ee973d8e9d3aa.
    */
-  'service_account_jwt_access'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJWTAccessCredentials);
+  'service_account_jwt_access'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJWTAccessCredentials | null);
   /**
    * Google IAM credentials.
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a9fc1fc101b41e680d47028166e76f9d0.
    */
-  'google_iam'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_GoogleIAMCredentials);
+  'google_iam'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_GoogleIAMCredentials | null);
   /**
    * Custom authenticator credentials.
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a823c6a4b19ffc71fb33e90154ee2ad07.
    * https://grpc.io/docs/guides/auth.html#extending-grpc-to-support-other-authentication-mechanisms.
    */
-  'from_plugin'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin);
+  'from_plugin'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin | null);
   /**
    * Custom security token service which implements OAuth 2.0 token exchange.
    * https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-16
    * See https://github.com/grpc/grpc/pull/19587.
    */
-  'sts_service'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_StsService);
+  'sts_service'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_StsService | null);
   'credential_specifier'?: "access_token"|"google_compute_engine"|"google_refresh_token"|"service_account_jwt_access"|"google_iam"|"from_plugin"|"sts_service";
 }
 
@@ -66,7 +66,7 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials__O
    * Google Compute Engine credentials.
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a6beb3ac70ff94bd2ebbd89b8f21d1f61
    */
-  'google_compute_engine'?: (_google_protobuf_Empty__Output);
+  'google_compute_engine'?: (_google_protobuf_Empty__Output | null);
   /**
    * Google refresh token credentials.
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a96901c997b91bc6513b08491e0dca37c.
@@ -76,24 +76,24 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials__O
    * Service Account JWT Access credentials.
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a92a9f959d6102461f66ee973d8e9d3aa.
    */
-  'service_account_jwt_access'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJWTAccessCredentials__Output);
+  'service_account_jwt_access'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJWTAccessCredentials__Output | null);
   /**
    * Google IAM credentials.
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a9fc1fc101b41e680d47028166e76f9d0.
    */
-  'google_iam'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_GoogleIAMCredentials__Output);
+  'google_iam'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_GoogleIAMCredentials__Output | null);
   /**
    * Custom authenticator credentials.
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a823c6a4b19ffc71fb33e90154ee2ad07.
    * https://grpc.io/docs/guides/auth.html#extending-grpc-to-support-other-authentication-mechanisms.
    */
-  'from_plugin'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin__Output);
+  'from_plugin'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin__Output | null);
   /**
    * Custom security token service which implements OAuth 2.0 token exchange.
    * https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-16
    * See https://github.com/grpc/grpc/pull/19587.
    */
-  'sts_service'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_StsService__Output);
+  'sts_service'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_StsService__Output | null);
   'credential_specifier': "access_token"|"google_compute_engine"|"google_refresh_token"|"service_account_jwt_access"|"google_iam"|"from_plugin"|"sts_service";
 }
 
@@ -114,7 +114,7 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelArgs__Outpu
   /**
    * See grpc_types.h GRPC_ARG #defines for keys that work here.
    */
-  'args'?: ({[key: string]: _envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelArgs_Value__Output});
+  'args': ({[key: string]: _envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelArgs_Value__Output});
 }
 
 /**
@@ -122,12 +122,12 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelArgs__Outpu
  * credential types.
  */
 export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelCredentials {
-  'ssl_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_SslCredentials);
+  'ssl_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_SslCredentials | null);
   /**
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a6beb3ac70ff94bd2ebbd89b8f21d1f61
    */
-  'google_default'?: (_google_protobuf_Empty);
-  'local_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_GoogleLocalCredentials);
+  'google_default'?: (_google_protobuf_Empty | null);
+  'local_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_GoogleLocalCredentials | null);
   'credential_specifier'?: "ssl_credentials"|"google_default"|"local_credentials";
 }
 
@@ -136,12 +136,12 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelCredentials
  * credential types.
  */
 export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelCredentials__Output {
-  'ssl_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_SslCredentials__Output);
+  'ssl_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_SslCredentials__Output | null);
   /**
    * https://grpc.io/grpc/cpp/namespacegrpc.html#a6beb3ac70ff94bd2ebbd89b8f21d1f61
    */
-  'google_default'?: (_google_protobuf_Empty__Output);
-  'local_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_GoogleLocalCredentials__Output);
+  'google_default'?: (_google_protobuf_Empty__Output | null);
+  'local_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_GoogleLocalCredentials__Output | null);
   'credential_specifier': "ssl_credentials"|"google_default"|"local_credentials";
 }
 
@@ -183,7 +183,7 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc {
    * :ref:`channel_credentials <envoy_api_field_config.core.v3.GrpcService.GoogleGrpc.channel_credentials>`.
    */
   'target_uri'?: (string);
-  'channel_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelCredentials);
+  'channel_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelCredentials | null);
   /**
    * A set of call credentials that can be composed with `channel credentials
    * <https://grpc.io/docs/guides/auth.html#credential-types>`_.
@@ -211,16 +211,16 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc {
    * Additional configuration for site-specific customizations of the Google
    * gRPC library.
    */
-  'config'?: (_google_protobuf_Struct);
+  'config'?: (_google_protobuf_Struct | null);
   /**
    * How many bytes each stream can buffer internally.
    * If not set an implementation defined default is applied (1MiB).
    */
-  'per_stream_buffer_limit_bytes'?: (_google_protobuf_UInt32Value);
+  'per_stream_buffer_limit_bytes'?: (_google_protobuf_UInt32Value | null);
   /**
    * Custom channels args.
    */
-  'channel_args'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelArgs);
+  'channel_args'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelArgs | null);
 }
 
 /**
@@ -233,7 +233,7 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc__Output {
    * :ref:`channel_credentials <envoy_api_field_config.core.v3.GrpcService.GoogleGrpc.channel_credentials>`.
    */
   'target_uri': (string);
-  'channel_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelCredentials__Output);
+  'channel_credentials': (_envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelCredentials__Output | null);
   /**
    * A set of call credentials that can be composed with `channel credentials
    * <https://grpc.io/docs/guides/auth.html#credential-types>`_.
@@ -261,16 +261,16 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc__Output {
    * Additional configuration for site-specific customizations of the Google
    * gRPC library.
    */
-  'config'?: (_google_protobuf_Struct__Output);
+  'config': (_google_protobuf_Struct__Output | null);
   /**
    * How many bytes each stream can buffer internally.
    * If not set an implementation defined default is applied (1MiB).
    */
-  'per_stream_buffer_limit_bytes'?: (_google_protobuf_UInt32Value__Output);
+  'per_stream_buffer_limit_bytes': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Custom channels args.
    */
-  'channel_args'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelArgs__Output);
+  'channel_args': (_envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelArgs__Output | null);
 }
 
 export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_GoogleIAMCredentials {
@@ -299,13 +299,13 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_GoogleLocalCredent
 
 export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin {
   'name'?: (string);
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
   'config_type'?: "typed_config";
 }
 
 export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin__Output {
   'name': (string);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   'config_type': "typed_config";
 }
 
@@ -326,15 +326,15 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_SslCredentials {
   /**
    * PEM encoded server root certificates.
    */
-  'root_certs'?: (_envoy_config_core_v3_DataSource);
+  'root_certs'?: (_envoy_config_core_v3_DataSource | null);
   /**
    * PEM encoded client private key.
    */
-  'private_key'?: (_envoy_config_core_v3_DataSource);
+  'private_key'?: (_envoy_config_core_v3_DataSource | null);
   /**
    * PEM encoded client certificate chain.
    */
-  'cert_chain'?: (_envoy_config_core_v3_DataSource);
+  'cert_chain'?: (_envoy_config_core_v3_DataSource | null);
 }
 
 /**
@@ -344,15 +344,15 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_SslCredentials__Ou
   /**
    * PEM encoded server root certificates.
    */
-  'root_certs'?: (_envoy_config_core_v3_DataSource__Output);
+  'root_certs': (_envoy_config_core_v3_DataSource__Output | null);
   /**
    * PEM encoded client private key.
    */
-  'private_key'?: (_envoy_config_core_v3_DataSource__Output);
+  'private_key': (_envoy_config_core_v3_DataSource__Output | null);
   /**
    * PEM encoded client certificate chain.
    */
-  'cert_chain'?: (_envoy_config_core_v3_DataSource__Output);
+  'cert_chain': (_envoy_config_core_v3_DataSource__Output | null);
 }
 
 /**
@@ -494,18 +494,18 @@ export interface GrpcService {
    * See the :ref:`gRPC services overview <arch_overview_grpc_services>`
    * documentation for discussion on gRPC client selection.
    */
-  'envoy_grpc'?: (_envoy_config_core_v3_GrpcService_EnvoyGrpc);
+  'envoy_grpc'?: (_envoy_config_core_v3_GrpcService_EnvoyGrpc | null);
   /**
    * `Google C++ gRPC client <https://github.com/grpc/grpc>`_
    * See the :ref:`gRPC services overview <arch_overview_grpc_services>`
    * documentation for discussion on gRPC client selection.
    */
-  'google_grpc'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc);
+  'google_grpc'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc | null);
   /**
    * The timeout for the gRPC request. This is the timeout for a specific
    * request.
    */
-  'timeout'?: (_google_protobuf_Duration);
+  'timeout'?: (_google_protobuf_Duration | null);
   /**
    * Additional metadata to include in streams initiated to the GrpcService. This can be used for
    * scenarios in which additional ad hoc authorization headers (e.g. ``x-foo-bar: baz-key``) are to
@@ -528,18 +528,18 @@ export interface GrpcService__Output {
    * See the :ref:`gRPC services overview <arch_overview_grpc_services>`
    * documentation for discussion on gRPC client selection.
    */
-  'envoy_grpc'?: (_envoy_config_core_v3_GrpcService_EnvoyGrpc__Output);
+  'envoy_grpc'?: (_envoy_config_core_v3_GrpcService_EnvoyGrpc__Output | null);
   /**
    * `Google C++ gRPC client <https://github.com/grpc/grpc>`_
    * See the :ref:`gRPC services overview <arch_overview_grpc_services>`
    * documentation for discussion on gRPC client selection.
    */
-  'google_grpc'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc__Output);
+  'google_grpc'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc__Output | null);
   /**
    * The timeout for the gRPC request. This is the timeout for a specific
    * request.
    */
-  'timeout'?: (_google_protobuf_Duration__Output);
+  'timeout': (_google_protobuf_Duration__Output | null);
   /**
    * Additional metadata to include in streams initiated to the GrpcService. This can be used for
    * scenarios in which additional ad hoc authorization headers (e.g. ``x-foo-bar: baz-key``) are to

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HeaderValueOption.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HeaderValueOption.ts
@@ -10,12 +10,12 @@ export interface HeaderValueOption {
   /**
    * Header name/value pair that this option applies to.
    */
-  'header'?: (_envoy_config_core_v3_HeaderValue);
+  'header'?: (_envoy_config_core_v3_HeaderValue | null);
   /**
    * Should the value be appended? If true (default), the value is appended to
    * existing values. Otherwise it replaces any existing values.
    */
-  'append'?: (_google_protobuf_BoolValue);
+  'append'?: (_google_protobuf_BoolValue | null);
 }
 
 /**
@@ -25,10 +25,10 @@ export interface HeaderValueOption__Output {
   /**
    * Header name/value pair that this option applies to.
    */
-  'header'?: (_envoy_config_core_v3_HeaderValue__Output);
+  'header': (_envoy_config_core_v3_HeaderValue__Output | null);
   /**
    * Should the value be appended? If true (default), the value is appended to
    * existing values. Otherwise it replaces any existing values.
    */
-  'append'?: (_google_protobuf_BoolValue__Output);
+  'append': (_google_protobuf_BoolValue__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HealthCheck.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HealthCheck.ts
@@ -20,7 +20,7 @@ export interface _envoy_config_core_v3_HealthCheck_CustomHealthCheck {
    * The registered name of the custom health checker.
    */
   'name'?: (string);
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
   /**
    * A custom health checker specific configuration which depends on the custom health checker
    * being instantiated. See :api:`envoy/config/health_checker` for reference.
@@ -36,7 +36,7 @@ export interface _envoy_config_core_v3_HealthCheck_CustomHealthCheck__Output {
    * The registered name of the custom health checker.
    */
   'name': (string);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   /**
    * A custom health checker specific configuration which depends on the custom health checker
    * being instantiated. See :api:`envoy/config/health_checker` for reference.
@@ -111,11 +111,11 @@ export interface _envoy_config_core_v3_HealthCheck_HttpHealthCheck {
   /**
    * [#not-implemented-hide:] HTTP specific payload.
    */
-  'send'?: (_envoy_config_core_v3_HealthCheck_Payload);
+  'send'?: (_envoy_config_core_v3_HealthCheck_Payload | null);
   /**
    * [#not-implemented-hide:] HTTP specific response.
    */
-  'receive'?: (_envoy_config_core_v3_HealthCheck_Payload);
+  'receive'?: (_envoy_config_core_v3_HealthCheck_Payload | null);
   /**
    * Specifies a list of HTTP headers that should be added to each request that is sent to the
    * health checked cluster. For more information, including details on header value syntax, see
@@ -145,7 +145,7 @@ export interface _envoy_config_core_v3_HealthCheck_HttpHealthCheck {
    * <envoy_api_msg_type.matcher.v3.StringMatcher>`. See the :ref:`architecture overview
    * <arch_overview_health_checking_identity>` for more information.
    */
-  'service_name_matcher'?: (_envoy_type_matcher_v3_StringMatcher);
+  'service_name_matcher'?: (_envoy_type_matcher_v3_StringMatcher | null);
 }
 
 /**
@@ -167,11 +167,11 @@ export interface _envoy_config_core_v3_HealthCheck_HttpHealthCheck__Output {
   /**
    * [#not-implemented-hide:] HTTP specific payload.
    */
-  'send'?: (_envoy_config_core_v3_HealthCheck_Payload__Output);
+  'send': (_envoy_config_core_v3_HealthCheck_Payload__Output | null);
   /**
    * [#not-implemented-hide:] HTTP specific response.
    */
-  'receive'?: (_envoy_config_core_v3_HealthCheck_Payload__Output);
+  'receive': (_envoy_config_core_v3_HealthCheck_Payload__Output | null);
   /**
    * Specifies a list of HTTP headers that should be added to each request that is sent to the
    * health checked cluster. For more information, including details on header value syntax, see
@@ -201,7 +201,7 @@ export interface _envoy_config_core_v3_HealthCheck_HttpHealthCheck__Output {
    * <envoy_api_msg_type.matcher.v3.StringMatcher>`. See the :ref:`architecture overview
    * <arch_overview_health_checking_identity>` for more information.
    */
-  'service_name_matcher'?: (_envoy_type_matcher_v3_StringMatcher__Output);
+  'service_name_matcher': (_envoy_type_matcher_v3_StringMatcher__Output | null);
 }
 
 /**
@@ -258,7 +258,7 @@ export interface _envoy_config_core_v3_HealthCheck_TcpHealthCheck {
   /**
    * Empty payloads imply a connect-only health check.
    */
-  'send'?: (_envoy_config_core_v3_HealthCheck_Payload);
+  'send'?: (_envoy_config_core_v3_HealthCheck_Payload | null);
   /**
    * When checking the response, “fuzzy” matching is performed such that each
    * binary block must be found, and in the order specified, but not
@@ -271,7 +271,7 @@ export interface _envoy_config_core_v3_HealthCheck_TcpHealthCheck__Output {
   /**
    * Empty payloads imply a connect-only health check.
    */
-  'send'?: (_envoy_config_core_v3_HealthCheck_Payload__Output);
+  'send': (_envoy_config_core_v3_HealthCheck_Payload__Output | null);
   /**
    * When checking the response, “fuzzy” matching is performed such that each
    * binary block must be found, and in the order specified, but not
@@ -320,48 +320,48 @@ export interface HealthCheck {
    * The time to wait for a health check response. If the timeout is reached the
    * health check attempt will be considered a failure.
    */
-  'timeout'?: (_google_protobuf_Duration);
+  'timeout'?: (_google_protobuf_Duration | null);
   /**
    * The interval between health checks.
    */
-  'interval'?: (_google_protobuf_Duration);
+  'interval'?: (_google_protobuf_Duration | null);
   /**
    * An optional jitter amount in milliseconds. If specified, during every
    * interval Envoy will add interval_jitter to the wait time.
    */
-  'interval_jitter'?: (_google_protobuf_Duration);
+  'interval_jitter'?: (_google_protobuf_Duration | null);
   /**
    * The number of unhealthy health checks required before a host is marked
    * unhealthy. Note that for *http* health checking if a host responds with 503
    * this threshold is ignored and the host is considered unhealthy immediately.
    */
-  'unhealthy_threshold'?: (_google_protobuf_UInt32Value);
+  'unhealthy_threshold'?: (_google_protobuf_UInt32Value | null);
   /**
    * The number of healthy health checks required before a host is marked
    * healthy. Note that during startup, only a single successful health check is
    * required to mark a host healthy.
    */
-  'healthy_threshold'?: (_google_protobuf_UInt32Value);
+  'healthy_threshold'?: (_google_protobuf_UInt32Value | null);
   /**
    * [#not-implemented-hide:] Non-serving port for health checking.
    */
-  'alt_port'?: (_google_protobuf_UInt32Value);
+  'alt_port'?: (_google_protobuf_UInt32Value | null);
   /**
    * Reuse health check connection between health checks. Default is true.
    */
-  'reuse_connection'?: (_google_protobuf_BoolValue);
+  'reuse_connection'?: (_google_protobuf_BoolValue | null);
   /**
    * HTTP health check.
    */
-  'http_health_check'?: (_envoy_config_core_v3_HealthCheck_HttpHealthCheck);
+  'http_health_check'?: (_envoy_config_core_v3_HealthCheck_HttpHealthCheck | null);
   /**
    * TCP health check.
    */
-  'tcp_health_check'?: (_envoy_config_core_v3_HealthCheck_TcpHealthCheck);
+  'tcp_health_check'?: (_envoy_config_core_v3_HealthCheck_TcpHealthCheck | null);
   /**
    * gRPC health check.
    */
-  'grpc_health_check'?: (_envoy_config_core_v3_HealthCheck_GrpcHealthCheck);
+  'grpc_health_check'?: (_envoy_config_core_v3_HealthCheck_GrpcHealthCheck | null);
   /**
    * The "no traffic interval" is a special health check interval that is used when a cluster has
    * never had traffic routed to it. This lower interval allows cluster information to be kept up to
@@ -372,11 +372,11 @@ export interface HealthCheck {
    * 
    * The default value for "no traffic interval" is 60 seconds.
    */
-  'no_traffic_interval'?: (_google_protobuf_Duration);
+  'no_traffic_interval'?: (_google_protobuf_Duration | null);
   /**
    * Custom health check.
    */
-  'custom_health_check'?: (_envoy_config_core_v3_HealthCheck_CustomHealthCheck);
+  'custom_health_check'?: (_envoy_config_core_v3_HealthCheck_CustomHealthCheck | null);
   /**
    * The "unhealthy interval" is a health check interval that is used for hosts that are marked as
    * unhealthy. As soon as the host is marked as healthy, Envoy will shift back to using the
@@ -384,7 +384,7 @@ export interface HealthCheck {
    * 
    * The default value for "unhealthy interval" is the same as "interval".
    */
-  'unhealthy_interval'?: (_google_protobuf_Duration);
+  'unhealthy_interval'?: (_google_protobuf_Duration | null);
   /**
    * The "unhealthy edge interval" is a special health check interval that is used for the first
    * health check right after a host is marked as unhealthy. For subsequent health checks
@@ -393,7 +393,7 @@ export interface HealthCheck {
    * 
    * The default value for "unhealthy edge interval" is the same as "unhealthy interval".
    */
-  'unhealthy_edge_interval'?: (_google_protobuf_Duration);
+  'unhealthy_edge_interval'?: (_google_protobuf_Duration | null);
   /**
    * The "healthy edge interval" is a special health check interval that is used for the first
    * health check right after a host is marked as healthy. For subsequent health checks
@@ -401,7 +401,7 @@ export interface HealthCheck {
    * 
    * The default value for "healthy edge interval" is the same as the default interval.
    */
-  'healthy_edge_interval'?: (_google_protobuf_Duration);
+  'healthy_edge_interval'?: (_google_protobuf_Duration | null);
   /**
    * Specifies the path to the :ref:`health check event log <arch_overview_health_check_logging>`.
    * If empty, no event log will be written.
@@ -427,17 +427,17 @@ export interface HealthCheck {
    * checking after for a random time in ms between 0 and initial_jitter. This only
    * applies to the first health check.
    */
-  'initial_jitter'?: (_google_protobuf_Duration);
+  'initial_jitter'?: (_google_protobuf_Duration | null);
   /**
    * This allows overriding the cluster TLS settings, just for health check connections.
    */
-  'tls_options'?: (_envoy_config_core_v3_HealthCheck_TlsOptions);
+  'tls_options'?: (_envoy_config_core_v3_HealthCheck_TlsOptions | null);
   /**
    * [#not-implemented-hide:]
    * The gRPC service for the health check event service.
    * If empty, health check events won't be sent to a remote endpoint.
    */
-  'event_service'?: (_envoy_config_core_v3_EventServiceConfig);
+  'event_service'?: (_envoy_config_core_v3_EventServiceConfig | null);
   /**
    * Optional key/value pairs that will be used to match a transport socket from those specified in the cluster's
    * :ref:`tranport socket matches <envoy_api_field_config.cluster.v3.Cluster.transport_socket_matches>`.
@@ -470,7 +470,7 @@ export interface HealthCheck {
    * the cluster's :ref:`transport socket <envoy_api_field_config.cluster.v3.Cluster.transport_socket>`
    * will be used for health check socket configuration.
    */
-  'transport_socket_match_criteria'?: (_google_protobuf_Struct);
+  'transport_socket_match_criteria'?: (_google_protobuf_Struct | null);
   /**
    * The "no traffic healthy interval" is a special health check interval that
    * is used for hosts that are currently passing active health checking
@@ -486,7 +486,7 @@ export interface HealthCheck {
    * If no_traffic_healthy_interval is not set, it will default to the
    * no traffic interval and send that interval regardless of health state.
    */
-  'no_traffic_healthy_interval'?: (_google_protobuf_Duration);
+  'no_traffic_healthy_interval'?: (_google_protobuf_Duration | null);
   'health_checker'?: "http_health_check"|"tcp_health_check"|"grpc_health_check"|"custom_health_check";
 }
 
@@ -498,48 +498,48 @@ export interface HealthCheck__Output {
    * The time to wait for a health check response. If the timeout is reached the
    * health check attempt will be considered a failure.
    */
-  'timeout'?: (_google_protobuf_Duration__Output);
+  'timeout': (_google_protobuf_Duration__Output | null);
   /**
    * The interval between health checks.
    */
-  'interval'?: (_google_protobuf_Duration__Output);
+  'interval': (_google_protobuf_Duration__Output | null);
   /**
    * An optional jitter amount in milliseconds. If specified, during every
    * interval Envoy will add interval_jitter to the wait time.
    */
-  'interval_jitter'?: (_google_protobuf_Duration__Output);
+  'interval_jitter': (_google_protobuf_Duration__Output | null);
   /**
    * The number of unhealthy health checks required before a host is marked
    * unhealthy. Note that for *http* health checking if a host responds with 503
    * this threshold is ignored and the host is considered unhealthy immediately.
    */
-  'unhealthy_threshold'?: (_google_protobuf_UInt32Value__Output);
+  'unhealthy_threshold': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The number of healthy health checks required before a host is marked
    * healthy. Note that during startup, only a single successful health check is
    * required to mark a host healthy.
    */
-  'healthy_threshold'?: (_google_protobuf_UInt32Value__Output);
+  'healthy_threshold': (_google_protobuf_UInt32Value__Output | null);
   /**
    * [#not-implemented-hide:] Non-serving port for health checking.
    */
-  'alt_port'?: (_google_protobuf_UInt32Value__Output);
+  'alt_port': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Reuse health check connection between health checks. Default is true.
    */
-  'reuse_connection'?: (_google_protobuf_BoolValue__Output);
+  'reuse_connection': (_google_protobuf_BoolValue__Output | null);
   /**
    * HTTP health check.
    */
-  'http_health_check'?: (_envoy_config_core_v3_HealthCheck_HttpHealthCheck__Output);
+  'http_health_check'?: (_envoy_config_core_v3_HealthCheck_HttpHealthCheck__Output | null);
   /**
    * TCP health check.
    */
-  'tcp_health_check'?: (_envoy_config_core_v3_HealthCheck_TcpHealthCheck__Output);
+  'tcp_health_check'?: (_envoy_config_core_v3_HealthCheck_TcpHealthCheck__Output | null);
   /**
    * gRPC health check.
    */
-  'grpc_health_check'?: (_envoy_config_core_v3_HealthCheck_GrpcHealthCheck__Output);
+  'grpc_health_check'?: (_envoy_config_core_v3_HealthCheck_GrpcHealthCheck__Output | null);
   /**
    * The "no traffic interval" is a special health check interval that is used when a cluster has
    * never had traffic routed to it. This lower interval allows cluster information to be kept up to
@@ -550,11 +550,11 @@ export interface HealthCheck__Output {
    * 
    * The default value for "no traffic interval" is 60 seconds.
    */
-  'no_traffic_interval'?: (_google_protobuf_Duration__Output);
+  'no_traffic_interval': (_google_protobuf_Duration__Output | null);
   /**
    * Custom health check.
    */
-  'custom_health_check'?: (_envoy_config_core_v3_HealthCheck_CustomHealthCheck__Output);
+  'custom_health_check'?: (_envoy_config_core_v3_HealthCheck_CustomHealthCheck__Output | null);
   /**
    * The "unhealthy interval" is a health check interval that is used for hosts that are marked as
    * unhealthy. As soon as the host is marked as healthy, Envoy will shift back to using the
@@ -562,7 +562,7 @@ export interface HealthCheck__Output {
    * 
    * The default value for "unhealthy interval" is the same as "interval".
    */
-  'unhealthy_interval'?: (_google_protobuf_Duration__Output);
+  'unhealthy_interval': (_google_protobuf_Duration__Output | null);
   /**
    * The "unhealthy edge interval" is a special health check interval that is used for the first
    * health check right after a host is marked as unhealthy. For subsequent health checks
@@ -571,7 +571,7 @@ export interface HealthCheck__Output {
    * 
    * The default value for "unhealthy edge interval" is the same as "unhealthy interval".
    */
-  'unhealthy_edge_interval'?: (_google_protobuf_Duration__Output);
+  'unhealthy_edge_interval': (_google_protobuf_Duration__Output | null);
   /**
    * The "healthy edge interval" is a special health check interval that is used for the first
    * health check right after a host is marked as healthy. For subsequent health checks
@@ -579,7 +579,7 @@ export interface HealthCheck__Output {
    * 
    * The default value for "healthy edge interval" is the same as the default interval.
    */
-  'healthy_edge_interval'?: (_google_protobuf_Duration__Output);
+  'healthy_edge_interval': (_google_protobuf_Duration__Output | null);
   /**
    * Specifies the path to the :ref:`health check event log <arch_overview_health_check_logging>`.
    * If empty, no event log will be written.
@@ -605,17 +605,17 @@ export interface HealthCheck__Output {
    * checking after for a random time in ms between 0 and initial_jitter. This only
    * applies to the first health check.
    */
-  'initial_jitter'?: (_google_protobuf_Duration__Output);
+  'initial_jitter': (_google_protobuf_Duration__Output | null);
   /**
    * This allows overriding the cluster TLS settings, just for health check connections.
    */
-  'tls_options'?: (_envoy_config_core_v3_HealthCheck_TlsOptions__Output);
+  'tls_options': (_envoy_config_core_v3_HealthCheck_TlsOptions__Output | null);
   /**
    * [#not-implemented-hide:]
    * The gRPC service for the health check event service.
    * If empty, health check events won't be sent to a remote endpoint.
    */
-  'event_service'?: (_envoy_config_core_v3_EventServiceConfig__Output);
+  'event_service': (_envoy_config_core_v3_EventServiceConfig__Output | null);
   /**
    * Optional key/value pairs that will be used to match a transport socket from those specified in the cluster's
    * :ref:`tranport socket matches <envoy_api_field_config.cluster.v3.Cluster.transport_socket_matches>`.
@@ -648,7 +648,7 @@ export interface HealthCheck__Output {
    * the cluster's :ref:`transport socket <envoy_api_field_config.cluster.v3.Cluster.transport_socket>`
    * will be used for health check socket configuration.
    */
-  'transport_socket_match_criteria'?: (_google_protobuf_Struct__Output);
+  'transport_socket_match_criteria': (_google_protobuf_Struct__Output | null);
   /**
    * The "no traffic healthy interval" is a special health check interval that
    * is used for hosts that are currently passing active health checking
@@ -664,6 +664,6 @@ export interface HealthCheck__Output {
    * If no_traffic_healthy_interval is not set, it will default to the
    * no traffic interval and send that interval regardless of health state.
    */
-  'no_traffic_healthy_interval'?: (_google_protobuf_Duration__Output);
+  'no_traffic_healthy_interval': (_google_protobuf_Duration__Output | null);
   'health_checker': "http_health_check"|"tcp_health_check"|"grpc_health_check"|"custom_health_check";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Http1ProtocolOptions.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Http1ProtocolOptions.ts
@@ -10,7 +10,7 @@ export interface _envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat {
    * Note that while this results in most headers following conventional casing, certain headers
    * are not covered. For example, the "TE" header will be formatted as "Te".
    */
-  'proper_case_words'?: (_envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat_ProperCaseWords);
+  'proper_case_words'?: (_envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat_ProperCaseWords | null);
   'header_format'?: "proper_case_words";
 }
 
@@ -22,7 +22,7 @@ export interface _envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat__Out
    * Note that while this results in most headers following conventional casing, certain headers
    * are not covered. For example, the "TE" header will be formatted as "Te".
    */
-  'proper_case_words'?: (_envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat_ProperCaseWords__Output);
+  'proper_case_words'?: (_envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat_ProperCaseWords__Output | null);
   'header_format': "proper_case_words";
 }
 
@@ -42,7 +42,7 @@ export interface Http1ProtocolOptions {
    * envoy as their HTTP proxy. In Unix, for example, this is typically done by setting the
    * *http_proxy* environment variable.
    */
-  'allow_absolute_url'?: (_google_protobuf_BoolValue);
+  'allow_absolute_url'?: (_google_protobuf_BoolValue | null);
   /**
    * Handle incoming HTTP/1.0 and HTTP 0.9 requests.
    * This is off by default, and not fully standards compliant. There is support for pre-HTTP/1.1
@@ -60,7 +60,7 @@ export interface Http1ProtocolOptions {
    * Describes how the keys for response headers should be formatted. By default, all header keys
    * are lower cased.
    */
-  'header_key_format'?: (_envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat);
+  'header_key_format'?: (_envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat | null);
   /**
    * Enables trailers for HTTP/1. By default the HTTP/1 codec drops proxied trailers.
    * 
@@ -92,7 +92,7 @@ export interface Http1ProtocolOptions {
    * If set, this overrides any HCM :ref:`stream_error_on_invalid_http_messaging
    * <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_error_on_invalid_http_message>`.
    */
-  'override_stream_error_on_invalid_http_message'?: (_google_protobuf_BoolValue);
+  'override_stream_error_on_invalid_http_message'?: (_google_protobuf_BoolValue | null);
 }
 
 /**
@@ -105,7 +105,7 @@ export interface Http1ProtocolOptions__Output {
    * envoy as their HTTP proxy. In Unix, for example, this is typically done by setting the
    * *http_proxy* environment variable.
    */
-  'allow_absolute_url'?: (_google_protobuf_BoolValue__Output);
+  'allow_absolute_url': (_google_protobuf_BoolValue__Output | null);
   /**
    * Handle incoming HTTP/1.0 and HTTP 0.9 requests.
    * This is off by default, and not fully standards compliant. There is support for pre-HTTP/1.1
@@ -123,7 +123,7 @@ export interface Http1ProtocolOptions__Output {
    * Describes how the keys for response headers should be formatted. By default, all header keys
    * are lower cased.
    */
-  'header_key_format'?: (_envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat__Output);
+  'header_key_format': (_envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat__Output | null);
   /**
    * Enables trailers for HTTP/1. By default the HTTP/1 codec drops proxied trailers.
    * 
@@ -155,5 +155,5 @@ export interface Http1ProtocolOptions__Output {
    * If set, this overrides any HCM :ref:`stream_error_on_invalid_http_messaging
    * <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_error_on_invalid_http_message>`.
    */
-  'override_stream_error_on_invalid_http_message'?: (_google_protobuf_BoolValue__Output);
+  'override_stream_error_on_invalid_http_message': (_google_protobuf_BoolValue__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Http2ProtocolOptions.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Http2ProtocolOptions.ts
@@ -12,11 +12,11 @@ export interface _envoy_config_core_v3_Http2ProtocolOptions_SettingsParameter {
   /**
    * The 16 bit parameter identifier.
    */
-  'identifier'?: (_google_protobuf_UInt32Value);
+  'identifier'?: (_google_protobuf_UInt32Value | null);
   /**
    * The 32 bit parameter value.
    */
-  'value'?: (_google_protobuf_UInt32Value);
+  'value'?: (_google_protobuf_UInt32Value | null);
 }
 
 /**
@@ -27,11 +27,11 @@ export interface _envoy_config_core_v3_Http2ProtocolOptions_SettingsParameter__O
   /**
    * The 16 bit parameter identifier.
    */
-  'identifier'?: (_google_protobuf_UInt32Value__Output);
+  'identifier': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The 32 bit parameter value.
    */
-  'value'?: (_google_protobuf_UInt32Value__Output);
+  'value': (_google_protobuf_UInt32Value__Output | null);
 }
 
 /**
@@ -44,7 +44,7 @@ export interface Http2ProtocolOptions {
    * range from 0 to 4294967295 (2^32 - 1) and defaults to 4096. 0 effectively disables header
    * compression.
    */
-  'hpack_table_size'?: (_google_protobuf_UInt32Value);
+  'hpack_table_size'?: (_google_protobuf_UInt32Value | null);
   /**
    * `Maximum concurrent streams <https://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2>`_
    * allowed for peer on one HTTP/2 connection. Valid values range from 1 to 2147483647 (2^31 - 1)
@@ -54,7 +54,7 @@ export interface Http2ProtocolOptions {
    * on a single connection. If the limit is reached, Envoy may queue requests or establish
    * additional connections (as allowed per circuit breaker limits).
    */
-  'max_concurrent_streams'?: (_google_protobuf_UInt32Value);
+  'max_concurrent_streams'?: (_google_protobuf_UInt32Value | null);
   /**
    * `Initial stream-level flow-control window
    * <https://httpwg.org/specs/rfc7540.html#rfc.section.6.9.2>`_ size. Valid values range from 65535
@@ -68,12 +68,12 @@ export interface Http2ProtocolOptions {
    * HTTP/2 codec buffers. Once the buffer reaches this pointer, watermark callbacks will fire to
    * stop the flow of data to the codec buffers.
    */
-  'initial_stream_window_size'?: (_google_protobuf_UInt32Value);
+  'initial_stream_window_size'?: (_google_protobuf_UInt32Value | null);
   /**
    * Similar to *initial_stream_window_size*, but for connection-level flow-control
    * window. Currently, this has the same minimum/maximum/default as *initial_stream_window_size*.
    */
-  'initial_connection_window_size'?: (_google_protobuf_UInt32Value);
+  'initial_connection_window_size'?: (_google_protobuf_UInt32Value | null);
   /**
    * Allows proxying Websocket and other upgrades over H2 connect.
    */
@@ -95,7 +95,7 @@ export interface Http2ProtocolOptions {
    * NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
    * `envoy.reloadable_features.upstream_http2_flood_checks` flag.
    */
-  'max_outbound_frames'?: (_google_protobuf_UInt32Value);
+  'max_outbound_frames'?: (_google_protobuf_UInt32Value | null);
   /**
    * Limit the number of pending outbound downstream frames of types PING, SETTINGS and RST_STREAM,
    * preventing high memory utilization when receiving continuous stream of these frames. Exceeding
@@ -105,7 +105,7 @@ export interface Http2ProtocolOptions {
    * NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
    * `envoy.reloadable_features.upstream_http2_flood_checks` flag.
    */
-  'max_outbound_control_frames'?: (_google_protobuf_UInt32Value);
+  'max_outbound_control_frames'?: (_google_protobuf_UInt32Value | null);
   /**
    * Limit the number of consecutive inbound frames of types HEADERS, CONTINUATION and DATA with an
    * empty payload and no end stream flag. Those frames have no legitimate use and are abusive, but
@@ -116,7 +116,7 @@ export interface Http2ProtocolOptions {
    * NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
    * `envoy.reloadable_features.upstream_http2_flood_checks` flag.
    */
-  'max_consecutive_inbound_frames_with_empty_payload'?: (_google_protobuf_UInt32Value);
+  'max_consecutive_inbound_frames_with_empty_payload'?: (_google_protobuf_UInt32Value | null);
   /**
    * Limit the number of inbound PRIORITY frames allowed per each opened stream. If the number
    * of PRIORITY frames received over the lifetime of connection exceeds the value calculated
@@ -132,7 +132,7 @@ export interface Http2ProtocolOptions {
    * NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
    * `envoy.reloadable_features.upstream_http2_flood_checks` flag.
    */
-  'max_inbound_priority_frames_per_stream'?: (_google_protobuf_UInt32Value);
+  'max_inbound_priority_frames_per_stream'?: (_google_protobuf_UInt32Value | null);
   /**
    * Limit the number of inbound WINDOW_UPDATE frames allowed per DATA frame sent. If the number
    * of WINDOW_UPDATE frames received over the lifetime of connection exceeds the value calculated
@@ -151,7 +151,7 @@ export interface Http2ProtocolOptions {
    * NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
    * `envoy.reloadable_features.upstream_http2_flood_checks` flag.
    */
-  'max_inbound_window_update_frames_per_data_frame_sent'?: (_google_protobuf_UInt32Value);
+  'max_inbound_window_update_frames_per_data_frame_sent'?: (_google_protobuf_UInt32Value | null);
   /**
    * Allows invalid HTTP messaging and headers. When this option is disabled (default), then
    * the whole HTTP/2 connection is terminated upon receiving invalid HEADERS frame. However,
@@ -206,12 +206,12 @@ export interface Http2ProtocolOptions {
    * 
    * See `RFC7540, sec. 8.1 <https://tools.ietf.org/html/rfc7540#section-8.1>`_ for details.
    */
-  'override_stream_error_on_invalid_http_message'?: (_google_protobuf_BoolValue);
+  'override_stream_error_on_invalid_http_message'?: (_google_protobuf_BoolValue | null);
   /**
    * Send HTTP/2 PING frames to verify that the connection is still healthy. If the remote peer
    * does not respond within the configured timeout, the connection will be aborted.
    */
-  'connection_keepalive'?: (_envoy_config_core_v3_KeepaliveSettings);
+  'connection_keepalive'?: (_envoy_config_core_v3_KeepaliveSettings | null);
 }
 
 /**
@@ -224,7 +224,7 @@ export interface Http2ProtocolOptions__Output {
    * range from 0 to 4294967295 (2^32 - 1) and defaults to 4096. 0 effectively disables header
    * compression.
    */
-  'hpack_table_size'?: (_google_protobuf_UInt32Value__Output);
+  'hpack_table_size': (_google_protobuf_UInt32Value__Output | null);
   /**
    * `Maximum concurrent streams <https://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2>`_
    * allowed for peer on one HTTP/2 connection. Valid values range from 1 to 2147483647 (2^31 - 1)
@@ -234,7 +234,7 @@ export interface Http2ProtocolOptions__Output {
    * on a single connection. If the limit is reached, Envoy may queue requests or establish
    * additional connections (as allowed per circuit breaker limits).
    */
-  'max_concurrent_streams'?: (_google_protobuf_UInt32Value__Output);
+  'max_concurrent_streams': (_google_protobuf_UInt32Value__Output | null);
   /**
    * `Initial stream-level flow-control window
    * <https://httpwg.org/specs/rfc7540.html#rfc.section.6.9.2>`_ size. Valid values range from 65535
@@ -248,12 +248,12 @@ export interface Http2ProtocolOptions__Output {
    * HTTP/2 codec buffers. Once the buffer reaches this pointer, watermark callbacks will fire to
    * stop the flow of data to the codec buffers.
    */
-  'initial_stream_window_size'?: (_google_protobuf_UInt32Value__Output);
+  'initial_stream_window_size': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Similar to *initial_stream_window_size*, but for connection-level flow-control
    * window. Currently, this has the same minimum/maximum/default as *initial_stream_window_size*.
    */
-  'initial_connection_window_size'?: (_google_protobuf_UInt32Value__Output);
+  'initial_connection_window_size': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Allows proxying Websocket and other upgrades over H2 connect.
    */
@@ -275,7 +275,7 @@ export interface Http2ProtocolOptions__Output {
    * NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
    * `envoy.reloadable_features.upstream_http2_flood_checks` flag.
    */
-  'max_outbound_frames'?: (_google_protobuf_UInt32Value__Output);
+  'max_outbound_frames': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Limit the number of pending outbound downstream frames of types PING, SETTINGS and RST_STREAM,
    * preventing high memory utilization when receiving continuous stream of these frames. Exceeding
@@ -285,7 +285,7 @@ export interface Http2ProtocolOptions__Output {
    * NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
    * `envoy.reloadable_features.upstream_http2_flood_checks` flag.
    */
-  'max_outbound_control_frames'?: (_google_protobuf_UInt32Value__Output);
+  'max_outbound_control_frames': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Limit the number of consecutive inbound frames of types HEADERS, CONTINUATION and DATA with an
    * empty payload and no end stream flag. Those frames have no legitimate use and are abusive, but
@@ -296,7 +296,7 @@ export interface Http2ProtocolOptions__Output {
    * NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
    * `envoy.reloadable_features.upstream_http2_flood_checks` flag.
    */
-  'max_consecutive_inbound_frames_with_empty_payload'?: (_google_protobuf_UInt32Value__Output);
+  'max_consecutive_inbound_frames_with_empty_payload': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Limit the number of inbound PRIORITY frames allowed per each opened stream. If the number
    * of PRIORITY frames received over the lifetime of connection exceeds the value calculated
@@ -312,7 +312,7 @@ export interface Http2ProtocolOptions__Output {
    * NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
    * `envoy.reloadable_features.upstream_http2_flood_checks` flag.
    */
-  'max_inbound_priority_frames_per_stream'?: (_google_protobuf_UInt32Value__Output);
+  'max_inbound_priority_frames_per_stream': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Limit the number of inbound WINDOW_UPDATE frames allowed per DATA frame sent. If the number
    * of WINDOW_UPDATE frames received over the lifetime of connection exceeds the value calculated
@@ -331,7 +331,7 @@ export interface Http2ProtocolOptions__Output {
    * NOTE: flood and abuse mitigation for upstream connections is presently enabled by the
    * `envoy.reloadable_features.upstream_http2_flood_checks` flag.
    */
-  'max_inbound_window_update_frames_per_data_frame_sent'?: (_google_protobuf_UInt32Value__Output);
+  'max_inbound_window_update_frames_per_data_frame_sent': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Allows invalid HTTP messaging and headers. When this option is disabled (default), then
    * the whole HTTP/2 connection is terminated upon receiving invalid HEADERS frame. However,
@@ -386,10 +386,10 @@ export interface Http2ProtocolOptions__Output {
    * 
    * See `RFC7540, sec. 8.1 <https://tools.ietf.org/html/rfc7540#section-8.1>`_ for details.
    */
-  'override_stream_error_on_invalid_http_message'?: (_google_protobuf_BoolValue__Output);
+  'override_stream_error_on_invalid_http_message': (_google_protobuf_BoolValue__Output | null);
   /**
    * Send HTTP/2 PING frames to verify that the connection is still healthy. If the remote peer
    * does not respond within the configured timeout, the connection will be aborted.
    */
-  'connection_keepalive'?: (_envoy_config_core_v3_KeepaliveSettings__Output);
+  'connection_keepalive': (_envoy_config_core_v3_KeepaliveSettings__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HttpProtocolOptions.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HttpProtocolOptions.ts
@@ -53,13 +53,13 @@ export interface HttpProtocolOptions {
    * is configured, this timeout is scaled for downstream connections according to the value for
    * :ref:`HTTP_DOWNSTREAM_CONNECTION_IDLE <envoy_api_enum_value_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType.HTTP_DOWNSTREAM_CONNECTION_IDLE>`.
    */
-  'idle_timeout'?: (_google_protobuf_Duration);
+  'idle_timeout'?: (_google_protobuf_Duration | null);
   /**
    * The maximum number of headers. If unconfigured, the default
    * maximum number of request headers allowed is 100. Requests that exceed this limit will receive
    * a 431 response for HTTP/1.x and cause a stream reset for HTTP/2.
    */
-  'max_headers_count'?: (_google_protobuf_UInt32Value);
+  'max_headers_count'?: (_google_protobuf_UInt32Value | null);
   /**
    * The maximum duration of a connection. The duration is defined as a period since a connection
    * was established. If not set, there is no max duration. When max_connection_duration is reached
@@ -68,12 +68,12 @@ export interface HttpProtocolOptions {
    * <envoy_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout>`.
    * Note: not implemented for upstream connections.
    */
-  'max_connection_duration'?: (_google_protobuf_Duration);
+  'max_connection_duration'?: (_google_protobuf_Duration | null);
   /**
    * Total duration to keep alive an HTTP request/response stream. If the time limit is reached the stream will be
    * reset independent of any other timeouts. If not specified, this value is not set.
    */
-  'max_stream_duration'?: (_google_protobuf_Duration);
+  'max_stream_duration'?: (_google_protobuf_Duration | null);
   /**
    * Action to take when a client request with a header name containing underscore characters is received.
    * If this setting is not specified, the value defaults to ALLOW.
@@ -104,13 +104,13 @@ export interface HttpProtocolOptions__Output {
    * is configured, this timeout is scaled for downstream connections according to the value for
    * :ref:`HTTP_DOWNSTREAM_CONNECTION_IDLE <envoy_api_enum_value_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType.HTTP_DOWNSTREAM_CONNECTION_IDLE>`.
    */
-  'idle_timeout'?: (_google_protobuf_Duration__Output);
+  'idle_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * The maximum number of headers. If unconfigured, the default
    * maximum number of request headers allowed is 100. Requests that exceed this limit will receive
    * a 431 response for HTTP/1.x and cause a stream reset for HTTP/2.
    */
-  'max_headers_count'?: (_google_protobuf_UInt32Value__Output);
+  'max_headers_count': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The maximum duration of a connection. The duration is defined as a period since a connection
    * was established. If not set, there is no max duration. When max_connection_duration is reached
@@ -119,12 +119,12 @@ export interface HttpProtocolOptions__Output {
    * <envoy_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout>`.
    * Note: not implemented for upstream connections.
    */
-  'max_connection_duration'?: (_google_protobuf_Duration__Output);
+  'max_connection_duration': (_google_protobuf_Duration__Output | null);
   /**
    * Total duration to keep alive an HTTP request/response stream. If the time limit is reached the stream will be
    * reset independent of any other timeouts. If not specified, this value is not set.
    */
-  'max_stream_duration'?: (_google_protobuf_Duration__Output);
+  'max_stream_duration': (_google_protobuf_Duration__Output | null);
   /**
    * Action to take when a client request with a header name containing underscore characters is received.
    * If this setting is not specified, the value defaults to ALLOW.

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HttpUri.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HttpUri.ts
@@ -30,7 +30,7 @@ export interface HttpUri {
   /**
    * Sets the maximum duration in milliseconds that a response can take to arrive upon request.
    */
-  'timeout'?: (_google_protobuf_Duration);
+  'timeout'?: (_google_protobuf_Duration | null);
   /**
    * Specify how `uri` is to be fetched. Today, this requires an explicit
    * cluster, but in the future we may support dynamic cluster creation or
@@ -68,7 +68,7 @@ export interface HttpUri__Output {
   /**
    * Sets the maximum duration in milliseconds that a response can take to arrive upon request.
    */
-  'timeout'?: (_google_protobuf_Duration__Output);
+  'timeout': (_google_protobuf_Duration__Output | null);
   /**
    * Specify how `uri` is to be fetched. Today, this requires an explicit
    * cluster, but in the future we may support dynamic cluster creation or

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/KeepaliveSettings.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/KeepaliveSettings.ts
@@ -7,34 +7,34 @@ export interface KeepaliveSettings {
   /**
    * Send HTTP/2 PING frames at this period, in order to test that the connection is still alive.
    */
-  'interval'?: (_google_protobuf_Duration);
+  'interval'?: (_google_protobuf_Duration | null);
   /**
    * How long to wait for a response to a keepalive PING. If a response is not received within this
    * time period, the connection will be aborted.
    */
-  'timeout'?: (_google_protobuf_Duration);
+  'timeout'?: (_google_protobuf_Duration | null);
   /**
    * A random jitter amount as a percentage of interval that will be added to each interval.
    * A value of zero means there will be no jitter.
    * The default value is 15%.
    */
-  'interval_jitter'?: (_envoy_type_v3_Percent);
+  'interval_jitter'?: (_envoy_type_v3_Percent | null);
 }
 
 export interface KeepaliveSettings__Output {
   /**
    * Send HTTP/2 PING frames at this period, in order to test that the connection is still alive.
    */
-  'interval'?: (_google_protobuf_Duration__Output);
+  'interval': (_google_protobuf_Duration__Output | null);
   /**
    * How long to wait for a response to a keepalive PING. If a response is not received within this
    * time period, the connection will be aborted.
    */
-  'timeout'?: (_google_protobuf_Duration__Output);
+  'timeout': (_google_protobuf_Duration__Output | null);
   /**
    * A random jitter amount as a percentage of interval that will be added to each interval.
    * A value of zero means there will be no jitter.
    * The default value is 15%.
    */
-  'interval_jitter'?: (_envoy_type_v3_Percent__Output);
+  'interval_jitter': (_envoy_type_v3_Percent__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Metadata.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Metadata.ts
@@ -63,5 +63,5 @@ export interface Metadata__Output {
    * Key is the reverse DNS filter name, e.g. com.acme.widget. The envoy.*
    * namespace is reserved for Envoy's built-in filters.
    */
-  'filter_metadata'?: ({[key: string]: _google_protobuf_Struct__Output});
+  'filter_metadata': ({[key: string]: _google_protobuf_Struct__Output});
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Node.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Node.ts
@@ -41,11 +41,11 @@ export interface Node {
    * Opaque metadata extending the node identifier. Envoy will pass this
    * directly to the management server.
    */
-  'metadata'?: (_google_protobuf_Struct);
+  'metadata'?: (_google_protobuf_Struct | null);
   /**
    * Locality specifying where the Envoy instance is running.
    */
-  'locality'?: (_envoy_config_core_v3_Locality);
+  'locality'?: (_envoy_config_core_v3_Locality | null);
   /**
    * Free-form string that identifies the entity requesting config.
    * E.g. "envoy" or "grpc"
@@ -59,7 +59,7 @@ export interface Node {
   /**
    * Structured version of the entity requesting config.
    */
-  'user_agent_build_version'?: (_envoy_config_core_v3_BuildVersion);
+  'user_agent_build_version'?: (_envoy_config_core_v3_BuildVersion | null);
   /**
    * List of extensions and their versions supported by the node.
    */
@@ -117,11 +117,11 @@ export interface Node__Output {
    * Opaque metadata extending the node identifier. Envoy will pass this
    * directly to the management server.
    */
-  'metadata'?: (_google_protobuf_Struct__Output);
+  'metadata': (_google_protobuf_Struct__Output | null);
   /**
    * Locality specifying where the Envoy instance is running.
    */
-  'locality'?: (_envoy_config_core_v3_Locality__Output);
+  'locality': (_envoy_config_core_v3_Locality__Output | null);
   /**
    * Free-form string that identifies the entity requesting config.
    * E.g. "envoy" or "grpc"
@@ -135,7 +135,7 @@ export interface Node__Output {
   /**
    * Structured version of the entity requesting config.
    */
-  'user_agent_build_version'?: (_envoy_config_core_v3_BuildVersion__Output);
+  'user_agent_build_version'?: (_envoy_config_core_v3_BuildVersion__Output | null);
   /**
    * List of extensions and their versions supported by the node.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RateLimitSettings.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RateLimitSettings.ts
@@ -11,12 +11,12 @@ export interface RateLimitSettings {
    * Maximum number of tokens to be used for rate limiting discovery request calls. If not set, a
    * default value of 100 will be used.
    */
-  'max_tokens'?: (_google_protobuf_UInt32Value);
+  'max_tokens'?: (_google_protobuf_UInt32Value | null);
   /**
    * Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
    * per second will be used.
    */
-  'fill_rate'?: (_google_protobuf_DoubleValue);
+  'fill_rate'?: (_google_protobuf_DoubleValue | null);
 }
 
 /**
@@ -27,10 +27,10 @@ export interface RateLimitSettings__Output {
    * Maximum number of tokens to be used for rate limiting discovery request calls. If not set, a
    * default value of 100 will be used.
    */
-  'max_tokens'?: (_google_protobuf_UInt32Value__Output);
+  'max_tokens': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
    * per second will be used.
    */
-  'fill_rate'?: (_google_protobuf_DoubleValue__Output);
+  'fill_rate': (_google_protobuf_DoubleValue__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RemoteDataSource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RemoteDataSource.ts
@@ -10,7 +10,7 @@ export interface RemoteDataSource {
   /**
    * The HTTP URI to fetch the remote data.
    */
-  'http_uri'?: (_envoy_config_core_v3_HttpUri);
+  'http_uri'?: (_envoy_config_core_v3_HttpUri | null);
   /**
    * SHA256 string for verifying data.
    */
@@ -18,7 +18,7 @@ export interface RemoteDataSource {
   /**
    * Retry policy for fetching remote data.
    */
-  'retry_policy'?: (_envoy_config_core_v3_RetryPolicy);
+  'retry_policy'?: (_envoy_config_core_v3_RetryPolicy | null);
 }
 
 /**
@@ -28,7 +28,7 @@ export interface RemoteDataSource__Output {
   /**
    * The HTTP URI to fetch the remote data.
    */
-  'http_uri'?: (_envoy_config_core_v3_HttpUri__Output);
+  'http_uri': (_envoy_config_core_v3_HttpUri__Output | null);
   /**
    * SHA256 string for verifying data.
    */
@@ -36,5 +36,5 @@ export interface RemoteDataSource__Output {
   /**
    * Retry policy for fetching remote data.
    */
-  'retry_policy'?: (_envoy_config_core_v3_RetryPolicy__Output);
+  'retry_policy': (_envoy_config_core_v3_RetryPolicy__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RetryPolicy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RetryPolicy.ts
@@ -12,12 +12,12 @@ export interface RetryPolicy {
    * This parameter is optional, in which case the default base interval is 1000 milliseconds. The
    * default maximum interval is 10 times the base interval.
    */
-  'retry_back_off'?: (_envoy_config_core_v3_BackoffStrategy);
+  'retry_back_off'?: (_envoy_config_core_v3_BackoffStrategy | null);
   /**
    * Specifies the allowed number of retries. This parameter is optional and
    * defaults to 1.
    */
-  'num_retries'?: (_google_protobuf_UInt32Value);
+  'num_retries'?: (_google_protobuf_UInt32Value | null);
 }
 
 /**
@@ -29,10 +29,10 @@ export interface RetryPolicy__Output {
    * This parameter is optional, in which case the default base interval is 1000 milliseconds. The
    * default maximum interval is 10 times the base interval.
    */
-  'retry_back_off'?: (_envoy_config_core_v3_BackoffStrategy__Output);
+  'retry_back_off': (_envoy_config_core_v3_BackoffStrategy__Output | null);
   /**
    * Specifies the allowed number of retries. This parameter is optional and
    * defaults to 1.
    */
-  'num_retries'?: (_google_protobuf_UInt32Value__Output);
+  'num_retries': (_google_protobuf_UInt32Value__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RuntimeFeatureFlag.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RuntimeFeatureFlag.ts
@@ -9,7 +9,7 @@ export interface RuntimeFeatureFlag {
   /**
    * Default value if runtime value is not available.
    */
-  'default_value'?: (_google_protobuf_BoolValue);
+  'default_value'?: (_google_protobuf_BoolValue | null);
   /**
    * Runtime key to get value for comparison. This value is used if defined. The boolean value must
    * be represented via its
@@ -25,7 +25,7 @@ export interface RuntimeFeatureFlag__Output {
   /**
    * Default value if runtime value is not available.
    */
-  'default_value'?: (_google_protobuf_BoolValue__Output);
+  'default_value': (_google_protobuf_BoolValue__Output | null);
   /**
    * Runtime key to get value for comparison. This value is used if defined. The boolean value must
    * be represented via its

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RuntimeFractionalPercent.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RuntimeFractionalPercent.ts
@@ -18,7 +18,7 @@ export interface RuntimeFractionalPercent {
   /**
    * Default value if the runtime value's for the numerator/denominator keys are not available.
    */
-  'default_value'?: (_envoy_type_v3_FractionalPercent);
+  'default_value'?: (_envoy_type_v3_FractionalPercent | null);
   /**
    * Runtime key for a YAML representation of a FractionalPercent.
    */
@@ -41,7 +41,7 @@ export interface RuntimeFractionalPercent__Output {
   /**
    * Default value if the runtime value's for the numerator/denominator keys are not available.
    */
-  'default_value'?: (_envoy_type_v3_FractionalPercent__Output);
+  'default_value': (_envoy_type_v3_FractionalPercent__Output | null);
   /**
    * Runtime key for a YAML representation of a FractionalPercent.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RuntimePercent.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RuntimePercent.ts
@@ -9,7 +9,7 @@ export interface RuntimePercent {
   /**
    * Default value if runtime value is not available.
    */
-  'default_value'?: (_envoy_type_v3_Percent);
+  'default_value'?: (_envoy_type_v3_Percent | null);
   /**
    * Runtime key to get value for comparison. This value is used if defined.
    */
@@ -23,7 +23,7 @@ export interface RuntimePercent__Output {
   /**
    * Default value if runtime value is not available.
    */
-  'default_value'?: (_envoy_type_v3_Percent__Output);
+  'default_value': (_envoy_type_v3_Percent__Output | null);
   /**
    * Runtime key to get value for comparison. This value is used if defined.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SubstitutionFormatString.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SubstitutionFormatString.ts
@@ -53,7 +53,7 @@ export interface SubstitutionFormatString {
    * "message": "My error message"
    * }
    */
-  'json_format'?: (_google_protobuf_Struct);
+  'json_format'?: (_google_protobuf_Struct | null);
   /**
    * If set to true, when command operators are evaluated to null,
    * 
@@ -91,7 +91,7 @@ export interface SubstitutionFormatString {
    * 
    * upstream connect error:503:path=/foo
    */
-  'text_format_source'?: (_envoy_config_core_v3_DataSource);
+  'text_format_source'?: (_envoy_config_core_v3_DataSource | null);
   /**
    * Specifies a collection of Formatter plugins that can be called from the access log configuration.
    * See the formatters extensions documentation for details.
@@ -149,7 +149,7 @@ export interface SubstitutionFormatString__Output {
    * "message": "My error message"
    * }
    */
-  'json_format'?: (_google_protobuf_Struct__Output);
+  'json_format'?: (_google_protobuf_Struct__Output | null);
   /**
    * If set to true, when command operators are evaluated to null,
    * 
@@ -187,7 +187,7 @@ export interface SubstitutionFormatString__Output {
    * 
    * upstream connect error:503:path=/foo
    */
-  'text_format_source'?: (_envoy_config_core_v3_DataSource__Output);
+  'text_format_source'?: (_envoy_config_core_v3_DataSource__Output | null);
   /**
    * Specifies a collection of Formatter plugins that can be called from the access log configuration.
    * See the formatters extensions documentation for details.

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/TcpKeepalive.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/TcpKeepalive.ts
@@ -8,18 +8,18 @@ export interface TcpKeepalive {
    * the connection is dead. Default is to use the OS level configuration (unless
    * overridden, Linux defaults to 9.)
    */
-  'keepalive_probes'?: (_google_protobuf_UInt32Value);
+  'keepalive_probes'?: (_google_protobuf_UInt32Value | null);
   /**
    * The number of seconds a connection needs to be idle before keep-alive probes
    * start being sent. Default is to use the OS level configuration (unless
    * overridden, Linux defaults to 7200s (i.e., 2 hours.)
    */
-  'keepalive_time'?: (_google_protobuf_UInt32Value);
+  'keepalive_time'?: (_google_protobuf_UInt32Value | null);
   /**
    * The number of seconds between keep-alive probes. Default is to use the OS
    * level configuration (unless overridden, Linux defaults to 75s.)
    */
-  'keepalive_interval'?: (_google_protobuf_UInt32Value);
+  'keepalive_interval'?: (_google_protobuf_UInt32Value | null);
 }
 
 export interface TcpKeepalive__Output {
@@ -28,16 +28,16 @@ export interface TcpKeepalive__Output {
    * the connection is dead. Default is to use the OS level configuration (unless
    * overridden, Linux defaults to 9.)
    */
-  'keepalive_probes'?: (_google_protobuf_UInt32Value__Output);
+  'keepalive_probes': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The number of seconds a connection needs to be idle before keep-alive probes
    * start being sent. Default is to use the OS level configuration (unless
    * overridden, Linux defaults to 7200s (i.e., 2 hours.)
    */
-  'keepalive_time'?: (_google_protobuf_UInt32Value__Output);
+  'keepalive_time': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The number of seconds between keep-alive probes. Default is to use the OS
    * level configuration (unless overridden, Linux defaults to 75s.)
    */
-  'keepalive_interval'?: (_google_protobuf_UInt32Value__Output);
+  'keepalive_interval': (_google_protobuf_UInt32Value__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/TransportSocket.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/TransportSocket.ts
@@ -14,7 +14,7 @@ export interface TransportSocket {
    * socket implementation.
    */
   'name'?: (string);
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
   /**
    * Implementation specific configuration which depends on the implementation being instantiated.
    * See the supported transport socket implementations for further documentation.
@@ -34,7 +34,7 @@ export interface TransportSocket__Output {
    * socket implementation.
    */
   'name': (string);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   /**
    * Implementation specific configuration which depends on the implementation being instantiated.
    * See the supported transport socket implementations for further documentation.

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/TypedExtensionConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/TypedExtensionConfig.ts
@@ -19,7 +19,7 @@ export interface TypedExtensionConfig {
    * :ref:`extension configuration overview
    * <config_overview_extension_configuration>` for further details.
    */
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
 }
 
 /**
@@ -39,5 +39,5 @@ export interface TypedExtensionConfig__Output {
    * :ref:`extension configuration overview
    * <config_overview_extension_configuration>` for further details.
    */
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config': (_google_protobuf_Any__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/ClusterLoadAssignment.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/ClusterLoadAssignment.ts
@@ -17,7 +17,7 @@ export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy_DropOver
   /**
    * Percentage of traffic that should be dropped for the category.
    */
-  'drop_percentage'?: (_envoy_type_v3_FractionalPercent);
+  'drop_percentage'?: (_envoy_type_v3_FractionalPercent | null);
 }
 
 /**
@@ -31,7 +31,7 @@ export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy_DropOver
   /**
    * Percentage of traffic that should be dropped for the category.
    */
-  'drop_percentage'?: (_envoy_type_v3_FractionalPercent__Output);
+  'drop_percentage': (_envoy_type_v3_FractionalPercent__Output | null);
 }
 
 /**
@@ -78,14 +78,14 @@ export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy {
    * Read more at :ref:`priority levels <arch_overview_load_balancing_priority_levels>` and
    * :ref:`localities <arch_overview_load_balancing_locality_weighted_lb>`.
    */
-  'overprovisioning_factor'?: (_google_protobuf_UInt32Value);
+  'overprovisioning_factor'?: (_google_protobuf_UInt32Value | null);
   /**
    * The max time until which the endpoints from this assignment can be used.
    * If no new assignments are received before this time expires the endpoints
    * are considered stale and should be marked unhealthy.
    * Defaults to 0 which means endpoints never go stale.
    */
-  'endpoint_stale_after'?: (_google_protobuf_Duration);
+  'endpoint_stale_after'?: (_google_protobuf_Duration | null);
 }
 
 /**
@@ -132,14 +132,14 @@ export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy__Output 
    * Read more at :ref:`priority levels <arch_overview_load_balancing_priority_levels>` and
    * :ref:`localities <arch_overview_load_balancing_locality_weighted_lb>`.
    */
-  'overprovisioning_factor'?: (_google_protobuf_UInt32Value__Output);
+  'overprovisioning_factor': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The max time until which the endpoints from this assignment can be used.
    * If no new assignments are received before this time expires the endpoints
    * are considered stale and should be marked unhealthy.
    * Defaults to 0 which means endpoints never go stale.
    */
-  'endpoint_stale_after'?: (_google_protobuf_Duration__Output);
+  'endpoint_stale_after': (_google_protobuf_Duration__Output | null);
 }
 
 /**
@@ -169,7 +169,7 @@ export interface ClusterLoadAssignment {
   /**
    * Load balancing policy settings.
    */
-  'policy'?: (_envoy_config_endpoint_v3_ClusterLoadAssignment_Policy);
+  'policy'?: (_envoy_config_endpoint_v3_ClusterLoadAssignment_Policy | null);
   /**
    * Map of named endpoints that can be referenced in LocalityLbEndpoints.
    * [#not-implemented-hide:]
@@ -204,10 +204,10 @@ export interface ClusterLoadAssignment__Output {
   /**
    * Load balancing policy settings.
    */
-  'policy'?: (_envoy_config_endpoint_v3_ClusterLoadAssignment_Policy__Output);
+  'policy': (_envoy_config_endpoint_v3_ClusterLoadAssignment_Policy__Output | null);
   /**
    * Map of named endpoints that can be referenced in LocalityLbEndpoints.
    * [#not-implemented-hide:]
    */
-  'named_endpoints'?: ({[key: string]: _envoy_config_endpoint_v3_Endpoint__Output});
+  'named_endpoints': ({[key: string]: _envoy_config_endpoint_v3_Endpoint__Output});
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/ClusterStats.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/ClusterStats.ts
@@ -56,7 +56,7 @@ export interface ClusterStats {
    * and the *LoadStatsResponse* message sent from the management server, this may be longer than
    * the requested load reporting interval in the *LoadStatsResponse*.
    */
-  'load_report_interval'?: (_google_protobuf_Duration);
+  'load_report_interval'?: (_google_protobuf_Duration | null);
   /**
    * Information about deliberately dropped requests for each category specified
    * in the DropOverload policy.
@@ -100,7 +100,7 @@ export interface ClusterStats__Output {
    * and the *LoadStatsResponse* message sent from the management server, this may be longer than
    * the requested load reporting interval in the *LoadStatsResponse*.
    */
-  'load_report_interval'?: (_google_protobuf_Duration__Output);
+  'load_report_interval': (_google_protobuf_Duration__Output | null);
   /**
    * Information about deliberately dropped requests for each category specified
    * in the DropOverload policy.

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/Endpoint.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/Endpoint.ts
@@ -63,7 +63,7 @@ export interface Endpoint {
    * in the Address). For LOGICAL or STRICT DNS, it is expected to be hostname,
    * and will be resolved via DNS.
    */
-  'address'?: (_envoy_config_core_v3_Address);
+  'address'?: (_envoy_config_core_v3_Address | null);
   /**
    * The optional health check configuration is used as configuration for the
    * health checker to contact the health checked host.
@@ -73,7 +73,7 @@ export interface Endpoint {
    * This takes into effect only for upstream clusters with
    * :ref:`active health checking <arch_overview_health_checking>` enabled.
    */
-  'health_check_config'?: (_envoy_config_endpoint_v3_Endpoint_HealthCheckConfig);
+  'health_check_config'?: (_envoy_config_endpoint_v3_Endpoint_HealthCheckConfig | null);
   /**
    * The hostname associated with this endpoint. This hostname is not used for routing or address
    * resolution. If provided, it will be associated with the endpoint, and can be used for features
@@ -98,7 +98,7 @@ export interface Endpoint__Output {
    * in the Address). For LOGICAL or STRICT DNS, it is expected to be hostname,
    * and will be resolved via DNS.
    */
-  'address'?: (_envoy_config_core_v3_Address__Output);
+  'address': (_envoy_config_core_v3_Address__Output | null);
   /**
    * The optional health check configuration is used as configuration for the
    * health checker to contact the health checked host.
@@ -108,7 +108,7 @@ export interface Endpoint__Output {
    * This takes into effect only for upstream clusters with
    * :ref:`active health checking <arch_overview_health_checking>` enabled.
    */
-  'health_check_config'?: (_envoy_config_endpoint_v3_Endpoint_HealthCheckConfig__Output);
+  'health_check_config': (_envoy_config_endpoint_v3_Endpoint_HealthCheckConfig__Output | null);
   /**
    * The hostname associated with this endpoint. This hostname is not used for routing or address
    * resolution. If provided, it will be associated with the endpoint, and can be used for features

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/LbEndpoint.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/LbEndpoint.ts
@@ -10,7 +10,7 @@ import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output a
  * [#next-free-field: 6]
  */
 export interface LbEndpoint {
-  'endpoint'?: (_envoy_config_endpoint_v3_Endpoint);
+  'endpoint'?: (_envoy_config_endpoint_v3_Endpoint | null);
   /**
    * Optional health status when known and supplied by EDS server.
    */
@@ -24,7 +24,7 @@ export interface LbEndpoint {
    * :ref:`RouteAction <envoy_api_msg_config.route.v3.RouteAction>` metadata_match field
    * to subset the endpoints considered in cluster load balancing.
    */
-  'metadata'?: (_envoy_config_core_v3_Metadata);
+  'metadata'?: (_envoy_config_core_v3_Metadata | null);
   /**
    * The optional load balancing weight of the upstream host; at least 1.
    * Envoy uses the load balancing weight in some of the built in load
@@ -36,7 +36,7 @@ export interface LbEndpoint {
    * weight in a locality. The sum of the weights of all endpoints in the
    * endpoint's locality must not exceed uint32_t maximal value (4294967295).
    */
-  'load_balancing_weight'?: (_google_protobuf_UInt32Value);
+  'load_balancing_weight'?: (_google_protobuf_UInt32Value | null);
   /**
    * [#not-implemented-hide:]
    */
@@ -52,7 +52,7 @@ export interface LbEndpoint {
  * [#next-free-field: 6]
  */
 export interface LbEndpoint__Output {
-  'endpoint'?: (_envoy_config_endpoint_v3_Endpoint__Output);
+  'endpoint'?: (_envoy_config_endpoint_v3_Endpoint__Output | null);
   /**
    * Optional health status when known and supplied by EDS server.
    */
@@ -66,7 +66,7 @@ export interface LbEndpoint__Output {
    * :ref:`RouteAction <envoy_api_msg_config.route.v3.RouteAction>` metadata_match field
    * to subset the endpoints considered in cluster load balancing.
    */
-  'metadata'?: (_envoy_config_core_v3_Metadata__Output);
+  'metadata': (_envoy_config_core_v3_Metadata__Output | null);
   /**
    * The optional load balancing weight of the upstream host; at least 1.
    * Envoy uses the load balancing weight in some of the built in load
@@ -78,7 +78,7 @@ export interface LbEndpoint__Output {
    * weight in a locality. The sum of the weights of all endpoints in the
    * endpoint's locality must not exceed uint32_t maximal value (4294967295).
    */
-  'load_balancing_weight'?: (_google_protobuf_UInt32Value__Output);
+  'load_balancing_weight': (_google_protobuf_UInt32Value__Output | null);
   /**
    * [#not-implemented-hide:]
    */

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/LocalityLbEndpoints.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/LocalityLbEndpoints.ts
@@ -15,7 +15,7 @@ export interface LocalityLbEndpoints {
   /**
    * Identifies location of where the upstream hosts run.
    */
-  'locality'?: (_envoy_config_core_v3_Locality);
+  'locality'?: (_envoy_config_core_v3_Locality | null);
   /**
    * The group of endpoints belonging to the locality specified.
    */
@@ -33,7 +33,7 @@ export interface LocalityLbEndpoints {
    * specified when locality weighted load balancing is enabled, the locality is
    * assigned no load.
    */
-  'load_balancing_weight'?: (_google_protobuf_UInt32Value);
+  'load_balancing_weight'?: (_google_protobuf_UInt32Value | null);
   /**
    * Optional: the priority for this LocalityLbEndpoints. If unspecified this will
    * default to the highest priority (0).
@@ -54,7 +54,7 @@ export interface LocalityLbEndpoints {
    * to determine where to route the requests.
    * [#not-implemented-hide:]
    */
-  'proximity'?: (_google_protobuf_UInt32Value);
+  'proximity'?: (_google_protobuf_UInt32Value | null);
 }
 
 /**
@@ -68,7 +68,7 @@ export interface LocalityLbEndpoints__Output {
   /**
    * Identifies location of where the upstream hosts run.
    */
-  'locality'?: (_envoy_config_core_v3_Locality__Output);
+  'locality': (_envoy_config_core_v3_Locality__Output | null);
   /**
    * The group of endpoints belonging to the locality specified.
    */
@@ -86,7 +86,7 @@ export interface LocalityLbEndpoints__Output {
    * specified when locality weighted load balancing is enabled, the locality is
    * assigned no load.
    */
-  'load_balancing_weight'?: (_google_protobuf_UInt32Value__Output);
+  'load_balancing_weight': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Optional: the priority for this LocalityLbEndpoints. If unspecified this will
    * default to the highest priority (0).
@@ -107,5 +107,5 @@ export interface LocalityLbEndpoints__Output {
    * to determine where to route the requests.
    * [#not-implemented-hide:]
    */
-  'proximity'?: (_google_protobuf_UInt32Value__Output);
+  'proximity': (_google_protobuf_UInt32Value__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/UpstreamEndpointStats.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/UpstreamEndpointStats.ts
@@ -12,7 +12,7 @@ export interface UpstreamEndpointStats {
   /**
    * Upstream host address.
    */
-  'address'?: (_envoy_config_core_v3_Address);
+  'address'?: (_envoy_config_core_v3_Address | null);
   /**
    * The total number of requests successfully completed by the endpoints in the
    * locality. These include non-5xx responses for HTTP, where errors
@@ -45,7 +45,7 @@ export interface UpstreamEndpointStats {
    * Opaque and implementation dependent metadata of the
    * endpoint. Envoy will pass this directly to the management server.
    */
-  'metadata'?: (_google_protobuf_Struct);
+  'metadata'?: (_google_protobuf_Struct | null);
   /**
    * The total number of requests that were issued to this endpoint
    * since the last report. A single TCP connection, HTTP or gRPC
@@ -61,7 +61,7 @@ export interface UpstreamEndpointStats__Output {
   /**
    * Upstream host address.
    */
-  'address'?: (_envoy_config_core_v3_Address__Output);
+  'address': (_envoy_config_core_v3_Address__Output | null);
   /**
    * The total number of requests successfully completed by the endpoints in the
    * locality. These include non-5xx responses for HTTP, where errors
@@ -94,7 +94,7 @@ export interface UpstreamEndpointStats__Output {
    * Opaque and implementation dependent metadata of the
    * endpoint. Envoy will pass this directly to the management server.
    */
-  'metadata'?: (_google_protobuf_Struct__Output);
+  'metadata': (_google_protobuf_Struct__Output | null);
   /**
    * The total number of requests that were issued to this endpoint
    * since the last report. A single TCP connection, HTTP or gRPC

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/UpstreamLocalityStats.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/UpstreamLocalityStats.ts
@@ -16,7 +16,7 @@ export interface UpstreamLocalityStats {
    * Name of zone, region and optionally endpoint group these metrics were
    * collected from. Zone and region names could be empty if unknown.
    */
-  'locality'?: (_envoy_config_core_v3_Locality);
+  'locality'?: (_envoy_config_core_v3_Locality | null);
   /**
    * The total number of requests successfully completed by the endpoints in the
    * locality.
@@ -65,7 +65,7 @@ export interface UpstreamLocalityStats__Output {
    * Name of zone, region and optionally endpoint group these metrics were
    * collected from. Zone and region names could be empty if unknown.
    */
-  'locality'?: (_envoy_config_core_v3_Locality__Output);
+  'locality': (_envoy_config_core_v3_Locality__Output | null);
   /**
    * The total number of requests successfully completed by the endpoints in the
    * locality.

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/ApiListener.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/ApiListener.ts
@@ -17,7 +17,7 @@ export interface ApiListener {
    * and http_connection_manager.proto depends on rds.proto, which is in the same directory as
    * lds.proto, so lds.proto cannot depend on this file.]
    */
-  'api_listener'?: (_google_protobuf_Any);
+  'api_listener'?: (_google_protobuf_Any | null);
 }
 
 /**
@@ -35,5 +35,5 @@ export interface ApiListener__Output {
    * and http_connection_manager.proto depends on rds.proto, which is in the same directory as
    * lds.proto, so lds.proto cannot depend on this file.]
    */
-  'api_listener'?: (_google_protobuf_Any__Output);
+  'api_listener': (_google_protobuf_Any__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Filter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Filter.ts
@@ -16,14 +16,14 @@ export interface Filter {
    * Filter specific configuration which depends on the filter being
    * instantiated. See the supported filters for further documentation.
    */
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
   /**
    * Configuration source specifier for an extension configuration discovery
    * service. In case of a failure and without the default configuration, the
    * listener closes the connections.
    * [#not-implemented-hide:]
    */
-  'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource);
+  'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource | null);
   'config_type'?: "typed_config"|"config_discovery";
 }
 
@@ -40,13 +40,13 @@ export interface Filter__Output {
    * Filter specific configuration which depends on the filter being
    * instantiated. See the supported filters for further documentation.
    */
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   /**
    * Configuration source specifier for an extension configuration discovery
    * service. In case of a failure and without the default configuration, the
    * listener closes the connections.
    * [#not-implemented-hide:]
    */
-  'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource__Output);
+  'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource__Output | null);
   'config_type': "typed_config"|"config_discovery";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/FilterChain.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/FilterChain.ts
@@ -23,7 +23,7 @@ export interface _envoy_config_listener_v3_FilterChain_OnDemandConfiguration {
    * Upon failure or timeout, all connections related to this filter chain will be closed.
    * Rebuilding will start again on the next new connection.
    */
-  'rebuild_timeout'?: (_google_protobuf_Duration);
+  'rebuild_timeout'?: (_google_protobuf_Duration | null);
 }
 
 /**
@@ -42,7 +42,7 @@ export interface _envoy_config_listener_v3_FilterChain_OnDemandConfiguration__Ou
    * Upon failure or timeout, all connections related to this filter chain will be closed.
    * Rebuilding will start again on the next new connection.
    */
-  'rebuild_timeout'?: (_google_protobuf_Duration__Output);
+  'rebuild_timeout': (_google_protobuf_Duration__Output | null);
 }
 
 /**
@@ -54,7 +54,7 @@ export interface FilterChain {
   /**
    * The criteria to use when matching a connection to this filter chain.
    */
-  'filter_chain_match'?: (_envoy_config_listener_v3_FilterChainMatch);
+  'filter_chain_match'?: (_envoy_config_listener_v3_FilterChainMatch | null);
   /**
    * A list of individual network filters that make up the filter chain for
    * connections established with the listener. Order matters as the filters are
@@ -74,11 +74,11 @@ export interface FilterChain {
    * :ref:`PROXY protocol listener filter <config_listener_filters_proxy_protocol>`
    * explicitly instead.
    */
-  'use_proxy_proto'?: (_google_protobuf_BoolValue);
+  'use_proxy_proto'?: (_google_protobuf_BoolValue | null);
   /**
    * [#not-implemented-hide:] filter chain metadata.
    */
-  'metadata'?: (_envoy_config_core_v3_Metadata);
+  'metadata'?: (_envoy_config_core_v3_Metadata | null);
   /**
    * Optional custom transport socket implementation to use for downstream connections.
    * To setup TLS, set a transport socket with name `tls` and
@@ -86,7 +86,7 @@ export interface FilterChain {
    * If no transport socket configuration is specified, new connections
    * will be set up with plaintext.
    */
-  'transport_socket'?: (_envoy_config_core_v3_TransportSocket);
+  'transport_socket'?: (_envoy_config_core_v3_TransportSocket | null);
   /**
    * [#not-implemented-hide:] The unique name (or empty) by which this filter chain is known. If no
    * name is provided, Envoy will allocate an internal UUID for the filter chain. If the filter
@@ -98,13 +98,13 @@ export interface FilterChain {
    * If this field is not empty, the filter chain will be built on-demand.
    * Otherwise, the filter chain will be built normally and block listener warming.
    */
-  'on_demand_configuration'?: (_envoy_config_listener_v3_FilterChain_OnDemandConfiguration);
+  'on_demand_configuration'?: (_envoy_config_listener_v3_FilterChain_OnDemandConfiguration | null);
   /**
    * If present and nonzero, the amount of time to allow incoming connections to complete any
    * transport socket negotiations. If this expires before the transport reports connection
    * establishment, the connection is summarily closed.
    */
-  'transport_socket_connect_timeout'?: (_google_protobuf_Duration);
+  'transport_socket_connect_timeout'?: (_google_protobuf_Duration | null);
 }
 
 /**
@@ -116,7 +116,7 @@ export interface FilterChain__Output {
   /**
    * The criteria to use when matching a connection to this filter chain.
    */
-  'filter_chain_match'?: (_envoy_config_listener_v3_FilterChainMatch__Output);
+  'filter_chain_match': (_envoy_config_listener_v3_FilterChainMatch__Output | null);
   /**
    * A list of individual network filters that make up the filter chain for
    * connections established with the listener. Order matters as the filters are
@@ -136,11 +136,11 @@ export interface FilterChain__Output {
    * :ref:`PROXY protocol listener filter <config_listener_filters_proxy_protocol>`
    * explicitly instead.
    */
-  'use_proxy_proto'?: (_google_protobuf_BoolValue__Output);
+  'use_proxy_proto': (_google_protobuf_BoolValue__Output | null);
   /**
    * [#not-implemented-hide:] filter chain metadata.
    */
-  'metadata'?: (_envoy_config_core_v3_Metadata__Output);
+  'metadata': (_envoy_config_core_v3_Metadata__Output | null);
   /**
    * Optional custom transport socket implementation to use for downstream connections.
    * To setup TLS, set a transport socket with name `tls` and
@@ -148,7 +148,7 @@ export interface FilterChain__Output {
    * If no transport socket configuration is specified, new connections
    * will be set up with plaintext.
    */
-  'transport_socket'?: (_envoy_config_core_v3_TransportSocket__Output);
+  'transport_socket': (_envoy_config_core_v3_TransportSocket__Output | null);
   /**
    * [#not-implemented-hide:] The unique name (or empty) by which this filter chain is known. If no
    * name is provided, Envoy will allocate an internal UUID for the filter chain. If the filter
@@ -160,11 +160,11 @@ export interface FilterChain__Output {
    * If this field is not empty, the filter chain will be built on-demand.
    * Otherwise, the filter chain will be built normally and block listener warming.
    */
-  'on_demand_configuration'?: (_envoy_config_listener_v3_FilterChain_OnDemandConfiguration__Output);
+  'on_demand_configuration': (_envoy_config_listener_v3_FilterChain_OnDemandConfiguration__Output | null);
   /**
    * If present and nonzero, the amount of time to allow incoming connections to complete any
    * transport socket negotiations. If this expires before the transport reports connection
    * establishment, the connection is summarily closed.
    */
-  'transport_socket_connect_timeout'?: (_google_protobuf_Duration__Output);
+  'transport_socket_connect_timeout': (_google_protobuf_Duration__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/FilterChainMatch.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/FilterChainMatch.ts
@@ -78,7 +78,7 @@ export interface FilterChainMatch {
   /**
    * [#not-implemented-hide:]
    */
-  'suffix_len'?: (_google_protobuf_UInt32Value);
+  'suffix_len'?: (_google_protobuf_UInt32Value | null);
   /**
    * The criteria is satisfied if the source IP address of the downstream
    * connection is contained in at least one of the specified subnets. If the
@@ -96,7 +96,7 @@ export interface FilterChainMatch {
    * Optional destination port to consider when use_original_dst is set on the
    * listener in determining a filter chain match.
    */
-  'destination_port'?: (_google_protobuf_UInt32Value);
+  'destination_port'?: (_google_protobuf_UInt32Value | null);
   /**
    * If non-empty, a transport protocol to consider when determining a filter chain match.
    * This value will be compared against the transport protocol of a new connection, when
@@ -211,7 +211,7 @@ export interface FilterChainMatch__Output {
   /**
    * [#not-implemented-hide:]
    */
-  'suffix_len'?: (_google_protobuf_UInt32Value__Output);
+  'suffix_len': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The criteria is satisfied if the source IP address of the downstream
    * connection is contained in at least one of the specified subnets. If the
@@ -229,7 +229,7 @@ export interface FilterChainMatch__Output {
    * Optional destination port to consider when use_original_dst is set on the
    * listener in determining a filter chain match.
    */
-  'destination_port'?: (_google_protobuf_UInt32Value__Output);
+  'destination_port': (_google_protobuf_UInt32Value__Output | null);
   /**
    * If non-empty, a transport protocol to consider when determining a filter chain match.
    * This value will be compared against the transport protocol of a new connection, when

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Listener.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Listener.ts
@@ -21,7 +21,7 @@ export interface _envoy_config_listener_v3_Listener_ConnectionBalanceConfig {
   /**
    * If specified, the listener will use the exact connection balancer.
    */
-  'exact_balance'?: (_envoy_config_listener_v3_Listener_ConnectionBalanceConfig_ExactBalance);
+  'exact_balance'?: (_envoy_config_listener_v3_Listener_ConnectionBalanceConfig_ExactBalance | null);
   'balance_type'?: "exact_balance";
 }
 
@@ -32,7 +32,7 @@ export interface _envoy_config_listener_v3_Listener_ConnectionBalanceConfig__Out
   /**
    * If specified, the listener will use the exact connection balancer.
    */
-  'exact_balance'?: (_envoy_config_listener_v3_Listener_ConnectionBalanceConfig_ExactBalance__Output);
+  'exact_balance'?: (_envoy_config_listener_v3_Listener_ConnectionBalanceConfig_ExactBalance__Output | null);
   'balance_type': "exact_balance";
 }
 
@@ -48,7 +48,7 @@ export interface _envoy_config_listener_v3_Listener_DeprecatedV1 {
    * This is deprecated. Use :ref:`Listener.bind_to_port
    * <envoy_api_field_config.listener.v3.Listener.bind_to_port>`
    */
-  'bind_to_port'?: (_google_protobuf_BoolValue);
+  'bind_to_port'?: (_google_protobuf_BoolValue | null);
 }
 
 /**
@@ -63,7 +63,7 @@ export interface _envoy_config_listener_v3_Listener_DeprecatedV1__Output {
    * This is deprecated. Use :ref:`Listener.bind_to_port
    * <envoy_api_field_config.listener.v3.Listener.bind_to_port>`
    */
-  'bind_to_port'?: (_google_protobuf_BoolValue__Output);
+  'bind_to_port': (_google_protobuf_BoolValue__Output | null);
 }
 
 // Original file: deps/envoy-api/envoy/config/listener/v3/listener.proto
@@ -119,7 +119,7 @@ export interface Listener {
    * that is governed by the bind rules of the OS. E.g., multiple listeners can listen on port 0 on
    * Linux as the actual port will be allocated by the OS.
    */
-  'address'?: (_envoy_config_core_v3_Address);
+  'address'?: (_envoy_config_core_v3_Address | null);
   /**
    * A list of filter chains to consider for this listener. The
    * :ref:`FilterChain <envoy_api_msg_config.listener.v3.FilterChain>` with the most specific
@@ -137,20 +137,20 @@ export interface Listener {
    * original destination address. If there is no listener associated with the original destination
    * address, the connection is handled by the listener that receives it. Defaults to false.
    */
-  'use_original_dst'?: (_google_protobuf_BoolValue);
+  'use_original_dst'?: (_google_protobuf_BoolValue | null);
   /**
    * Soft limit on size of the listener’s new connection read and write buffers.
    * If unspecified, an implementation defined default is applied (1MiB).
    */
-  'per_connection_buffer_limit_bytes'?: (_google_protobuf_UInt32Value);
+  'per_connection_buffer_limit_bytes'?: (_google_protobuf_UInt32Value | null);
   /**
    * Listener metadata.
    */
-  'metadata'?: (_envoy_config_core_v3_Metadata);
+  'metadata'?: (_envoy_config_core_v3_Metadata | null);
   /**
    * [#not-implemented-hide:]
    */
-  'deprecated_v1'?: (_envoy_config_listener_v3_Listener_DeprecatedV1);
+  'deprecated_v1'?: (_envoy_config_listener_v3_Listener_DeprecatedV1 | null);
   /**
    * The type of draining to perform at a listener-wide level.
    */
@@ -183,7 +183,7 @@ export interface Listener {
    * When this flag is not set (default), the socket is not modified, i.e. the transparent option
    * is neither set nor reset.
    */
-  'transparent'?: (_google_protobuf_BoolValue);
+  'transparent'?: (_google_protobuf_BoolValue | null);
   /**
    * Whether the listener should set the *IP_FREEBIND* socket option. When this
    * flag is set to true, listeners can be bound to an IP address that is not
@@ -192,7 +192,7 @@ export interface Listener {
    * (default), the socket is not modified, i.e. the option is neither enabled
    * nor disabled.
    */
-  'freebind'?: (_google_protobuf_BoolValue);
+  'freebind'?: (_google_protobuf_BoolValue | null);
   /**
    * Whether the listener should accept TCP Fast Open (TFO) connections.
    * When this flag is set to a value greater than 0, the option TCP_FASTOPEN is enabled on
@@ -209,7 +209,7 @@ export interface Listener {
    * On macOS, only values of 0, 1, and unset are valid; other values may result in an error.
    * To set the queue length on macOS, set the net.inet.tcp.fastopen_backlog kernel parameter.
    */
-  'tcp_fast_open_queue_length'?: (_google_protobuf_UInt32Value);
+  'tcp_fast_open_queue_length'?: (_google_protobuf_UInt32Value | null);
   /**
    * Additional socket options that may not be present in Envoy source code or
    * precompiled binaries.
@@ -221,7 +221,7 @@ export interface Listener {
    * `continue_on_listener_filters_timeout` is set to true. Specify 0 to disable the
    * timeout. If not specified, a default timeout of 15s is used.
    */
-  'listener_filters_timeout'?: (_google_protobuf_Duration);
+  'listener_filters_timeout'?: (_google_protobuf_Duration | null);
   /**
    * Specifies the intended direction of the traffic relative to the local Envoy.
    */
@@ -244,7 +244,7 @@ export interface Listener {
    * <envoy_api_field_config.listener.v3.UdpListenerConfig.udp_listener_name>` = "raw_udp_listener" for
    * creating a packet-oriented UDP listener. If not present, treat it as "raw_udp_listener".
    */
-  'udp_listener_config'?: (_envoy_config_listener_v3_UdpListenerConfig);
+  'udp_listener_config'?: (_envoy_config_listener_v3_UdpListenerConfig | null);
   /**
    * Used to represent an API listener, which is used in non-proxy clients. The type of API
    * exposed to the non-proxy application depends on the type of API listener.
@@ -263,13 +263,13 @@ export interface Listener {
    * socket listener and the various types of API listener. That way, a given Listener message
    * can structurally only contain the fields of the relevant type.]
    */
-  'api_listener'?: (_envoy_config_listener_v3_ApiListener);
+  'api_listener'?: (_envoy_config_listener_v3_ApiListener | null);
   /**
    * The listener's connection balancer configuration, currently only applicable to TCP listeners.
    * If no configuration is specified, Envoy will not attempt to balance active connections between
    * worker threads.
    */
-  'connection_balance_config'?: (_envoy_config_listener_v3_Listener_ConnectionBalanceConfig);
+  'connection_balance_config'?: (_envoy_config_listener_v3_Listener_ConnectionBalanceConfig | null);
   /**
    * When this flag is set to true, listeners set the *SO_REUSEPORT* socket option and
    * create one socket for each worker thread. This makes inbound connections
@@ -298,24 +298,24 @@ export interface Listener {
    * If not present, treat it as "udp_default_writer".
    * [#not-implemented-hide:]
    */
-  'udp_writer_config'?: (_envoy_config_core_v3_TypedExtensionConfig);
+  'udp_writer_config'?: (_envoy_config_core_v3_TypedExtensionConfig | null);
   /**
    * The maximum length a tcp listener's pending connections queue can grow to. If no value is
    * provided net.core.somaxconn will be used on Linux and 128 otherwise.
    */
-  'tcp_backlog_size'?: (_google_protobuf_UInt32Value);
+  'tcp_backlog_size'?: (_google_protobuf_UInt32Value | null);
   /**
    * The default filter chain if none of the filter chain matches. If no default filter chain is supplied,
    * the connection will be closed. The filter chain match is ignored in this field.
    */
-  'default_filter_chain'?: (_envoy_config_listener_v3_FilterChain);
+  'default_filter_chain'?: (_envoy_config_listener_v3_FilterChain | null);
   /**
    * Whether the listener should bind to the port. A listener that doesn't
    * bind can only receive connections redirected from other listeners that set
    * :ref:`use_original_dst <envoy_api_field_config.listener.v3.Listener.use_original_dst>`
    * to true. Default is true.
    */
-  'bind_to_port'?: (_google_protobuf_BoolValue);
+  'bind_to_port'?: (_google_protobuf_BoolValue | null);
 }
 
 /**
@@ -333,7 +333,7 @@ export interface Listener__Output {
    * that is governed by the bind rules of the OS. E.g., multiple listeners can listen on port 0 on
    * Linux as the actual port will be allocated by the OS.
    */
-  'address'?: (_envoy_config_core_v3_Address__Output);
+  'address': (_envoy_config_core_v3_Address__Output | null);
   /**
    * A list of filter chains to consider for this listener. The
    * :ref:`FilterChain <envoy_api_msg_config.listener.v3.FilterChain>` with the most specific
@@ -351,20 +351,20 @@ export interface Listener__Output {
    * original destination address. If there is no listener associated with the original destination
    * address, the connection is handled by the listener that receives it. Defaults to false.
    */
-  'use_original_dst'?: (_google_protobuf_BoolValue__Output);
+  'use_original_dst': (_google_protobuf_BoolValue__Output | null);
   /**
    * Soft limit on size of the listener’s new connection read and write buffers.
    * If unspecified, an implementation defined default is applied (1MiB).
    */
-  'per_connection_buffer_limit_bytes'?: (_google_protobuf_UInt32Value__Output);
+  'per_connection_buffer_limit_bytes': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Listener metadata.
    */
-  'metadata'?: (_envoy_config_core_v3_Metadata__Output);
+  'metadata': (_envoy_config_core_v3_Metadata__Output | null);
   /**
    * [#not-implemented-hide:]
    */
-  'deprecated_v1'?: (_envoy_config_listener_v3_Listener_DeprecatedV1__Output);
+  'deprecated_v1': (_envoy_config_listener_v3_Listener_DeprecatedV1__Output | null);
   /**
    * The type of draining to perform at a listener-wide level.
    */
@@ -397,7 +397,7 @@ export interface Listener__Output {
    * When this flag is not set (default), the socket is not modified, i.e. the transparent option
    * is neither set nor reset.
    */
-  'transparent'?: (_google_protobuf_BoolValue__Output);
+  'transparent': (_google_protobuf_BoolValue__Output | null);
   /**
    * Whether the listener should set the *IP_FREEBIND* socket option. When this
    * flag is set to true, listeners can be bound to an IP address that is not
@@ -406,7 +406,7 @@ export interface Listener__Output {
    * (default), the socket is not modified, i.e. the option is neither enabled
    * nor disabled.
    */
-  'freebind'?: (_google_protobuf_BoolValue__Output);
+  'freebind': (_google_protobuf_BoolValue__Output | null);
   /**
    * Whether the listener should accept TCP Fast Open (TFO) connections.
    * When this flag is set to a value greater than 0, the option TCP_FASTOPEN is enabled on
@@ -423,7 +423,7 @@ export interface Listener__Output {
    * On macOS, only values of 0, 1, and unset are valid; other values may result in an error.
    * To set the queue length on macOS, set the net.inet.tcp.fastopen_backlog kernel parameter.
    */
-  'tcp_fast_open_queue_length'?: (_google_protobuf_UInt32Value__Output);
+  'tcp_fast_open_queue_length': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Additional socket options that may not be present in Envoy source code or
    * precompiled binaries.
@@ -435,7 +435,7 @@ export interface Listener__Output {
    * `continue_on_listener_filters_timeout` is set to true. Specify 0 to disable the
    * timeout. If not specified, a default timeout of 15s is used.
    */
-  'listener_filters_timeout'?: (_google_protobuf_Duration__Output);
+  'listener_filters_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * Specifies the intended direction of the traffic relative to the local Envoy.
    */
@@ -458,7 +458,7 @@ export interface Listener__Output {
    * <envoy_api_field_config.listener.v3.UdpListenerConfig.udp_listener_name>` = "raw_udp_listener" for
    * creating a packet-oriented UDP listener. If not present, treat it as "raw_udp_listener".
    */
-  'udp_listener_config'?: (_envoy_config_listener_v3_UdpListenerConfig__Output);
+  'udp_listener_config': (_envoy_config_listener_v3_UdpListenerConfig__Output | null);
   /**
    * Used to represent an API listener, which is used in non-proxy clients. The type of API
    * exposed to the non-proxy application depends on the type of API listener.
@@ -477,13 +477,13 @@ export interface Listener__Output {
    * socket listener and the various types of API listener. That way, a given Listener message
    * can structurally only contain the fields of the relevant type.]
    */
-  'api_listener'?: (_envoy_config_listener_v3_ApiListener__Output);
+  'api_listener': (_envoy_config_listener_v3_ApiListener__Output | null);
   /**
    * The listener's connection balancer configuration, currently only applicable to TCP listeners.
    * If no configuration is specified, Envoy will not attempt to balance active connections between
    * worker threads.
    */
-  'connection_balance_config'?: (_envoy_config_listener_v3_Listener_ConnectionBalanceConfig__Output);
+  'connection_balance_config': (_envoy_config_listener_v3_Listener_ConnectionBalanceConfig__Output | null);
   /**
    * When this flag is set to true, listeners set the *SO_REUSEPORT* socket option and
    * create one socket for each worker thread. This makes inbound connections
@@ -512,22 +512,22 @@ export interface Listener__Output {
    * If not present, treat it as "udp_default_writer".
    * [#not-implemented-hide:]
    */
-  'udp_writer_config'?: (_envoy_config_core_v3_TypedExtensionConfig__Output);
+  'udp_writer_config': (_envoy_config_core_v3_TypedExtensionConfig__Output | null);
   /**
    * The maximum length a tcp listener's pending connections queue can grow to. If no value is
    * provided net.core.somaxconn will be used on Linux and 128 otherwise.
    */
-  'tcp_backlog_size'?: (_google_protobuf_UInt32Value__Output);
+  'tcp_backlog_size': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The default filter chain if none of the filter chain matches. If no default filter chain is supplied,
    * the connection will be closed. The filter chain match is ignored in this field.
    */
-  'default_filter_chain'?: (_envoy_config_listener_v3_FilterChain__Output);
+  'default_filter_chain': (_envoy_config_listener_v3_FilterChain__Output | null);
   /**
    * Whether the listener should bind to the port. A listener that doesn't
    * bind can only receive connections redirected from other listeners that set
    * :ref:`use_original_dst <envoy_api_field_config.listener.v3.Listener.use_original_dst>`
    * to true. Default is true.
    */
-  'bind_to_port'?: (_google_protobuf_BoolValue__Output);
+  'bind_to_port': (_google_protobuf_BoolValue__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/ListenerFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/ListenerFilter.ts
@@ -9,13 +9,13 @@ export interface ListenerFilter {
    * :ref:`supported filter <config_listener_filters>`.
    */
   'name'?: (string);
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
   /**
    * Optional match predicate used to disable the filter. The filter is enabled when this field is empty.
    * See :ref:`ListenerFilterChainMatchPredicate <envoy_api_msg_config.listener.v3.ListenerFilterChainMatchPredicate>`
    * for further examples.
    */
-  'filter_disabled'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate);
+  'filter_disabled'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate | null);
   /**
    * Filter specific configuration which depends on the filter being instantiated.
    * See the supported filters for further documentation.
@@ -29,13 +29,13 @@ export interface ListenerFilter__Output {
    * :ref:`supported filter <config_listener_filters>`.
    */
   'name': (string);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   /**
    * Optional match predicate used to disable the filter. The filter is enabled when this field is empty.
    * See :ref:`ListenerFilterChainMatchPredicate <envoy_api_msg_config.listener.v3.ListenerFilterChainMatchPredicate>`
    * for further examples.
    */
-  'filter_disabled'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate__Output);
+  'filter_disabled': (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate__Output | null);
   /**
    * Filter specific configuration which depends on the filter being instantiated.
    * See the supported filters for further documentation.

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/ListenerFilterChainMatchPredicate.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/ListenerFilterChainMatchPredicate.ts
@@ -57,16 +57,16 @@ export interface ListenerFilterChainMatchPredicate {
    * A set that describes a logical OR. If any member of the set matches, the match configuration
    * matches.
    */
-  'or_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate_MatchSet);
+  'or_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate_MatchSet | null);
   /**
    * A set that describes a logical AND. If all members of the set match, the match configuration
    * matches.
    */
-  'and_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate_MatchSet);
+  'and_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate_MatchSet | null);
   /**
    * A negation match. The match configuration will match if the negated match condition matches.
    */
-  'not_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate);
+  'not_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate | null);
   /**
    * The match configuration will always match.
    */
@@ -75,7 +75,7 @@ export interface ListenerFilterChainMatchPredicate {
    * Match destination port. Particularly, the match evaluation must use the recovered local port if
    * the owning listener filter is after :ref:`an original_dst listener filter <config_listener_filters_original_dst>`.
    */
-  'destination_port_range'?: (_envoy_type_v3_Int32Range);
+  'destination_port_range'?: (_envoy_type_v3_Int32Range | null);
   'rule'?: "or_match"|"and_match"|"not_match"|"any_match"|"destination_port_range";
 }
 
@@ -113,16 +113,16 @@ export interface ListenerFilterChainMatchPredicate__Output {
    * A set that describes a logical OR. If any member of the set matches, the match configuration
    * matches.
    */
-  'or_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate_MatchSet__Output);
+  'or_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate_MatchSet__Output | null);
   /**
    * A set that describes a logical AND. If all members of the set match, the match configuration
    * matches.
    */
-  'and_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate_MatchSet__Output);
+  'and_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate_MatchSet__Output | null);
   /**
    * A negation match. The match configuration will match if the negated match condition matches.
    */
-  'not_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate__Output);
+  'not_match'?: (_envoy_config_listener_v3_ListenerFilterChainMatchPredicate__Output | null);
   /**
    * The match configuration will always match.
    */
@@ -131,6 +131,6 @@ export interface ListenerFilterChainMatchPredicate__Output {
    * Match destination port. Particularly, the match evaluation must use the recovered local port if
    * the owning listener filter is after :ref:`an original_dst listener filter <config_listener_filters_original_dst>`.
    */
-  'destination_port_range'?: (_envoy_type_v3_Int32Range__Output);
+  'destination_port_range'?: (_envoy_type_v3_Int32Range__Output | null);
   'rule': "or_match"|"and_match"|"not_match"|"any_match"|"destination_port_range";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/UdpListenerConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/UdpListenerConfig.ts
@@ -9,7 +9,7 @@ export interface UdpListenerConfig {
    * If not specified, treat as "raw_udp_listener".
    */
   'udp_listener_name'?: (string);
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
   /**
    * Used to create a specific listener factory. To some factory, e.g.
    * "raw_udp_listener", config is not needed.
@@ -24,7 +24,7 @@ export interface UdpListenerConfig__Output {
    * If not specified, treat as "raw_udp_listener".
    */
   'udp_listener_name': (string);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   /**
    * Used to create a specific listener factory. To some factory, e.g.
    * "raw_udp_listener", config is not needed.

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/CorsPolicy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/CorsPolicy.ts
@@ -27,7 +27,7 @@ export interface CorsPolicy {
   /**
    * Specifies whether the resource allows credentials.
    */
-  'allow_credentials'?: (_google_protobuf_BoolValue);
+  'allow_credentials'?: (_google_protobuf_BoolValue | null);
   /**
    * Specifies the % of requests for which the CORS filter is enabled.
    * 
@@ -37,7 +37,7 @@ export interface CorsPolicy {
    * If :ref:`runtime_key <envoy_api_field_config.core.v3.RuntimeFractionalPercent.runtime_key>` is
    * specified, Envoy will lookup the runtime key to get the percentage of requests to filter.
    */
-  'filter_enabled'?: (_envoy_config_core_v3_RuntimeFractionalPercent);
+  'filter_enabled'?: (_envoy_config_core_v3_RuntimeFractionalPercent | null);
   /**
    * Specifies the % of requests for which the CORS policies will be evaluated and tracked, but not
    * enforced.
@@ -49,7 +49,7 @@ export interface CorsPolicy {
    * Envoy will lookup the runtime key to get the percentage of requests for which it will evaluate
    * and track the request's *Origin* to determine if it's valid but will not enforce any policies.
    */
-  'shadow_enabled'?: (_envoy_config_core_v3_RuntimeFractionalPercent);
+  'shadow_enabled'?: (_envoy_config_core_v3_RuntimeFractionalPercent | null);
   /**
    * Specifies string patterns that match allowed origins. An origin is allowed if any of the
    * string matchers match.
@@ -81,7 +81,7 @@ export interface CorsPolicy__Output {
   /**
    * Specifies whether the resource allows credentials.
    */
-  'allow_credentials'?: (_google_protobuf_BoolValue__Output);
+  'allow_credentials': (_google_protobuf_BoolValue__Output | null);
   /**
    * Specifies the % of requests for which the CORS filter is enabled.
    * 
@@ -91,7 +91,7 @@ export interface CorsPolicy__Output {
    * If :ref:`runtime_key <envoy_api_field_config.core.v3.RuntimeFractionalPercent.runtime_key>` is
    * specified, Envoy will lookup the runtime key to get the percentage of requests to filter.
    */
-  'filter_enabled'?: (_envoy_config_core_v3_RuntimeFractionalPercent__Output);
+  'filter_enabled'?: (_envoy_config_core_v3_RuntimeFractionalPercent__Output | null);
   /**
    * Specifies the % of requests for which the CORS policies will be evaluated and tracked, but not
    * enforced.
@@ -103,7 +103,7 @@ export interface CorsPolicy__Output {
    * Envoy will lookup the runtime key to get the percentage of requests for which it will evaluate
    * and track the request's *Origin* to determine if it's valid but will not enforce any policies.
    */
-  'shadow_enabled'?: (_envoy_config_core_v3_RuntimeFractionalPercent__Output);
+  'shadow_enabled': (_envoy_config_core_v3_RuntimeFractionalPercent__Output | null);
   /**
    * Specifies string patterns that match allowed origins. An origin is allowed if any of the
    * string matchers match.

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Decorator.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Decorator.ts
@@ -17,7 +17,7 @@ export interface Decorator {
   /**
    * Whether the decorated details should be propagated to the other party. The default is true.
    */
-  'propagate'?: (_google_protobuf_BoolValue);
+  'propagate'?: (_google_protobuf_BoolValue | null);
 }
 
 export interface Decorator__Output {
@@ -35,5 +35,5 @@ export interface Decorator__Output {
   /**
    * Whether the decorated details should be propagated to the other party. The default is true.
    */
-  'propagate'?: (_google_protobuf_BoolValue__Output);
+  'propagate': (_google_protobuf_BoolValue__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/DirectResponseAction.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/DirectResponseAction.ts
@@ -17,7 +17,7 @@ export interface DirectResponseAction {
    * :ref:`envoy_api_msg_config.route.v3.Route`, :ref:`envoy_api_msg_config.route.v3.RouteConfiguration` or
    * :ref:`envoy_api_msg_config.route.v3.VirtualHost`.
    */
-  'body'?: (_envoy_config_core_v3_DataSource);
+  'body'?: (_envoy_config_core_v3_DataSource | null);
 }
 
 export interface DirectResponseAction__Output {
@@ -35,5 +35,5 @@ export interface DirectResponseAction__Output {
    * :ref:`envoy_api_msg_config.route.v3.Route`, :ref:`envoy_api_msg_config.route.v3.RouteConfiguration` or
    * :ref:`envoy_api_msg_config.route.v3.VirtualHost`.
    */
-  'body'?: (_envoy_config_core_v3_DataSource__Output);
+  'body': (_envoy_config_core_v3_DataSource__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/FilterAction.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/FilterAction.ts
@@ -6,12 +6,12 @@ import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__
  * A filter-defined action type.
  */
 export interface FilterAction {
-  'action'?: (_google_protobuf_Any);
+  'action'?: (_google_protobuf_Any | null);
 }
 
 /**
  * A filter-defined action type.
  */
 export interface FilterAction__Output {
-  'action'?: (_google_protobuf_Any__Output);
+  'action': (_google_protobuf_Any__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/FilterConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/FilterConfig.ts
@@ -15,7 +15,7 @@ export interface FilterConfig {
   /**
    * The filter config.
    */
-  'config'?: (_google_protobuf_Any);
+  'config'?: (_google_protobuf_Any | null);
   /**
    * If true, the filter is optional, meaning that if the client does
    * not support the specified filter, it may ignore the map entry rather
@@ -37,7 +37,7 @@ export interface FilterConfig__Output {
   /**
    * The filter config.
    */
-  'config'?: (_google_protobuf_Any__Output);
+  'config': (_google_protobuf_Any__Output | null);
   /**
    * If true, the filter is optional, meaning that if the client does
    * not support the specified filter, it may ignore the map entry rather

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/HeaderMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/HeaderMatcher.ts
@@ -53,7 +53,7 @@ export interface HeaderMatcher {
    * * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
    * "-1somestring"
    */
-  'range_match'?: (_envoy_type_v3_Int64Range);
+  'range_match'?: (_envoy_type_v3_Int64Range | null);
   /**
    * If specified, header match will be performed based on whether the header is in the
    * request.
@@ -91,7 +91,7 @@ export interface HeaderMatcher {
    * header value must match the regex. The rule will not match if only a subsequence of the
    * request header value matches the regex.
    */
-  'safe_regex_match'?: (_envoy_type_matcher_v3_RegexMatcher);
+  'safe_regex_match'?: (_envoy_type_matcher_v3_RegexMatcher | null);
   /**
    * If specified, header match will be performed based on whether the header value contains
    * the given value or not.
@@ -157,7 +157,7 @@ export interface HeaderMatcher__Output {
    * * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
    * "-1somestring"
    */
-  'range_match'?: (_envoy_type_v3_Int64Range__Output);
+  'range_match'?: (_envoy_type_v3_Int64Range__Output | null);
   /**
    * If specified, header match will be performed based on whether the header is in the
    * request.
@@ -195,7 +195,7 @@ export interface HeaderMatcher__Output {
    * header value must match the regex. The rule will not match if only a subsequence of the
    * request header value matches the regex.
    */
-  'safe_regex_match'?: (_envoy_type_matcher_v3_RegexMatcher__Output);
+  'safe_regex_match'?: (_envoy_type_matcher_v3_RegexMatcher__Output | null);
   /**
    * If specified, header match will be performed based on whether the header value contains
    * the given value or not.

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/HedgePolicy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/HedgePolicy.ts
@@ -13,14 +13,14 @@ export interface HedgePolicy {
    * Defaults to 1.
    * [#not-implemented-hide:]
    */
-  'initial_requests'?: (_google_protobuf_UInt32Value);
+  'initial_requests'?: (_google_protobuf_UInt32Value | null);
   /**
    * Specifies a probability that an additional upstream request should be sent
    * on top of what is specified by initial_requests.
    * Defaults to 0.
    * [#not-implemented-hide:]
    */
-  'additional_request_chance'?: (_envoy_type_v3_FractionalPercent);
+  'additional_request_chance'?: (_envoy_type_v3_FractionalPercent | null);
   /**
    * Indicates that a hedged request should be sent when the per-try timeout is hit.
    * This means that a retry will be issued without resetting the original request, leaving multiple upstream requests in flight.
@@ -49,14 +49,14 @@ export interface HedgePolicy__Output {
    * Defaults to 1.
    * [#not-implemented-hide:]
    */
-  'initial_requests'?: (_google_protobuf_UInt32Value__Output);
+  'initial_requests': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Specifies a probability that an additional upstream request should be sent
    * on top of what is specified by initial_requests.
    * Defaults to 0.
    * [#not-implemented-hide:]
    */
-  'additional_request_chance'?: (_envoy_type_v3_FractionalPercent__Output);
+  'additional_request_chance': (_envoy_type_v3_FractionalPercent__Output | null);
   /**
    * Indicates that a hedged request should be sent when the per-try timeout is hit.
    * This means that a retry will be issued without resetting the original request, leaving multiple upstream requests in flight.

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/InternalRedirectPolicy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/InternalRedirectPolicy.ts
@@ -17,7 +17,7 @@ export interface InternalRedirectPolicy {
    * 
    * If not specified, at most one redirect will be followed.
    */
-  'max_internal_redirects'?: (_google_protobuf_UInt32Value);
+  'max_internal_redirects'?: (_google_protobuf_UInt32Value | null);
   /**
    * Defines what upstream response codes are allowed to trigger internal redirect. If unspecified,
    * only 302 will be treated as internal redirect.
@@ -51,7 +51,7 @@ export interface InternalRedirectPolicy__Output {
    * 
    * If not specified, at most one redirect will be followed.
    */
-  'max_internal_redirects'?: (_google_protobuf_UInt32Value__Output);
+  'max_internal_redirects': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Defines what upstream response codes are allowed to trigger internal redirect. If unspecified,
    * only 302 will be treated as internal redirect.

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/QueryParameterMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/QueryParameterMatcher.ts
@@ -16,7 +16,7 @@ export interface QueryParameterMatcher {
   /**
    * Specifies whether a query parameter value should match against a string.
    */
-  'string_match'?: (_envoy_type_matcher_v3_StringMatcher);
+  'string_match'?: (_envoy_type_matcher_v3_StringMatcher | null);
   /**
    * Specifies whether a query parameter should be present.
    */
@@ -38,7 +38,7 @@ export interface QueryParameterMatcher__Output {
   /**
    * Specifies whether a query parameter value should match against a string.
    */
-  'string_match'?: (_envoy_type_matcher_v3_StringMatcher__Output);
+  'string_match'?: (_envoy_type_matcher_v3_StringMatcher__Output | null);
   /**
    * Specifies whether a query parameter should be present.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RateLimit.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RateLimit.ts
@@ -13,42 +13,42 @@ export interface _envoy_config_route_v3_RateLimit_Action {
   /**
    * Rate limit on source cluster.
    */
-  'source_cluster'?: (_envoy_config_route_v3_RateLimit_Action_SourceCluster);
+  'source_cluster'?: (_envoy_config_route_v3_RateLimit_Action_SourceCluster | null);
   /**
    * Rate limit on destination cluster.
    */
-  'destination_cluster'?: (_envoy_config_route_v3_RateLimit_Action_DestinationCluster);
+  'destination_cluster'?: (_envoy_config_route_v3_RateLimit_Action_DestinationCluster | null);
   /**
    * Rate limit on request headers.
    */
-  'request_headers'?: (_envoy_config_route_v3_RateLimit_Action_RequestHeaders);
+  'request_headers'?: (_envoy_config_route_v3_RateLimit_Action_RequestHeaders | null);
   /**
    * Rate limit on remote address.
    */
-  'remote_address'?: (_envoy_config_route_v3_RateLimit_Action_RemoteAddress);
+  'remote_address'?: (_envoy_config_route_v3_RateLimit_Action_RemoteAddress | null);
   /**
    * Rate limit on a generic key.
    */
-  'generic_key'?: (_envoy_config_route_v3_RateLimit_Action_GenericKey);
+  'generic_key'?: (_envoy_config_route_v3_RateLimit_Action_GenericKey | null);
   /**
    * Rate limit on the existence of request headers.
    */
-  'header_value_match'?: (_envoy_config_route_v3_RateLimit_Action_HeaderValueMatch);
+  'header_value_match'?: (_envoy_config_route_v3_RateLimit_Action_HeaderValueMatch | null);
   /**
    * Rate limit on dynamic metadata.
    * 
    * .. attention::
    * This field has been deprecated in favor of the :ref:`metadata <envoy_api_field_config.route.v3.RateLimit.Action.metadata>` field
    */
-  'dynamic_metadata'?: (_envoy_config_route_v3_RateLimit_Action_DynamicMetaData);
+  'dynamic_metadata'?: (_envoy_config_route_v3_RateLimit_Action_DynamicMetaData | null);
   /**
    * Rate limit on metadata.
    */
-  'metadata'?: (_envoy_config_route_v3_RateLimit_Action_MetaData);
+  'metadata'?: (_envoy_config_route_v3_RateLimit_Action_MetaData | null);
   /**
    * Rate limit descriptor extension. See the rate limit descriptor extensions documentation.
    */
-  'extension'?: (_envoy_config_core_v3_TypedExtensionConfig);
+  'extension'?: (_envoy_config_core_v3_TypedExtensionConfig | null);
   'action_specifier'?: "source_cluster"|"destination_cluster"|"request_headers"|"remote_address"|"generic_key"|"header_value_match"|"dynamic_metadata"|"metadata"|"extension";
 }
 
@@ -59,42 +59,42 @@ export interface _envoy_config_route_v3_RateLimit_Action__Output {
   /**
    * Rate limit on source cluster.
    */
-  'source_cluster'?: (_envoy_config_route_v3_RateLimit_Action_SourceCluster__Output);
+  'source_cluster'?: (_envoy_config_route_v3_RateLimit_Action_SourceCluster__Output | null);
   /**
    * Rate limit on destination cluster.
    */
-  'destination_cluster'?: (_envoy_config_route_v3_RateLimit_Action_DestinationCluster__Output);
+  'destination_cluster'?: (_envoy_config_route_v3_RateLimit_Action_DestinationCluster__Output | null);
   /**
    * Rate limit on request headers.
    */
-  'request_headers'?: (_envoy_config_route_v3_RateLimit_Action_RequestHeaders__Output);
+  'request_headers'?: (_envoy_config_route_v3_RateLimit_Action_RequestHeaders__Output | null);
   /**
    * Rate limit on remote address.
    */
-  'remote_address'?: (_envoy_config_route_v3_RateLimit_Action_RemoteAddress__Output);
+  'remote_address'?: (_envoy_config_route_v3_RateLimit_Action_RemoteAddress__Output | null);
   /**
    * Rate limit on a generic key.
    */
-  'generic_key'?: (_envoy_config_route_v3_RateLimit_Action_GenericKey__Output);
+  'generic_key'?: (_envoy_config_route_v3_RateLimit_Action_GenericKey__Output | null);
   /**
    * Rate limit on the existence of request headers.
    */
-  'header_value_match'?: (_envoy_config_route_v3_RateLimit_Action_HeaderValueMatch__Output);
+  'header_value_match'?: (_envoy_config_route_v3_RateLimit_Action_HeaderValueMatch__Output | null);
   /**
    * Rate limit on dynamic metadata.
    * 
    * .. attention::
    * This field has been deprecated in favor of the :ref:`metadata <envoy_api_field_config.route.v3.RateLimit.Action.metadata>` field
    */
-  'dynamic_metadata'?: (_envoy_config_route_v3_RateLimit_Action_DynamicMetaData__Output);
+  'dynamic_metadata'?: (_envoy_config_route_v3_RateLimit_Action_DynamicMetaData__Output | null);
   /**
    * Rate limit on metadata.
    */
-  'metadata'?: (_envoy_config_route_v3_RateLimit_Action_MetaData__Output);
+  'metadata'?: (_envoy_config_route_v3_RateLimit_Action_MetaData__Output | null);
   /**
    * Rate limit descriptor extension. See the rate limit descriptor extensions documentation.
    */
-  'extension'?: (_envoy_config_core_v3_TypedExtensionConfig__Output);
+  'extension'?: (_envoy_config_core_v3_TypedExtensionConfig__Output | null);
   'action_specifier': "source_cluster"|"destination_cluster"|"request_headers"|"remote_address"|"generic_key"|"header_value_match"|"dynamic_metadata"|"metadata"|"extension";
 }
 
@@ -160,7 +160,7 @@ export interface _envoy_config_route_v3_RateLimit_Action_DynamicMetaData {
    * Metadata struct that defines the key and path to retrieve the string value. A match will
    * only happen if the value in the dynamic metadata is of type string.
    */
-  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey);
+  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey | null);
   /**
    * An optional value to use if *metadata_key* is empty. If not set and
    * no value is present under the metadata_key then no descriptor is generated.
@@ -188,7 +188,7 @@ export interface _envoy_config_route_v3_RateLimit_Action_DynamicMetaData__Output
    * Metadata struct that defines the key and path to retrieve the string value. A match will
    * only happen if the value in the dynamic metadata is of type string.
    */
-  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey__Output);
+  'metadata_key': (_envoy_type_metadata_v3_MetadataKey__Output | null);
   /**
    * An optional value to use if *metadata_key* is empty. If not set and
    * no value is present under the metadata_key then no descriptor is generated.
@@ -206,7 +206,7 @@ export interface _envoy_config_route_v3_RateLimit_Override_DynamicMetadata {
    * and a "unit" property with a value parseable to :ref:`RateLimitUnit
    * enum <envoy_api_enum_type.v3.RateLimitUnit>`
    */
-  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey);
+  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey | null);
 }
 
 /**
@@ -219,7 +219,7 @@ export interface _envoy_config_route_v3_RateLimit_Override_DynamicMetadata__Outp
    * and a "unit" property with a value parseable to :ref:`RateLimitUnit
    * enum <envoy_api_enum_type.v3.RateLimitUnit>`
    */
-  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey__Output);
+  'metadata_key': (_envoy_type_metadata_v3_MetadataKey__Output | null);
 }
 
 /**
@@ -278,7 +278,7 @@ export interface _envoy_config_route_v3_RateLimit_Action_HeaderValueMatch {
    * descriptor entry when the request does not match the headers. The
    * default value is true.
    */
-  'expect_match'?: (_google_protobuf_BoolValue);
+  'expect_match'?: (_google_protobuf_BoolValue | null);
   /**
    * Specifies a set of headers that the rate limit action should match
    * on. The action will check the request’s headers against all the
@@ -307,7 +307,7 @@ export interface _envoy_config_route_v3_RateLimit_Action_HeaderValueMatch__Outpu
    * descriptor entry when the request does not match the headers. The
    * default value is true.
    */
-  'expect_match'?: (_google_protobuf_BoolValue__Output);
+  'expect_match': (_google_protobuf_BoolValue__Output | null);
   /**
    * Specifies a set of headers that the rate limit action should match
    * on. The action will check the request’s headers against all the
@@ -334,7 +334,7 @@ export interface _envoy_config_route_v3_RateLimit_Action_MetaData {
    * Metadata struct that defines the key and path to retrieve the string value. A match will
    * only happen if the value in the metadata is of type string.
    */
-  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey);
+  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey | null);
   /**
    * An optional value to use if *metadata_key* is empty. If not set and
    * no value is present under the metadata_key then no descriptor is generated.
@@ -362,7 +362,7 @@ export interface _envoy_config_route_v3_RateLimit_Action_MetaData__Output {
    * Metadata struct that defines the key and path to retrieve the string value. A match will
    * only happen if the value in the metadata is of type string.
    */
-  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey__Output);
+  'metadata_key': (_envoy_type_metadata_v3_MetadataKey__Output | null);
   /**
    * An optional value to use if *metadata_key* is empty. If not set and
    * no value is present under the metadata_key then no descriptor is generated.
@@ -378,7 +378,7 @@ export interface _envoy_config_route_v3_RateLimit_Override {
   /**
    * Limit override from dynamic metadata.
    */
-  'dynamic_metadata'?: (_envoy_config_route_v3_RateLimit_Override_DynamicMetadata);
+  'dynamic_metadata'?: (_envoy_config_route_v3_RateLimit_Override_DynamicMetadata | null);
   'override_specifier'?: "dynamic_metadata";
 }
 
@@ -386,7 +386,7 @@ export interface _envoy_config_route_v3_RateLimit_Override__Output {
   /**
    * Limit override from dynamic metadata.
    */
-  'dynamic_metadata'?: (_envoy_config_route_v3_RateLimit_Override_DynamicMetadata__Output);
+  'dynamic_metadata'?: (_envoy_config_route_v3_RateLimit_Override_DynamicMetadata__Output | null);
   'override_specifier': "dynamic_metadata";
 }
 
@@ -517,7 +517,7 @@ export interface RateLimit {
    * 
    * The filter supports a range of 0 - 10 inclusively for stage numbers.
    */
-  'stage'?: (_google_protobuf_UInt32Value);
+  'stage'?: (_google_protobuf_UInt32Value | null);
   /**
    * The key to be set in runtime to disable this rate limit configuration.
    */
@@ -537,7 +537,7 @@ export interface RateLimit {
    * from metadata, no override is provided. See :ref:`rate limit override
    * <config_http_filters_rate_limit_rate_limit_override>` for more information.
    */
-  'limit'?: (_envoy_config_route_v3_RateLimit_Override);
+  'limit'?: (_envoy_config_route_v3_RateLimit_Override | null);
 }
 
 /**
@@ -554,7 +554,7 @@ export interface RateLimit__Output {
    * 
    * The filter supports a range of 0 - 10 inclusively for stage numbers.
    */
-  'stage'?: (_google_protobuf_UInt32Value__Output);
+  'stage': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The key to be set in runtime to disable this rate limit configuration.
    */
@@ -574,5 +574,5 @@ export interface RateLimit__Output {
    * from metadata, no override is provided. See :ref:`rate limit override
    * <config_http_filters_rate_limit_rate_limit_override>` for more information.
    */
-  'limit'?: (_envoy_config_route_v3_RateLimit_Override__Output);
+  'limit': (_envoy_config_route_v3_RateLimit_Override__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RedirectAction.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RedirectAction.ts
@@ -112,7 +112,7 @@ export interface RedirectAction {
    * would do a case-insensitive match and transform path ``/aaa/XxX/bbb`` to
    * ``/aaa/yyy/bbb``.
    */
-  'regex_rewrite'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute);
+  'regex_rewrite'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute | null);
   /**
    * When the scheme redirection take place, the following rules apply:
    * 1. If the source URI scheme is `http` and the port is explicitly
@@ -209,7 +209,7 @@ export interface RedirectAction__Output {
    * would do a case-insensitive match and transform path ``/aaa/XxX/bbb`` to
    * ``/aaa/yyy/bbb``.
    */
-  'regex_rewrite'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute__Output);
+  'regex_rewrite'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute__Output | null);
   /**
    * When the scheme redirection take place, the following rules apply:
    * 1. If the source URI scheme is `http` and the port is explicitly

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RetryPolicy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RetryPolicy.ts
@@ -64,7 +64,7 @@ export interface _envoy_config_route_v3_RetryPolicy_RateLimitedRetryBackOff {
    * header contains an interval longer than this then it will be discarded and
    * the next header will be tried. Defaults to 300 seconds.
    */
-  'max_interval'?: (_google_protobuf_Duration);
+  'max_interval'?: (_google_protobuf_Duration | null);
 }
 
 /**
@@ -125,7 +125,7 @@ export interface _envoy_config_route_v3_RetryPolicy_RateLimitedRetryBackOff__Out
    * header contains an interval longer than this then it will be discarded and
    * the next header will be tried. Defaults to 300 seconds.
    */
-  'max_interval'?: (_google_protobuf_Duration__Output);
+  'max_interval': (_google_protobuf_Duration__Output | null);
 }
 
 export interface _envoy_config_route_v3_RetryPolicy_ResetHeader {
@@ -172,14 +172,14 @@ export interface _envoy_config_route_v3_RetryPolicy_RetryBackOff {
    * See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion of Envoy's
    * back-off algorithm.
    */
-  'base_interval'?: (_google_protobuf_Duration);
+  'base_interval'?: (_google_protobuf_Duration | null);
   /**
    * Specifies the maximum interval between retries. This parameter is optional, but must be
    * greater than or equal to the `base_interval` if set. The default is 10 times the
    * `base_interval`. See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion
    * of Envoy's back-off algorithm.
    */
-  'max_interval'?: (_google_protobuf_Duration);
+  'max_interval'?: (_google_protobuf_Duration | null);
 }
 
 export interface _envoy_config_route_v3_RetryPolicy_RetryBackOff__Output {
@@ -189,37 +189,37 @@ export interface _envoy_config_route_v3_RetryPolicy_RetryBackOff__Output {
    * See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion of Envoy's
    * back-off algorithm.
    */
-  'base_interval'?: (_google_protobuf_Duration__Output);
+  'base_interval': (_google_protobuf_Duration__Output | null);
   /**
    * Specifies the maximum interval between retries. This parameter is optional, but must be
    * greater than or equal to the `base_interval` if set. The default is 10 times the
    * `base_interval`. See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion
    * of Envoy's back-off algorithm.
    */
-  'max_interval'?: (_google_protobuf_Duration__Output);
+  'max_interval': (_google_protobuf_Duration__Output | null);
 }
 
 export interface _envoy_config_route_v3_RetryPolicy_RetryHostPredicate {
   'name'?: (string);
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
   'config_type'?: "typed_config";
 }
 
 export interface _envoy_config_route_v3_RetryPolicy_RetryHostPredicate__Output {
   'name': (string);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   'config_type': "typed_config";
 }
 
 export interface _envoy_config_route_v3_RetryPolicy_RetryPriority {
   'name'?: (string);
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
   'config_type'?: "typed_config";
 }
 
 export interface _envoy_config_route_v3_RetryPolicy_RetryPriority__Output {
   'name': (string);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   'config_type': "typed_config";
 }
 
@@ -239,7 +239,7 @@ export interface RetryPolicy {
    * defaults to 1. These are the same conditions documented for
    * :ref:`config_http_filters_router_x-envoy-max-retries`.
    */
-  'num_retries'?: (_google_protobuf_UInt32Value);
+  'num_retries'?: (_google_protobuf_UInt32Value | null);
   /**
    * Specifies a non-zero upstream timeout per retry attempt. This parameter is optional. The
    * same conditions documented for
@@ -253,13 +253,13 @@ export interface RetryPolicy {
    * retry policy, a request that times out will not be retried as the total timeout budget
    * would have been exhausted.
    */
-  'per_try_timeout'?: (_google_protobuf_Duration);
+  'per_try_timeout'?: (_google_protobuf_Duration | null);
   /**
    * Specifies an implementation of a RetryPriority which is used to determine the
    * distribution of load across priorities used for retries. Refer to
    * :ref:`retry plugin configuration <arch_overview_http_retry_plugins>` for more details.
    */
-  'retry_priority'?: (_envoy_config_route_v3_RetryPolicy_RetryPriority);
+  'retry_priority'?: (_envoy_config_route_v3_RetryPolicy_RetryPriority | null);
   /**
    * Specifies a collection of RetryHostPredicates that will be consulted when selecting a host
    * for retries. If any of the predicates reject the host, host selection will be reattempted.
@@ -284,7 +284,7 @@ export interface RetryPolicy {
    * the base interval. The documentation for :ref:`config_http_filters_router_x-envoy-max-retries`
    * describes Envoy's back-off algorithm.
    */
-  'retry_back_off'?: (_envoy_config_route_v3_RetryPolicy_RetryBackOff);
+  'retry_back_off'?: (_envoy_config_route_v3_RetryPolicy_RetryBackOff | null);
   /**
    * HTTP response headers that trigger a retry if present in the response. A retry will be
    * triggered if any of the header matches match the upstream response headers.
@@ -304,7 +304,7 @@ export interface RetryPolicy {
    * default exponential back off strategy (configured using `retry_back_off`)
    * whenever a response includes the matching headers.
    */
-  'rate_limited_retry_back_off'?: (_envoy_config_route_v3_RetryPolicy_RateLimitedRetryBackOff);
+  'rate_limited_retry_back_off'?: (_envoy_config_route_v3_RetryPolicy_RateLimitedRetryBackOff | null);
 }
 
 /**
@@ -323,7 +323,7 @@ export interface RetryPolicy__Output {
    * defaults to 1. These are the same conditions documented for
    * :ref:`config_http_filters_router_x-envoy-max-retries`.
    */
-  'num_retries'?: (_google_protobuf_UInt32Value__Output);
+  'num_retries': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Specifies a non-zero upstream timeout per retry attempt. This parameter is optional. The
    * same conditions documented for
@@ -337,13 +337,13 @@ export interface RetryPolicy__Output {
    * retry policy, a request that times out will not be retried as the total timeout budget
    * would have been exhausted.
    */
-  'per_try_timeout'?: (_google_protobuf_Duration__Output);
+  'per_try_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * Specifies an implementation of a RetryPriority which is used to determine the
    * distribution of load across priorities used for retries. Refer to
    * :ref:`retry plugin configuration <arch_overview_http_retry_plugins>` for more details.
    */
-  'retry_priority'?: (_envoy_config_route_v3_RetryPolicy_RetryPriority__Output);
+  'retry_priority': (_envoy_config_route_v3_RetryPolicy_RetryPriority__Output | null);
   /**
    * Specifies a collection of RetryHostPredicates that will be consulted when selecting a host
    * for retries. If any of the predicates reject the host, host selection will be reattempted.
@@ -368,7 +368,7 @@ export interface RetryPolicy__Output {
    * the base interval. The documentation for :ref:`config_http_filters_router_x-envoy-max-retries`
    * describes Envoy's back-off algorithm.
    */
-  'retry_back_off'?: (_envoy_config_route_v3_RetryPolicy_RetryBackOff__Output);
+  'retry_back_off': (_envoy_config_route_v3_RetryPolicy_RetryBackOff__Output | null);
   /**
    * HTTP response headers that trigger a retry if present in the response. A retry will be
    * triggered if any of the header matches match the upstream response headers.
@@ -388,5 +388,5 @@ export interface RetryPolicy__Output {
    * default exponential back off strategy (configured using `retry_back_off`)
    * whenever a response includes the matching headers.
    */
-  'rate_limited_retry_back_off'?: (_envoy_config_route_v3_RetryPolicy_RateLimitedRetryBackOff__Output);
+  'rate_limited_retry_back_off': (_envoy_config_route_v3_RetryPolicy_RateLimitedRetryBackOff__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Route.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Route.ts
@@ -26,15 +26,15 @@ export interface Route {
   /**
    * Route matching parameters.
    */
-  'match'?: (_envoy_config_route_v3_RouteMatch);
+  'match'?: (_envoy_config_route_v3_RouteMatch | null);
   /**
    * Route request to some upstream cluster.
    */
-  'route'?: (_envoy_config_route_v3_RouteAction);
+  'route'?: (_envoy_config_route_v3_RouteAction | null);
   /**
    * Return a redirect.
    */
-  'redirect'?: (_envoy_config_route_v3_RedirectAction);
+  'redirect'?: (_envoy_config_route_v3_RedirectAction | null);
   /**
    * The Metadata field can be used to provide additional information
    * about the route. It can be used for configuration, stats, and logging.
@@ -42,15 +42,15 @@ export interface Route {
    * For instance, if the metadata is intended for the Router filter,
    * the filter name should be specified as *envoy.filters.http.router*.
    */
-  'metadata'?: (_envoy_config_core_v3_Metadata);
+  'metadata'?: (_envoy_config_core_v3_Metadata | null);
   /**
    * Decorator for the matched route.
    */
-  'decorator'?: (_envoy_config_route_v3_Decorator);
+  'decorator'?: (_envoy_config_route_v3_Decorator | null);
   /**
    * Return an arbitrary HTTP response directly, without proxying.
    */
-  'direct_response'?: (_envoy_config_route_v3_DirectResponseAction);
+  'direct_response'?: (_envoy_config_route_v3_DirectResponseAction | null);
   /**
    * Specifies a set of headers that will be added to requests matching this
    * route. Headers specified at this level are applied before headers from the
@@ -98,13 +98,13 @@ export interface Route {
    * Presence of the object defines whether the connection manager's tracing configuration
    * is overridden by this route specific instance.
    */
-  'tracing'?: (_envoy_config_route_v3_Tracing);
+  'tracing'?: (_envoy_config_route_v3_Tracing | null);
   /**
    * The maximum bytes which will be buffered for retries and shadowing.
    * If set, the bytes actually buffered will be the minimum value of this and the
    * listener per_connection_buffer_limit_bytes.
    */
-  'per_request_buffer_limit_bytes'?: (_google_protobuf_UInt32Value);
+  'per_request_buffer_limit_bytes'?: (_google_protobuf_UInt32Value | null);
   /**
    * [#not-implemented-hide:]
    * If true, a filter will define the action (e.g., it could dynamically generate the
@@ -112,7 +112,7 @@ export interface Route {
    * [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
    * implemented]
    */
-  'filter_action'?: (_envoy_config_route_v3_FilterAction);
+  'filter_action'?: (_envoy_config_route_v3_FilterAction | null);
   'action'?: "route"|"redirect"|"direct_response"|"filter_action";
 }
 
@@ -130,15 +130,15 @@ export interface Route__Output {
   /**
    * Route matching parameters.
    */
-  'match'?: (_envoy_config_route_v3_RouteMatch__Output);
+  'match': (_envoy_config_route_v3_RouteMatch__Output | null);
   /**
    * Route request to some upstream cluster.
    */
-  'route'?: (_envoy_config_route_v3_RouteAction__Output);
+  'route'?: (_envoy_config_route_v3_RouteAction__Output | null);
   /**
    * Return a redirect.
    */
-  'redirect'?: (_envoy_config_route_v3_RedirectAction__Output);
+  'redirect'?: (_envoy_config_route_v3_RedirectAction__Output | null);
   /**
    * The Metadata field can be used to provide additional information
    * about the route. It can be used for configuration, stats, and logging.
@@ -146,15 +146,15 @@ export interface Route__Output {
    * For instance, if the metadata is intended for the Router filter,
    * the filter name should be specified as *envoy.filters.http.router*.
    */
-  'metadata'?: (_envoy_config_core_v3_Metadata__Output);
+  'metadata': (_envoy_config_core_v3_Metadata__Output | null);
   /**
    * Decorator for the matched route.
    */
-  'decorator'?: (_envoy_config_route_v3_Decorator__Output);
+  'decorator': (_envoy_config_route_v3_Decorator__Output | null);
   /**
    * Return an arbitrary HTTP response directly, without proxying.
    */
-  'direct_response'?: (_envoy_config_route_v3_DirectResponseAction__Output);
+  'direct_response'?: (_envoy_config_route_v3_DirectResponseAction__Output | null);
   /**
    * Specifies a set of headers that will be added to requests matching this
    * route. Headers specified at this level are applied before headers from the
@@ -193,7 +193,7 @@ export interface Route__Output {
    * :ref:`FilterConfig<envoy_api_msg_config.route.v3.FilterConfig>`
    * message to specify additional options.]
    */
-  'typed_per_filter_config'?: ({[key: string]: _google_protobuf_Any__Output});
+  'typed_per_filter_config': ({[key: string]: _google_protobuf_Any__Output});
   /**
    * Name for the route.
    */
@@ -202,13 +202,13 @@ export interface Route__Output {
    * Presence of the object defines whether the connection manager's tracing configuration
    * is overridden by this route specific instance.
    */
-  'tracing'?: (_envoy_config_route_v3_Tracing__Output);
+  'tracing': (_envoy_config_route_v3_Tracing__Output | null);
   /**
    * The maximum bytes which will be buffered for retries and shadowing.
    * If set, the bytes actually buffered will be the minimum value of this and the
    * listener per_connection_buffer_limit_bytes.
    */
-  'per_request_buffer_limit_bytes'?: (_google_protobuf_UInt32Value__Output);
+  'per_request_buffer_limit_bytes': (_google_protobuf_UInt32Value__Output | null);
   /**
    * [#not-implemented-hide:]
    * If true, a filter will define the action (e.g., it could dynamically generate the
@@ -216,6 +216,6 @@ export interface Route__Output {
    * [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
    * implemented]
    */
-  'filter_action'?: (_envoy_config_route_v3_FilterAction__Output);
+  'filter_action'?: (_envoy_config_route_v3_FilterAction__Output | null);
   'action': "route"|"redirect"|"direct_response"|"filter_action";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteAction.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteAction.ts
@@ -37,7 +37,7 @@ export interface _envoy_config_route_v3_RouteAction_UpgradeConfig_ConnectConfig 
   /**
    * If present, the proxy protocol header will be prepended to the CONNECT payload sent upstream.
    */
-  'proxy_protocol_config'?: (_envoy_config_core_v3_ProxyProtocolConfig);
+  'proxy_protocol_config'?: (_envoy_config_core_v3_ProxyProtocolConfig | null);
   /**
    * If set, the route will also allow forwarding POST payload as raw TCP.
    */
@@ -52,7 +52,7 @@ export interface _envoy_config_route_v3_RouteAction_UpgradeConfig_ConnectConfig_
   /**
    * If present, the proxy protocol header will be prepended to the CONNECT payload sent upstream.
    */
-  'proxy_protocol_config'?: (_envoy_config_core_v3_ProxyProtocolConfig__Output);
+  'proxy_protocol_config': (_envoy_config_core_v3_ProxyProtocolConfig__Output | null);
   /**
    * If set, the route will also allow forwarding POST payload as raw TCP.
    */
@@ -101,7 +101,7 @@ export interface _envoy_config_route_v3_RouteAction_HashPolicy_Cookie {
    * not present. If the TTL is present and zero, the generated cookie will
    * be a session cookie.
    */
-  'ttl'?: (_google_protobuf_Duration);
+  'ttl'?: (_google_protobuf_Duration | null);
   /**
    * The name of the path for the cookie. If no path is specified here, no path
    * will be set for the cookie.
@@ -137,7 +137,7 @@ export interface _envoy_config_route_v3_RouteAction_HashPolicy_Cookie__Output {
    * not present. If the TTL is present and zero, the generated cookie will
    * be a session cookie.
    */
-  'ttl'?: (_google_protobuf_Duration__Output);
+  'ttl': (_google_protobuf_Duration__Output | null);
   /**
    * The name of the path for the cookie. If no path is specified here, no path
    * will be set for the cookie.
@@ -172,23 +172,23 @@ export interface _envoy_config_route_v3_RouteAction_HashPolicy {
   /**
    * Header hash policy.
    */
-  'header'?: (_envoy_config_route_v3_RouteAction_HashPolicy_Header);
+  'header'?: (_envoy_config_route_v3_RouteAction_HashPolicy_Header | null);
   /**
    * Cookie hash policy.
    */
-  'cookie'?: (_envoy_config_route_v3_RouteAction_HashPolicy_Cookie);
+  'cookie'?: (_envoy_config_route_v3_RouteAction_HashPolicy_Cookie | null);
   /**
    * Connection properties hash policy.
    */
-  'connection_properties'?: (_envoy_config_route_v3_RouteAction_HashPolicy_ConnectionProperties);
+  'connection_properties'?: (_envoy_config_route_v3_RouteAction_HashPolicy_ConnectionProperties | null);
   /**
    * Query parameter hash policy.
    */
-  'query_parameter'?: (_envoy_config_route_v3_RouteAction_HashPolicy_QueryParameter);
+  'query_parameter'?: (_envoy_config_route_v3_RouteAction_HashPolicy_QueryParameter | null);
   /**
    * Filter state hash policy.
    */
-  'filter_state'?: (_envoy_config_route_v3_RouteAction_HashPolicy_FilterState);
+  'filter_state'?: (_envoy_config_route_v3_RouteAction_HashPolicy_FilterState | null);
   /**
    * The flag that short-circuits the hash computing. This field provides a
    * 'fallback' style of configuration: "if a terminal policy doesn't work,
@@ -223,23 +223,23 @@ export interface _envoy_config_route_v3_RouteAction_HashPolicy__Output {
   /**
    * Header hash policy.
    */
-  'header'?: (_envoy_config_route_v3_RouteAction_HashPolicy_Header__Output);
+  'header'?: (_envoy_config_route_v3_RouteAction_HashPolicy_Header__Output | null);
   /**
    * Cookie hash policy.
    */
-  'cookie'?: (_envoy_config_route_v3_RouteAction_HashPolicy_Cookie__Output);
+  'cookie'?: (_envoy_config_route_v3_RouteAction_HashPolicy_Cookie__Output | null);
   /**
    * Connection properties hash policy.
    */
-  'connection_properties'?: (_envoy_config_route_v3_RouteAction_HashPolicy_ConnectionProperties__Output);
+  'connection_properties'?: (_envoy_config_route_v3_RouteAction_HashPolicy_ConnectionProperties__Output | null);
   /**
    * Query parameter hash policy.
    */
-  'query_parameter'?: (_envoy_config_route_v3_RouteAction_HashPolicy_QueryParameter__Output);
+  'query_parameter'?: (_envoy_config_route_v3_RouteAction_HashPolicy_QueryParameter__Output | null);
   /**
    * Filter state hash policy.
    */
-  'filter_state'?: (_envoy_config_route_v3_RouteAction_HashPolicy_FilterState__Output);
+  'filter_state'?: (_envoy_config_route_v3_RouteAction_HashPolicy_FilterState__Output | null);
   /**
    * The flag that short-circuits the hash computing. This field provides a
    * 'fallback' style of configuration: "if a terminal policy doesn't work,
@@ -275,7 +275,7 @@ export interface _envoy_config_route_v3_RouteAction_HashPolicy_Header {
    * If specified, the request header value will be rewritten and used
    * to produce the hash key.
    */
-  'regex_rewrite'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute);
+  'regex_rewrite'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute | null);
 }
 
 export interface _envoy_config_route_v3_RouteAction_HashPolicy_Header__Output {
@@ -288,7 +288,7 @@ export interface _envoy_config_route_v3_RouteAction_HashPolicy_Header__Output {
    * If specified, the request header value will be rewritten and used
    * to produce the hash key.
    */
-  'regex_rewrite'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute__Output);
+  'regex_rewrite': (_envoy_type_matcher_v3_RegexMatchAndSubstitute__Output | null);
 }
 
 // Original file: deps/envoy-api/envoy/config/route/v3/route_components.proto
@@ -313,14 +313,14 @@ export interface _envoy_config_route_v3_RouteAction_MaxStreamDuration {
    * HttpConnectionManager max_stream_duration timeout will be disabled for
    * this route.
    */
-  'max_stream_duration'?: (_google_protobuf_Duration);
+  'max_stream_duration'?: (_google_protobuf_Duration | null);
   /**
    * If present, and the request contains a `grpc-timeout header
    * <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_, use that value as the
    * *max_stream_duration*, but limit the applied timeout to the maximum value specified here.
    * If set to 0, the `grpc-timeout` header is used without modification.
    */
-  'grpc_timeout_header_max'?: (_google_protobuf_Duration);
+  'grpc_timeout_header_max'?: (_google_protobuf_Duration | null);
   /**
    * If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by
    * subtracting the provided duration from the header. This is useful for allowing Envoy to set
@@ -329,7 +329,7 @@ export interface _envoy_config_route_v3_RouteAction_MaxStreamDuration {
    * by the client. If, after applying the offset, the resulting timeout is zero or negative,
    * the stream will timeout immediately.
    */
-  'grpc_timeout_header_offset'?: (_google_protobuf_Duration);
+  'grpc_timeout_header_offset'?: (_google_protobuf_Duration | null);
 }
 
 export interface _envoy_config_route_v3_RouteAction_MaxStreamDuration__Output {
@@ -343,14 +343,14 @@ export interface _envoy_config_route_v3_RouteAction_MaxStreamDuration__Output {
    * HttpConnectionManager max_stream_duration timeout will be disabled for
    * this route.
    */
-  'max_stream_duration'?: (_google_protobuf_Duration__Output);
+  'max_stream_duration': (_google_protobuf_Duration__Output | null);
   /**
    * If present, and the request contains a `grpc-timeout header
    * <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_, use that value as the
    * *max_stream_duration*, but limit the applied timeout to the maximum value specified here.
    * If set to 0, the `grpc-timeout` header is used without modification.
    */
-  'grpc_timeout_header_max'?: (_google_protobuf_Duration__Output);
+  'grpc_timeout_header_max': (_google_protobuf_Duration__Output | null);
   /**
    * If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by
    * subtracting the provided duration from the header. This is useful for allowing Envoy to set
@@ -359,7 +359,7 @@ export interface _envoy_config_route_v3_RouteAction_MaxStreamDuration__Output {
    * by the client. If, after applying the offset, the resulting timeout is zero or negative,
    * the stream will timeout immediately.
    */
-  'grpc_timeout_header_offset'?: (_google_protobuf_Duration__Output);
+  'grpc_timeout_header_offset': (_google_protobuf_Duration__Output | null);
 }
 
 export interface _envoy_config_route_v3_RouteAction_HashPolicy_QueryParameter {
@@ -409,11 +409,11 @@ export interface _envoy_config_route_v3_RouteAction_RequestMirrorPolicy {
    * number is <= the value of the numerator N, or if the key is not present, the default
    * value, the request will be mirrored.
    */
-  'runtime_fraction'?: (_envoy_config_core_v3_RuntimeFractionalPercent);
+  'runtime_fraction'?: (_envoy_config_core_v3_RuntimeFractionalPercent | null);
   /**
    * Determines if the trace span should be sampled. Defaults to true.
    */
-  'trace_sampled'?: (_google_protobuf_BoolValue);
+  'trace_sampled'?: (_google_protobuf_BoolValue | null);
 }
 
 /**
@@ -445,11 +445,11 @@ export interface _envoy_config_route_v3_RouteAction_RequestMirrorPolicy__Output 
    * number is <= the value of the numerator N, or if the key is not present, the default
    * value, the request will be mirrored.
    */
-  'runtime_fraction'?: (_envoy_config_core_v3_RuntimeFractionalPercent__Output);
+  'runtime_fraction': (_envoy_config_core_v3_RuntimeFractionalPercent__Output | null);
   /**
    * Determines if the trace span should be sampled. Defaults to true.
    */
-  'trace_sampled'?: (_google_protobuf_BoolValue__Output);
+  'trace_sampled': (_google_protobuf_BoolValue__Output | null);
 }
 
 /**
@@ -470,14 +470,14 @@ export interface _envoy_config_route_v3_RouteAction_UpgradeConfig {
   /**
    * Determines if upgrades are available on this route. Defaults to true.
    */
-  'enabled'?: (_google_protobuf_BoolValue);
+  'enabled'?: (_google_protobuf_BoolValue | null);
   /**
    * Configuration for sending data upstream as a raw data payload. This is used for
    * CONNECT requests, when forwarding CONNECT payload as raw TCP.
    * Note that CONNECT support is currently considered alpha in Envoy.
    * [#comment:TODO(htuch): Replace the above comment with an alpha tag.
    */
-  'connect_config'?: (_envoy_config_route_v3_RouteAction_UpgradeConfig_ConnectConfig);
+  'connect_config'?: (_envoy_config_route_v3_RouteAction_UpgradeConfig_ConnectConfig | null);
 }
 
 /**
@@ -498,14 +498,14 @@ export interface _envoy_config_route_v3_RouteAction_UpgradeConfig__Output {
   /**
    * Determines if upgrades are available on this route. Defaults to true.
    */
-  'enabled'?: (_google_protobuf_BoolValue__Output);
+  'enabled': (_google_protobuf_BoolValue__Output | null);
   /**
    * Configuration for sending data upstream as a raw data payload. This is used for
    * CONNECT requests, when forwarding CONNECT payload as raw TCP.
    * Note that CONNECT support is currently considered alpha in Envoy.
    * [#comment:TODO(htuch): Replace the above comment with an alpha tag.
    */
-  'connect_config'?: (_envoy_config_route_v3_RouteAction_UpgradeConfig_ConnectConfig__Output);
+  'connect_config': (_envoy_config_route_v3_RouteAction_UpgradeConfig_ConnectConfig__Output | null);
 }
 
 /**
@@ -540,7 +540,7 @@ export interface RouteAction {
    * :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
    * for additional documentation.
    */
-  'weighted_clusters'?: (_envoy_config_route_v3_WeightedCluster);
+  'weighted_clusters'?: (_envoy_config_route_v3_WeightedCluster | null);
   /**
    * Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints
    * in the upstream cluster with metadata matching what's set in this field will be considered
@@ -548,7 +548,7 @@ export interface RouteAction {
    * <envoy_api_field_config.route.v3.RouteAction.weighted_clusters>`, metadata will be merged, with values
    * provided there taking precedence. The filter name should be specified as *envoy.lb*.
    */
-  'metadata_match'?: (_envoy_config_core_v3_Metadata);
+  'metadata_match'?: (_envoy_config_core_v3_Metadata | null);
   /**
    * Indicates that during forwarding, the matched prefix (or path) should be
    * swapped with this value. This option allows application URLs to be rooted
@@ -595,7 +595,7 @@ export interface RouteAction {
    * type *strict_dns* or *logical_dns*. Setting this to true with other cluster
    * types has no effect.
    */
-  'auto_host_rewrite'?: (_google_protobuf_BoolValue);
+  'auto_host_rewrite'?: (_google_protobuf_BoolValue | null);
   /**
    * Specifies the upstream timeout for the route. If not specified, the default is 15s. This
    * spans between the point at which the entire downstream request (i.e. end-of-stream) has been
@@ -609,13 +609,13 @@ export interface RouteAction {
    * :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
    * :ref:`retry overview <arch_overview_http_routing_retry>`.
    */
-  'timeout'?: (_google_protobuf_Duration);
+  'timeout'?: (_google_protobuf_Duration | null);
   /**
    * Indicates that the route has a retry policy. Note that if this is set,
    * it'll take precedence over the virtual host level retry policy entirely
    * (e.g.: policies are not merged, most internal one becomes the enforced policy).
    */
-  'retry_policy'?: (_envoy_config_route_v3_RetryPolicy);
+  'retry_policy'?: (_envoy_config_route_v3_RetryPolicy | null);
   /**
    * Optionally specifies the :ref:`routing priority <arch_overview_http_routing_priority>`.
    */
@@ -633,7 +633,7 @@ export interface RouteAction {
    * 
    * This field is deprecated. Please use :ref:`vh_rate_limits <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimitPerRoute.vh_rate_limits>`
    */
-  'include_vh_rate_limits'?: (_google_protobuf_BoolValue);
+  'include_vh_rate_limits'?: (_google_protobuf_BoolValue | null);
   /**
    * Specifies a list of hash policies to use for ring hash load balancing. Each
    * hash policy is evaluated individually and the combined result is used to
@@ -652,7 +652,7 @@ export interface RouteAction {
   /**
    * Indicates that the route has a CORS policy.
    */
-  'cors'?: (_envoy_config_route_v3_CorsPolicy);
+  'cors'?: (_envoy_config_route_v3_CorsPolicy | null);
   /**
    * The HTTP status code to use when configured cluster is not found.
    * The default response code is 503 Service Unavailable.
@@ -680,7 +680,7 @@ export interface RouteAction {
    * :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
    * :ref:`retry overview <arch_overview_http_routing_retry>`.
    */
-  'max_grpc_timeout'?: (_google_protobuf_Duration);
+  'max_grpc_timeout'?: (_google_protobuf_Duration | null);
   /**
    * Specifies the idle timeout for the route. If not specified, there is no per-route idle timeout,
    * although the connection manager wide :ref:`stream_idle_timeout
@@ -705,7 +705,7 @@ export interface RouteAction {
    * is configured, this timeout is scaled according to the value for
    * :ref:`HTTP_DOWNSTREAM_STREAM_IDLE <envoy_api_enum_value_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType.HTTP_DOWNSTREAM_STREAM_IDLE>`.
    */
-  'idle_timeout'?: (_google_protobuf_Duration);
+  'idle_timeout'?: (_google_protobuf_Duration | null);
   'upgrade_configs'?: (_envoy_config_route_v3_RouteAction_UpgradeConfig)[];
   'internal_redirect_action'?: (_envoy_config_route_v3_RouteAction_InternalRedirectAction | keyof typeof _envoy_config_route_v3_RouteAction_InternalRedirectAction);
   /**
@@ -713,7 +713,7 @@ export interface RouteAction {
    * it'll take precedence over the virtual host level hedge policy entirely
    * (e.g.: policies are not merged, most internal one becomes the enforced policy).
    */
-  'hedge_policy'?: (_envoy_config_route_v3_HedgePolicy);
+  'hedge_policy'?: (_envoy_config_route_v3_HedgePolicy | null);
   /**
    * Deprecated by :ref:`grpc_timeout_header_offset <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`.
    * If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
@@ -724,7 +724,7 @@ export interface RouteAction {
    * ensures that the offset will only ever decrease the timeout and never set it to 0 (meaning
    * infinity).
    */
-  'grpc_timeout_offset'?: (_google_protobuf_Duration);
+  'grpc_timeout_offset'?: (_google_protobuf_Duration | null);
   /**
    * Indicates that during forwarding, the host header will be swapped with the content of given
    * downstream or :ref:`custom <config_http_conn_man_headers_custom_request_headers>` header.
@@ -760,7 +760,7 @@ export interface RouteAction {
    * 
    * If not specified, at most one redirect will be followed.
    */
-  'max_internal_redirects'?: (_google_protobuf_UInt32Value);
+  'max_internal_redirects'?: (_google_protobuf_UInt32Value | null);
   /**
    * Indicates that during forwarding, portions of the path that match the
    * pattern should be rewritten, even allowing the substitution of capture
@@ -791,7 +791,7 @@ export interface RouteAction {
    * would do a case-insensitive match and transform path ``/aaa/XxX/bbb`` to
    * ``/aaa/yyy/bbb``.
    */
-  'regex_rewrite'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute);
+  'regex_rewrite'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute | null);
   /**
    * [#not-implemented-hide:]
    * Specifies the configuration for retry policy extension. Note that if this is set, it'll take
@@ -799,14 +799,14 @@ export interface RouteAction {
    * most internal one becomes the enforced policy). :ref:`Retry policy <envoy_api_field_config.route.v3.VirtualHost.retry_policy>`
    * should not be set if this field is used.
    */
-  'retry_policy_typed_config'?: (_google_protobuf_Any);
+  'retry_policy_typed_config'?: (_google_protobuf_Any | null);
   /**
    * If present, Envoy will try to follow an upstream redirect response instead of proxying the
    * response back to the downstream. An upstream redirect response is defined
    * by :ref:`redirect_response_codes
    * <envoy_api_field_config.route.v3.InternalRedirectPolicy.redirect_response_codes>`.
    */
-  'internal_redirect_policy'?: (_envoy_config_route_v3_InternalRedirectPolicy);
+  'internal_redirect_policy'?: (_envoy_config_route_v3_InternalRedirectPolicy | null);
   /**
    * Indicates that during forwarding, the host header will be swapped with
    * the result of the regex substitution executed on path value with query and fragment removed.
@@ -824,11 +824,11 @@ export interface RouteAction {
    * 
    * Would rewrite the host header to `envoyproxy.io` given the path `/envoyproxy.io/some/path`.
    */
-  'host_rewrite_path_regex'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute);
+  'host_rewrite_path_regex'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute | null);
   /**
    * Specifies the maximum stream duration for this route.
    */
-  'max_stream_duration'?: (_envoy_config_route_v3_RouteAction_MaxStreamDuration);
+  'max_stream_duration'?: (_envoy_config_route_v3_RouteAction_MaxStreamDuration | null);
   'cluster_specifier'?: "cluster"|"cluster_header"|"weighted_clusters";
   'host_rewrite_specifier'?: "host_rewrite_literal"|"auto_host_rewrite"|"host_rewrite_header"|"host_rewrite_path_regex";
 }
@@ -865,7 +865,7 @@ export interface RouteAction__Output {
    * :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
    * for additional documentation.
    */
-  'weighted_clusters'?: (_envoy_config_route_v3_WeightedCluster__Output);
+  'weighted_clusters'?: (_envoy_config_route_v3_WeightedCluster__Output | null);
   /**
    * Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints
    * in the upstream cluster with metadata matching what's set in this field will be considered
@@ -873,7 +873,7 @@ export interface RouteAction__Output {
    * <envoy_api_field_config.route.v3.RouteAction.weighted_clusters>`, metadata will be merged, with values
    * provided there taking precedence. The filter name should be specified as *envoy.lb*.
    */
-  'metadata_match'?: (_envoy_config_core_v3_Metadata__Output);
+  'metadata_match': (_envoy_config_core_v3_Metadata__Output | null);
   /**
    * Indicates that during forwarding, the matched prefix (or path) should be
    * swapped with this value. This option allows application URLs to be rooted
@@ -920,7 +920,7 @@ export interface RouteAction__Output {
    * type *strict_dns* or *logical_dns*. Setting this to true with other cluster
    * types has no effect.
    */
-  'auto_host_rewrite'?: (_google_protobuf_BoolValue__Output);
+  'auto_host_rewrite'?: (_google_protobuf_BoolValue__Output | null);
   /**
    * Specifies the upstream timeout for the route. If not specified, the default is 15s. This
    * spans between the point at which the entire downstream request (i.e. end-of-stream) has been
@@ -934,13 +934,13 @@ export interface RouteAction__Output {
    * :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
    * :ref:`retry overview <arch_overview_http_routing_retry>`.
    */
-  'timeout'?: (_google_protobuf_Duration__Output);
+  'timeout': (_google_protobuf_Duration__Output | null);
   /**
    * Indicates that the route has a retry policy. Note that if this is set,
    * it'll take precedence over the virtual host level retry policy entirely
    * (e.g.: policies are not merged, most internal one becomes the enforced policy).
    */
-  'retry_policy'?: (_envoy_config_route_v3_RetryPolicy__Output);
+  'retry_policy': (_envoy_config_route_v3_RetryPolicy__Output | null);
   /**
    * Optionally specifies the :ref:`routing priority <arch_overview_http_routing_priority>`.
    */
@@ -958,7 +958,7 @@ export interface RouteAction__Output {
    * 
    * This field is deprecated. Please use :ref:`vh_rate_limits <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimitPerRoute.vh_rate_limits>`
    */
-  'include_vh_rate_limits'?: (_google_protobuf_BoolValue__Output);
+  'include_vh_rate_limits': (_google_protobuf_BoolValue__Output | null);
   /**
    * Specifies a list of hash policies to use for ring hash load balancing. Each
    * hash policy is evaluated individually and the combined result is used to
@@ -977,7 +977,7 @@ export interface RouteAction__Output {
   /**
    * Indicates that the route has a CORS policy.
    */
-  'cors'?: (_envoy_config_route_v3_CorsPolicy__Output);
+  'cors': (_envoy_config_route_v3_CorsPolicy__Output | null);
   /**
    * The HTTP status code to use when configured cluster is not found.
    * The default response code is 503 Service Unavailable.
@@ -1005,7 +1005,7 @@ export interface RouteAction__Output {
    * :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
    * :ref:`retry overview <arch_overview_http_routing_retry>`.
    */
-  'max_grpc_timeout'?: (_google_protobuf_Duration__Output);
+  'max_grpc_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * Specifies the idle timeout for the route. If not specified, there is no per-route idle timeout,
    * although the connection manager wide :ref:`stream_idle_timeout
@@ -1030,7 +1030,7 @@ export interface RouteAction__Output {
    * is configured, this timeout is scaled according to the value for
    * :ref:`HTTP_DOWNSTREAM_STREAM_IDLE <envoy_api_enum_value_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType.HTTP_DOWNSTREAM_STREAM_IDLE>`.
    */
-  'idle_timeout'?: (_google_protobuf_Duration__Output);
+  'idle_timeout': (_google_protobuf_Duration__Output | null);
   'upgrade_configs': (_envoy_config_route_v3_RouteAction_UpgradeConfig__Output)[];
   'internal_redirect_action': (keyof typeof _envoy_config_route_v3_RouteAction_InternalRedirectAction);
   /**
@@ -1038,7 +1038,7 @@ export interface RouteAction__Output {
    * it'll take precedence over the virtual host level hedge policy entirely
    * (e.g.: policies are not merged, most internal one becomes the enforced policy).
    */
-  'hedge_policy'?: (_envoy_config_route_v3_HedgePolicy__Output);
+  'hedge_policy': (_envoy_config_route_v3_HedgePolicy__Output | null);
   /**
    * Deprecated by :ref:`grpc_timeout_header_offset <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`.
    * If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
@@ -1049,7 +1049,7 @@ export interface RouteAction__Output {
    * ensures that the offset will only ever decrease the timeout and never set it to 0 (meaning
    * infinity).
    */
-  'grpc_timeout_offset'?: (_google_protobuf_Duration__Output);
+  'grpc_timeout_offset': (_google_protobuf_Duration__Output | null);
   /**
    * Indicates that during forwarding, the host header will be swapped with the content of given
    * downstream or :ref:`custom <config_http_conn_man_headers_custom_request_headers>` header.
@@ -1085,7 +1085,7 @@ export interface RouteAction__Output {
    * 
    * If not specified, at most one redirect will be followed.
    */
-  'max_internal_redirects'?: (_google_protobuf_UInt32Value__Output);
+  'max_internal_redirects': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Indicates that during forwarding, portions of the path that match the
    * pattern should be rewritten, even allowing the substitution of capture
@@ -1116,7 +1116,7 @@ export interface RouteAction__Output {
    * would do a case-insensitive match and transform path ``/aaa/XxX/bbb`` to
    * ``/aaa/yyy/bbb``.
    */
-  'regex_rewrite'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute__Output);
+  'regex_rewrite': (_envoy_type_matcher_v3_RegexMatchAndSubstitute__Output | null);
   /**
    * [#not-implemented-hide:]
    * Specifies the configuration for retry policy extension. Note that if this is set, it'll take
@@ -1124,14 +1124,14 @@ export interface RouteAction__Output {
    * most internal one becomes the enforced policy). :ref:`Retry policy <envoy_api_field_config.route.v3.VirtualHost.retry_policy>`
    * should not be set if this field is used.
    */
-  'retry_policy_typed_config'?: (_google_protobuf_Any__Output);
+  'retry_policy_typed_config': (_google_protobuf_Any__Output | null);
   /**
    * If present, Envoy will try to follow an upstream redirect response instead of proxying the
    * response back to the downstream. An upstream redirect response is defined
    * by :ref:`redirect_response_codes
    * <envoy_api_field_config.route.v3.InternalRedirectPolicy.redirect_response_codes>`.
    */
-  'internal_redirect_policy'?: (_envoy_config_route_v3_InternalRedirectPolicy__Output);
+  'internal_redirect_policy': (_envoy_config_route_v3_InternalRedirectPolicy__Output | null);
   /**
    * Indicates that during forwarding, the host header will be swapped with
    * the result of the regex substitution executed on path value with query and fragment removed.
@@ -1149,11 +1149,11 @@ export interface RouteAction__Output {
    * 
    * Would rewrite the host header to `envoyproxy.io` given the path `/envoyproxy.io/some/path`.
    */
-  'host_rewrite_path_regex'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute__Output);
+  'host_rewrite_path_regex'?: (_envoy_type_matcher_v3_RegexMatchAndSubstitute__Output | null);
   /**
    * Specifies the maximum stream duration for this route.
    */
-  'max_stream_duration'?: (_envoy_config_route_v3_RouteAction_MaxStreamDuration__Output);
+  'max_stream_duration': (_envoy_config_route_v3_RouteAction_MaxStreamDuration__Output | null);
   'cluster_specifier': "cluster"|"cluster_header"|"weighted_clusters";
   'host_rewrite_specifier': "host_rewrite_literal"|"auto_host_rewrite"|"host_rewrite_header"|"host_rewrite_path_regex";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteConfiguration.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteConfiguration.ts
@@ -66,7 +66,7 @@ export interface RouteConfiguration {
    * option. Users may wish to override the default behavior in certain cases (for example when
    * using CDS with a static route table).
    */
-  'validate_clusters'?: (_google_protobuf_BoolValue);
+  'validate_clusters'?: (_google_protobuf_BoolValue | null);
   /**
    * Specifies a list of HTTP headers that should be removed from each request
    * routed by the HTTP connection manager.
@@ -80,7 +80,7 @@ export interface RouteConfiguration {
    * generate a routing table for a given RouteConfiguration, with *vhds* derived configuration
    * taking precedence.
    */
-  'vhds'?: (_envoy_config_route_v3_Vhds);
+  'vhds'?: (_envoy_config_route_v3_Vhds | null);
   /**
    * By default, headers that should be added/removed are evaluated from most to least specific:
    * 
@@ -106,7 +106,7 @@ export interface RouteConfiguration {
    * this to be larger than the default 4KB, since the allocated memory for direct response body
    * is not subject to data plane buffering controls.
    */
-  'max_direct_response_body_size_bytes'?: (_google_protobuf_UInt32Value);
+  'max_direct_response_body_size_bytes'?: (_google_protobuf_UInt32Value | null);
 }
 
 /**
@@ -169,7 +169,7 @@ export interface RouteConfiguration__Output {
    * option. Users may wish to override the default behavior in certain cases (for example when
    * using CDS with a static route table).
    */
-  'validate_clusters'?: (_google_protobuf_BoolValue__Output);
+  'validate_clusters': (_google_protobuf_BoolValue__Output | null);
   /**
    * Specifies a list of HTTP headers that should be removed from each request
    * routed by the HTTP connection manager.
@@ -183,7 +183,7 @@ export interface RouteConfiguration__Output {
    * generate a routing table for a given RouteConfiguration, with *vhds* derived configuration
    * taking precedence.
    */
-  'vhds'?: (_envoy_config_route_v3_Vhds__Output);
+  'vhds': (_envoy_config_route_v3_Vhds__Output | null);
   /**
    * By default, headers that should be added/removed are evaluated from most to least specific:
    * 
@@ -209,5 +209,5 @@ export interface RouteConfiguration__Output {
    * this to be larger than the default 4KB, since the allocated memory for direct response body
    * is not subject to data plane buffering controls.
    */
-  'max_direct_response_body_size_bytes'?: (_google_protobuf_UInt32Value__Output);
+  'max_direct_response_body_size_bytes': (_google_protobuf_UInt32Value__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteMatch.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteMatch.ts
@@ -29,12 +29,12 @@ export interface _envoy_config_route_v3_RouteMatch_TlsContextMatchOptions {
    * If specified, the route will match against whether or not a certificate is presented.
    * If not specified, certificate presentation status (true or false) will not be considered when route matching.
    */
-  'presented'?: (_google_protobuf_BoolValue);
+  'presented'?: (_google_protobuf_BoolValue | null);
   /**
    * If specified, the route will match against whether or not a certificate is validated.
    * If not specified, certificate validation status (true or false) will not be considered when route matching.
    */
-  'validated'?: (_google_protobuf_BoolValue);
+  'validated'?: (_google_protobuf_BoolValue | null);
 }
 
 export interface _envoy_config_route_v3_RouteMatch_TlsContextMatchOptions__Output {
@@ -42,12 +42,12 @@ export interface _envoy_config_route_v3_RouteMatch_TlsContextMatchOptions__Outpu
    * If specified, the route will match against whether or not a certificate is presented.
    * If not specified, certificate presentation status (true or false) will not be considered when route matching.
    */
-  'presented'?: (_google_protobuf_BoolValue__Output);
+  'presented': (_google_protobuf_BoolValue__Output | null);
   /**
    * If specified, the route will match against whether or not a certificate is validated.
    * If not specified, certificate validation status (true or false) will not be considered when route matching.
    */
-  'validated'?: (_google_protobuf_BoolValue__Output);
+  'validated': (_google_protobuf_BoolValue__Output | null);
 }
 
 /**
@@ -68,7 +68,7 @@ export interface RouteMatch {
    * Indicates that prefix/path matching should be case sensitive. The default
    * is true.
    */
-  'case_sensitive'?: (_google_protobuf_BoolValue);
+  'case_sensitive'?: (_google_protobuf_BoolValue | null);
   /**
    * Specifies a set of headers that the route should match on. The router will
    * check the request’s headers against all the specified headers in the route
@@ -90,7 +90,7 @@ export interface RouteMatch {
    * that the content-type header has a application/grpc or one of the various
    * application/grpc+ values.
    */
-  'grpc'?: (_envoy_config_route_v3_RouteMatch_GrpcRouteMatchOptions);
+  'grpc'?: (_envoy_config_route_v3_RouteMatch_GrpcRouteMatchOptions | null);
   /**
    * Indicates that the route should additionally match on a runtime key. Every time the route
    * is considered for a match, it must also fall under the percentage of matches indicated by
@@ -109,7 +109,7 @@ export interface RouteMatch {
    * instance, a runtime key lookup returning the value "42" would parse as a FractionalPercent
    * whose numerator is 42 and denominator is HUNDRED. This preserves legacy semantics.
    */
-  'runtime_fraction'?: (_envoy_config_core_v3_RuntimeFractionalPercent);
+  'runtime_fraction'?: (_envoy_config_core_v3_RuntimeFractionalPercent | null);
   /**
    * If specified, the route is a regular expression rule meaning that the
    * regex must match the *:path* header once the query string is removed. The entire path
@@ -124,14 +124,14 @@ export interface RouteMatch {
    * on :path, etc. The issue with that is it is unclear how to generically deal with query string
    * stripping. This needs more thought.]
    */
-  'safe_regex'?: (_envoy_type_matcher_v3_RegexMatcher);
+  'safe_regex'?: (_envoy_type_matcher_v3_RegexMatcher | null);
   /**
    * If specified, the client tls context will be matched against the defined
    * match options.
    * 
    * [#next-major-version: unify with RBAC]
    */
-  'tls_context'?: (_envoy_config_route_v3_RouteMatch_TlsContextMatchOptions);
+  'tls_context'?: (_envoy_config_route_v3_RouteMatch_TlsContextMatchOptions | null);
   /**
    * If this is used as the matcher, the matcher will only match CONNECT requests.
    * Note that this will not match HTTP/2 upgrade-style CONNECT requests
@@ -143,7 +143,7 @@ export interface RouteMatch {
    * Note that CONNECT support is currently considered alpha in Envoy.
    * [#comment:TODO(htuch): Replace the above comment with an alpha tag.
    */
-  'connect_matcher'?: (_envoy_config_route_v3_RouteMatch_ConnectMatcher);
+  'connect_matcher'?: (_envoy_config_route_v3_RouteMatch_ConnectMatcher | null);
   'path_specifier'?: "prefix"|"path"|"safe_regex"|"connect_matcher";
 }
 
@@ -165,7 +165,7 @@ export interface RouteMatch__Output {
    * Indicates that prefix/path matching should be case sensitive. The default
    * is true.
    */
-  'case_sensitive'?: (_google_protobuf_BoolValue__Output);
+  'case_sensitive': (_google_protobuf_BoolValue__Output | null);
   /**
    * Specifies a set of headers that the route should match on. The router will
    * check the request’s headers against all the specified headers in the route
@@ -187,7 +187,7 @@ export interface RouteMatch__Output {
    * that the content-type header has a application/grpc or one of the various
    * application/grpc+ values.
    */
-  'grpc'?: (_envoy_config_route_v3_RouteMatch_GrpcRouteMatchOptions__Output);
+  'grpc': (_envoy_config_route_v3_RouteMatch_GrpcRouteMatchOptions__Output | null);
   /**
    * Indicates that the route should additionally match on a runtime key. Every time the route
    * is considered for a match, it must also fall under the percentage of matches indicated by
@@ -206,7 +206,7 @@ export interface RouteMatch__Output {
    * instance, a runtime key lookup returning the value "42" would parse as a FractionalPercent
    * whose numerator is 42 and denominator is HUNDRED. This preserves legacy semantics.
    */
-  'runtime_fraction'?: (_envoy_config_core_v3_RuntimeFractionalPercent__Output);
+  'runtime_fraction': (_envoy_config_core_v3_RuntimeFractionalPercent__Output | null);
   /**
    * If specified, the route is a regular expression rule meaning that the
    * regex must match the *:path* header once the query string is removed. The entire path
@@ -221,14 +221,14 @@ export interface RouteMatch__Output {
    * on :path, etc. The issue with that is it is unclear how to generically deal with query string
    * stripping. This needs more thought.]
    */
-  'safe_regex'?: (_envoy_type_matcher_v3_RegexMatcher__Output);
+  'safe_regex'?: (_envoy_type_matcher_v3_RegexMatcher__Output | null);
   /**
    * If specified, the client tls context will be matched against the defined
    * match options.
    * 
    * [#next-major-version: unify with RBAC]
    */
-  'tls_context'?: (_envoy_config_route_v3_RouteMatch_TlsContextMatchOptions__Output);
+  'tls_context': (_envoy_config_route_v3_RouteMatch_TlsContextMatchOptions__Output | null);
   /**
    * If this is used as the matcher, the matcher will only match CONNECT requests.
    * Note that this will not match HTTP/2 upgrade-style CONNECT requests
@@ -240,6 +240,6 @@ export interface RouteMatch__Output {
    * Note that CONNECT support is currently considered alpha in Envoy.
    * [#comment:TODO(htuch): Replace the above comment with an alpha tag.
    */
-  'connect_matcher'?: (_envoy_config_route_v3_RouteMatch_ConnectMatcher__Output);
+  'connect_matcher'?: (_envoy_config_route_v3_RouteMatch_ConnectMatcher__Output | null);
   'path_specifier': "prefix"|"path"|"safe_regex"|"connect_matcher";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/ScopedRouteConfiguration.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/ScopedRouteConfiguration.ts
@@ -123,7 +123,7 @@ export interface ScopedRouteConfiguration {
   /**
    * The key to match against.
    */
-  'key'?: (_envoy_config_route_v3_ScopedRouteConfiguration_Key);
+  'key'?: (_envoy_config_route_v3_ScopedRouteConfiguration_Key | null);
   /**
    * Whether the RouteConfiguration should be loaded on demand.
    */
@@ -204,7 +204,7 @@ export interface ScopedRouteConfiguration__Output {
   /**
    * The key to match against.
    */
-  'key'?: (_envoy_config_route_v3_ScopedRouteConfiguration_Key__Output);
+  'key': (_envoy_config_route_v3_ScopedRouteConfiguration_Key__Output | null);
   /**
    * Whether the RouteConfiguration should be loaded on demand.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Tracing.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Tracing.ts
@@ -12,7 +12,7 @@ export interface Tracing {
    * <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'client_sampling'?: (_envoy_type_v3_FractionalPercent);
+  'client_sampling'?: (_envoy_type_v3_FractionalPercent | null);
   /**
    * Target percentage of requests managed by this HTTP connection manager that will be randomly
    * selected for trace generation, if not requested by the client or not forced. This field is
@@ -20,7 +20,7 @@ export interface Tracing {
    * :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'random_sampling'?: (_envoy_type_v3_FractionalPercent);
+  'random_sampling'?: (_envoy_type_v3_FractionalPercent | null);
   /**
    * Target percentage of requests managed by this HTTP connection manager that will be traced
    * after all other sampling checks have been applied (client-directed, force tracing, random
@@ -31,7 +31,7 @@ export interface Tracing {
    * :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'overall_sampling'?: (_envoy_type_v3_FractionalPercent);
+  'overall_sampling'?: (_envoy_type_v3_FractionalPercent | null);
   /**
    * A list of custom tags with unique tag name to create tags for the active span.
    * It will take effect after merging with the :ref:`corresponding configuration
@@ -52,7 +52,7 @@ export interface Tracing__Output {
    * <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'client_sampling'?: (_envoy_type_v3_FractionalPercent__Output);
+  'client_sampling': (_envoy_type_v3_FractionalPercent__Output | null);
   /**
    * Target percentage of requests managed by this HTTP connection manager that will be randomly
    * selected for trace generation, if not requested by the client or not forced. This field is
@@ -60,7 +60,7 @@ export interface Tracing__Output {
    * :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'random_sampling'?: (_envoy_type_v3_FractionalPercent__Output);
+  'random_sampling': (_envoy_type_v3_FractionalPercent__Output | null);
   /**
    * Target percentage of requests managed by this HTTP connection manager that will be traced
    * after all other sampling checks have been applied (client-directed, force tracing, random
@@ -71,7 +71,7 @@ export interface Tracing__Output {
    * :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'overall_sampling'?: (_envoy_type_v3_FractionalPercent__Output);
+  'overall_sampling': (_envoy_type_v3_FractionalPercent__Output | null);
   /**
    * A list of custom tags with unique tag name to create tags for the active span.
    * It will take effect after merging with the :ref:`corresponding configuration

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Vhds.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Vhds.ts
@@ -6,12 +6,12 @@ export interface Vhds {
   /**
    * Configuration source specifier for VHDS.
    */
-  'config_source'?: (_envoy_config_core_v3_ConfigSource);
+  'config_source'?: (_envoy_config_core_v3_ConfigSource | null);
 }
 
 export interface Vhds__Output {
   /**
    * Configuration source specifier for VHDS.
    */
-  'config_source'?: (_envoy_config_core_v3_ConfigSource__Output);
+  'config_source': (_envoy_config_core_v3_ConfigSource__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/VirtualHost.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/VirtualHost.ts
@@ -96,7 +96,7 @@ export interface VirtualHost {
   /**
    * Indicates that the virtual host has a CORS policy.
    */
-  'cors'?: (_envoy_config_route_v3_CorsPolicy);
+  'cors'?: (_envoy_config_route_v3_CorsPolicy | null);
   /**
    * Specifies a list of HTTP headers that should be added to each response
    * handled by this virtual host. Headers specified at this level are applied
@@ -145,19 +145,19 @@ export interface VirtualHost {
    * route level entry will take precedence over this config and it'll be treated
    * independently (e.g.: values are not inherited).
    */
-  'retry_policy'?: (_envoy_config_route_v3_RetryPolicy);
+  'retry_policy'?: (_envoy_config_route_v3_RetryPolicy | null);
   /**
    * Indicates the hedge policy for all routes in this virtual host. Note that setting a
    * route level entry will take precedence over this config and it'll be treated
    * independently (e.g.: values are not inherited).
    */
-  'hedge_policy'?: (_envoy_config_route_v3_HedgePolicy);
+  'hedge_policy'?: (_envoy_config_route_v3_HedgePolicy | null);
   /**
    * The maximum bytes which will be buffered for retries and shadowing.
    * If set and a route-specific limit is not set, the bytes actually buffered will be the minimum
    * value of this and the listener per_connection_buffer_limit_bytes.
    */
-  'per_request_buffer_limit_bytes'?: (_google_protobuf_UInt32Value);
+  'per_request_buffer_limit_bytes'?: (_google_protobuf_UInt32Value | null);
   /**
    * Decides whether the :ref:`x-envoy-attempt-count
    * <config_http_filters_router_x-envoy-attempt-count>` header should be included
@@ -176,7 +176,7 @@ export interface VirtualHost {
    * inherited). :ref:`Retry policy <envoy_api_field_config.route.v3.VirtualHost.retry_policy>` should not be
    * set if this field is used.
    */
-  'retry_policy_typed_config'?: (_google_protobuf_Any);
+  'retry_policy_typed_config'?: (_google_protobuf_Any | null);
 }
 
 /**
@@ -246,7 +246,7 @@ export interface VirtualHost__Output {
   /**
    * Indicates that the virtual host has a CORS policy.
    */
-  'cors'?: (_envoy_config_route_v3_CorsPolicy__Output);
+  'cors': (_envoy_config_route_v3_CorsPolicy__Output | null);
   /**
    * Specifies a list of HTTP headers that should be added to each response
    * handled by this virtual host. Headers specified at this level are applied
@@ -289,25 +289,25 @@ export interface VirtualHost__Output {
    * :ref:`FilterConfig<envoy_api_msg_config.route.v3.FilterConfig>`
    * message to specify additional options.]
    */
-  'typed_per_filter_config'?: ({[key: string]: _google_protobuf_Any__Output});
+  'typed_per_filter_config': ({[key: string]: _google_protobuf_Any__Output});
   /**
    * Indicates the retry policy for all routes in this virtual host. Note that setting a
    * route level entry will take precedence over this config and it'll be treated
    * independently (e.g.: values are not inherited).
    */
-  'retry_policy'?: (_envoy_config_route_v3_RetryPolicy__Output);
+  'retry_policy': (_envoy_config_route_v3_RetryPolicy__Output | null);
   /**
    * Indicates the hedge policy for all routes in this virtual host. Note that setting a
    * route level entry will take precedence over this config and it'll be treated
    * independently (e.g.: values are not inherited).
    */
-  'hedge_policy'?: (_envoy_config_route_v3_HedgePolicy__Output);
+  'hedge_policy': (_envoy_config_route_v3_HedgePolicy__Output | null);
   /**
    * The maximum bytes which will be buffered for retries and shadowing.
    * If set and a route-specific limit is not set, the bytes actually buffered will be the minimum
    * value of this and the listener per_connection_buffer_limit_bytes.
    */
-  'per_request_buffer_limit_bytes'?: (_google_protobuf_UInt32Value__Output);
+  'per_request_buffer_limit_bytes': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Decides whether the :ref:`x-envoy-attempt-count
    * <config_http_filters_router_x-envoy-attempt-count>` header should be included
@@ -326,5 +326,5 @@ export interface VirtualHost__Output {
    * inherited). :ref:`Retry policy <envoy_api_field_config.route.v3.VirtualHost.retry_policy>` should not be
    * set if this field is used.
    */
-  'retry_policy_typed_config'?: (_google_protobuf_Any__Output);
+  'retry_policy_typed_config': (_google_protobuf_Any__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/WeightedCluster.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/WeightedCluster.ts
@@ -20,7 +20,7 @@ export interface _envoy_config_route_v3_WeightedCluster_ClusterWeight {
    * the choice of an upstream cluster is determined by its weight. The sum of weights across all
    * entries in the clusters array must add up to the total_weight, which defaults to 100.
    */
-  'weight'?: (_google_protobuf_UInt32Value);
+  'weight'?: (_google_protobuf_UInt32Value | null);
   /**
    * Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in
    * the upstream cluster with metadata matching what is set in this field will be considered for
@@ -28,7 +28,7 @@ export interface _envoy_config_route_v3_WeightedCluster_ClusterWeight {
    * :ref:`RouteAction.metadata_match <envoy_api_field_config.route.v3.RouteAction.metadata_match>`, with
    * values here taking precedence. The filter name should be specified as *envoy.lb*.
    */
-  'metadata_match'?: (_envoy_config_core_v3_Metadata);
+  'metadata_match'?: (_envoy_config_core_v3_Metadata | null);
   /**
    * Specifies a list of headers to be added to requests when this cluster is selected
    * through the enclosing :ref:`envoy_api_msg_config.route.v3.RouteAction`.
@@ -87,7 +87,7 @@ export interface _envoy_config_route_v3_WeightedCluster_ClusterWeight__Output {
    * the choice of an upstream cluster is determined by its weight. The sum of weights across all
    * entries in the clusters array must add up to the total_weight, which defaults to 100.
    */
-  'weight'?: (_google_protobuf_UInt32Value__Output);
+  'weight': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in
    * the upstream cluster with metadata matching what is set in this field will be considered for
@@ -95,7 +95,7 @@ export interface _envoy_config_route_v3_WeightedCluster_ClusterWeight__Output {
    * :ref:`RouteAction.metadata_match <envoy_api_field_config.route.v3.RouteAction.metadata_match>`, with
    * values here taking precedence. The filter name should be specified as *envoy.lb*.
    */
-  'metadata_match'?: (_envoy_config_core_v3_Metadata__Output);
+  'metadata_match': (_envoy_config_core_v3_Metadata__Output | null);
   /**
    * Specifies a list of headers to be added to requests when this cluster is selected
    * through the enclosing :ref:`envoy_api_msg_config.route.v3.RouteAction`.
@@ -136,7 +136,7 @@ export interface _envoy_config_route_v3_WeightedCluster_ClusterWeight__Output {
    * :ref:`FilterConfig<envoy_api_msg_config.route.v3.FilterConfig>`
    * message to specify additional options.]
    */
-  'typed_per_filter_config'?: ({[key: string]: _google_protobuf_Any__Output});
+  'typed_per_filter_config': ({[key: string]: _google_protobuf_Any__Output});
 }
 
 /**
@@ -167,7 +167,7 @@ export interface WeightedCluster {
    * Specifies the total weight across all clusters. The sum of all cluster weights must equal this
    * value, which must be greater than 0. Defaults to 100.
    */
-  'total_weight'?: (_google_protobuf_UInt32Value);
+  'total_weight'?: (_google_protobuf_UInt32Value | null);
 }
 
 /**
@@ -198,5 +198,5 @@ export interface WeightedCluster__Output {
    * Specifies the total weight across all clusters. The sum of all cluster weights must equal this
    * value, which must be greater than 0. Defaults to 100.
    */
-  'total_weight'?: (_google_protobuf_UInt32Value__Output);
+  'total_weight': (_google_protobuf_UInt32Value__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/trace/v3/Tracing.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/trace/v3/Tracing.ts
@@ -23,7 +23,7 @@ export interface _envoy_config_trace_v3_Tracing_Http {
    * - *envoy.tracers.xray*
    */
   'name'?: (string);
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
   /**
    * Trace driver specific configuration which depends on the driver being instantiated.
    * See the trace drivers for examples:
@@ -59,7 +59,7 @@ export interface _envoy_config_trace_v3_Tracing_Http__Output {
    * - *envoy.tracers.xray*
    */
   'name': (string);
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   /**
    * Trace driver specific configuration which depends on the driver being instantiated.
    * See the trace drivers for examples:
@@ -89,7 +89,7 @@ export interface Tracing {
   /**
    * Provides configuration for the HTTP tracer.
    */
-  'http'?: (_envoy_config_trace_v3_Tracing_Http);
+  'http'?: (_envoy_config_trace_v3_Tracing_Http | null);
 }
 
 /**
@@ -107,5 +107,5 @@ export interface Tracing__Output {
   /**
    * Provides configuration for the HTTP tracer.
    */
-  'http'?: (_envoy_config_trace_v3_Tracing_Http__Output);
+  'http': (_envoy_config_trace_v3_Tracing_Http__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/common/fault/v3/FaultDelay.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/common/fault/v3/FaultDelay.ts
@@ -1,0 +1,81 @@
+// Original file: deps/envoy-api/envoy/extensions/filters/common/fault/v3/fault.proto
+
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../../../../google/protobuf/Duration';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from '../../../../../../envoy/type/v3/FractionalPercent';
+
+// Original file: deps/envoy-api/envoy/extensions/filters/common/fault/v3/fault.proto
+
+export enum _envoy_extensions_filters_common_fault_v3_FaultDelay_FaultDelayType {
+  /**
+   * Unused and deprecated.
+   */
+  FIXED = 0,
+}
+
+/**
+ * Fault delays are controlled via an HTTP header (if applicable). See the
+ * :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
+ * more information.
+ */
+export interface _envoy_extensions_filters_common_fault_v3_FaultDelay_HeaderDelay {
+}
+
+/**
+ * Fault delays are controlled via an HTTP header (if applicable). See the
+ * :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
+ * more information.
+ */
+export interface _envoy_extensions_filters_common_fault_v3_FaultDelay_HeaderDelay__Output {
+}
+
+/**
+ * Delay specification is used to inject latency into the
+ * HTTP/gRPC/Mongo/Redis operation or delay proxying of TCP connections.
+ * [#next-free-field: 6]
+ */
+export interface FaultDelay {
+  /**
+   * Add a fixed delay before forwarding the operation upstream. See
+   * https://developers.google.com/protocol-buffers/docs/proto3#json for
+   * the JSON/YAML Duration mapping. For HTTP/Mongo/Redis, the specified
+   * delay will be injected before a new request/operation. For TCP
+   * connections, the proxying of the connection upstream will be delayed
+   * for the specified period. This is required if type is FIXED.
+   */
+  'fixed_delay'?: (_google_protobuf_Duration | null);
+  /**
+   * The percentage of operations/connections/requests on which the delay will be injected.
+   */
+  'percentage'?: (_envoy_type_v3_FractionalPercent | null);
+  /**
+   * Fault delays are controlled via an HTTP header (if applicable).
+   */
+  'header_delay'?: (_envoy_extensions_filters_common_fault_v3_FaultDelay_HeaderDelay | null);
+  'fault_delay_secifier'?: "fixed_delay"|"header_delay";
+}
+
+/**
+ * Delay specification is used to inject latency into the
+ * HTTP/gRPC/Mongo/Redis operation or delay proxying of TCP connections.
+ * [#next-free-field: 6]
+ */
+export interface FaultDelay__Output {
+  /**
+   * Add a fixed delay before forwarding the operation upstream. See
+   * https://developers.google.com/protocol-buffers/docs/proto3#json for
+   * the JSON/YAML Duration mapping. For HTTP/Mongo/Redis, the specified
+   * delay will be injected before a new request/operation. For TCP
+   * connections, the proxying of the connection upstream will be delayed
+   * for the specified period. This is required if type is FIXED.
+   */
+  'fixed_delay'?: (_google_protobuf_Duration__Output | null);
+  /**
+   * The percentage of operations/connections/requests on which the delay will be injected.
+   */
+  'percentage': (_envoy_type_v3_FractionalPercent__Output | null);
+  /**
+   * Fault delays are controlled via an HTTP header (if applicable).
+   */
+  'header_delay'?: (_envoy_extensions_filters_common_fault_v3_FaultDelay_HeaderDelay__Output | null);
+  'fault_delay_secifier': "fixed_delay"|"header_delay";
+}

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/common/fault/v3/FaultRateLimit.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/common/fault/v3/FaultRateLimit.ts
@@ -1,0 +1,78 @@
+// Original file: deps/envoy-api/envoy/extensions/filters/common/fault/v3/fault.proto
+
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from '../../../../../../envoy/type/v3/FractionalPercent';
+import type { Long } from '@grpc/proto-loader';
+
+/**
+ * Describes a fixed/constant rate limit.
+ */
+export interface _envoy_extensions_filters_common_fault_v3_FaultRateLimit_FixedLimit {
+  /**
+   * The limit supplied in KiB/s.
+   */
+  'limit_kbps'?: (number | string | Long);
+}
+
+/**
+ * Describes a fixed/constant rate limit.
+ */
+export interface _envoy_extensions_filters_common_fault_v3_FaultRateLimit_FixedLimit__Output {
+  /**
+   * The limit supplied in KiB/s.
+   */
+  'limit_kbps': (string);
+}
+
+/**
+ * Rate limits are controlled via an HTTP header (if applicable). See the
+ * :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
+ * more information.
+ */
+export interface _envoy_extensions_filters_common_fault_v3_FaultRateLimit_HeaderLimit {
+}
+
+/**
+ * Rate limits are controlled via an HTTP header (if applicable). See the
+ * :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
+ * more information.
+ */
+export interface _envoy_extensions_filters_common_fault_v3_FaultRateLimit_HeaderLimit__Output {
+}
+
+/**
+ * Describes a rate limit to be applied.
+ */
+export interface FaultRateLimit {
+  /**
+   * A fixed rate limit.
+   */
+  'fixed_limit'?: (_envoy_extensions_filters_common_fault_v3_FaultRateLimit_FixedLimit | null);
+  /**
+   * The percentage of operations/connections/requests on which the rate limit will be injected.
+   */
+  'percentage'?: (_envoy_type_v3_FractionalPercent | null);
+  /**
+   * Rate limits are controlled via an HTTP header (if applicable).
+   */
+  'header_limit'?: (_envoy_extensions_filters_common_fault_v3_FaultRateLimit_HeaderLimit | null);
+  'limit_type'?: "fixed_limit"|"header_limit";
+}
+
+/**
+ * Describes a rate limit to be applied.
+ */
+export interface FaultRateLimit__Output {
+  /**
+   * A fixed rate limit.
+   */
+  'fixed_limit'?: (_envoy_extensions_filters_common_fault_v3_FaultRateLimit_FixedLimit__Output | null);
+  /**
+   * The percentage of operations/connections/requests on which the rate limit will be injected.
+   */
+  'percentage': (_envoy_type_v3_FractionalPercent__Output | null);
+  /**
+   * Rate limits are controlled via an HTTP header (if applicable).
+   */
+  'header_limit'?: (_envoy_extensions_filters_common_fault_v3_FaultRateLimit_HeaderLimit__Output | null);
+  'limit_type': "fixed_limit"|"header_limit";
+}

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/http/fault/v3/FaultAbort.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/http/fault/v3/FaultAbort.ts
@@ -1,0 +1,67 @@
+// Original file: deps/envoy-api/envoy/extensions/filters/http/fault/v3/fault.proto
+
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from '../../../../../../envoy/type/v3/FractionalPercent';
+
+/**
+ * Fault aborts are controlled via an HTTP header (if applicable). See the
+ * :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
+ * more information.
+ */
+export interface _envoy_extensions_filters_http_fault_v3_FaultAbort_HeaderAbort {
+}
+
+/**
+ * Fault aborts are controlled via an HTTP header (if applicable). See the
+ * :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
+ * more information.
+ */
+export interface _envoy_extensions_filters_http_fault_v3_FaultAbort_HeaderAbort__Output {
+}
+
+/**
+ * [#next-free-field: 6]
+ */
+export interface FaultAbort {
+  /**
+   * HTTP status code to use to abort the HTTP request.
+   */
+  'http_status'?: (number);
+  /**
+   * The percentage of requests/operations/connections that will be aborted with the error code
+   * provided.
+   */
+  'percentage'?: (_envoy_type_v3_FractionalPercent | null);
+  /**
+   * Fault aborts are controlled via an HTTP header (if applicable).
+   */
+  'header_abort'?: (_envoy_extensions_filters_http_fault_v3_FaultAbort_HeaderAbort | null);
+  /**
+   * gRPC status code to use to abort the gRPC request.
+   */
+  'grpc_status'?: (number);
+  'error_type'?: "http_status"|"grpc_status"|"header_abort";
+}
+
+/**
+ * [#next-free-field: 6]
+ */
+export interface FaultAbort__Output {
+  /**
+   * HTTP status code to use to abort the HTTP request.
+   */
+  'http_status'?: (number);
+  /**
+   * The percentage of requests/operations/connections that will be aborted with the error code
+   * provided.
+   */
+  'percentage': (_envoy_type_v3_FractionalPercent__Output | null);
+  /**
+   * Fault aborts are controlled via an HTTP header (if applicable).
+   */
+  'header_abort'?: (_envoy_extensions_filters_http_fault_v3_FaultAbort_HeaderAbort__Output | null);
+  /**
+   * gRPC status code to use to abort the gRPC request.
+   */
+  'grpc_status'?: (number);
+  'error_type': "http_status"|"grpc_status"|"header_abort";
+}

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/http/fault/v3/HTTPFault.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/http/fault/v3/HTTPFault.ts
@@ -1,0 +1,213 @@
+// Original file: deps/envoy-api/envoy/extensions/filters/http/fault/v3/fault.proto
+
+import type { FaultDelay as _envoy_extensions_filters_common_fault_v3_FaultDelay, FaultDelay__Output as _envoy_extensions_filters_common_fault_v3_FaultDelay__Output } from '../../../../../../envoy/extensions/filters/common/fault/v3/FaultDelay';
+import type { FaultAbort as _envoy_extensions_filters_http_fault_v3_FaultAbort, FaultAbort__Output as _envoy_extensions_filters_http_fault_v3_FaultAbort__Output } from '../../../../../../envoy/extensions/filters/http/fault/v3/FaultAbort';
+import type { HeaderMatcher as _envoy_config_route_v3_HeaderMatcher, HeaderMatcher__Output as _envoy_config_route_v3_HeaderMatcher__Output } from '../../../../../../envoy/config/route/v3/HeaderMatcher';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from '../../../../../../google/protobuf/UInt32Value';
+import type { FaultRateLimit as _envoy_extensions_filters_common_fault_v3_FaultRateLimit, FaultRateLimit__Output as _envoy_extensions_filters_common_fault_v3_FaultRateLimit__Output } from '../../../../../../envoy/extensions/filters/common/fault/v3/FaultRateLimit';
+
+/**
+ * [#next-free-field: 15]
+ */
+export interface HTTPFault {
+  /**
+   * If specified, the filter will inject delays based on the values in the
+   * object.
+   */
+  'delay'?: (_envoy_extensions_filters_common_fault_v3_FaultDelay | null);
+  /**
+   * If specified, the filter will abort requests based on the values in
+   * the object. At least *abort* or *delay* must be specified.
+   */
+  'abort'?: (_envoy_extensions_filters_http_fault_v3_FaultAbort | null);
+  /**
+   * Specifies the name of the (destination) upstream cluster that the
+   * filter should match on. Fault injection will be restricted to requests
+   * bound to the specific upstream cluster.
+   */
+  'upstream_cluster'?: (string);
+  /**
+   * Specifies a set of headers that the filter should match on. The fault
+   * injection filter can be applied selectively to requests that match a set of
+   * headers specified in the fault filter config. The chances of actual fault
+   * injection further depend on the value of the :ref:`percentage
+   * <envoy_api_field_extensions.filters.http.fault.v3.FaultAbort.percentage>` field.
+   * The filter will check the request's headers against all the specified
+   * headers in the filter config. A match will happen if all the headers in the
+   * config are present in the request with the same values (or based on
+   * presence if the *value* field is not in the config).
+   */
+  'headers'?: (_envoy_config_route_v3_HeaderMatcher)[];
+  /**
+   * Faults are injected for the specified list of downstream hosts. If this
+   * setting is not set, faults are injected for all downstream nodes.
+   * Downstream node name is taken from :ref:`the HTTP
+   * x-envoy-downstream-service-node
+   * <config_http_conn_man_headers_downstream-service-node>` header and compared
+   * against downstream_nodes list.
+   */
+  'downstream_nodes'?: (string)[];
+  /**
+   * The maximum number of faults that can be active at a single time via the configured fault
+   * filter. Note that because this setting can be overridden at the route level, it's possible
+   * for the number of active faults to be greater than this value (if injected via a different
+   * route). If not specified, defaults to unlimited. This setting can be overridden via
+   * `runtime <config_http_filters_fault_injection_runtime>` and any faults that are not injected
+   * due to overflow will be indicated via the `faults_overflow
+   * <config_http_filters_fault_injection_stats>` stat.
+   * 
+   * .. attention::
+   * Like other :ref:`circuit breakers <arch_overview_circuit_break>` in Envoy, this is a fuzzy
+   * limit. It's possible for the number of active faults to rise slightly above the configured
+   * amount due to the implementation details.
+   */
+  'max_active_faults'?: (_google_protobuf_UInt32Value | null);
+  /**
+   * The response rate limit to be applied to the response body of the stream. When configured,
+   * the percentage can be overridden by the :ref:`fault.http.rate_limit.response_percent
+   * <config_http_filters_fault_injection_runtime>` runtime key.
+   * 
+   * .. attention::
+   * This is a per-stream limit versus a connection level limit. This means that concurrent streams
+   * will each get an independent limit.
+   */
+  'response_rate_limit'?: (_envoy_extensions_filters_common_fault_v3_FaultRateLimit | null);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.delay.fixed_delay_percent
+   */
+  'delay_percent_runtime'?: (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.abort.abort_percent
+   */
+  'abort_percent_runtime'?: (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.delay.fixed_duration_ms
+   */
+  'delay_duration_runtime'?: (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.abort.http_status
+   */
+  'abort_http_status_runtime'?: (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.max_active_faults
+   */
+  'max_active_faults_runtime'?: (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.rate_limit.response_percent
+   */
+  'response_rate_limit_percent_runtime'?: (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.abort.grpc_status
+   */
+  'abort_grpc_status_runtime'?: (string);
+}
+
+/**
+ * [#next-free-field: 15]
+ */
+export interface HTTPFault__Output {
+  /**
+   * If specified, the filter will inject delays based on the values in the
+   * object.
+   */
+  'delay': (_envoy_extensions_filters_common_fault_v3_FaultDelay__Output | null);
+  /**
+   * If specified, the filter will abort requests based on the values in
+   * the object. At least *abort* or *delay* must be specified.
+   */
+  'abort': (_envoy_extensions_filters_http_fault_v3_FaultAbort__Output | null);
+  /**
+   * Specifies the name of the (destination) upstream cluster that the
+   * filter should match on. Fault injection will be restricted to requests
+   * bound to the specific upstream cluster.
+   */
+  'upstream_cluster': (string);
+  /**
+   * Specifies a set of headers that the filter should match on. The fault
+   * injection filter can be applied selectively to requests that match a set of
+   * headers specified in the fault filter config. The chances of actual fault
+   * injection further depend on the value of the :ref:`percentage
+   * <envoy_api_field_extensions.filters.http.fault.v3.FaultAbort.percentage>` field.
+   * The filter will check the request's headers against all the specified
+   * headers in the filter config. A match will happen if all the headers in the
+   * config are present in the request with the same values (or based on
+   * presence if the *value* field is not in the config).
+   */
+  'headers': (_envoy_config_route_v3_HeaderMatcher__Output)[];
+  /**
+   * Faults are injected for the specified list of downstream hosts. If this
+   * setting is not set, faults are injected for all downstream nodes.
+   * Downstream node name is taken from :ref:`the HTTP
+   * x-envoy-downstream-service-node
+   * <config_http_conn_man_headers_downstream-service-node>` header and compared
+   * against downstream_nodes list.
+   */
+  'downstream_nodes': (string)[];
+  /**
+   * The maximum number of faults that can be active at a single time via the configured fault
+   * filter. Note that because this setting can be overridden at the route level, it's possible
+   * for the number of active faults to be greater than this value (if injected via a different
+   * route). If not specified, defaults to unlimited. This setting can be overridden via
+   * `runtime <config_http_filters_fault_injection_runtime>` and any faults that are not injected
+   * due to overflow will be indicated via the `faults_overflow
+   * <config_http_filters_fault_injection_stats>` stat.
+   * 
+   * .. attention::
+   * Like other :ref:`circuit breakers <arch_overview_circuit_break>` in Envoy, this is a fuzzy
+   * limit. It's possible for the number of active faults to rise slightly above the configured
+   * amount due to the implementation details.
+   */
+  'max_active_faults': (_google_protobuf_UInt32Value__Output | null);
+  /**
+   * The response rate limit to be applied to the response body of the stream. When configured,
+   * the percentage can be overridden by the :ref:`fault.http.rate_limit.response_percent
+   * <config_http_filters_fault_injection_runtime>` runtime key.
+   * 
+   * .. attention::
+   * This is a per-stream limit versus a connection level limit. This means that concurrent streams
+   * will each get an independent limit.
+   */
+  'response_rate_limit': (_envoy_extensions_filters_common_fault_v3_FaultRateLimit__Output | null);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.delay.fixed_delay_percent
+   */
+  'delay_percent_runtime': (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.abort.abort_percent
+   */
+  'abort_percent_runtime': (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.delay.fixed_duration_ms
+   */
+  'delay_duration_runtime': (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.abort.http_status
+   */
+  'abort_http_status_runtime': (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.max_active_faults
+   */
+  'max_active_faults_runtime': (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.rate_limit.response_percent
+   */
+  'response_rate_limit_percent_runtime': (string);
+  /**
+   * The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+   * runtime. The default is: fault.http.abort.grpc_status
+   */
+  'abort_grpc_status_runtime': (string);
+}

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpConnectionManager.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpConnectionManager.ts
@@ -132,7 +132,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
   /**
    * Whether to forward the subject of the client cert. Defaults to false.
    */
-  'subject'?: (_google_protobuf_BoolValue);
+  'subject'?: (_google_protobuf_BoolValue | null);
   /**
    * Whether to forward the entire client cert in URL encoded PEM format. This will appear in the
    * XFCC header comma separated from other values with the value Cert="PEM".
@@ -165,7 +165,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
   /**
    * Whether to forward the subject of the client cert. Defaults to false.
    */
-  'subject'?: (_google_protobuf_BoolValue__Output);
+  'subject': (_google_protobuf_BoolValue__Output | null);
   /**
    * Whether to forward the entire client cert in URL encoded PEM format. This will appear in the
    * XFCC header comma separated from other values with the value Cert="PEM".
@@ -203,7 +203,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'client_sampling'?: (_envoy_type_v3_Percent);
+  'client_sampling'?: (_envoy_type_v3_Percent | null);
   /**
    * Target percentage of requests managed by this HTTP connection manager that will be randomly
    * selected for trace generation, if not requested by the client or not forced. This field is
@@ -211,7 +211,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'random_sampling'?: (_envoy_type_v3_Percent);
+  'random_sampling'?: (_envoy_type_v3_Percent | null);
   /**
    * Target percentage of requests managed by this HTTP connection manager that will be traced
    * after all other sampling checks have been applied (client-directed, force tracing, random
@@ -222,7 +222,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'overall_sampling'?: (_envoy_type_v3_Percent);
+  'overall_sampling'?: (_envoy_type_v3_Percent | null);
   /**
    * Whether to annotate spans with additional data. If true, spans will include logs for stream
    * events.
@@ -233,7 +233,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * truncate lengthy request paths to meet the needs of a tracing backend.
    * Default: 256
    */
-  'max_path_tag_length'?: (_google_protobuf_UInt32Value);
+  'max_path_tag_length'?: (_google_protobuf_UInt32Value | null);
   /**
    * A list of custom tags with unique tag name to create tags for the active span.
    */
@@ -250,7 +250,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * Such a constraint is inherent to OpenCensus itself. It cannot be overcome without changes
    * on OpenCensus side.
    */
-  'provider'?: (_envoy_config_trace_v3_Tracing_Http);
+  'provider'?: (_envoy_config_trace_v3_Tracing_Http | null);
 }
 
 /**
@@ -265,7 +265,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'client_sampling'?: (_envoy_type_v3_Percent__Output);
+  'client_sampling': (_envoy_type_v3_Percent__Output | null);
   /**
    * Target percentage of requests managed by this HTTP connection manager that will be randomly
    * selected for trace generation, if not requested by the client or not forced. This field is
@@ -273,7 +273,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'random_sampling'?: (_envoy_type_v3_Percent__Output);
+  'random_sampling': (_envoy_type_v3_Percent__Output | null);
   /**
    * Target percentage of requests managed by this HTTP connection manager that will be traced
    * after all other sampling checks have been applied (client-directed, force tracing, random
@@ -284,7 +284,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
    * Default: 100%
    */
-  'overall_sampling'?: (_envoy_type_v3_Percent__Output);
+  'overall_sampling': (_envoy_type_v3_Percent__Output | null);
   /**
    * Whether to annotate spans with additional data. If true, spans will include logs for stream
    * events.
@@ -295,7 +295,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * truncate lengthy request paths to meet the needs of a tracing backend.
    * Default: 256
    */
-  'max_path_tag_length'?: (_google_protobuf_UInt32Value__Output);
+  'max_path_tag_length': (_google_protobuf_UInt32Value__Output | null);
   /**
    * A list of custom tags with unique tag name to create tags for the active span.
    */
@@ -312,7 +312,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * Such a constraint is inherent to OpenCensus itself. It cannot be overcome without changes
    * on OpenCensus side.
    */
-  'provider'?: (_envoy_config_trace_v3_Tracing_Http__Output);
+  'provider': (_envoy_config_trace_v3_Tracing_Http__Output | null);
 }
 
 /**
@@ -349,7 +349,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * <envoy_api_field_config.route.v3.RouteAction.upgrade_configs>` as documented in the
    * :ref:`upgrade documentation <arch_overview_upgrades>`.
    */
-  'enabled'?: (_google_protobuf_BoolValue);
+  'enabled'?: (_google_protobuf_BoolValue | null);
 }
 
 /**
@@ -386,7 +386,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * <envoy_api_field_config.route.v3.RouteAction.upgrade_configs>` as documented in the
    * :ref:`upgrade documentation <arch_overview_upgrades>`.
    */
-  'enabled'?: (_google_protobuf_BoolValue__Output);
+  'enabled': (_google_protobuf_BoolValue__Output | null);
 }
 
 /**
@@ -406,11 +406,11 @@ export interface HttpConnectionManager {
   /**
    * The connection manager’s route table will be dynamically loaded via the RDS API.
    */
-  'rds'?: (_envoy_extensions_filters_network_http_connection_manager_v3_Rds);
+  'rds'?: (_envoy_extensions_filters_network_http_connection_manager_v3_Rds | null);
   /**
    * The route table for the connection manager is static and is specified in this property.
    */
-  'route_config'?: (_envoy_config_route_v3_RouteConfiguration);
+  'route_config'?: (_envoy_config_route_v3_RouteConfiguration | null);
   /**
    * A list of individual HTTP filters that make up the filter chain for
    * requests made to the connection manager. :ref:`Order matters <arch_overview_http_filters_ordering>`
@@ -422,21 +422,21 @@ export interface HttpConnectionManager {
    * and :ref:`config_http_conn_man_headers_downstream-service-cluster` headers. See the linked
    * documentation for more information. Defaults to false.
    */
-  'add_user_agent'?: (_google_protobuf_BoolValue);
+  'add_user_agent'?: (_google_protobuf_BoolValue | null);
   /**
    * Presence of the object defines whether the connection manager
    * emits :ref:`tracing <arch_overview_tracing>` data to the :ref:`configured tracing provider
    * <envoy_api_msg_config.trace.v3.Tracing>`.
    */
-  'tracing'?: (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_Tracing);
+  'tracing'?: (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_Tracing | null);
   /**
    * Additional HTTP/1 settings that are passed to the HTTP/1 codec.
    */
-  'http_protocol_options'?: (_envoy_config_core_v3_Http1ProtocolOptions);
+  'http_protocol_options'?: (_envoy_config_core_v3_Http1ProtocolOptions | null);
   /**
    * Additional HTTP/2 settings that are passed directly to the HTTP/2 codec.
    */
-  'http2_protocol_options'?: (_envoy_config_core_v3_Http2ProtocolOptions);
+  'http2_protocol_options'?: (_envoy_config_core_v3_Http2ProtocolOptions | null);
   /**
    * An optional override that the connection manager will write to the server
    * header in responses. If not set, the default is *envoy*.
@@ -453,7 +453,7 @@ export interface HttpConnectionManager {
    * draining. The default grace period is 5000 milliseconds (5 seconds) if this
    * option is not specified.
    */
-  'drain_timeout'?: (_google_protobuf_Duration);
+  'drain_timeout'?: (_google_protobuf_Duration | null);
   /**
    * Configuration for :ref:`HTTP access logs <arch_overview_access_logs>`
    * emitted by the connection manager.
@@ -468,14 +468,14 @@ export interface HttpConnectionManager {
    * :ref:`config_http_conn_man_headers_x-envoy-internal`, and
    * :ref:`config_http_conn_man_headers_x-envoy-external-address` for more information.
    */
-  'use_remote_address'?: (_google_protobuf_BoolValue);
+  'use_remote_address'?: (_google_protobuf_BoolValue | null);
   /**
    * Whether the connection manager will generate the :ref:`x-request-id
    * <config_http_conn_man_headers_x-request-id>` header if it does not exist. This defaults to
    * true. Generating a random UUID4 is expensive so in high throughput scenarios where this feature
    * is not desired it can be disabled.
    */
-  'generate_request_id'?: (_google_protobuf_BoolValue);
+  'generate_request_id'?: (_google_protobuf_BoolValue | null);
   /**
    * How to handle the :ref:`config_http_conn_man_headers_x-forwarded-client-cert` (XFCC) HTTP
    * header.
@@ -490,7 +490,7 @@ export interface HttpConnectionManager {
    * *By* is always set when the client certificate presents the URI type Subject Alternative Name
    * value.
    */
-  'set_current_client_cert_details'?: (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_SetCurrentClientCertDetails);
+  'set_current_client_cert_details'?: (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_SetCurrentClientCertDetails | null);
   /**
    * If proxy_100_continue is true, Envoy will proxy incoming "Expect:
    * 100-continue" headers upstream, and forward "100 Continue" responses
@@ -580,14 +580,14 @@ export interface HttpConnectionManager {
    * A value of 0 will completely disable the connection manager stream idle
    * timeout, although per-route idle timeout overrides will continue to apply.
    */
-  'stream_idle_timeout'?: (_google_protobuf_Duration);
+  'stream_idle_timeout'?: (_google_protobuf_Duration | null);
   /**
    * Configures what network addresses are considered internal for stats and header sanitation
    * purposes. If unspecified, only RFC1918 IP addresses will be considered internal.
    * See the documentation for :ref:`config_http_conn_man_headers_x-envoy-internal` for more
    * information about internal/external addresses.
    */
-  'internal_address_config'?: (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_InternalAddressConfig);
+  'internal_address_config'?: (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_InternalAddressConfig | null);
   /**
    * The delayed close timeout is for downstream connections managed by the HTTP connection manager.
    * It is defined as a grace period after connection close processing has been locally initiated
@@ -620,14 +620,14 @@ export interface HttpConnectionManager {
    * connection's socket will be closed immediately after the write flush is completed or will
    * never close if the write flush does not complete.
    */
-  'delayed_close_timeout'?: (_google_protobuf_Duration);
+  'delayed_close_timeout'?: (_google_protobuf_Duration | null);
   /**
    * The amount of time that Envoy will wait for the entire request to be received.
    * The timer is activated when the request is initiated, and is disarmed when the last byte of the
    * request is sent upstream (i.e. all decoding filters have processed the request), OR when the
    * response is initiated. If not specified or set to 0, this timeout is disabled.
    */
-  'request_timeout'?: (_google_protobuf_Duration);
+  'request_timeout'?: (_google_protobuf_Duration | null);
   /**
    * The maximum request headers size for incoming connections.
    * If unconfigured, the default max request headers allowed is 60 KiB.
@@ -635,7 +635,7 @@ export interface HttpConnectionManager {
    * The max configurable limit is 96 KiB, based on current implementation
    * constraints.
    */
-  'max_request_headers_kb'?: (_google_protobuf_UInt32Value);
+  'max_request_headers_kb'?: (_google_protobuf_UInt32Value | null);
   /**
    * Should paths be normalized according to RFC 3986 before any processing of
    * requests by HTTP filters or routing? This affects the upstream *:path* header
@@ -649,13 +649,13 @@ export interface HttpConnectionManager {
    * Note that Envoy does not perform
    * `case normalization <https://tools.ietf.org/html/rfc3986#section-6.2.2.1>`_
    */
-  'normalize_path'?: (_google_protobuf_BoolValue);
+  'normalize_path'?: (_google_protobuf_BoolValue | null);
   /**
    * A route table will be dynamically assigned to each request based on request attributes
    * (e.g., the value of a header). The "routing scopes" (i.e., route tables) and "scope keys" are
    * specified in this message.
    */
-  'scoped_routes'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes);
+  'scoped_routes'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes | null);
   /**
    * Whether the connection manager will keep the :ref:`x-request-id
    * <config_http_conn_man_headers_x-request-id>` header if passed for a request that is edge
@@ -681,7 +681,7 @@ export interface HttpConnectionManager {
    * Additional settings for HTTP requests handled by the connection manager. These will be
    * applicable to both HTTP1 and HTTP2 requests.
    */
-  'common_http_protocol_options'?: (_envoy_config_core_v3_HttpProtocolOptions);
+  'common_http_protocol_options'?: (_envoy_config_core_v3_HttpProtocolOptions | null);
   /**
    * The configuration of the request ID extension. This includes operations such as
    * generation, validation, and associated tracing operations.
@@ -694,7 +694,7 @@ export interface HttpConnectionManager {
    * 
    * 3. Tracing decision (sampled, forced, etc) is set in 14th byte of the UUID.
    */
-  'request_id_extension'?: (_envoy_extensions_filters_network_http_connection_manager_v3_RequestIDExtension);
+  'request_id_extension'?: (_envoy_extensions_filters_network_http_connection_manager_v3_RequestIDExtension | null);
   /**
    * If set, Envoy will always set :ref:`x-request-id <config_http_conn_man_headers_x-request-id>` header in response.
    * If this is false or not set, the request ID is returned in responses only if tracing is forced using
@@ -706,7 +706,7 @@ export interface HttpConnectionManager {
    * body text and response content type. If not specified, status code and text body are hard
    * coded in Envoy, the response content type is plain text.
    */
-  'local_reply_config'?: (_envoy_extensions_filters_network_http_connection_manager_v3_LocalReplyConfig);
+  'local_reply_config'?: (_envoy_extensions_filters_network_http_connection_manager_v3_LocalReplyConfig | null);
   /**
    * Determines if the port part should be removed from host/authority header before any processing
    * of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v3.Listener.address>`
@@ -735,13 +735,13 @@ export interface HttpConnectionManager {
    * *not* the deprecated but similarly named :ref:`stream_error_on_invalid_http_messaging
    * <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.stream_error_on_invalid_http_messaging>`
    */
-  'stream_error_on_invalid_http_message'?: (_google_protobuf_BoolValue);
+  'stream_error_on_invalid_http_message'?: (_google_protobuf_BoolValue | null);
   /**
    * The amount of time that Envoy will wait for the request headers to be received. The timer is
    * activated when the first byte of the headers is received, and is disarmed when the last byte of
    * the headers has been received. If not specified or set to 0, this timeout is disabled.
    */
-  'request_headers_timeout'?: (_google_protobuf_Duration);
+  'request_headers_timeout'?: (_google_protobuf_Duration | null);
   /**
    * Determines if the port part should be removed from host/authority header before any processing
    * of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
@@ -773,11 +773,11 @@ export interface HttpConnectionManager__Output {
   /**
    * The connection manager’s route table will be dynamically loaded via the RDS API.
    */
-  'rds'?: (_envoy_extensions_filters_network_http_connection_manager_v3_Rds__Output);
+  'rds'?: (_envoy_extensions_filters_network_http_connection_manager_v3_Rds__Output | null);
   /**
    * The route table for the connection manager is static and is specified in this property.
    */
-  'route_config'?: (_envoy_config_route_v3_RouteConfiguration__Output);
+  'route_config'?: (_envoy_config_route_v3_RouteConfiguration__Output | null);
   /**
    * A list of individual HTTP filters that make up the filter chain for
    * requests made to the connection manager. :ref:`Order matters <arch_overview_http_filters_ordering>`
@@ -789,21 +789,21 @@ export interface HttpConnectionManager__Output {
    * and :ref:`config_http_conn_man_headers_downstream-service-cluster` headers. See the linked
    * documentation for more information. Defaults to false.
    */
-  'add_user_agent'?: (_google_protobuf_BoolValue__Output);
+  'add_user_agent': (_google_protobuf_BoolValue__Output | null);
   /**
    * Presence of the object defines whether the connection manager
    * emits :ref:`tracing <arch_overview_tracing>` data to the :ref:`configured tracing provider
    * <envoy_api_msg_config.trace.v3.Tracing>`.
    */
-  'tracing'?: (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_Tracing__Output);
+  'tracing': (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_Tracing__Output | null);
   /**
    * Additional HTTP/1 settings that are passed to the HTTP/1 codec.
    */
-  'http_protocol_options'?: (_envoy_config_core_v3_Http1ProtocolOptions__Output);
+  'http_protocol_options': (_envoy_config_core_v3_Http1ProtocolOptions__Output | null);
   /**
    * Additional HTTP/2 settings that are passed directly to the HTTP/2 codec.
    */
-  'http2_protocol_options'?: (_envoy_config_core_v3_Http2ProtocolOptions__Output);
+  'http2_protocol_options': (_envoy_config_core_v3_Http2ProtocolOptions__Output | null);
   /**
    * An optional override that the connection manager will write to the server
    * header in responses. If not set, the default is *envoy*.
@@ -820,7 +820,7 @@ export interface HttpConnectionManager__Output {
    * draining. The default grace period is 5000 milliseconds (5 seconds) if this
    * option is not specified.
    */
-  'drain_timeout'?: (_google_protobuf_Duration__Output);
+  'drain_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * Configuration for :ref:`HTTP access logs <arch_overview_access_logs>`
    * emitted by the connection manager.
@@ -835,14 +835,14 @@ export interface HttpConnectionManager__Output {
    * :ref:`config_http_conn_man_headers_x-envoy-internal`, and
    * :ref:`config_http_conn_man_headers_x-envoy-external-address` for more information.
    */
-  'use_remote_address'?: (_google_protobuf_BoolValue__Output);
+  'use_remote_address': (_google_protobuf_BoolValue__Output | null);
   /**
    * Whether the connection manager will generate the :ref:`x-request-id
    * <config_http_conn_man_headers_x-request-id>` header if it does not exist. This defaults to
    * true. Generating a random UUID4 is expensive so in high throughput scenarios where this feature
    * is not desired it can be disabled.
    */
-  'generate_request_id'?: (_google_protobuf_BoolValue__Output);
+  'generate_request_id': (_google_protobuf_BoolValue__Output | null);
   /**
    * How to handle the :ref:`config_http_conn_man_headers_x-forwarded-client-cert` (XFCC) HTTP
    * header.
@@ -857,7 +857,7 @@ export interface HttpConnectionManager__Output {
    * *By* is always set when the client certificate presents the URI type Subject Alternative Name
    * value.
    */
-  'set_current_client_cert_details'?: (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_SetCurrentClientCertDetails__Output);
+  'set_current_client_cert_details': (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_SetCurrentClientCertDetails__Output | null);
   /**
    * If proxy_100_continue is true, Envoy will proxy incoming "Expect:
    * 100-continue" headers upstream, and forward "100 Continue" responses
@@ -947,14 +947,14 @@ export interface HttpConnectionManager__Output {
    * A value of 0 will completely disable the connection manager stream idle
    * timeout, although per-route idle timeout overrides will continue to apply.
    */
-  'stream_idle_timeout'?: (_google_protobuf_Duration__Output);
+  'stream_idle_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * Configures what network addresses are considered internal for stats and header sanitation
    * purposes. If unspecified, only RFC1918 IP addresses will be considered internal.
    * See the documentation for :ref:`config_http_conn_man_headers_x-envoy-internal` for more
    * information about internal/external addresses.
    */
-  'internal_address_config'?: (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_InternalAddressConfig__Output);
+  'internal_address_config': (_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_InternalAddressConfig__Output | null);
   /**
    * The delayed close timeout is for downstream connections managed by the HTTP connection manager.
    * It is defined as a grace period after connection close processing has been locally initiated
@@ -987,14 +987,14 @@ export interface HttpConnectionManager__Output {
    * connection's socket will be closed immediately after the write flush is completed or will
    * never close if the write flush does not complete.
    */
-  'delayed_close_timeout'?: (_google_protobuf_Duration__Output);
+  'delayed_close_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * The amount of time that Envoy will wait for the entire request to be received.
    * The timer is activated when the request is initiated, and is disarmed when the last byte of the
    * request is sent upstream (i.e. all decoding filters have processed the request), OR when the
    * response is initiated. If not specified or set to 0, this timeout is disabled.
    */
-  'request_timeout'?: (_google_protobuf_Duration__Output);
+  'request_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * The maximum request headers size for incoming connections.
    * If unconfigured, the default max request headers allowed is 60 KiB.
@@ -1002,7 +1002,7 @@ export interface HttpConnectionManager__Output {
    * The max configurable limit is 96 KiB, based on current implementation
    * constraints.
    */
-  'max_request_headers_kb'?: (_google_protobuf_UInt32Value__Output);
+  'max_request_headers_kb': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Should paths be normalized according to RFC 3986 before any processing of
    * requests by HTTP filters or routing? This affects the upstream *:path* header
@@ -1016,13 +1016,13 @@ export interface HttpConnectionManager__Output {
    * Note that Envoy does not perform
    * `case normalization <https://tools.ietf.org/html/rfc3986#section-6.2.2.1>`_
    */
-  'normalize_path'?: (_google_protobuf_BoolValue__Output);
+  'normalize_path': (_google_protobuf_BoolValue__Output | null);
   /**
    * A route table will be dynamically assigned to each request based on request attributes
    * (e.g., the value of a header). The "routing scopes" (i.e., route tables) and "scope keys" are
    * specified in this message.
    */
-  'scoped_routes'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes__Output);
+  'scoped_routes'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes__Output | null);
   /**
    * Whether the connection manager will keep the :ref:`x-request-id
    * <config_http_conn_man_headers_x-request-id>` header if passed for a request that is edge
@@ -1048,7 +1048,7 @@ export interface HttpConnectionManager__Output {
    * Additional settings for HTTP requests handled by the connection manager. These will be
    * applicable to both HTTP1 and HTTP2 requests.
    */
-  'common_http_protocol_options'?: (_envoy_config_core_v3_HttpProtocolOptions__Output);
+  'common_http_protocol_options': (_envoy_config_core_v3_HttpProtocolOptions__Output | null);
   /**
    * The configuration of the request ID extension. This includes operations such as
    * generation, validation, and associated tracing operations.
@@ -1061,7 +1061,7 @@ export interface HttpConnectionManager__Output {
    * 
    * 3. Tracing decision (sampled, forced, etc) is set in 14th byte of the UUID.
    */
-  'request_id_extension'?: (_envoy_extensions_filters_network_http_connection_manager_v3_RequestIDExtension__Output);
+  'request_id_extension': (_envoy_extensions_filters_network_http_connection_manager_v3_RequestIDExtension__Output | null);
   /**
    * If set, Envoy will always set :ref:`x-request-id <config_http_conn_man_headers_x-request-id>` header in response.
    * If this is false or not set, the request ID is returned in responses only if tracing is forced using
@@ -1073,7 +1073,7 @@ export interface HttpConnectionManager__Output {
    * body text and response content type. If not specified, status code and text body are hard
    * coded in Envoy, the response content type is plain text.
    */
-  'local_reply_config'?: (_envoy_extensions_filters_network_http_connection_manager_v3_LocalReplyConfig__Output);
+  'local_reply_config': (_envoy_extensions_filters_network_http_connection_manager_v3_LocalReplyConfig__Output | null);
   /**
    * Determines if the port part should be removed from host/authority header before any processing
    * of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v3.Listener.address>`
@@ -1102,13 +1102,13 @@ export interface HttpConnectionManager__Output {
    * *not* the deprecated but similarly named :ref:`stream_error_on_invalid_http_messaging
    * <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.stream_error_on_invalid_http_messaging>`
    */
-  'stream_error_on_invalid_http_message'?: (_google_protobuf_BoolValue__Output);
+  'stream_error_on_invalid_http_message': (_google_protobuf_BoolValue__Output | null);
   /**
    * The amount of time that Envoy will wait for the request headers to be received. The timer is
    * activated when the first byte of the headers is received, and is disarmed when the last byte of
    * the headers has been received. If not specified or set to 0, this timeout is disabled.
    */
-  'request_headers_timeout'?: (_google_protobuf_Duration__Output);
+  'request_headers_timeout': (_google_protobuf_Duration__Output | null);
   /**
    * Determines if the port part should be removed from host/authority header before any processing
    * of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpFilter.ts
@@ -17,13 +17,13 @@ export interface HttpFilter {
    * Filter specific configuration which depends on the filter being instantiated. See the supported
    * filters for further documentation.
    */
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
   /**
    * Configuration source specifier for an extension configuration discovery service.
    * In case of a failure and without the default configuration, the HTTP listener responds with code 500.
    * Extension configs delivered through this mechanism are not expected to require warming (see https://github.com/envoyproxy/envoy/issues/12061).
    */
-  'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource);
+  'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource | null);
   /**
    * If true, clients that do not support this filter may ignore the
    * filter but otherwise accept the config.
@@ -48,13 +48,13 @@ export interface HttpFilter__Output {
    * Filter specific configuration which depends on the filter being instantiated. See the supported
    * filters for further documentation.
    */
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config'?: (_google_protobuf_Any__Output | null);
   /**
    * Configuration source specifier for an extension configuration discovery service.
    * In case of a failure and without the default configuration, the HTTP listener responds with code 500.
    * Extension configs delivered through this mechanism are not expected to require warming (see https://github.com/envoyproxy/envoy/issues/12061).
    */
-  'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource__Output);
+  'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource__Output | null);
   /**
    * If true, clients that do not support this filter may ignore the
    * filter but otherwise accept the config.

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/LocalReplyConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/LocalReplyConfig.ts
@@ -51,7 +51,7 @@ export interface LocalReplyConfig {
    * "path": "/foo"
    * }
    */
-  'body_format'?: (_envoy_config_core_v3_SubstitutionFormatString);
+  'body_format'?: (_envoy_config_core_v3_SubstitutionFormatString | null);
 }
 
 /**
@@ -102,5 +102,5 @@ export interface LocalReplyConfig__Output {
    * "path": "/foo"
    * }
    */
-  'body_format'?: (_envoy_config_core_v3_SubstitutionFormatString__Output);
+  'body_format': (_envoy_config_core_v3_SubstitutionFormatString__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/Rds.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/Rds.ts
@@ -6,7 +6,7 @@ export interface Rds {
   /**
    * Configuration source specifier for RDS.
    */
-  'config_source'?: (_envoy_config_core_v3_ConfigSource);
+  'config_source'?: (_envoy_config_core_v3_ConfigSource | null);
   /**
    * The name of the route configuration. This name will be passed to the RDS
    * API. This allows an Envoy configuration with multiple HTTP listeners (and
@@ -20,7 +20,7 @@ export interface Rds__Output {
   /**
    * Configuration source specifier for RDS.
    */
-  'config_source'?: (_envoy_config_core_v3_ConfigSource__Output);
+  'config_source': (_envoy_config_core_v3_ConfigSource__Output | null);
   /**
    * The name of the route configuration. This name will be passed to the RDS
    * API. This allows an Envoy configuration with multiple HTTP listeners (and

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/RequestIDExtension.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/RequestIDExtension.ts
@@ -6,12 +6,12 @@ export interface RequestIDExtension {
   /**
    * Request ID extension specific configuration.
    */
-  'typed_config'?: (_google_protobuf_Any);
+  'typed_config'?: (_google_protobuf_Any | null);
 }
 
 export interface RequestIDExtension__Output {
   /**
    * Request ID extension specific configuration.
    */
-  'typed_config'?: (_google_protobuf_Any__Output);
+  'typed_config': (_google_protobuf_Any__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/ResponseMapper.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/ResponseMapper.ts
@@ -14,21 +14,21 @@ export interface ResponseMapper {
   /**
    * Filter to determine if this mapper should apply.
    */
-  'filter'?: (_envoy_config_accesslog_v3_AccessLogFilter);
+  'filter'?: (_envoy_config_accesslog_v3_AccessLogFilter | null);
   /**
    * The new response status code if specified.
    */
-  'status_code'?: (_google_protobuf_UInt32Value);
+  'status_code'?: (_google_protobuf_UInt32Value | null);
   /**
    * The new local reply body text if specified. It will be used in the `%LOCAL_REPLY_BODY%`
    * command operator in the `body_format`.
    */
-  'body'?: (_envoy_config_core_v3_DataSource);
+  'body'?: (_envoy_config_core_v3_DataSource | null);
   /**
    * A per mapper `body_format` to override the :ref:`body_format <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.LocalReplyConfig.body_format>`.
    * It will be used when this mapper is matched.
    */
-  'body_format_override'?: (_envoy_config_core_v3_SubstitutionFormatString);
+  'body_format_override'?: (_envoy_config_core_v3_SubstitutionFormatString | null);
   /**
    * HTTP headers to add to a local reply. This allows the response mapper to append, to add
    * or to override headers of any local reply before it is sent to a downstream client.
@@ -44,21 +44,21 @@ export interface ResponseMapper__Output {
   /**
    * Filter to determine if this mapper should apply.
    */
-  'filter'?: (_envoy_config_accesslog_v3_AccessLogFilter__Output);
+  'filter': (_envoy_config_accesslog_v3_AccessLogFilter__Output | null);
   /**
    * The new response status code if specified.
    */
-  'status_code'?: (_google_protobuf_UInt32Value__Output);
+  'status_code': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The new local reply body text if specified. It will be used in the `%LOCAL_REPLY_BODY%`
    * command operator in the `body_format`.
    */
-  'body'?: (_envoy_config_core_v3_DataSource__Output);
+  'body': (_envoy_config_core_v3_DataSource__Output | null);
   /**
    * A per mapper `body_format` to override the :ref:`body_format <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.LocalReplyConfig.body_format>`.
    * It will be used when this mapper is matched.
    */
-  'body_format_override'?: (_envoy_config_core_v3_SubstitutionFormatString__Output);
+  'body_format_override': (_envoy_config_core_v3_SubstitutionFormatString__Output | null);
   /**
    * HTTP headers to add to a local reply. This allows the response mapper to append, to add
    * or to override headers of any local reply before it is sent to a downstream client.

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/ScopedRds.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/ScopedRds.ts
@@ -6,12 +6,12 @@ export interface ScopedRds {
   /**
    * Configuration source specifier for scoped RDS.
    */
-  'scoped_rds_config_source'?: (_envoy_config_core_v3_ConfigSource);
+  'scoped_rds_config_source'?: (_envoy_config_core_v3_ConfigSource | null);
 }
 
 export interface ScopedRds__Output {
   /**
    * Configuration source specifier for scoped RDS.
    */
-  'scoped_rds_config_source'?: (_envoy_config_core_v3_ConfigSource__Output);
+  'scoped_rds_config_source': (_envoy_config_core_v3_ConfigSource__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/ScopedRoutes.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/ScopedRoutes.ts
@@ -11,7 +11,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Sc
   /**
    * Specifies how a header field's value should be extracted.
    */
-  'header_value_extractor'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor);
+  'header_value_extractor'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor | null);
   'type'?: "header_value_extractor";
 }
 
@@ -22,7 +22,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Sc
   /**
    * Specifies how a header field's value should be extracted.
    */
-  'header_value_extractor'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor__Output);
+  'header_value_extractor'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor__Output | null);
   'type': "header_value_extractor";
 }
 
@@ -70,7 +70,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Sc
   /**
    * Specifies the key value pair to extract the value from.
    */
-  'element'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_KvElement);
+  'element'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_KvElement | null);
   'extract_type'?: "index"|"element";
 }
 
@@ -118,7 +118,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Sc
   /**
    * Specifies the key value pair to extract the value from.
    */
-  'element'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_KvElement__Output);
+  'element'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_KvElement__Output | null);
   'extract_type': "index"|"element";
 }
 
@@ -209,13 +209,13 @@ export interface ScopedRoutes {
   /**
    * The algorithm to use for constructing a scope key for each request.
    */
-  'scope_key_builder'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder);
+  'scope_key_builder'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder | null);
   /**
    * Configuration source specifier for RDS.
    * This config source is used to subscribe to RouteConfiguration resources specified in
    * ScopedRouteConfiguration messages.
    */
-  'rds_config_source'?: (_envoy_config_core_v3_ConfigSource);
+  'rds_config_source'?: (_envoy_config_core_v3_ConfigSource | null);
   /**
    * The set of routing scopes corresponding to the HCM. A scope is assigned to a request by
    * matching a key constructed from the request's attributes according to the algorithm specified
@@ -223,7 +223,7 @@ export interface ScopedRoutes {
    * :ref:`ScopeKeyBuilder<envoy_api_msg_extensions.filters.network.http_connection_manager.v3.ScopedRoutes.ScopeKeyBuilder>`
    * in this message.
    */
-  'scoped_route_configurations_list'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRouteConfigurationsList);
+  'scoped_route_configurations_list'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRouteConfigurationsList | null);
   /**
    * The set of routing scopes associated with the HCM will be dynamically loaded via the SRDS
    * API. A scope is assigned to a request by matching a key constructed from the request's
@@ -231,7 +231,7 @@ export interface ScopedRoutes {
    * :ref:`ScopeKeyBuilder<envoy_api_msg_extensions.filters.network.http_connection_manager.v3.ScopedRoutes.ScopeKeyBuilder>`
    * in this message.
    */
-  'scoped_rds'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRds);
+  'scoped_rds'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRds | null);
   'config_specifier'?: "scoped_route_configurations_list"|"scoped_rds";
 }
 
@@ -246,13 +246,13 @@ export interface ScopedRoutes__Output {
   /**
    * The algorithm to use for constructing a scope key for each request.
    */
-  'scope_key_builder'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder__Output);
+  'scope_key_builder': (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder__Output | null);
   /**
    * Configuration source specifier for RDS.
    * This config source is used to subscribe to RouteConfiguration resources specified in
    * ScopedRouteConfiguration messages.
    */
-  'rds_config_source'?: (_envoy_config_core_v3_ConfigSource__Output);
+  'rds_config_source': (_envoy_config_core_v3_ConfigSource__Output | null);
   /**
    * The set of routing scopes corresponding to the HCM. A scope is assigned to a request by
    * matching a key constructed from the request's attributes according to the algorithm specified
@@ -260,7 +260,7 @@ export interface ScopedRoutes__Output {
    * :ref:`ScopeKeyBuilder<envoy_api_msg_extensions.filters.network.http_connection_manager.v3.ScopedRoutes.ScopeKeyBuilder>`
    * in this message.
    */
-  'scoped_route_configurations_list'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRouteConfigurationsList__Output);
+  'scoped_route_configurations_list'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRouteConfigurationsList__Output | null);
   /**
    * The set of routing scopes associated with the HCM will be dynamically loaded via the SRDS
    * API. A scope is assigned to a request by matching a key constructed from the request's
@@ -268,6 +268,6 @@ export interface ScopedRoutes__Output {
    * :ref:`ScopeKeyBuilder<envoy_api_msg_extensions.filters.network.http_connection_manager.v3.ScopedRoutes.ScopeKeyBuilder>`
    * in this message.
    */
-  'scoped_rds'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRds__Output);
+  'scoped_rds'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRds__Output | null);
   'config_specifier': "scoped_route_configurations_list"|"scoped_rds";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/discovery/v2/AggregatedDiscoveryService.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/discovery/v2/AggregatedDiscoveryService.ts
@@ -1,6 +1,7 @@
 // Original file: deps/envoy-api/envoy/service/discovery/v2/ads.proto
 
 import type * as grpc from '@grpc/grpc-js'
+import type { MethodDefinition } from '@grpc/proto-loader'
 import type { DeltaDiscoveryRequest as _envoy_api_v2_DeltaDiscoveryRequest, DeltaDiscoveryRequest__Output as _envoy_api_v2_DeltaDiscoveryRequest__Output } from '../../../../envoy/api/v2/DeltaDiscoveryRequest';
 import type { DeltaDiscoveryResponse as _envoy_api_v2_DeltaDiscoveryResponse, DeltaDiscoveryResponse__Output as _envoy_api_v2_DeltaDiscoveryResponse__Output } from '../../../../envoy/api/v2/DeltaDiscoveryResponse';
 import type { DiscoveryRequest as _envoy_api_v2_DiscoveryRequest, DiscoveryRequest__Output as _envoy_api_v2_DiscoveryRequest__Output } from '../../../../envoy/api/v2/DiscoveryRequest';
@@ -49,4 +50,9 @@ export interface AggregatedDiscoveryServiceHandlers extends grpc.UntypedServiceI
    */
   StreamAggregatedResources: grpc.handleBidiStreamingCall<_envoy_api_v2_DiscoveryRequest__Output, _envoy_api_v2_DiscoveryResponse>;
   
+}
+
+export interface AggregatedDiscoveryServiceDefinition extends grpc.ServiceDefinition {
+  DeltaAggregatedResources: MethodDefinition<_envoy_api_v2_DeltaDiscoveryRequest, _envoy_api_v2_DeltaDiscoveryResponse, _envoy_api_v2_DeltaDiscoveryRequest__Output, _envoy_api_v2_DeltaDiscoveryResponse__Output>
+  StreamAggregatedResources: MethodDefinition<_envoy_api_v2_DiscoveryRequest, _envoy_api_v2_DiscoveryResponse, _envoy_api_v2_DiscoveryRequest__Output, _envoy_api_v2_DiscoveryResponse__Output>
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/AggregatedDiscoveryService.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/AggregatedDiscoveryService.ts
@@ -1,6 +1,7 @@
 // Original file: deps/envoy-api/envoy/service/discovery/v3/ads.proto
 
 import type * as grpc from '@grpc/grpc-js'
+import type { MethodDefinition } from '@grpc/proto-loader'
 import type { DeltaDiscoveryRequest as _envoy_service_discovery_v3_DeltaDiscoveryRequest, DeltaDiscoveryRequest__Output as _envoy_service_discovery_v3_DeltaDiscoveryRequest__Output } from '../../../../envoy/service/discovery/v3/DeltaDiscoveryRequest';
 import type { DeltaDiscoveryResponse as _envoy_service_discovery_v3_DeltaDiscoveryResponse, DeltaDiscoveryResponse__Output as _envoy_service_discovery_v3_DeltaDiscoveryResponse__Output } from '../../../../envoy/service/discovery/v3/DeltaDiscoveryResponse';
 import type { DiscoveryRequest as _envoy_service_discovery_v3_DiscoveryRequest, DiscoveryRequest__Output as _envoy_service_discovery_v3_DiscoveryRequest__Output } from '../../../../envoy/service/discovery/v3/DiscoveryRequest';
@@ -49,4 +50,9 @@ export interface AggregatedDiscoveryServiceHandlers extends grpc.UntypedServiceI
    */
   StreamAggregatedResources: grpc.handleBidiStreamingCall<_envoy_service_discovery_v3_DiscoveryRequest__Output, _envoy_service_discovery_v3_DiscoveryResponse>;
   
+}
+
+export interface AggregatedDiscoveryServiceDefinition extends grpc.ServiceDefinition {
+  DeltaAggregatedResources: MethodDefinition<_envoy_service_discovery_v3_DeltaDiscoveryRequest, _envoy_service_discovery_v3_DeltaDiscoveryResponse, _envoy_service_discovery_v3_DeltaDiscoveryRequest__Output, _envoy_service_discovery_v3_DeltaDiscoveryResponse__Output>
+  StreamAggregatedResources: MethodDefinition<_envoy_service_discovery_v3_DiscoveryRequest, _envoy_service_discovery_v3_DiscoveryResponse, _envoy_service_discovery_v3_DiscoveryRequest__Output, _envoy_service_discovery_v3_DiscoveryResponse__Output>
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/DeltaDiscoveryRequest.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/DeltaDiscoveryRequest.ts
@@ -42,7 +42,7 @@ export interface DeltaDiscoveryRequest {
   /**
    * The node making the request.
    */
-  'node'?: (_envoy_config_core_v3_Node);
+  'node'?: (_envoy_config_core_v3_Node | null);
   /**
    * Type of the resource that is being requested, e.g.
    * "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This does not need to be set if
@@ -101,7 +101,7 @@ export interface DeltaDiscoveryRequest {
    * failed to update configuration. The *message* field in *error_details*
    * provides the Envoy internal exception related to the failure.
    */
-  'error_detail'?: (_google_rpc_Status);
+  'error_detail'?: (_google_rpc_Status | null);
 }
 
 /**
@@ -143,7 +143,7 @@ export interface DeltaDiscoveryRequest__Output {
   /**
    * The node making the request.
    */
-  'node'?: (_envoy_config_core_v3_Node__Output);
+  'node': (_envoy_config_core_v3_Node__Output | null);
   /**
    * Type of the resource that is being requested, e.g.
    * "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This does not need to be set if
@@ -202,5 +202,5 @@ export interface DeltaDiscoveryRequest__Output {
    * failed to update configuration. The *message* field in *error_details*
    * provides the Envoy internal exception related to the failure.
    */
-  'error_detail'?: (_google_rpc_Status__Output);
+  'error_detail': (_google_rpc_Status__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/DeltaDiscoveryResponse.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/DeltaDiscoveryResponse.ts
@@ -35,7 +35,7 @@ export interface DeltaDiscoveryResponse {
    * [#not-implemented-hide:]
    * The control plane instance that sent the response.
    */
-  'control_plane'?: (_envoy_config_core_v3_ControlPlane);
+  'control_plane'?: (_envoy_config_core_v3_ControlPlane | null);
 }
 
 /**
@@ -70,5 +70,5 @@ export interface DeltaDiscoveryResponse__Output {
    * [#not-implemented-hide:]
    * The control plane instance that sent the response.
    */
-  'control_plane'?: (_envoy_config_core_v3_ControlPlane__Output);
+  'control_plane': (_envoy_config_core_v3_ControlPlane__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/DiscoveryRequest.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/DiscoveryRequest.ts
@@ -22,7 +22,7 @@ export interface DiscoveryRequest {
   /**
    * The node making the request.
    */
-  'node'?: (_envoy_config_core_v3_Node);
+  'node'?: (_envoy_config_core_v3_Node | null);
   /**
    * List of resources to subscribe to, e.g. list of cluster names or a route
    * configuration name. If this is empty, all resources for the API are
@@ -53,7 +53,7 @@ export interface DiscoveryRequest {
    * internal exception related to the failure. It is only intended for consumption during manual
    * debugging, the string provided is not guaranteed to be stable across Envoy versions.
    */
-  'error_detail'?: (_google_rpc_Status);
+  'error_detail'?: (_google_rpc_Status | null);
 }
 
 /**
@@ -75,7 +75,7 @@ export interface DiscoveryRequest__Output {
   /**
    * The node making the request.
    */
-  'node'?: (_envoy_config_core_v3_Node__Output);
+  'node': (_envoy_config_core_v3_Node__Output | null);
   /**
    * List of resources to subscribe to, e.g. list of cluster names or a route
    * configuration name. If this is empty, all resources for the API are
@@ -106,5 +106,5 @@ export interface DiscoveryRequest__Output {
    * internal exception related to the failure. It is only intended for consumption during manual
    * debugging, the string provided is not guaranteed to be stable across Envoy versions.
    */
-  'error_detail'?: (_google_rpc_Status__Output);
+  'error_detail': (_google_rpc_Status__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/DiscoveryResponse.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/DiscoveryResponse.ts
@@ -51,7 +51,7 @@ export interface DiscoveryResponse {
   /**
    * The control plane instance that sent the response.
    */
-  'control_plane'?: (_envoy_config_core_v3_ControlPlane);
+  'control_plane'?: (_envoy_config_core_v3_ControlPlane | null);
 }
 
 /**
@@ -102,5 +102,5 @@ export interface DiscoveryResponse__Output {
   /**
    * The control plane instance that sent the response.
    */
-  'control_plane'?: (_envoy_config_core_v3_ControlPlane__Output);
+  'control_plane': (_envoy_config_core_v3_ControlPlane__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/Resource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/Resource.ts
@@ -41,7 +41,7 @@ export interface Resource {
   /**
    * The resource being tracked.
    */
-  'resource'?: (_google_protobuf_Any);
+  'resource'?: (_google_protobuf_Any | null);
   /**
    * The resource's name, to distinguish it from others of the same type of resource.
    */
@@ -65,12 +65,12 @@ export interface Resource {
    * testing where the fault injection should be terminated in the event that Envoy loses contact
    * with the management server.
    */
-  'ttl'?: (_google_protobuf_Duration);
+  'ttl'?: (_google_protobuf_Duration | null);
   /**
    * Cache control properties for the resource.
    * [#not-implemented-hide:]
    */
-  'cache_control'?: (_envoy_service_discovery_v3_Resource_CacheControl);
+  'cache_control'?: (_envoy_service_discovery_v3_Resource_CacheControl | null);
 }
 
 /**
@@ -85,7 +85,7 @@ export interface Resource__Output {
   /**
    * The resource being tracked.
    */
-  'resource'?: (_google_protobuf_Any__Output);
+  'resource': (_google_protobuf_Any__Output | null);
   /**
    * The resource's name, to distinguish it from others of the same type of resource.
    */
@@ -109,10 +109,10 @@ export interface Resource__Output {
    * testing where the fault injection should be terminated in the event that Envoy loses contact
    * with the management server.
    */
-  'ttl'?: (_google_protobuf_Duration__Output);
+  'ttl': (_google_protobuf_Duration__Output | null);
   /**
    * Cache control properties for the resource.
    * [#not-implemented-hide:]
    */
-  'cache_control'?: (_envoy_service_discovery_v3_Resource_CacheControl__Output);
+  'cache_control': (_envoy_service_discovery_v3_Resource_CacheControl__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v2/LoadReportingService.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v2/LoadReportingService.ts
@@ -1,6 +1,7 @@
 // Original file: deps/envoy-api/envoy/service/load_stats/v2/lrs.proto
 
 import type * as grpc from '@grpc/grpc-js'
+import type { MethodDefinition } from '@grpc/proto-loader'
 import type { LoadStatsRequest as _envoy_service_load_stats_v2_LoadStatsRequest, LoadStatsRequest__Output as _envoy_service_load_stats_v2_LoadStatsRequest__Output } from '../../../../envoy/service/load_stats/v2/LoadStatsRequest';
 import type { LoadStatsResponse as _envoy_service_load_stats_v2_LoadStatsResponse, LoadStatsResponse__Output as _envoy_service_load_stats_v2_LoadStatsResponse__Output } from '../../../../envoy/service/load_stats/v2/LoadStatsResponse';
 
@@ -105,4 +106,8 @@ export interface LoadReportingServiceHandlers extends grpc.UntypedServiceImpleme
    */
   StreamLoadStats: grpc.handleBidiStreamingCall<_envoy_service_load_stats_v2_LoadStatsRequest__Output, _envoy_service_load_stats_v2_LoadStatsResponse>;
   
+}
+
+export interface LoadReportingServiceDefinition extends grpc.ServiceDefinition {
+  StreamLoadStats: MethodDefinition<_envoy_service_load_stats_v2_LoadStatsRequest, _envoy_service_load_stats_v2_LoadStatsResponse, _envoy_service_load_stats_v2_LoadStatsRequest__Output, _envoy_service_load_stats_v2_LoadStatsResponse__Output>
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v2/LoadStatsRequest.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v2/LoadStatsRequest.ts
@@ -11,7 +11,7 @@ export interface LoadStatsRequest {
   /**
    * Node identifier for Envoy instance.
    */
-  'node'?: (_envoy_api_v2_core_Node);
+  'node'?: (_envoy_api_v2_core_Node | null);
   /**
    * A list of load stats to report.
    */
@@ -26,7 +26,7 @@ export interface LoadStatsRequest__Output {
   /**
    * Node identifier for Envoy instance.
    */
-  'node'?: (_envoy_api_v2_core_Node__Output);
+  'node': (_envoy_api_v2_core_Node__Output | null);
   /**
    * A list of load stats to report.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v2/LoadStatsResponse.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v2/LoadStatsResponse.ts
@@ -22,7 +22,7 @@ export interface LoadStatsResponse {
    * of inobservability that might otherwise exists between the messages. New clusters are not
    * subject to this consideration.
    */
-  'load_reporting_interval'?: (_google_protobuf_Duration);
+  'load_reporting_interval'?: (_google_protobuf_Duration | null);
   /**
    * Set to *true* if the management server supports endpoint granularity
    * report.
@@ -56,7 +56,7 @@ export interface LoadStatsResponse__Output {
    * of inobservability that might otherwise exists between the messages. New clusters are not
    * subject to this consideration.
    */
-  'load_reporting_interval'?: (_google_protobuf_Duration__Output);
+  'load_reporting_interval': (_google_protobuf_Duration__Output | null);
   /**
    * Set to *true* if the management server supports endpoint granularity
    * report.

--- a/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v3/LoadReportingService.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v3/LoadReportingService.ts
@@ -1,6 +1,7 @@
 // Original file: deps/envoy-api/envoy/service/load_stats/v3/lrs.proto
 
 import type * as grpc from '@grpc/grpc-js'
+import type { MethodDefinition } from '@grpc/proto-loader'
 import type { LoadStatsRequest as _envoy_service_load_stats_v3_LoadStatsRequest, LoadStatsRequest__Output as _envoy_service_load_stats_v3_LoadStatsRequest__Output } from '../../../../envoy/service/load_stats/v3/LoadStatsRequest';
 import type { LoadStatsResponse as _envoy_service_load_stats_v3_LoadStatsResponse, LoadStatsResponse__Output as _envoy_service_load_stats_v3_LoadStatsResponse__Output } from '../../../../envoy/service/load_stats/v3/LoadStatsResponse';
 
@@ -105,4 +106,8 @@ export interface LoadReportingServiceHandlers extends grpc.UntypedServiceImpleme
    */
   StreamLoadStats: grpc.handleBidiStreamingCall<_envoy_service_load_stats_v3_LoadStatsRequest__Output, _envoy_service_load_stats_v3_LoadStatsResponse>;
   
+}
+
+export interface LoadReportingServiceDefinition extends grpc.ServiceDefinition {
+  StreamLoadStats: MethodDefinition<_envoy_service_load_stats_v3_LoadStatsRequest, _envoy_service_load_stats_v3_LoadStatsResponse, _envoy_service_load_stats_v3_LoadStatsRequest__Output, _envoy_service_load_stats_v3_LoadStatsResponse__Output>
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v3/LoadStatsRequest.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v3/LoadStatsRequest.ts
@@ -10,7 +10,7 @@ export interface LoadStatsRequest {
   /**
    * Node identifier for Envoy instance.
    */
-  'node'?: (_envoy_config_core_v3_Node);
+  'node'?: (_envoy_config_core_v3_Node | null);
   /**
    * A list of load stats to report.
    */
@@ -24,7 +24,7 @@ export interface LoadStatsRequest__Output {
   /**
    * Node identifier for Envoy instance.
    */
-  'node'?: (_envoy_config_core_v3_Node__Output);
+  'node': (_envoy_config_core_v3_Node__Output | null);
   /**
    * A list of load stats to report.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v3/LoadStatsResponse.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/load_stats/v3/LoadStatsResponse.ts
@@ -22,7 +22,7 @@ export interface LoadStatsResponse {
    * of inobservability that might otherwise exists between the messages. New clusters are not
    * subject to this consideration.
    */
-  'load_reporting_interval'?: (_google_protobuf_Duration);
+  'load_reporting_interval'?: (_google_protobuf_Duration | null);
   /**
    * Set to *true* if the management server supports endpoint granularity
    * report.
@@ -56,7 +56,7 @@ export interface LoadStatsResponse__Output {
    * of inobservability that might otherwise exists between the messages. New clusters are not
    * subject to this consideration.
    */
-  'load_reporting_interval'?: (_google_protobuf_Duration__Output);
+  'load_reporting_interval': (_google_protobuf_Duration__Output | null);
   /**
    * Set to *true* if the management server supports endpoint granularity
    * report.

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/DoubleMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/DoubleMatcher.ts
@@ -10,7 +10,7 @@ export interface DoubleMatcher {
    * If specified, the input double value must be in the range specified here.
    * Note: The range is using half-open interval semantics [start, end).
    */
-  'range'?: (_envoy_type_v3_DoubleRange);
+  'range'?: (_envoy_type_v3_DoubleRange | null);
   /**
    * If specified, the input double value must be equal to the value specified here.
    */
@@ -26,7 +26,7 @@ export interface DoubleMatcher__Output {
    * If specified, the input double value must be in the range specified here.
    * Note: The range is using half-open interval semantics [start, end).
    */
-  'range'?: (_envoy_type_v3_DoubleRange__Output);
+  'range'?: (_envoy_type_v3_DoubleRange__Output | null);
   /**
    * If specified, the input double value must be equal to the value specified here.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/ListMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/ListMatcher.ts
@@ -9,7 +9,7 @@ export interface ListMatcher {
   /**
    * If specified, at least one of the values in the list must match the value specified.
    */
-  'one_of'?: (_envoy_type_matcher_v3_ValueMatcher);
+  'one_of'?: (_envoy_type_matcher_v3_ValueMatcher | null);
   'match_pattern'?: "one_of";
 }
 
@@ -20,6 +20,6 @@ export interface ListMatcher__Output {
   /**
    * If specified, at least one of the values in the list must match the value specified.
    */
-  'one_of'?: (_envoy_type_matcher_v3_ValueMatcher__Output);
+  'one_of'?: (_envoy_type_matcher_v3_ValueMatcher__Output | null);
   'match_pattern': "one_of";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/MetadataMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/MetadataMatcher.ts
@@ -43,7 +43,7 @@ export interface MetadataMatcher {
   /**
    * The MetadataMatcher is matched if the value retrieved by path is matched to this value.
    */
-  'value'?: (_envoy_type_matcher_v3_ValueMatcher);
+  'value'?: (_envoy_type_matcher_v3_ValueMatcher | null);
 }
 
 /**
@@ -61,5 +61,5 @@ export interface MetadataMatcher__Output {
   /**
    * The MetadataMatcher is matched if the value retrieved by path is matched to this value.
    */
-  'value'?: (_envoy_type_matcher_v3_ValueMatcher__Output);
+  'value': (_envoy_type_matcher_v3_ValueMatcher__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/RegexMatchAndSubstitute.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/RegexMatchAndSubstitute.ts
@@ -18,7 +18,7 @@ export interface RegexMatchAndSubstitute {
    * used in the pattern to extract portions of the subject string, and then
    * referenced in the substitution string.
    */
-  'pattern'?: (_envoy_type_matcher_v3_RegexMatcher);
+  'pattern'?: (_envoy_type_matcher_v3_RegexMatcher | null);
   /**
    * The string that should be substituted into matching portions of the
    * subject string during a substitution operation to produce a new string.
@@ -49,7 +49,7 @@ export interface RegexMatchAndSubstitute__Output {
    * used in the pattern to extract portions of the subject string, and then
    * referenced in the substitution string.
    */
-  'pattern'?: (_envoy_type_matcher_v3_RegexMatcher__Output);
+  'pattern': (_envoy_type_matcher_v3_RegexMatcher__Output | null);
   /**
    * The string that should be substituted into matching portions of the
    * subject string during a substitution operation to produce a new string.

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/RegexMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/RegexMatcher.ts
@@ -27,7 +27,7 @@ export interface _envoy_type_matcher_v3_RegexMatcher_GoogleRE2 {
    * This field is deprecated; regexp validation should be performed on the management server
    * instead of being done by each individual client.
    */
-  'max_program_size'?: (_google_protobuf_UInt32Value);
+  'max_program_size'?: (_google_protobuf_UInt32Value | null);
 }
 
 /**
@@ -55,7 +55,7 @@ export interface _envoy_type_matcher_v3_RegexMatcher_GoogleRE2__Output {
    * This field is deprecated; regexp validation should be performed on the management server
    * instead of being done by each individual client.
    */
-  'max_program_size'?: (_google_protobuf_UInt32Value__Output);
+  'max_program_size': (_google_protobuf_UInt32Value__Output | null);
 }
 
 /**
@@ -65,7 +65,7 @@ export interface RegexMatcher {
   /**
    * Google's RE2 regex engine.
    */
-  'google_re2'?: (_envoy_type_matcher_v3_RegexMatcher_GoogleRE2);
+  'google_re2'?: (_envoy_type_matcher_v3_RegexMatcher_GoogleRE2 | null);
   /**
    * The regex match string. The string must be supported by the configured engine.
    */
@@ -80,7 +80,7 @@ export interface RegexMatcher__Output {
   /**
    * Google's RE2 regex engine.
    */
-  'google_re2'?: (_envoy_type_matcher_v3_RegexMatcher_GoogleRE2__Output);
+  'google_re2'?: (_envoy_type_matcher_v3_RegexMatcher_GoogleRE2__Output | null);
   /**
    * The regex match string. The string must be supported by the configured engine.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/StringMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/StringMatcher.ts
@@ -36,7 +36,7 @@ export interface StringMatcher {
   /**
    * The input string must match the regular expression specified here.
    */
-  'safe_regex'?: (_envoy_type_matcher_v3_RegexMatcher);
+  'safe_regex'?: (_envoy_type_matcher_v3_RegexMatcher | null);
   /**
    * If true, indicates the exact/prefix/suffix matching should be case insensitive. This has no
    * effect for the safe_regex match.
@@ -89,7 +89,7 @@ export interface StringMatcher__Output {
   /**
    * The input string must match the regular expression specified here.
    */
-  'safe_regex'?: (_envoy_type_matcher_v3_RegexMatcher__Output);
+  'safe_regex'?: (_envoy_type_matcher_v3_RegexMatcher__Output | null);
   /**
    * If true, indicates the exact/prefix/suffix matching should be case insensitive. This has no
    * effect for the safe_regex match.

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/ValueMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/ValueMatcher.ts
@@ -25,17 +25,17 @@ export interface ValueMatcher {
   /**
    * If specified, a match occurs if and only if the target value is a NullValue.
    */
-  'null_match'?: (_envoy_type_matcher_v3_ValueMatcher_NullMatch);
+  'null_match'?: (_envoy_type_matcher_v3_ValueMatcher_NullMatch | null);
   /**
    * If specified, a match occurs if and only if the target value is a double value and is
    * matched to this field.
    */
-  'double_match'?: (_envoy_type_matcher_v3_DoubleMatcher);
+  'double_match'?: (_envoy_type_matcher_v3_DoubleMatcher | null);
   /**
    * If specified, a match occurs if and only if the target value is a string value and is
    * matched to this field.
    */
-  'string_match'?: (_envoy_type_matcher_v3_StringMatcher);
+  'string_match'?: (_envoy_type_matcher_v3_StringMatcher | null);
   /**
    * If specified, a match occurs if and only if the target value is a bool value and is equal
    * to this field.
@@ -51,7 +51,7 @@ export interface ValueMatcher {
    * If specified, a match occurs if and only if the target value is a list value and
    * is matched to this field.
    */
-  'list_match'?: (_envoy_type_matcher_v3_ListMatcher);
+  'list_match'?: (_envoy_type_matcher_v3_ListMatcher | null);
   /**
    * Specifies how to match a value.
    */
@@ -67,17 +67,17 @@ export interface ValueMatcher__Output {
   /**
    * If specified, a match occurs if and only if the target value is a NullValue.
    */
-  'null_match'?: (_envoy_type_matcher_v3_ValueMatcher_NullMatch__Output);
+  'null_match'?: (_envoy_type_matcher_v3_ValueMatcher_NullMatch__Output | null);
   /**
    * If specified, a match occurs if and only if the target value is a double value and is
    * matched to this field.
    */
-  'double_match'?: (_envoy_type_matcher_v3_DoubleMatcher__Output);
+  'double_match'?: (_envoy_type_matcher_v3_DoubleMatcher__Output | null);
   /**
    * If specified, a match occurs if and only if the target value is a string value and is
    * matched to this field.
    */
-  'string_match'?: (_envoy_type_matcher_v3_StringMatcher__Output);
+  'string_match'?: (_envoy_type_matcher_v3_StringMatcher__Output | null);
   /**
    * If specified, a match occurs if and only if the target value is a bool value and is equal
    * to this field.
@@ -93,7 +93,7 @@ export interface ValueMatcher__Output {
    * If specified, a match occurs if and only if the target value is a list value and
    * is matched to this field.
    */
-  'list_match'?: (_envoy_type_matcher_v3_ListMatcher__Output);
+  'list_match'?: (_envoy_type_matcher_v3_ListMatcher__Output | null);
   /**
    * Specifies how to match a value.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/type/metadata/v3/MetadataKind.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/metadata/v3/MetadataKind.ts
@@ -58,19 +58,19 @@ export interface MetadataKind {
   /**
    * Request kind of metadata.
    */
-  'request'?: (_envoy_type_metadata_v3_MetadataKind_Request);
+  'request'?: (_envoy_type_metadata_v3_MetadataKind_Request | null);
   /**
    * Route kind of metadata.
    */
-  'route'?: (_envoy_type_metadata_v3_MetadataKind_Route);
+  'route'?: (_envoy_type_metadata_v3_MetadataKind_Route | null);
   /**
    * Cluster kind of metadata.
    */
-  'cluster'?: (_envoy_type_metadata_v3_MetadataKind_Cluster);
+  'cluster'?: (_envoy_type_metadata_v3_MetadataKind_Cluster | null);
   /**
    * Host kind of metadata.
    */
-  'host'?: (_envoy_type_metadata_v3_MetadataKind_Host);
+  'host'?: (_envoy_type_metadata_v3_MetadataKind_Host | null);
   'kind'?: "request"|"route"|"cluster"|"host";
 }
 
@@ -81,18 +81,18 @@ export interface MetadataKind__Output {
   /**
    * Request kind of metadata.
    */
-  'request'?: (_envoy_type_metadata_v3_MetadataKind_Request__Output);
+  'request'?: (_envoy_type_metadata_v3_MetadataKind_Request__Output | null);
   /**
    * Route kind of metadata.
    */
-  'route'?: (_envoy_type_metadata_v3_MetadataKind_Route__Output);
+  'route'?: (_envoy_type_metadata_v3_MetadataKind_Route__Output | null);
   /**
    * Cluster kind of metadata.
    */
-  'cluster'?: (_envoy_type_metadata_v3_MetadataKind_Cluster__Output);
+  'cluster'?: (_envoy_type_metadata_v3_MetadataKind_Cluster__Output | null);
   /**
    * Host kind of metadata.
    */
-  'host'?: (_envoy_type_metadata_v3_MetadataKind_Host__Output);
+  'host'?: (_envoy_type_metadata_v3_MetadataKind_Host__Output | null);
   'kind': "request"|"route"|"cluster"|"host";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/type/tracing/v3/CustomTag.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/tracing/v3/CustomTag.ts
@@ -98,11 +98,11 @@ export interface _envoy_type_tracing_v3_CustomTag_Metadata {
   /**
    * Specify what kind of metadata to obtain tag value from.
    */
-  'kind'?: (_envoy_type_metadata_v3_MetadataKind);
+  'kind'?: (_envoy_type_metadata_v3_MetadataKind | null);
   /**
    * Metadata key to define the path to retrieve the tag value.
    */
-  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey);
+  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey | null);
   /**
    * When no valid metadata is found,
    * the tag value would be populated with this default value if specified,
@@ -122,11 +122,11 @@ export interface _envoy_type_tracing_v3_CustomTag_Metadata__Output {
   /**
    * Specify what kind of metadata to obtain tag value from.
    */
-  'kind'?: (_envoy_type_metadata_v3_MetadataKind__Output);
+  'kind': (_envoy_type_metadata_v3_MetadataKind__Output | null);
   /**
    * Metadata key to define the path to retrieve the tag value.
    */
-  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey__Output);
+  'metadata_key': (_envoy_type_metadata_v3_MetadataKey__Output | null);
   /**
    * When no valid metadata is found,
    * the tag value would be populated with this default value if specified,
@@ -147,19 +147,19 @@ export interface CustomTag {
   /**
    * A literal custom tag.
    */
-  'literal'?: (_envoy_type_tracing_v3_CustomTag_Literal);
+  'literal'?: (_envoy_type_tracing_v3_CustomTag_Literal | null);
   /**
    * An environment custom tag.
    */
-  'environment'?: (_envoy_type_tracing_v3_CustomTag_Environment);
+  'environment'?: (_envoy_type_tracing_v3_CustomTag_Environment | null);
   /**
    * A request header custom tag.
    */
-  'request_header'?: (_envoy_type_tracing_v3_CustomTag_Header);
+  'request_header'?: (_envoy_type_tracing_v3_CustomTag_Header | null);
   /**
    * A custom tag to obtain tag value from the metadata.
    */
-  'metadata'?: (_envoy_type_tracing_v3_CustomTag_Metadata);
+  'metadata'?: (_envoy_type_tracing_v3_CustomTag_Metadata | null);
   /**
    * Used to specify what kind of custom tag.
    */
@@ -178,19 +178,19 @@ export interface CustomTag__Output {
   /**
    * A literal custom tag.
    */
-  'literal'?: (_envoy_type_tracing_v3_CustomTag_Literal__Output);
+  'literal'?: (_envoy_type_tracing_v3_CustomTag_Literal__Output | null);
   /**
    * An environment custom tag.
    */
-  'environment'?: (_envoy_type_tracing_v3_CustomTag_Environment__Output);
+  'environment'?: (_envoy_type_tracing_v3_CustomTag_Environment__Output | null);
   /**
    * A request header custom tag.
    */
-  'request_header'?: (_envoy_type_tracing_v3_CustomTag_Header__Output);
+  'request_header'?: (_envoy_type_tracing_v3_CustomTag_Header__Output | null);
   /**
    * A custom tag to obtain tag value from the metadata.
    */
-  'metadata'?: (_envoy_type_tracing_v3_CustomTag_Metadata__Output);
+  'metadata'?: (_envoy_type_tracing_v3_CustomTag_Metadata__Output | null);
   /**
    * Used to specify what kind of custom tag.
    */

--- a/packages/grpc-js-xds/src/generated/fault.ts
+++ b/packages/grpc-js-xds/src/generated/fault.ts
@@ -1,0 +1,220 @@
+import type * as grpc from '@grpc/grpc-js';
+import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
+
+
+type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
+  new(...args: ConstructorParameters<Constructor>): Subtype;
+};
+
+export interface ProtoGrpcType {
+  envoy: {
+    annotations: {
+    }
+    config: {
+      core: {
+        v3: {
+          Address: MessageTypeDefinition
+          AggregatedConfigSource: MessageTypeDefinition
+          ApiConfigSource: MessageTypeDefinition
+          ApiVersion: EnumTypeDefinition
+          AsyncDataSource: MessageTypeDefinition
+          BackoffStrategy: MessageTypeDefinition
+          BindConfig: MessageTypeDefinition
+          BuildVersion: MessageTypeDefinition
+          CidrRange: MessageTypeDefinition
+          ConfigSource: MessageTypeDefinition
+          ControlPlane: MessageTypeDefinition
+          DataSource: MessageTypeDefinition
+          EnvoyInternalAddress: MessageTypeDefinition
+          Extension: MessageTypeDefinition
+          ExtensionConfigSource: MessageTypeDefinition
+          GrpcService: MessageTypeDefinition
+          HeaderMap: MessageTypeDefinition
+          HeaderValue: MessageTypeDefinition
+          HeaderValueOption: MessageTypeDefinition
+          HttpUri: MessageTypeDefinition
+          Locality: MessageTypeDefinition
+          Metadata: MessageTypeDefinition
+          Node: MessageTypeDefinition
+          Pipe: MessageTypeDefinition
+          ProxyProtocolConfig: MessageTypeDefinition
+          RateLimitSettings: MessageTypeDefinition
+          RemoteDataSource: MessageTypeDefinition
+          RequestMethod: EnumTypeDefinition
+          RetryPolicy: MessageTypeDefinition
+          RoutingPriority: EnumTypeDefinition
+          RuntimeDouble: MessageTypeDefinition
+          RuntimeFeatureFlag: MessageTypeDefinition
+          RuntimeFractionalPercent: MessageTypeDefinition
+          RuntimePercent: MessageTypeDefinition
+          RuntimeUInt32: MessageTypeDefinition
+          SelfConfigSource: MessageTypeDefinition
+          SocketAddress: MessageTypeDefinition
+          SocketOption: MessageTypeDefinition
+          TcpKeepalive: MessageTypeDefinition
+          TrafficDirection: EnumTypeDefinition
+          TransportSocket: MessageTypeDefinition
+          TypedExtensionConfig: MessageTypeDefinition
+          WatchedDirectory: MessageTypeDefinition
+        }
+      }
+      route: {
+        v3: {
+          CorsPolicy: MessageTypeDefinition
+          Decorator: MessageTypeDefinition
+          DirectResponseAction: MessageTypeDefinition
+          FilterAction: MessageTypeDefinition
+          FilterConfig: MessageTypeDefinition
+          HeaderMatcher: MessageTypeDefinition
+          HedgePolicy: MessageTypeDefinition
+          InternalRedirectPolicy: MessageTypeDefinition
+          QueryParameterMatcher: MessageTypeDefinition
+          RateLimit: MessageTypeDefinition
+          RedirectAction: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition
+          Route: MessageTypeDefinition
+          RouteAction: MessageTypeDefinition
+          RouteMatch: MessageTypeDefinition
+          Tracing: MessageTypeDefinition
+          VirtualCluster: MessageTypeDefinition
+          VirtualHost: MessageTypeDefinition
+          WeightedCluster: MessageTypeDefinition
+        }
+      }
+    }
+    extensions: {
+      filters: {
+        common: {
+          fault: {
+            v3: {
+              FaultDelay: MessageTypeDefinition
+              FaultRateLimit: MessageTypeDefinition
+            }
+          }
+        }
+        http: {
+          fault: {
+            v3: {
+              FaultAbort: MessageTypeDefinition
+              HTTPFault: MessageTypeDefinition
+            }
+          }
+        }
+      }
+    }
+    type: {
+      matcher: {
+        v3: {
+          ListStringMatcher: MessageTypeDefinition
+          RegexMatchAndSubstitute: MessageTypeDefinition
+          RegexMatcher: MessageTypeDefinition
+          StringMatcher: MessageTypeDefinition
+        }
+      }
+      metadata: {
+        v3: {
+          MetadataKey: MessageTypeDefinition
+          MetadataKind: MessageTypeDefinition
+        }
+      }
+      tracing: {
+        v3: {
+          CustomTag: MessageTypeDefinition
+        }
+      }
+      v3: {
+        DoubleRange: MessageTypeDefinition
+        FractionalPercent: MessageTypeDefinition
+        Int32Range: MessageTypeDefinition
+        Int64Range: MessageTypeDefinition
+        Percent: MessageTypeDefinition
+        SemanticVersion: MessageTypeDefinition
+      }
+    }
+  }
+  google: {
+    protobuf: {
+      Any: MessageTypeDefinition
+      BoolValue: MessageTypeDefinition
+      BytesValue: MessageTypeDefinition
+      DescriptorProto: MessageTypeDefinition
+      DoubleValue: MessageTypeDefinition
+      Duration: MessageTypeDefinition
+      Empty: MessageTypeDefinition
+      EnumDescriptorProto: MessageTypeDefinition
+      EnumOptions: MessageTypeDefinition
+      EnumValueDescriptorProto: MessageTypeDefinition
+      EnumValueOptions: MessageTypeDefinition
+      FieldDescriptorProto: MessageTypeDefinition
+      FieldOptions: MessageTypeDefinition
+      FileDescriptorProto: MessageTypeDefinition
+      FileDescriptorSet: MessageTypeDefinition
+      FileOptions: MessageTypeDefinition
+      FloatValue: MessageTypeDefinition
+      GeneratedCodeInfo: MessageTypeDefinition
+      Int32Value: MessageTypeDefinition
+      Int64Value: MessageTypeDefinition
+      ListValue: MessageTypeDefinition
+      MessageOptions: MessageTypeDefinition
+      MethodDescriptorProto: MessageTypeDefinition
+      MethodOptions: MessageTypeDefinition
+      NullValue: EnumTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition
+      OneofOptions: MessageTypeDefinition
+      ServiceDescriptorProto: MessageTypeDefinition
+      ServiceOptions: MessageTypeDefinition
+      SourceCodeInfo: MessageTypeDefinition
+      StringValue: MessageTypeDefinition
+      Struct: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition
+      UInt32Value: MessageTypeDefinition
+      UInt64Value: MessageTypeDefinition
+      UninterpretedOption: MessageTypeDefinition
+      Value: MessageTypeDefinition
+    }
+  }
+  udpa: {
+    annotations: {
+      FieldMigrateAnnotation: MessageTypeDefinition
+      FileMigrateAnnotation: MessageTypeDefinition
+      MigrateAnnotation: MessageTypeDefinition
+      PackageVersionStatus: EnumTypeDefinition
+      StatusAnnotation: MessageTypeDefinition
+      VersioningAnnotation: MessageTypeDefinition
+    }
+  }
+  validate: {
+    AnyRules: MessageTypeDefinition
+    BoolRules: MessageTypeDefinition
+    BytesRules: MessageTypeDefinition
+    DoubleRules: MessageTypeDefinition
+    DurationRules: MessageTypeDefinition
+    EnumRules: MessageTypeDefinition
+    FieldRules: MessageTypeDefinition
+    Fixed32Rules: MessageTypeDefinition
+    Fixed64Rules: MessageTypeDefinition
+    FloatRules: MessageTypeDefinition
+    Int32Rules: MessageTypeDefinition
+    Int64Rules: MessageTypeDefinition
+    KnownRegex: EnumTypeDefinition
+    MapRules: MessageTypeDefinition
+    MessageRules: MessageTypeDefinition
+    RepeatedRules: MessageTypeDefinition
+    SFixed32Rules: MessageTypeDefinition
+    SFixed64Rules: MessageTypeDefinition
+    SInt32Rules: MessageTypeDefinition
+    SInt64Rules: MessageTypeDefinition
+    StringRules: MessageTypeDefinition
+    TimestampRules: MessageTypeDefinition
+    UInt32Rules: MessageTypeDefinition
+    UInt64Rules: MessageTypeDefinition
+  }
+  xds: {
+    core: {
+      v3: {
+        Authority: MessageTypeDefinition
+      }
+    }
+  }
+}
+

--- a/packages/grpc-js-xds/src/generated/google/protobuf/DescriptorProto.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/DescriptorProto.ts
@@ -33,7 +33,7 @@ export interface DescriptorProto {
   'enumType'?: (_google_protobuf_EnumDescriptorProto)[];
   'extensionRange'?: (_google_protobuf_DescriptorProto_ExtensionRange)[];
   'extension'?: (_google_protobuf_FieldDescriptorProto)[];
-  'options'?: (_google_protobuf_MessageOptions);
+  'options'?: (_google_protobuf_MessageOptions | null);
   'oneofDecl'?: (_google_protobuf_OneofDescriptorProto)[];
   'reservedRange'?: (_google_protobuf_DescriptorProto_ReservedRange)[];
   'reservedName'?: (string)[];
@@ -46,7 +46,7 @@ export interface DescriptorProto__Output {
   'enumType': (_google_protobuf_EnumDescriptorProto__Output)[];
   'extensionRange': (_google_protobuf_DescriptorProto_ExtensionRange__Output)[];
   'extension': (_google_protobuf_FieldDescriptorProto__Output)[];
-  'options'?: (_google_protobuf_MessageOptions__Output);
+  'options': (_google_protobuf_MessageOptions__Output | null);
   'oneofDecl': (_google_protobuf_OneofDescriptorProto__Output)[];
   'reservedRange': (_google_protobuf_DescriptorProto_ReservedRange__Output)[];
   'reservedName': (string)[];

--- a/packages/grpc-js-xds/src/generated/google/protobuf/EnumDescriptorProto.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/EnumDescriptorProto.ts
@@ -6,11 +6,11 @@ import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output a
 export interface EnumDescriptorProto {
   'name'?: (string);
   'value'?: (_google_protobuf_EnumValueDescriptorProto)[];
-  'options'?: (_google_protobuf_EnumOptions);
+  'options'?: (_google_protobuf_EnumOptions | null);
 }
 
 export interface EnumDescriptorProto__Output {
   'name': (string);
   'value': (_google_protobuf_EnumValueDescriptorProto__Output)[];
-  'options'?: (_google_protobuf_EnumOptions__Output);
+  'options': (_google_protobuf_EnumOptions__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/EnumOptions.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/EnumOptions.ts
@@ -1,15 +1,18 @@
 // Original file: null
 
 import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from '../../udpa/annotations/MigrateAnnotation';
 
 export interface EnumOptions {
   'allowAlias'?: (boolean);
   'deprecated'?: (boolean);
   'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
+  '.udpa.annotations.enum_migrate'?: (_udpa_annotations_MigrateAnnotation | null);
 }
 
 export interface EnumOptions__Output {
   'allowAlias': (boolean);
   'deprecated': (boolean);
   'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
+  '.udpa.annotations.enum_migrate': (_udpa_annotations_MigrateAnnotation__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/EnumValueDescriptorProto.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/EnumValueDescriptorProto.ts
@@ -5,11 +5,11 @@ import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOp
 export interface EnumValueDescriptorProto {
   'name'?: (string);
   'number'?: (number);
-  'options'?: (_google_protobuf_EnumValueOptions);
+  'options'?: (_google_protobuf_EnumValueOptions | null);
 }
 
 export interface EnumValueDescriptorProto__Output {
   'name': (string);
   'number': (number);
-  'options'?: (_google_protobuf_EnumValueOptions__Output);
+  'options': (_google_protobuf_EnumValueOptions__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/EnumValueOptions.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/EnumValueOptions.ts
@@ -1,13 +1,18 @@
 // Original file: null
 
 import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from '../../udpa/annotations/MigrateAnnotation';
 
 export interface EnumValueOptions {
   'deprecated'?: (boolean);
   'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
+  '.envoy.annotations.disallowed_by_default_enum'?: (boolean);
+  '.udpa.annotations.enum_value_migrate'?: (_udpa_annotations_MigrateAnnotation | null);
 }
 
 export interface EnumValueOptions__Output {
   'deprecated': (boolean);
   'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
+  '.envoy.annotations.disallowed_by_default_enum': (boolean);
+  '.udpa.annotations.enum_value_migrate': (_udpa_annotations_MigrateAnnotation__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/FieldDescriptorProto.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/FieldDescriptorProto.ts
@@ -41,7 +41,7 @@ export interface FieldDescriptorProto {
   'type'?: (_google_protobuf_FieldDescriptorProto_Type | keyof typeof _google_protobuf_FieldDescriptorProto_Type);
   'typeName'?: (string);
   'defaultValue'?: (string);
-  'options'?: (_google_protobuf_FieldOptions);
+  'options'?: (_google_protobuf_FieldOptions | null);
   'oneofIndex'?: (number);
   'jsonName'?: (string);
 }
@@ -54,7 +54,7 @@ export interface FieldDescriptorProto__Output {
   'type': (keyof typeof _google_protobuf_FieldDescriptorProto_Type);
   'typeName': (string);
   'defaultValue': (string);
-  'options'?: (_google_protobuf_FieldOptions__Output);
+  'options': (_google_protobuf_FieldOptions__Output | null);
   'oneofIndex': (number);
   'jsonName': (string);
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/FieldOptions.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/FieldOptions.ts
@@ -2,6 +2,7 @@
 
 import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
 import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from '../../validate/FieldRules';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from '../../udpa/annotations/FieldMigrateAnnotation';
 
 // Original file: null
 
@@ -27,7 +28,10 @@ export interface FieldOptions {
   'jstype'?: (_google_protobuf_FieldOptions_JSType | keyof typeof _google_protobuf_FieldOptions_JSType);
   'weak'?: (boolean);
   'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
-  '.validate.rules'?: (_validate_FieldRules);
+  '.validate.rules'?: (_validate_FieldRules | null);
+  '.udpa.annotations.sensitive'?: (boolean);
+  '.udpa.annotations.field_migrate'?: (_udpa_annotations_FieldMigrateAnnotation | null);
+  '.envoy.annotations.disallowed_by_default'?: (boolean);
 }
 
 export interface FieldOptions__Output {
@@ -38,5 +42,8 @@ export interface FieldOptions__Output {
   'jstype': (keyof typeof _google_protobuf_FieldOptions_JSType);
   'weak': (boolean);
   'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
-  '.validate.rules'?: (_validate_FieldRules__Output);
+  '.validate.rules': (_validate_FieldRules__Output | null);
+  '.udpa.annotations.sensitive': (boolean);
+  '.udpa.annotations.field_migrate': (_udpa_annotations_FieldMigrateAnnotation__Output | null);
+  '.envoy.annotations.disallowed_by_default': (boolean);
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/FileDescriptorProto.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/FileDescriptorProto.ts
@@ -15,8 +15,8 @@ export interface FileDescriptorProto {
   'enumType'?: (_google_protobuf_EnumDescriptorProto)[];
   'service'?: (_google_protobuf_ServiceDescriptorProto)[];
   'extension'?: (_google_protobuf_FieldDescriptorProto)[];
-  'options'?: (_google_protobuf_FileOptions);
-  'sourceCodeInfo'?: (_google_protobuf_SourceCodeInfo);
+  'options'?: (_google_protobuf_FileOptions | null);
+  'sourceCodeInfo'?: (_google_protobuf_SourceCodeInfo | null);
   'publicDependency'?: (number)[];
   'weakDependency'?: (number)[];
   'syntax'?: (string);
@@ -30,8 +30,8 @@ export interface FileDescriptorProto__Output {
   'enumType': (_google_protobuf_EnumDescriptorProto__Output)[];
   'service': (_google_protobuf_ServiceDescriptorProto__Output)[];
   'extension': (_google_protobuf_FieldDescriptorProto__Output)[];
-  'options'?: (_google_protobuf_FileOptions__Output);
-  'sourceCodeInfo'?: (_google_protobuf_SourceCodeInfo__Output);
+  'options': (_google_protobuf_FileOptions__Output | null);
+  'sourceCodeInfo': (_google_protobuf_SourceCodeInfo__Output | null);
   'publicDependency': (number)[];
   'weakDependency': (number)[];
   'syntax': (string);

--- a/packages/grpc-js-xds/src/generated/google/protobuf/FileOptions.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/FileOptions.ts
@@ -1,6 +1,8 @@
 // Original file: null
 
 import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from '../../udpa/annotations/FileMigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from '../../udpa/annotations/StatusAnnotation';
 
 // Original file: null
 
@@ -26,6 +28,8 @@ export interface FileOptions {
   'objcClassPrefix'?: (string);
   'csharpNamespace'?: (string);
   'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
+  '.udpa.annotations.file_migrate'?: (_udpa_annotations_FileMigrateAnnotation | null);
+  '.udpa.annotations.file_status'?: (_udpa_annotations_StatusAnnotation | null);
 }
 
 export interface FileOptions__Output {
@@ -44,4 +48,6 @@ export interface FileOptions__Output {
   'objcClassPrefix': (string);
   'csharpNamespace': (string);
   'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
+  '.udpa.annotations.file_migrate': (_udpa_annotations_FileMigrateAnnotation__Output | null);
+  '.udpa.annotations.file_status': (_udpa_annotations_StatusAnnotation__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/MessageOptions.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/MessageOptions.ts
@@ -1,6 +1,8 @@
 // Original file: null
 
 import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from '../../udpa/annotations/VersioningAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from '../../udpa/annotations/MigrateAnnotation';
 
 export interface MessageOptions {
   'messageSetWireFormat'?: (boolean);
@@ -9,6 +11,8 @@ export interface MessageOptions {
   'mapEntry'?: (boolean);
   'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
   '.validate.disabled'?: (boolean);
+  '.udpa.annotations.versioning'?: (_udpa_annotations_VersioningAnnotation | null);
+  '.udpa.annotations.message_migrate'?: (_udpa_annotations_MigrateAnnotation | null);
 }
 
 export interface MessageOptions__Output {
@@ -18,4 +22,6 @@ export interface MessageOptions__Output {
   'mapEntry': (boolean);
   'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
   '.validate.disabled': (boolean);
+  '.udpa.annotations.versioning': (_udpa_annotations_VersioningAnnotation__Output | null);
+  '.udpa.annotations.message_migrate': (_udpa_annotations_MigrateAnnotation__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/MethodDescriptorProto.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/MethodDescriptorProto.ts
@@ -6,7 +6,7 @@ export interface MethodDescriptorProto {
   'name'?: (string);
   'inputType'?: (string);
   'outputType'?: (string);
-  'options'?: (_google_protobuf_MethodOptions);
+  'options'?: (_google_protobuf_MethodOptions | null);
   'clientStreaming'?: (boolean);
   'serverStreaming'?: (boolean);
 }
@@ -15,7 +15,7 @@ export interface MethodDescriptorProto__Output {
   'name': (string);
   'inputType': (string);
   'outputType': (string);
-  'options'?: (_google_protobuf_MethodOptions__Output);
+  'options': (_google_protobuf_MethodOptions__Output | null);
   'clientStreaming': (boolean);
   'serverStreaming': (boolean);
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/OneofDescriptorProto.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/OneofDescriptorProto.ts
@@ -4,10 +4,10 @@ import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Outpu
 
 export interface OneofDescriptorProto {
   'name'?: (string);
-  'options'?: (_google_protobuf_OneofOptions);
+  'options'?: (_google_protobuf_OneofOptions | null);
 }
 
 export interface OneofDescriptorProto__Output {
   'name': (string);
-  'options'?: (_google_protobuf_OneofOptions__Output);
+  'options': (_google_protobuf_OneofOptions__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/ServiceDescriptorProto.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/ServiceDescriptorProto.ts
@@ -6,11 +6,11 @@ import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions_
 export interface ServiceDescriptorProto {
   'name'?: (string);
   'method'?: (_google_protobuf_MethodDescriptorProto)[];
-  'options'?: (_google_protobuf_ServiceOptions);
+  'options'?: (_google_protobuf_ServiceOptions | null);
 }
 
 export interface ServiceDescriptorProto__Output {
   'name': (string);
   'method': (_google_protobuf_MethodDescriptorProto__Output)[];
-  'options'?: (_google_protobuf_ServiceOptions__Output);
+  'options': (_google_protobuf_ServiceOptions__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/Struct.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/Struct.ts
@@ -7,5 +7,5 @@ export interface Struct {
 }
 
 export interface Struct__Output {
-  'fields'?: ({[key: string]: _google_protobuf_Value__Output});
+  'fields': ({[key: string]: _google_protobuf_Value__Output});
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/Value.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/Value.ts
@@ -9,8 +9,8 @@ export interface Value {
   'numberValue'?: (number | string);
   'stringValue'?: (string);
   'boolValue'?: (boolean);
-  'structValue'?: (_google_protobuf_Struct);
-  'listValue'?: (_google_protobuf_ListValue);
+  'structValue'?: (_google_protobuf_Struct | null);
+  'listValue'?: (_google_protobuf_ListValue | null);
   'kind'?: "nullValue"|"numberValue"|"stringValue"|"boolValue"|"structValue"|"listValue";
 }
 
@@ -19,7 +19,7 @@ export interface Value__Output {
   'numberValue'?: (number);
   'stringValue'?: (string);
   'boolValue'?: (boolean);
-  'structValue'?: (_google_protobuf_Struct__Output);
-  'listValue'?: (_google_protobuf_ListValue__Output);
+  'structValue'?: (_google_protobuf_Struct__Output | null);
+  'listValue'?: (_google_protobuf_ListValue__Output | null);
   'kind': "nullValue"|"numberValue"|"stringValue"|"boolValue"|"structValue"|"listValue";
 }

--- a/packages/grpc-js-xds/src/generated/http_connection_manager.ts
+++ b/packages/grpc-js-xds/src/generated/http_connection_manager.ts
@@ -1,5 +1,5 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { ServiceDefinition, EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
+import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {

--- a/packages/grpc-js-xds/src/generated/listener.ts
+++ b/packages/grpc-js-xds/src/generated/listener.ts
@@ -1,5 +1,5 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { ServiceDefinition, EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
+import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {

--- a/packages/grpc-js-xds/src/generated/lrs.ts
+++ b/packages/grpc-js-xds/src/generated/lrs.ts
@@ -1,8 +1,8 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { ServiceDefinition, EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
+import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
-import type { LoadReportingServiceClient as _envoy_service_load_stats_v2_LoadReportingServiceClient } from './envoy/service/load_stats/v2/LoadReportingService';
-import type { LoadReportingServiceClient as _envoy_service_load_stats_v3_LoadReportingServiceClient } from './envoy/service/load_stats/v3/LoadReportingService';
+import type { LoadReportingServiceClient as _envoy_service_load_stats_v2_LoadReportingServiceClient, LoadReportingServiceDefinition as _envoy_service_load_stats_v2_LoadReportingServiceDefinition } from './envoy/service/load_stats/v2/LoadReportingService';
+import type { LoadReportingServiceClient as _envoy_service_load_stats_v3_LoadReportingServiceClient, LoadReportingServiceDefinition as _envoy_service_load_stats_v3_LoadReportingServiceDefinition } from './envoy/service/load_stats/v3/LoadReportingService';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -102,12 +102,12 @@ export interface ProtoGrpcType {
     service: {
       load_stats: {
         v2: {
-          LoadReportingService: SubtypeConstructor<typeof grpc.Client, _envoy_service_load_stats_v2_LoadReportingServiceClient> & { service: ServiceDefinition }
+          LoadReportingService: SubtypeConstructor<typeof grpc.Client, _envoy_service_load_stats_v2_LoadReportingServiceClient> & { service: _envoy_service_load_stats_v2_LoadReportingServiceDefinition }
           LoadStatsRequest: MessageTypeDefinition
           LoadStatsResponse: MessageTypeDefinition
         }
         v3: {
-          LoadReportingService: SubtypeConstructor<typeof grpc.Client, _envoy_service_load_stats_v3_LoadReportingServiceClient> & { service: ServiceDefinition }
+          LoadReportingService: SubtypeConstructor<typeof grpc.Client, _envoy_service_load_stats_v3_LoadReportingServiceClient> & { service: _envoy_service_load_stats_v3_LoadReportingServiceDefinition }
           LoadStatsRequest: MessageTypeDefinition
           LoadStatsResponse: MessageTypeDefinition
         }

--- a/packages/grpc-js-xds/src/generated/route.ts
+++ b/packages/grpc-js-xds/src/generated/route.ts
@@ -1,5 +1,5 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { ServiceDefinition, EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
+import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {

--- a/packages/grpc-js-xds/src/generated/typed_struct.ts
+++ b/packages/grpc-js-xds/src/generated/typed_struct.ts
@@ -1,5 +1,5 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { ServiceDefinition, EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
+import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {

--- a/packages/grpc-js-xds/src/generated/udpa/type/v1/TypedStruct.ts
+++ b/packages/grpc-js-xds/src/generated/udpa/type/v1/TypedStruct.ts
@@ -36,7 +36,7 @@ export interface TypedStruct {
   /**
    * A JSON representation of the above specified type.
    */
-  'value'?: (_google_protobuf_Struct);
+  'value'?: (_google_protobuf_Struct | null);
 }
 
 /**
@@ -73,5 +73,5 @@ export interface TypedStruct__Output {
   /**
    * A JSON representation of the above specified type.
    */
-  'value'?: (_google_protobuf_Struct__Output);
+  'value': (_google_protobuf_Struct__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/validate/DurationRules.ts
+++ b/packages/grpc-js-xds/src/generated/validate/DurationRules.ts
@@ -14,27 +14,27 @@ export interface DurationRules {
   /**
    * Const specifies that this field must be exactly the specified value
    */
-  'const'?: (_google_protobuf_Duration);
+  'const'?: (_google_protobuf_Duration | null);
   /**
    * Lt specifies that this field must be less than the specified value,
    * exclusive
    */
-  'lt'?: (_google_protobuf_Duration);
+  'lt'?: (_google_protobuf_Duration | null);
   /**
    * Lt specifies that this field must be less than the specified value,
    * inclusive
    */
-  'lte'?: (_google_protobuf_Duration);
+  'lte'?: (_google_protobuf_Duration | null);
   /**
    * Gt specifies that this field must be greater than the specified value,
    * exclusive
    */
-  'gt'?: (_google_protobuf_Duration);
+  'gt'?: (_google_protobuf_Duration | null);
   /**
    * Gte specifies that this field must be greater than the specified value,
    * inclusive
    */
-  'gte'?: (_google_protobuf_Duration);
+  'gte'?: (_google_protobuf_Duration | null);
   /**
    * In specifies that this field must be equal to one of the specified
    * values
@@ -59,27 +59,27 @@ export interface DurationRules__Output {
   /**
    * Const specifies that this field must be exactly the specified value
    */
-  'const'?: (_google_protobuf_Duration__Output);
+  'const': (_google_protobuf_Duration__Output | null);
   /**
    * Lt specifies that this field must be less than the specified value,
    * exclusive
    */
-  'lt'?: (_google_protobuf_Duration__Output);
+  'lt': (_google_protobuf_Duration__Output | null);
   /**
    * Lt specifies that this field must be less than the specified value,
    * inclusive
    */
-  'lte'?: (_google_protobuf_Duration__Output);
+  'lte': (_google_protobuf_Duration__Output | null);
   /**
    * Gt specifies that this field must be greater than the specified value,
    * exclusive
    */
-  'gt'?: (_google_protobuf_Duration__Output);
+  'gt': (_google_protobuf_Duration__Output | null);
   /**
    * Gte specifies that this field must be greater than the specified value,
    * inclusive
    */
-  'gte'?: (_google_protobuf_Duration__Output);
+  'gte': (_google_protobuf_Duration__Output | null);
   /**
    * In specifies that this field must be equal to one of the specified
    * values

--- a/packages/grpc-js-xds/src/generated/validate/FieldRules.ts
+++ b/packages/grpc-js-xds/src/generated/validate/FieldRules.ts
@@ -32,34 +32,34 @@ export interface FieldRules {
   /**
    * Scalar Field Types
    */
-  'float'?: (_validate_FloatRules);
-  'double'?: (_validate_DoubleRules);
-  'int32'?: (_validate_Int32Rules);
-  'int64'?: (_validate_Int64Rules);
-  'uint32'?: (_validate_UInt32Rules);
-  'uint64'?: (_validate_UInt64Rules);
-  'sint32'?: (_validate_SInt32Rules);
-  'sint64'?: (_validate_SInt64Rules);
-  'fixed32'?: (_validate_Fixed32Rules);
-  'fixed64'?: (_validate_Fixed64Rules);
-  'sfixed32'?: (_validate_SFixed32Rules);
-  'sfixed64'?: (_validate_SFixed64Rules);
-  'bool'?: (_validate_BoolRules);
-  'string'?: (_validate_StringRules);
-  'bytes'?: (_validate_BytesRules);
+  'float'?: (_validate_FloatRules | null);
+  'double'?: (_validate_DoubleRules | null);
+  'int32'?: (_validate_Int32Rules | null);
+  'int64'?: (_validate_Int64Rules | null);
+  'uint32'?: (_validate_UInt32Rules | null);
+  'uint64'?: (_validate_UInt64Rules | null);
+  'sint32'?: (_validate_SInt32Rules | null);
+  'sint64'?: (_validate_SInt64Rules | null);
+  'fixed32'?: (_validate_Fixed32Rules | null);
+  'fixed64'?: (_validate_Fixed64Rules | null);
+  'sfixed32'?: (_validate_SFixed32Rules | null);
+  'sfixed64'?: (_validate_SFixed64Rules | null);
+  'bool'?: (_validate_BoolRules | null);
+  'string'?: (_validate_StringRules | null);
+  'bytes'?: (_validate_BytesRules | null);
   /**
    * Complex Field Types
    */
-  'enum'?: (_validate_EnumRules);
-  'message'?: (_validate_MessageRules);
-  'repeated'?: (_validate_RepeatedRules);
-  'map'?: (_validate_MapRules);
+  'enum'?: (_validate_EnumRules | null);
+  'message'?: (_validate_MessageRules | null);
+  'repeated'?: (_validate_RepeatedRules | null);
+  'map'?: (_validate_MapRules | null);
   /**
    * Well-Known Field Types
    */
-  'any'?: (_validate_AnyRules);
-  'duration'?: (_validate_DurationRules);
-  'timestamp'?: (_validate_TimestampRules);
+  'any'?: (_validate_AnyRules | null);
+  'duration'?: (_validate_DurationRules | null);
+  'timestamp'?: (_validate_TimestampRules | null);
   'type'?: "float"|"double"|"int32"|"int64"|"uint32"|"uint64"|"sint32"|"sint64"|"fixed32"|"fixed64"|"sfixed32"|"sfixed64"|"bool"|"string"|"bytes"|"enum"|"repeated"|"map"|"any"|"duration"|"timestamp";
 }
 
@@ -71,33 +71,33 @@ export interface FieldRules__Output {
   /**
    * Scalar Field Types
    */
-  'float'?: (_validate_FloatRules__Output);
-  'double'?: (_validate_DoubleRules__Output);
-  'int32'?: (_validate_Int32Rules__Output);
-  'int64'?: (_validate_Int64Rules__Output);
-  'uint32'?: (_validate_UInt32Rules__Output);
-  'uint64'?: (_validate_UInt64Rules__Output);
-  'sint32'?: (_validate_SInt32Rules__Output);
-  'sint64'?: (_validate_SInt64Rules__Output);
-  'fixed32'?: (_validate_Fixed32Rules__Output);
-  'fixed64'?: (_validate_Fixed64Rules__Output);
-  'sfixed32'?: (_validate_SFixed32Rules__Output);
-  'sfixed64'?: (_validate_SFixed64Rules__Output);
-  'bool'?: (_validate_BoolRules__Output);
-  'string'?: (_validate_StringRules__Output);
-  'bytes'?: (_validate_BytesRules__Output);
+  'float'?: (_validate_FloatRules__Output | null);
+  'double'?: (_validate_DoubleRules__Output | null);
+  'int32'?: (_validate_Int32Rules__Output | null);
+  'int64'?: (_validate_Int64Rules__Output | null);
+  'uint32'?: (_validate_UInt32Rules__Output | null);
+  'uint64'?: (_validate_UInt64Rules__Output | null);
+  'sint32'?: (_validate_SInt32Rules__Output | null);
+  'sint64'?: (_validate_SInt64Rules__Output | null);
+  'fixed32'?: (_validate_Fixed32Rules__Output | null);
+  'fixed64'?: (_validate_Fixed64Rules__Output | null);
+  'sfixed32'?: (_validate_SFixed32Rules__Output | null);
+  'sfixed64'?: (_validate_SFixed64Rules__Output | null);
+  'bool'?: (_validate_BoolRules__Output | null);
+  'string'?: (_validate_StringRules__Output | null);
+  'bytes'?: (_validate_BytesRules__Output | null);
   /**
    * Complex Field Types
    */
-  'enum'?: (_validate_EnumRules__Output);
-  'message'?: (_validate_MessageRules__Output);
-  'repeated'?: (_validate_RepeatedRules__Output);
-  'map'?: (_validate_MapRules__Output);
+  'enum'?: (_validate_EnumRules__Output | null);
+  'message': (_validate_MessageRules__Output | null);
+  'repeated'?: (_validate_RepeatedRules__Output | null);
+  'map'?: (_validate_MapRules__Output | null);
   /**
    * Well-Known Field Types
    */
-  'any'?: (_validate_AnyRules__Output);
-  'duration'?: (_validate_DurationRules__Output);
-  'timestamp'?: (_validate_TimestampRules__Output);
+  'any'?: (_validate_AnyRules__Output | null);
+  'duration'?: (_validate_DurationRules__Output | null);
+  'timestamp'?: (_validate_TimestampRules__Output | null);
   'type': "float"|"double"|"int32"|"int64"|"uint32"|"uint64"|"sint32"|"sint64"|"fixed32"|"fixed64"|"sfixed32"|"sfixed64"|"bool"|"string"|"bytes"|"enum"|"repeated"|"map"|"any"|"duration"|"timestamp";
 }

--- a/packages/grpc-js-xds/src/generated/validate/MapRules.ts
+++ b/packages/grpc-js-xds/src/generated/validate/MapRules.ts
@@ -25,13 +25,13 @@ export interface MapRules {
   /**
    * Keys specifies the constraints to be applied to each key in the field.
    */
-  'keys'?: (_validate_FieldRules);
+  'keys'?: (_validate_FieldRules | null);
   /**
    * Values specifies the constraints to be applied to the value of each key
    * in the field. Message values will still have their validations evaluated
    * unless skip is specified here.
    */
-  'values'?: (_validate_FieldRules);
+  'values'?: (_validate_FieldRules | null);
 }
 
 /**
@@ -56,11 +56,11 @@ export interface MapRules__Output {
   /**
    * Keys specifies the constraints to be applied to each key in the field.
    */
-  'keys'?: (_validate_FieldRules__Output);
+  'keys': (_validate_FieldRules__Output | null);
   /**
    * Values specifies the constraints to be applied to the value of each key
    * in the field. Message values will still have their validations evaluated
    * unless skip is specified here.
    */
-  'values'?: (_validate_FieldRules__Output);
+  'values': (_validate_FieldRules__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/validate/RepeatedRules.ts
+++ b/packages/grpc-js-xds/src/generated/validate/RepeatedRules.ts
@@ -28,7 +28,7 @@ export interface RepeatedRules {
    * Repeated message fields will still execute validation against each item
    * unless skip is specified here.
    */
-  'items'?: (_validate_FieldRules);
+  'items'?: (_validate_FieldRules | null);
 }
 
 /**
@@ -56,5 +56,5 @@ export interface RepeatedRules__Output {
    * Repeated message fields will still execute validation against each item
    * unless skip is specified here.
    */
-  'items'?: (_validate_FieldRules__Output);
+  'items': (_validate_FieldRules__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/validate/TimestampRules.ts
+++ b/packages/grpc-js-xds/src/generated/validate/TimestampRules.ts
@@ -15,27 +15,27 @@ export interface TimestampRules {
   /**
    * Const specifies that this field must be exactly the specified value
    */
-  'const'?: (_google_protobuf_Timestamp);
+  'const'?: (_google_protobuf_Timestamp | null);
   /**
    * Lt specifies that this field must be less than the specified value,
    * exclusive
    */
-  'lt'?: (_google_protobuf_Timestamp);
+  'lt'?: (_google_protobuf_Timestamp | null);
   /**
    * Lte specifies that this field must be less than the specified value,
    * inclusive
    */
-  'lte'?: (_google_protobuf_Timestamp);
+  'lte'?: (_google_protobuf_Timestamp | null);
   /**
    * Gt specifies that this field must be greater than the specified value,
    * exclusive
    */
-  'gt'?: (_google_protobuf_Timestamp);
+  'gt'?: (_google_protobuf_Timestamp | null);
   /**
    * Gte specifies that this field must be greater than the specified value,
    * inclusive
    */
-  'gte'?: (_google_protobuf_Timestamp);
+  'gte'?: (_google_protobuf_Timestamp | null);
   /**
    * LtNow specifies that this must be less than the current time. LtNow
    * can only be used with the Within rule.
@@ -51,7 +51,7 @@ export interface TimestampRules {
    * current time. This constraint can be used alone or with the LtNow and
    * GtNow rules.
    */
-  'within'?: (_google_protobuf_Duration);
+  'within'?: (_google_protobuf_Duration | null);
 }
 
 /**
@@ -66,27 +66,27 @@ export interface TimestampRules__Output {
   /**
    * Const specifies that this field must be exactly the specified value
    */
-  'const'?: (_google_protobuf_Timestamp__Output);
+  'const': (_google_protobuf_Timestamp__Output | null);
   /**
    * Lt specifies that this field must be less than the specified value,
    * exclusive
    */
-  'lt'?: (_google_protobuf_Timestamp__Output);
+  'lt': (_google_protobuf_Timestamp__Output | null);
   /**
    * Lte specifies that this field must be less than the specified value,
    * inclusive
    */
-  'lte'?: (_google_protobuf_Timestamp__Output);
+  'lte': (_google_protobuf_Timestamp__Output | null);
   /**
    * Gt specifies that this field must be greater than the specified value,
    * exclusive
    */
-  'gt'?: (_google_protobuf_Timestamp__Output);
+  'gt': (_google_protobuf_Timestamp__Output | null);
   /**
    * Gte specifies that this field must be greater than the specified value,
    * inclusive
    */
-  'gte'?: (_google_protobuf_Timestamp__Output);
+  'gte': (_google_protobuf_Timestamp__Output | null);
   /**
    * LtNow specifies that this must be less than the current time. LtNow
    * can only be used with the Within rule.
@@ -102,5 +102,5 @@ export interface TimestampRules__Output {
    * current time. This constraint can be used alone or with the LtNow and
    * GtNow rules.
    */
-  'within'?: (_google_protobuf_Duration__Output);
+  'within': (_google_protobuf_Duration__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/xds/core/v3/CollectionEntry.ts
+++ b/packages/grpc-js-xds/src/generated/xds/core/v3/CollectionEntry.ts
@@ -22,7 +22,7 @@ export interface _xds_core_v3_CollectionEntry_InlineEntry {
   /**
    * The resource payload, including type URL.
    */
-  'resource'?: (_google_protobuf_Any);
+  'resource'?: (_google_protobuf_Any | null);
 }
 
 /**
@@ -44,7 +44,7 @@ export interface _xds_core_v3_CollectionEntry_InlineEntry__Output {
   /**
    * The resource payload, including type URL.
    */
-  'resource'?: (_google_protobuf_Any__Output);
+  'resource': (_google_protobuf_Any__Output | null);
 }
 
 /**
@@ -60,11 +60,11 @@ export interface CollectionEntry {
   /**
    * A resource locator describing how the member resource is to be located.
    */
-  'locator'?: (_xds_core_v3_ResourceLocator);
+  'locator'?: (_xds_core_v3_ResourceLocator | null);
   /**
    * The resource is inlined in the list collection.
    */
-  'inline_entry'?: (_xds_core_v3_CollectionEntry_InlineEntry);
+  'inline_entry'?: (_xds_core_v3_CollectionEntry_InlineEntry | null);
   'resource_specifier'?: "locator"|"inline_entry";
 }
 
@@ -81,10 +81,10 @@ export interface CollectionEntry__Output {
   /**
    * A resource locator describing how the member resource is to be located.
    */
-  'locator'?: (_xds_core_v3_ResourceLocator__Output);
+  'locator'?: (_xds_core_v3_ResourceLocator__Output | null);
   /**
    * The resource is inlined in the list collection.
    */
-  'inline_entry'?: (_xds_core_v3_CollectionEntry_InlineEntry__Output);
+  'inline_entry'?: (_xds_core_v3_CollectionEntry_InlineEntry__Output | null);
   'resource_specifier': "locator"|"inline_entry";
 }

--- a/packages/grpc-js-xds/src/generated/xds/core/v3/ResourceLocator.ts
+++ b/packages/grpc-js-xds/src/generated/xds/core/v3/ResourceLocator.ts
@@ -37,7 +37,7 @@ export interface _xds_core_v3_ResourceLocator_Directive {
    * resource, it will fallback to `bar`. Alternative resources do not need
    * to have equivalent content, but they should be functional substitutes.
    */
-  'alt'?: (_xds_core_v3_ResourceLocator);
+  'alt'?: (_xds_core_v3_ResourceLocator | null);
   /**
    * List collections support inlining of resources via the entry field in
    * Resource. These inlined Resource objects may have an optional name
@@ -83,7 +83,7 @@ export interface _xds_core_v3_ResourceLocator_Directive__Output {
    * resource, it will fallback to `bar`. Alternative resources do not need
    * to have equivalent content, but they should be functional substitutes.
    */
-  'alt'?: (_xds_core_v3_ResourceLocator__Output);
+  'alt'?: (_xds_core_v3_ResourceLocator__Output | null);
   /**
    * List collections support inlining of resources via the entry field in
    * Resource. These inlined Resource objects may have an optional name
@@ -150,7 +150,7 @@ export interface ResourceLocator {
    * there must be no additional context parameters set on the matched
    * resource.
    */
-  'exact_context'?: (_xds_core_v3_ContextParams);
+  'exact_context'?: (_xds_core_v3_ContextParams | null);
   /**
    * A list of directives that appear in the xDS resource locator #fragment.
    * 
@@ -208,7 +208,7 @@ export interface ResourceLocator__Output {
    * there must be no additional context parameters set on the matched
    * resource.
    */
-  'exact_context'?: (_xds_core_v3_ContextParams__Output);
+  'exact_context'?: (_xds_core_v3_ContextParams__Output | null);
   /**
    * A list of directives that appear in the xDS resource locator #fragment.
    * 

--- a/packages/grpc-js-xds/src/http-filter/fault-injection-filter.ts
+++ b/packages/grpc-js-xds/src/http-filter/fault-injection-filter.ts
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This is a non-public, unstable API, but it's very convenient
+import { loadProtosWithOptionsSync } from '@grpc/proto-loader/build/src/util';
+import { experimental, Metadata, status } from '@grpc/grpc-js';
+import { Any__Output } from '../generated/google/protobuf/Any';
+import Filter = experimental.Filter;
+import FilterFactory = experimental.FilterFactory;
+import BaseFilter = experimental.BaseFilter;
+import CallStream = experimental.CallStream;
+import { HttpFilterConfig, registerHttpFilter } from '../http-filter';
+import { HTTPFault__Output } from '../generated/envoy/extensions/filters/http/fault/v3/HTTPFault';
+import { envoyFractionToFraction, Fraction } from '../fraction';
+import { Duration__Output } from '../generated/google/protobuf/Duration';
+
+const resourceRoot = loadProtosWithOptionsSync([
+  'envoy/extendsion/filtesr/http/fault/v3/fault.proto'], {
+    keepCase: true,
+    includeDirs: [
+      // Paths are relative to src/build
+      __dirname + '/../../deps/udpa/',
+      __dirname + '/../../deps/envoy-api/',
+      __dirname + '/../../deps/protoc-gen-validate/'
+    ],
+  }
+);
+
+interface FixedDelayConfig {
+  kind: 'fixed';
+  durationMs: number;
+  percentage: Fraction;
+}
+
+interface HeaderDelayConfig {
+  kind: 'header';
+  percentage: Fraction;
+}
+
+interface GrpcAbortConfig {
+  kind: 'grpc';
+  code: status;
+  percentage: Fraction;
+}
+
+interface HeaderAbortConfig {
+  kind: 'header';
+  percentage: Fraction;
+}
+
+interface FaultInjectionConfig {
+  delay: FixedDelayConfig | HeaderDelayConfig | null;
+  abort: GrpcAbortConfig | HeaderAbortConfig | null;
+  maxActiveFaults: number;
+}
+
+interface FaultInjectionFilterConfig extends HttpFilterConfig {
+  typeUrl: 'type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault';
+  config: FaultInjectionConfig;
+}
+
+const FAULT_INJECTION_FILTER_URL = 'type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault';
+
+const toObjectOptions = {
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
+}
+
+function parseAnyMessage<MessageType>(message: Any__Output): MessageType | null {
+  const messageType = resourceRoot.lookup(message.type_url);
+  if (messageType) {
+    const decodedMessage = (messageType as any).decode(message.value);
+    return decodedMessage.$type.toObject(decodedMessage, toObjectOptions) as MessageType;
+  } else {
+    return null;
+  }
+}
+
+function durationToMs(duration: Duration__Output): number {
+  return Number.parseInt(duration.seconds) * 1000 + duration.nanos / 1_000_000;
+}
+
+function httpCodeToGrpcStatus(code: number): status {
+  switch (code) {
+    case 400: return status.INTERNAL;
+    case 401: return status.UNAUTHENTICATED;
+    case 403: return status.PERMISSION_DENIED;
+    case 404: return status.UNIMPLEMENTED;
+    case 429: return status.UNAVAILABLE;
+    case 502: return status.UNAVAILABLE;
+    case 503: return status.UNAVAILABLE;
+    case 504: return status.UNAVAILABLE;
+    default: return status.UNKNOWN;
+  }
+}
+
+function parseHTTPFaultConfig(encodedConfig: Any__Output): FaultInjectionFilterConfig | null {
+  if (encodedConfig.type_url !== FAULT_INJECTION_FILTER_URL) {
+    return null;
+  }
+  const parsedMessage = parseAnyMessage<HTTPFault__Output>(encodedConfig);
+  if (parsedMessage === null) {
+    return null;
+  }
+  const result: FaultInjectionConfig = {
+    delay: null,
+    abort: null,
+    maxActiveFaults: Infinity
+  };
+  // Parse delay field
+  if (parsedMessage.delay !== null) {
+    if (parsedMessage.delay.percentage === null) {
+      return null;
+    }
+    const percentage = envoyFractionToFraction(parsedMessage.delay.percentage);
+    switch (parsedMessage.delay.fault_delay_secifier /* sic */) {
+      case 'fixed_delay':
+        result.delay = {
+          kind: 'fixed',
+          durationMs: durationToMs(parsedMessage.delay.fixed_delay!),
+          percentage: percentage
+        };
+        break;
+      case 'header_delay':
+        result.delay = {
+          kind: 'header',
+          percentage: percentage
+        };
+        break;
+      default:
+        // Should not be possible
+        return null;
+    }
+  }
+  // Parse abort field
+  if (parsedMessage.abort !== null) {
+    if (parsedMessage.abort.percentage === null) {
+      return null;
+    }
+    const percentage = envoyFractionToFraction(parsedMessage.abort.percentage);
+    switch (parsedMessage.abort.error_type) {
+      case 'http_status':
+        result.abort = {
+          kind: 'grpc',
+          code: httpCodeToGrpcStatus(parsedMessage.abort.http_status!),
+          percentage: percentage
+        };
+        break;
+      case 'grpc_status':
+        result.abort = {
+          kind: 'grpc',
+          code: parsedMessage.abort.grpc_status!,
+          percentage: percentage
+        }
+        break;
+      case 'header_abort':
+        result.abort = {
+          kind: 'header',
+          percentage: percentage
+        };
+        break;
+      default:
+        // Should not be possible
+        return null;
+    }
+  }
+  // Parse max_active_faults field
+  if (parsedMessage.max_active_faults !== null) {
+    result.maxActiveFaults = parsedMessage.max_active_faults.value;
+  }
+  return {
+    typeUrl: FAULT_INJECTION_FILTER_URL,
+    config: result
+  };
+}
+
+function asyncTimeout(timeMs: number): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    setTimeout(() => {
+      resolve();
+    }, timeMs);
+  });
+}
+
+/**
+ * Returns true with probability numerator/denominator.
+ * @param numerator 
+ * @param denominator 
+ */
+function rollRandomPercentage(numerator: number, denominator: number): boolean {
+  return Math.random() * denominator < numerator;
+}
+
+const DELAY_DURATION_HEADER_KEY = 'x-envoy-fault-delay-request';
+const DELAY_PERCENTAGE_HEADER_KEY = 'x-envoy-fault-delay-request-percentage';
+const ABORT_GRPC_HEADER_KEY = 'x-envoy-fault-abort-grpc-request';
+const ABORT_HTTP_HEADER_KEY = 'x-envoy-fault-abort-request';
+const ABORT_PERCENTAGE_HEADER_KEY = 'x-envoy-fault-abort-request-percentage';
+
+const NUMBER_REGEX = /\d+/;
+
+let totalActiveFaults = 0;
+
+class FaultInjectionFilter extends BaseFilter implements Filter {
+  constructor(private callStream: CallStream, private config: FaultInjectionConfig) {
+    super();
+  }
+
+  async sendMetadata(metadataPromise: Promise<Metadata>): Promise<Metadata> {
+    const metadata = await metadataPromise;
+    // Handle delay
+    if (totalActiveFaults < this.config.maxActiveFaults && this.config.delay) {
+      let duration = 0;
+      let numerator = this.config.delay.percentage.numerator;
+      const denominator = this.config.delay.percentage.denominator;
+      if (this.config.delay.kind === 'fixed') {
+        duration = this.config.delay.durationMs;
+      } else {
+        const durationHeader = metadata.get(DELAY_DURATION_HEADER_KEY);
+        for (const value of durationHeader) {
+          if (typeof value !== 'string') {
+            continue;
+          }
+          if (NUMBER_REGEX.test(value)) {
+            duration = Number.parseInt(value);
+            break;
+          }
+        }
+        const percentageHeader = metadata.get(DELAY_PERCENTAGE_HEADER_KEY);
+        for (const value of percentageHeader) {
+          if (typeof value !== 'string') {
+            continue;
+          }
+          if (NUMBER_REGEX.test(value)) {
+            numerator = Math.min(numerator, Number.parseInt(value));
+            break;
+          }
+        }
+      }
+      if (rollRandomPercentage(numerator, denominator)) {
+        totalActiveFaults++;
+        await asyncTimeout(duration);
+        totalActiveFaults--;
+      }
+    }
+    // Handle abort
+    if (totalActiveFaults < this.config.maxActiveFaults && this.config.abort) {
+      let abortStatus: status | null = null;
+      let numerator = this.config.abort.percentage.numerator;
+      const denominator = this.config.abort.percentage.denominator;
+      if (this.config.abort.kind === 'grpc') {
+        abortStatus = this.config.abort.code;
+      } else {
+        const grpcStatusHeader = metadata.get(ABORT_GRPC_HEADER_KEY);
+        for (const value of grpcStatusHeader) {
+          if (typeof value !== 'string') {
+            continue;
+          }
+          if (NUMBER_REGEX.test(value)) {
+            abortStatus = Number.parseInt(value);
+            break;
+          }
+        }
+        /* Fall back to looking for HTTP status header if the gRPC status
+         * header is not present. */
+        if (abortStatus === null) {
+          const httpStatusHeader = metadata.get(ABORT_HTTP_HEADER_KEY);
+          for (const value of httpStatusHeader) {
+            if (typeof value !== 'string') {
+              continue;
+            }
+            if (NUMBER_REGEX.test(value)) {
+              abortStatus = httpCodeToGrpcStatus(Number.parseInt(value));
+              break;
+            }
+          }
+        }
+        const percentageHeader = metadata.get(ABORT_PERCENTAGE_HEADER_KEY);
+        for (const value of percentageHeader) {
+          if (typeof value !== 'string') {
+            continue;
+          }
+          if (NUMBER_REGEX.test(value)) {
+            numerator = Math.min(numerator, Number.parseInt(value));
+            break;
+          }
+        }
+      }
+      if (abortStatus !== null && rollRandomPercentage(numerator, denominator)) {
+        this.callStream.cancelWithStatus(abortStatus, 'Fault injected');
+      }
+    }
+    return metadata;
+  }
+}
+
+class FaultInjectionFilterFactory implements FilterFactory<FaultInjectionFilter> {
+  private config: FaultInjectionConfig;
+  constructor(config: HttpFilterConfig, overrideConfig?: HttpFilterConfig) {
+    if (overrideConfig?.typeUrl === FAULT_INJECTION_FILTER_URL) {
+      this.config = overrideConfig.config;
+    } else {
+      this.config = config.config;
+    }
+  }
+
+  createFilter(callStream: experimental.CallStream): FaultInjectionFilter {
+    return new FaultInjectionFilter(callStream, this.config);
+  }
+}
+
+export function setup() {
+  registerHttpFilter(FAULT_INJECTION_FILTER_URL, {
+    parseTopLevelFilterConfig: parseHTTPFaultConfig,
+    parseOverrideFilterConfig: parseHTTPFaultConfig,
+    httpFilterConstructor: FaultInjectionFilterFactory
+  });
+}

--- a/packages/grpc-js-xds/src/index.ts
+++ b/packages/grpc-js-xds/src/index.ts
@@ -23,6 +23,7 @@ import * as load_balancer_priority from './load-balancer-priority';
 import * as load_balancer_weighted_target from './load-balancer-weighted-target';
 import * as load_balancer_xds_cluster_manager from './load-balancer-xds-cluster-manager';
 import * as router_filter from './http-filter/router-filter';
+import * as fault_injection_filter from './http-filter/fault-injection-filter';
 
 /**
  * Register the "xds:" name scheme with the @grpc/grpc-js library.
@@ -36,4 +37,5 @@ export function register() {
   load_balancer_weighted_target.setup();
   load_balancer_xds_cluster_manager.setup();
   router_filter.setup();
+  fault_injection_filter.setup();
 }

--- a/packages/grpc-js-xds/src/matcher.ts
+++ b/packages/grpc-js-xds/src/matcher.ts
@@ -16,6 +16,7 @@
 
 import { Metadata } from "@grpc/grpc-js";
 import { RE2 } from "re2-wasm";
+import { Fraction, fractionToString } from "./fraction";
 
 /**
  * An object representing a predicate that determines whether a given
@@ -208,15 +209,6 @@ export class PathSafeRegexValueMatcher {
   toString() {
     return 'SafeRegex(' + this.targetRegexImpl.toString() + ')';
   }
-}
-
-export interface Fraction {
-  numerator: number;
-  denominator: number;
-}
-
-function fractionToString(fraction: Fraction): string {
-  return `${fraction.numerator}/${fraction.denominator}`;
 }
 
 export class FullMatcher implements Matcher {

--- a/packages/grpc-js-xds/src/resolver-xds.ts
+++ b/packages/grpc-js-xds/src/resolver-xds.ts
@@ -228,7 +228,7 @@ class XdsResolver implements Resolver {
       onValidUpdate: (update: Listener__Output) => {
         const httpConnectionManager = decodeSingleResource(HTTP_CONNECTION_MANGER_TYPE_URL_V3, update.api_listener!.api_listener!.value);
         const defaultTimeout = httpConnectionManager.common_http_protocol_options?.idle_timeout;
-        if (defaultTimeout === undefined) {
+        if (defaultTimeout === null || defaultTimeout === undefined) {
           this.latestDefaultTimeout = undefined;
         } else {
           this.latestDefaultTimeout = protoDurationToDuration(defaultTimeout);

--- a/packages/grpc-js-xds/src/xds-stream-state/rds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/rds-state.ts
@@ -137,7 +137,7 @@ export class RdsState implements XdsStreamState<RouteConfiguration__Output> {
         if (route.action !== 'route') {
           return false;
         }
-        if ((route.route === undefined) || SUPPORTED_CLUSTER_SPECIFIERS.indexOf(route.route.cluster_specifier) < 0) {
+        if ((route.route === undefined) || (route.route === null) || SUPPORTED_CLUSTER_SPECIFIERS.indexOf(route.route.cluster_specifier) < 0) {
           return false;
         }
         if (EXPERIMENTAL_FAULT_INJECTION) {


### PR DESCRIPTION
This is an implementation of [Proposal A33: Fault Injection](https://github.com/grpc/proposal/blob/master/A33-Fault-Injection.md), using the HTTP filter API added in #1853.