### PR TITLE
grpc-js: Map ETIMEDOUT errors to UNAVAILABLE

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -601,7 +601,7 @@ export class Http2CallStream implements Call {
                  * "Internal server error" message. */
                 details = `Received RST_STREAM with code ${stream.rstCode} (Internal server error)`;
               } else {
-                if (this.internalError.code === 'ECONNRESET') {
+                if (this.internalError.code === 'ECONNRESET' || this.internalError.code === 'ETIMEDOUT') {
                   code = Status.UNAVAILABLE;
                   details = this.internalError.message;
                 } else {


### PR DESCRIPTION
It was reported in https://github.com/grpc/grpc-node/issues/1769#issuecomment-894822111 that users see this error sometimes, and it means that from the client point of view, it looks like the connection dropped in the middle of a stream, so this is the proper code and it can make error handling smoother.