### PR TITLE
grpc-js: Handle errors thrown by writing to http2 stream

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -637,7 +637,15 @@ export class Http2CallStream implements Call {
             this.pendingWrite.length +
             ' (deferred)'
         );
-        stream.write(this.pendingWrite, this.pendingWriteCallback);
+        try {
+          stream.write(this.pendingWrite, this.pendingWriteCallback);
+        } catch (error) {
+          this.endCall({
+            code: Status.UNAVAILABLE,
+            details: `Write failed with error ${error.message}`,
+            metadata: new Metadata()
+          });
+        }
       }
       this.maybeCloseWrites();
     }
@@ -762,7 +770,15 @@ export class Http2CallStream implements Call {
         this.pendingWriteCallback = cb;
       } else {
         this.trace('sending data chunk of length ' + message.message.length);
-        this.http2Stream.write(message.message, cb);
+        try {
+          this.http2Stream.write(message.message, cb);
+        }  catch (error) {
+          this.endCall({
+            code: Status.UNAVAILABLE,
+            details: `Write failed with error ${error.message}`,
+            metadata: new Metadata()
+          });
+        }
         this.maybeCloseWrites();
       }
     }, this.handleFilterError.bind(this));


### PR DESCRIPTION
This should fix #1094. In [the status codes usage doc](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md) this event is in the category

> Some data transmitted (e.g., request metadata written to TCP connection) before connection breaks