### PR TITLE
fix(docs): supporst ⟶ supports

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -4,7 +4,7 @@ This guide is for troubleshooting the `grpc-js` library for Node.js
 
 ## Enabling extra logging and tracing
 
-Extra logging can be very useful for diagnosing problems. `grpc-js` supporst
+Extra logging can be very useful for diagnosing problems. `grpc-js` support
 the `GRPC_VERBOSITY` and `GRPC_TRACE` environment variables that can be used to increase the amount of information
 that gets printed to stderr.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -4,7 +4,7 @@ This guide is for troubleshooting the `grpc-js` library for Node.js
 
 ## Enabling extra logging and tracing
 
-Extra logging can be very useful for diagnosing problems. `grpc-js` support
+Extra logging can be very useful for diagnosing problems. `grpc-js` supports
 the `GRPC_VERBOSITY` and `GRPC_TRACE` environment variables that can be used to increase the amount of information
 that gets printed to stderr.
 


### PR DESCRIPTION
#### Changes : 

Fixed typo of 'support' inside [TROUBLESHOOTING.md](https://github.com/grpc/grpc-node/blob/master/TROUBLESHOOTING.md)

- Duplicate of #1874 

Please have a look @murgatroid99 