### PR TITLE
grpc-js: fixed miss content type option ant other option

### DIFF
--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -37,6 +37,7 @@ export interface ChannelOptions {
   'grpc.http_connect_target'?: string;
   'grpc.http_connect_creds'?: string;
   'grpc-node.max_session_memory'?: number;
+  'grpc.http_content_type'?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -402,7 +402,8 @@ export class ChannelImplementation implements Channel {
                     pickResult.subchannel!.startCallStream(
                       finalMetadata,
                       callStream,
-                      pickResult.extraFilterFactories
+                      pickResult.extraFilterFactories,
+                      this.options
                     );
                     /* If we reach this point, the call stream has started
                      * successfully */

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -655,14 +655,15 @@ export class Subchannel {
   startCallStream(
     metadata: Metadata,
     callStream: Http2CallStream,
-    extraFilterFactories: FilterFactory<Filter>[]
+    extraFilterFactories: FilterFactory<Filter>[],
+    options: ChannelOptions
   ) {
     const headers = metadata.toHttp2Headers();
     headers[HTTP2_HEADER_AUTHORITY] = callStream.getHost();
     headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;
     headers[HTTP2_HEADER_CONTENT_TYPE] = 'application/grpc';
     headers[HTTP2_HEADER_METHOD] = 'POST';
-    headers[HTTP2_HEADER_PATH] = callStream.getMethod();
+    headers[HTTP2_HEADER_PATH] = options['grpc.http_content_type'] || callStream.getMethod();
     headers[HTTP2_HEADER_TE] = 'trailers';
     let http2Stream: http2.ClientHttp2Stream;
     /* In theory, if an error is thrown by session.request because session has


### PR DESCRIPTION
https://chromium.googlesource.com/external/github.com/grpc/grpc/+/HEAD/doc/PROTOCOL-HTTP2.md


In this document, it is pointed out `Content-Type → “content-type” “application/grpc” [(“+proto” / “+json” / {custom})]`

So I think the content type is not always application/grpc, the server is entirely possible to have its own implementation

As a library that may be used for grpc client, we should support passing content type from outside

And ChannelOptions may also have other functions, such as keepalive_timeout_ms, max_receive_message_length

example code: `const client = new creator('127.0.0.1:31702', credentials.createInsecure(),{ 'grpc.http_content_type': 'application/grpc+json' });`

