### PR TITLE
grpc-js-xds: Distinguish v2 and v3 when handling messages

### DIFF
--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -435,32 +435,47 @@ export class XdsClient {
   private handleAdsResponse(message: DiscoveryResponse__Output) {
     let errorString: string | null;
     let serviceKind: AdsServiceKind;
+    let isV2: boolean;
+    switch (message.type_url) {
+      case EDS_TYPE_URL_V2:
+      case CDS_TYPE_URL_V2:
+      case RDS_TYPE_URL_V2:
+      case LDS_TYPE_URL_V2:
+        isV2 = true;
+        break;
+      default:
+        isV2 = false;
+    }
     switch (message.type_url) {
       case EDS_TYPE_URL_V2:
       case EDS_TYPE_URL_V3:
         errorString = this.adsState.eds.handleResponses(
-          getResponseMessages(EDS_TYPE_URL_V3, [EDS_TYPE_URL_V2, EDS_TYPE_URL_V3], message.resources)
+          getResponseMessages(EDS_TYPE_URL_V3, [EDS_TYPE_URL_V2, EDS_TYPE_URL_V3], message.resources),
+          isV2
         );
         serviceKind = 'eds';
         break;
       case CDS_TYPE_URL_V2:
       case CDS_TYPE_URL_V3:
         errorString = this.adsState.cds.handleResponses(
-          getResponseMessages(CDS_TYPE_URL_V3, [CDS_TYPE_URL_V2, CDS_TYPE_URL_V3], message.resources)
+          getResponseMessages(CDS_TYPE_URL_V3, [CDS_TYPE_URL_V2, CDS_TYPE_URL_V3], message.resources),
+          isV2
         );
         serviceKind = 'cds';
         break;
       case RDS_TYPE_URL_V2:
       case RDS_TYPE_URL_V3:
         errorString = this.adsState.rds.handleResponses(
-          getResponseMessages(RDS_TYPE_URL_V3, [RDS_TYPE_URL_V2, RDS_TYPE_URL_V3], message.resources)
+          getResponseMessages(RDS_TYPE_URL_V3, [RDS_TYPE_URL_V2, RDS_TYPE_URL_V3], message.resources),
+          isV2
         );
         serviceKind = 'rds';
         break;
       case LDS_TYPE_URL_V2:
       case LDS_TYPE_URL_V3:
         errorString = this.adsState.lds.handleResponses(
-          getResponseMessages(LDS_TYPE_URL_V3, [LDS_TYPE_URL_V2, LDS_TYPE_URL_V3], message.resources)
+          getResponseMessages(LDS_TYPE_URL_V3, [LDS_TYPE_URL_V2, LDS_TYPE_URL_V3], message.resources),
+          isV2
         );
         serviceKind = 'lds';
         break;

--- a/packages/grpc-js-xds/src/xds-stream-state/xds-stream-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/xds-stream-state.ts
@@ -18,7 +18,12 @@
 import { StatusObject } from "@grpc/grpc-js";
 
 export interface Watcher<UpdateType> {
-  onValidUpdate(update: UpdateType): void;
+  /* Including the isV2 flag here is a bit of a kludge. It would probably be
+   * better for XdsStreamState#handleResponses to transform the protobuf
+   * message type into a library-specific configuration object type, to
+   * remove a lot of duplicate logic, including logic for handling that
+   * flag. */
+  onValidUpdate(update: UpdateType, isV2: boolean): void;
   onTransientError(error: StatusObject): void;
   onResourceDoesNotExist(): void;
 }
@@ -32,7 +37,7 @@ export interface XdsStreamState<ResponseType> {
    * or null if it should be acked.
    * @param responses
    */
-  handleResponses(responses: ResponseType[]): string | null;
+  handleResponses(responses: ResponseType[], isV2: boolean): string | null;
 
   reportStreamError(status: StatusObject): void;
 }


### PR DESCRIPTION
The main purpose of this change is to implement the following line of [proposal A39](https://github.com/grpc/proposal/blob/master/A39-xds-http-filters.md):

> gRPC will support HTTP filters in xDS v3 only. Filters will continue to be ignored when speaking xDS v2.