### PR TITLE
grpc-js-xds: Log loaded bootstrap info in xDS client (1.2.x)

### DIFF
--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -799,6 +799,8 @@ export class XdsClient {
           ...node,
           client_features: ['envoy.lrs.supports_send_all_clusters'],
         };
+        trace('ADS Node: ' + JSON.stringify(this.adsNode, undefined, 2));
+        trace('LRS Node: ' + JSON.stringify(this.lrsNode, undefined, 2));
         const credentialsConfigs = bootstrapInfo.xdsServers[0].channelCreds;
         let channelCreds: ChannelCredentials | null = null;
         for (const config of credentialsConfigs) {

--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -785,6 +785,7 @@ export class XdsClient {
         if (this.hasShutdown) {
           return;
         }
+        trace('Loaded bootstrap info: ' + JSON.stringify(bootstrapInfo, undefined, 2));
         const node: Node = {
           ...bootstrapInfo.node,
           build_version: `gRPC Node Pure JS ${clientVersion}`,


### PR DESCRIPTION
#1908 for 1.2.x