### PR TITLE
grpc-js: Check for closed server stream before sending

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -429,7 +429,7 @@ export class Http2ServerCallStream<
   private checkCancelled(): boolean {
     /* In some cases the stream can become destroyed before the close event
      * fires. That creates a race condition that this check works around */
-    if (this.stream.destroyed) {
+    if (this.stream.destroyed || this.stream.closed) {
       this.cancelled = true;
     }
     return this.cancelled;


### PR DESCRIPTION
This fixes #1871, according to the person who filed the issue.