### PR TITLE
proto-loader: Avoid generating conflicting method names in service clients

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": "Google Inc.",
   "contributors": [
     {


### PR DESCRIPTION
I ran into this problem when generating code for [channelz.proto](https://github.com/grpc/grpc-proto/blob/master/grpc/channelz/v1/channelz.proto), because the service has a `GetChannel` method.