### PR TITLE
Allow resetting global subchannel pool

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -268,3 +268,5 @@ const clientVersion = require('../../package.json').version;
   load_balancer_pick_first.setup();
   load_balancer_round_robin.setup();
 })();
+
+export { resetGlobalSubchannelPool } from './subchannel-pool';

--- a/packages/grpc-js/src/subchannel-pool.ts
+++ b/packages/grpc-js/src/subchannel-pool.ts
@@ -163,7 +163,14 @@ export class SubchannelPool {
   }
 }
 
-const globalSubchannelPool = new SubchannelPool(true);
+let globalSubchannelPool = new SubchannelPool(true);
+
+/**
+ * Recreate the global subchannel pool.
+ */
+export function resetGlobalSubchannelPool(): void {
+  globalSubchannelPool = new SubchannelPool(true);
+}
 
 /**
  * Get either the global subchannel pool, or a new subchannel pool.


### PR DESCRIPTION
We are hitting an edge case of using grpc-js in AWS lambda. There is a very tiny chance that the first few subchannels created in the AWS Lambda were not able to receive a `connect` event from the socket and hang forever. 

A few attempts were tried but none of them fixs the issue other than recreating the subchannel. There's however no API that lets us do so.

On the other hand, AWS Lambda allows multiple invocations to reuse the same global subchannel pool. In the case the one global pool comes with dead connections, any subsequent invocations will hang there forever. 

We figured it would be very helpful to allow callsites to recreate the global subchannel pool when necessary. 