### PR TITLE
Add channelz support and the admin interface

### DIFF
--- a/packages/grpc-js-xds/src/load-balancer-eds.ts
+++ b/packages/grpc-js-xds/src/load-balancer-eds.ts
@@ -185,14 +185,7 @@ export class EdsLoadBalancer implements LoadBalancer {
   private concurrentRequests: number = 0;
 
   constructor(private readonly channelControlHelper: ChannelControlHelper) {
-    this.childBalancer = new ChildLoadBalancerHandler({
-      createSubchannel: (subchannelAddress, subchannelArgs) =>
-        this.channelControlHelper.createSubchannel(
-          subchannelAddress,
-          subchannelArgs
-        ),
-      requestReresolution: () =>
-        this.channelControlHelper.requestReresolution(),
+    this.childBalancer = new ChildLoadBalancerHandler(experimental.createChildChannelControlHelper(this.channelControlHelper, {
       updateState: (connectivityState, originalPicker) => {
         if (this.latestEdsUpdate === null) {
           return;
@@ -243,7 +236,7 @@ export class EdsLoadBalancer implements LoadBalancer {
         };
         this.channelControlHelper.updateState(connectivityState, edsPicker);
       },
-    });
+    }));
     this.watcher = {
       onValidUpdate: (update) => {
         trace('Received EDS update for ' + this.edsServiceName + ': ' + JSON.stringify(update, undefined, 2));

--- a/packages/grpc-js-xds/src/load-balancer-lrs.ts
+++ b/packages/grpc-js-xds/src/load-balancer-lrs.ts
@@ -174,20 +174,14 @@ export class LrsLoadBalancer implements LoadBalancer {
   private localityStatsReporter: XdsClusterLocalityStats | null = null;
 
   constructor(private channelControlHelper: ChannelControlHelper) {
-    this.childBalancer = new ChildLoadBalancerHandler({
-      createSubchannel: (subchannelAddress, subchannelArgs) =>
-        channelControlHelper.createSubchannel(
-          subchannelAddress,
-          subchannelArgs
-        ),
-      requestReresolution: () => channelControlHelper.requestReresolution(),
+    this.childBalancer = new ChildLoadBalancerHandler(experimental.createChildChannelControlHelper(channelControlHelper, {
       updateState: (connectivityState: ConnectivityState, picker: Picker) => {
         if (this.localityStatsReporter !== null) {
           picker = new LoadReportingPicker(picker, this.localityStatsReporter);
         }
         channelControlHelper.updateState(connectivityState, picker);
       },
-    });
+    }));
   }
 
   updateAddressList(

--- a/packages/grpc-js-xds/src/load-balancer-priority.ts
+++ b/packages/grpc-js-xds/src/load-balancer-priority.ts
@@ -139,23 +139,11 @@ export class PriorityLoadBalancer implements LoadBalancer {
     private failoverTimer: NodeJS.Timer | null = null;
     private deactivationTimer: NodeJS.Timer | null = null;
     constructor(private parent: PriorityLoadBalancer, private name: string) {
-      this.childBalancer = new ChildLoadBalancerHandler({
-        createSubchannel: (
-          subchannelAddress: SubchannelAddress,
-          subchannelArgs: ChannelOptions
-        ) => {
-          return this.parent.channelControlHelper.createSubchannel(
-            subchannelAddress,
-            subchannelArgs
-          );
-        },
+      this.childBalancer = new ChildLoadBalancerHandler(experimental.createChildChannelControlHelper(this.parent.channelControlHelper, {
         updateState: (connectivityState: ConnectivityState, picker: Picker) => {
           this.updateState(connectivityState, picker);
         },
-        requestReresolution: () => {
-          this.parent.channelControlHelper.requestReresolution();
-        },
-      });
+      }));
       this.picker = new QueuePicker(this.childBalancer);
     }
 

--- a/packages/grpc-js-xds/src/load-balancer-weighted-target.ts
+++ b/packages/grpc-js-xds/src/load-balancer-weighted-target.ts
@@ -168,17 +168,11 @@ export class WeightedTargetLoadBalancer implements LoadBalancer {
     private weight: number = 0;
 
     constructor(private parent: WeightedTargetLoadBalancer, private name: string) {
-      this.childBalancer = new ChildLoadBalancerHandler({
-        createSubchannel: (subchannelAddress, subchannelOptions) => {
-          return this.parent.channelControlHelper.createSubchannel(subchannelAddress, subchannelOptions);
-        },
-        updateState: (connectivityState, picker) => {
+      this.childBalancer = new ChildLoadBalancerHandler(experimental.createChildChannelControlHelper(this.parent.channelControlHelper, {
+        updateState: (connectivityState: ConnectivityState, picker: Picker) => {
           this.updateState(connectivityState, picker);
         },
-        requestReresolution: () => {
-          this.parent.channelControlHelper.requestReresolution();
-        }
-      });
+      }));
 
       this.picker = new QueuePicker(this.childBalancer);
     }

--- a/packages/grpc-js-xds/src/load-balancer-xds-cluster-manager.ts
+++ b/packages/grpc-js-xds/src/load-balancer-xds-cluster-manager.ts
@@ -131,17 +131,11 @@ class XdsClusterManager implements LoadBalancer {
     private childBalancer: ChildLoadBalancerHandler;
 
     constructor(private parent: XdsClusterManager, private name: string) {
-      this.childBalancer = new ChildLoadBalancerHandler({
-        createSubchannel: (subchannelAddress, subchannelOptions) => {
-          return this.parent.channelControlHelper.createSubchannel(subchannelAddress, subchannelOptions);
-        },
-        updateState: (connectivityState, picker) => {
+      this.childBalancer = new ChildLoadBalancerHandler(experimental.createChildChannelControlHelper(this.parent.channelControlHelper, {
+        updateState: (connectivityState: ConnectivityState, picker: Picker) => {
           this.updateState(connectivityState, picker);
         },
-        requestReresolution: () => {
-          this.parent.channelControlHelper.requestReresolution();
-        }
-      });
+      }));
 
       this.picker = new QueuePicker(this.childBalancer);
     }

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -15,7 +15,6 @@
   "types": "build/src/index.d.ts",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grpc/proto-loader": "^0.5.5",
     "@types/gulp": "^4.0.6",
     "@types/gulp-mocha": "0.0.32",
     "@types/lodash": "^4.14.108",
@@ -54,9 +53,11 @@
     "check": "gts check src/**/*.ts",
     "fix": "gts fix src/*.ts",
     "pretest": "npm run compile",
-    "posttest": "npm run check && madge -c ./build/src"
+    "posttest": "npm run check && madge -c ./build/src",
+    "generate-types": "proto-loader-gen-types --keepCase --longs String --enums String --defaults --oneofs --includeComments --includeDirs proto/ -O src/generated/ --grpcLib ../index channelz.proto"
   },
   "dependencies": {
+    "@grpc/proto-loader": "^0.6.4",
     "@types/node": ">=12.12.47"
   },
   "files": [

--- a/packages/grpc-js/proto/channelz.proto
+++ b/packages/grpc-js/proto/channelz.proto
@@ -1,0 +1,564 @@
+// Copyright 2018 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file defines an interface for exporting monitoring information
+// out of gRPC servers.  See the full design at
+// https://github.com/grpc/proposal/blob/master/A14-channelz.md
+//
+// The canonical version of this proto can be found at
+// https://github.com/grpc/grpc-proto/blob/master/grpc/channelz/v1/channelz.proto
+
+syntax = "proto3";
+
+package grpc.channelz.v1;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+option go_package = "google.golang.org/grpc/channelz/grpc_channelz_v1";
+option java_multiple_files = true;
+option java_package = "io.grpc.channelz.v1";
+option java_outer_classname = "ChannelzProto";
+
+// Channel is a logical grouping of channels, subchannels, and sockets.
+message Channel {
+  // The identifier for this channel. This should bet set.
+  ChannelRef ref = 1;
+  // Data specific to this channel.
+  ChannelData data = 2;
+  // At most one of 'channel_ref+subchannel_ref' and 'socket' is set.
+
+  // There are no ordering guarantees on the order of channel refs.
+  // There may not be cycles in the ref graph.
+  // A channel ref may be present in more than one channel or subchannel.
+  repeated ChannelRef channel_ref = 3;
+
+  // At most one of 'channel_ref+subchannel_ref' and 'socket' is set.
+  // There are no ordering guarantees on the order of subchannel refs.
+  // There may not be cycles in the ref graph.
+  // A sub channel ref may be present in more than one channel or subchannel.
+  repeated SubchannelRef subchannel_ref = 4;
+
+  // There are no ordering guarantees on the order of sockets.
+  repeated SocketRef socket_ref = 5;
+}
+
+// Subchannel is a logical grouping of channels, subchannels, and sockets.
+// A subchannel is load balanced over by it's ancestor
+message Subchannel {
+  // The identifier for this channel.
+  SubchannelRef ref = 1;
+  // Data specific to this channel.
+  ChannelData data = 2;
+  // At most one of 'channel_ref+subchannel_ref' and 'socket' is set.
+
+  // There are no ordering guarantees on the order of channel refs.
+  // There may not be cycles in the ref graph.
+  // A channel ref may be present in more than one channel or subchannel.
+  repeated ChannelRef channel_ref = 3;
+
+  // At most one of 'channel_ref+subchannel_ref' and 'socket' is set.
+  // There are no ordering guarantees on the order of subchannel refs.
+  // There may not be cycles in the ref graph.
+  // A sub channel ref may be present in more than one channel or subchannel.
+  repeated SubchannelRef subchannel_ref = 4;
+
+  // There are no ordering guarantees on the order of sockets.
+  repeated SocketRef socket_ref = 5;
+}
+
+// These come from the specified states in this document:
+// https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
+message ChannelConnectivityState {
+  enum State {
+    UNKNOWN = 0;
+    IDLE = 1;
+    CONNECTING = 2;
+    READY = 3;
+    TRANSIENT_FAILURE = 4;
+    SHUTDOWN = 5;
+  }
+  State state = 1;
+}
+
+// Channel data is data related to a specific Channel or Subchannel.
+message ChannelData {
+  // The connectivity state of the channel or subchannel.  Implementations
+  // should always set this.
+  ChannelConnectivityState state = 1;
+
+  // The target this channel originally tried to connect to.  May be absent
+  string target = 2;
+
+  // A trace of recent events on the channel.  May be absent.
+  ChannelTrace trace = 3;
+
+  // The number of calls started on the channel
+  int64 calls_started = 4;
+  // The number of calls that have completed with an OK status
+  int64 calls_succeeded = 5;
+  // The number of calls that have completed with a non-OK status
+  int64 calls_failed = 6;
+
+  // The last time a call was started on the channel.
+  google.protobuf.Timestamp last_call_started_timestamp = 7;
+}
+
+// A trace event is an interesting thing that happened to a channel or
+// subchannel, such as creation, address resolution, subchannel creation, etc.
+message ChannelTraceEvent {
+  // High level description of the event.
+  string description = 1;
+  // The supported severity levels of trace events.
+  enum Severity {
+    CT_UNKNOWN = 0;
+    CT_INFO = 1;
+    CT_WARNING = 2;
+    CT_ERROR = 3;
+  }
+  // the severity of the trace event
+  Severity severity = 2;
+  // When this event occurred.
+  google.protobuf.Timestamp timestamp = 3;
+  // ref of referenced channel or subchannel.
+  // Optional, only present if this event refers to a child object. For example,
+  // this field would be filled if this trace event was for a subchannel being
+  // created.
+  oneof child_ref {
+    ChannelRef channel_ref = 4;
+    SubchannelRef subchannel_ref = 5;
+  }
+}
+
+// ChannelTrace represents the recent events that have occurred on the channel.
+message ChannelTrace {
+  // Number of events ever logged in this tracing object. This can differ from
+  // events.size() because events can be overwritten or garbage collected by
+  // implementations.
+  int64 num_events_logged = 1;
+  // Time that this channel was created.
+  google.protobuf.Timestamp creation_timestamp = 2;
+  // List of events that have occurred on this channel.
+  repeated ChannelTraceEvent events = 3;
+}
+
+// ChannelRef is a reference to a Channel.
+message ChannelRef {
+  // The globally unique id for this channel.  Must be a positive number.
+  int64 channel_id = 1;
+  // An optional name associated with the channel.
+  string name = 2;
+  // Intentionally don't use field numbers from other refs.
+  reserved 3, 4, 5, 6, 7, 8;
+}
+
+// SubchannelRef is a reference to a Subchannel.
+message SubchannelRef {
+  // The globally unique id for this subchannel.  Must be a positive number.
+  int64 subchannel_id = 7;
+  // An optional name associated with the subchannel.
+  string name = 8;
+  // Intentionally don't use field numbers from other refs.
+  reserved 1, 2, 3, 4, 5, 6;
+}
+
+// SocketRef is a reference to a Socket.
+message SocketRef {
+  // The globally unique id for this socket.  Must be a positive number.
+  int64 socket_id = 3;
+  // An optional name associated with the socket.
+  string name = 4;
+  // Intentionally don't use field numbers from other refs.
+  reserved 1, 2, 5, 6, 7, 8;
+}
+
+// ServerRef is a reference to a Server.
+message ServerRef {
+  // A globally unique identifier for this server.  Must be a positive number.
+  int64 server_id = 5;
+  // An optional name associated with the server.
+  string name = 6;
+  // Intentionally don't use field numbers from other refs.
+  reserved 1, 2, 3, 4, 7, 8;
+}
+
+// Server represents a single server.  There may be multiple servers in a single
+// program.
+message Server {
+  // The identifier for a Server.  This should be set.
+  ServerRef ref = 1;
+  // The associated data of the Server.
+  ServerData data = 2;
+
+  // The sockets that the server is listening on.  There are no ordering
+  // guarantees.  This may be absent.
+  repeated SocketRef listen_socket = 3;
+}
+
+// ServerData is data for a specific Server.
+message ServerData {
+  // A trace of recent events on the server.  May be absent.
+  ChannelTrace trace = 1;
+
+  // The number of incoming calls started on the server
+  int64 calls_started = 2;
+  // The number of incoming calls that have completed with an OK status
+  int64 calls_succeeded = 3;
+  // The number of incoming calls that have a completed with a non-OK status
+  int64 calls_failed = 4;
+
+  // The last time a call was started on the server.
+  google.protobuf.Timestamp last_call_started_timestamp = 5;
+}
+
+// Information about an actual connection.  Pronounced "sock-ay".
+message Socket {
+  // The identifier for the Socket.
+  SocketRef ref = 1;
+
+  // Data specific to this Socket.
+  SocketData data = 2;
+  // The locally bound address.
+  Address local = 3;
+  // The remote bound address.  May be absent.
+  Address remote = 4;
+  // Security details for this socket.  May be absent if not available, or
+  // there is no security on the socket.
+  Security security = 5;
+
+  // Optional, represents the name of the remote endpoint, if different than
+  // the original target name.
+  string remote_name = 6;
+}
+
+// SocketData is data associated for a specific Socket.  The fields present
+// are specific to the implementation, so there may be minor differences in
+// the semantics.  (e.g. flow control windows)
+message SocketData {
+  // The number of streams that have been started.
+  int64 streams_started = 1;
+  // The number of streams that have ended successfully:
+  // On client side, received frame with eos bit set;
+  // On server side, sent frame with eos bit set.
+  int64 streams_succeeded = 2;
+  // The number of streams that have ended unsuccessfully:
+  // On client side, ended without receiving frame with eos bit set;
+  // On server side, ended without sending frame with eos bit set.
+  int64 streams_failed = 3;
+  // The number of grpc messages successfully sent on this socket.
+  int64 messages_sent = 4;
+  // The number of grpc messages received on this socket.
+  int64 messages_received = 5;
+
+  // The number of keep alives sent.  This is typically implemented with HTTP/2
+  // ping messages.
+  int64 keep_alives_sent = 6;
+
+  // The last time a stream was created by this endpoint.  Usually unset for
+  // servers.
+  google.protobuf.Timestamp last_local_stream_created_timestamp = 7;
+  // The last time a stream was created by the remote endpoint.  Usually unset
+  // for clients.
+  google.protobuf.Timestamp last_remote_stream_created_timestamp = 8;
+
+  // The last time a message was sent by this endpoint.
+  google.protobuf.Timestamp last_message_sent_timestamp = 9;
+  // The last time a message was received by this endpoint.
+  google.protobuf.Timestamp last_message_received_timestamp = 10;
+
+  // The amount of window, granted to the local endpoint by the remote endpoint.
+  // This may be slightly out of date due to network latency.  This does NOT
+  // include stream level or TCP level flow control info.
+  google.protobuf.Int64Value local_flow_control_window = 11;
+
+  // The amount of window, granted to the remote endpoint by the local endpoint.
+  // This may be slightly out of date due to network latency.  This does NOT
+  // include stream level or TCP level flow control info.
+  google.protobuf.Int64Value  remote_flow_control_window = 12;
+
+  // Socket options set on this socket.  May be absent if 'summary' is set
+  // on GetSocketRequest.
+  repeated SocketOption option = 13;
+}
+
+// Address represents the address used to create the socket.
+message Address {
+  message TcpIpAddress {
+    // Either the IPv4 or IPv6 address in bytes.  Will be either 4 bytes or 16
+    // bytes in length.
+    bytes ip_address = 1;
+    // 0-64k, or -1 if not appropriate.
+    int32 port = 2;
+  }
+  // A Unix Domain Socket address.
+  message UdsAddress {
+    string filename = 1;
+  }
+  // An address type not included above.
+  message OtherAddress {
+    // The human readable version of the value.  This value should be set.
+    string name = 1;
+    // The actual address message.
+    google.protobuf.Any value = 2;
+  }
+
+  oneof address {
+    TcpIpAddress tcpip_address = 1;
+    UdsAddress uds_address = 2;
+    OtherAddress other_address = 3;
+  }
+}
+
+// Security represents details about how secure the socket is.
+message Security {
+  message Tls {
+    oneof cipher_suite {
+      // The cipher suite name in the RFC 4346 format:
+      // https://tools.ietf.org/html/rfc4346#appendix-C
+      string standard_name = 1;
+      // Some other way to describe the cipher suite if
+      // the RFC 4346 name is not available.
+      string other_name = 2;
+    }
+    // the certificate used by this endpoint.
+    bytes local_certificate = 3;
+    // the certificate used by the remote endpoint.
+    bytes remote_certificate = 4;
+  }
+  message OtherSecurity {
+    // The human readable version of the value.
+    string name = 1;
+    // The actual security details message.
+    google.protobuf.Any value = 2;
+  }
+  oneof model {
+    Tls tls = 1;
+    OtherSecurity other = 2;
+  }
+}
+
+// SocketOption represents socket options for a socket.  Specifically, these
+// are the options returned by getsockopt().
+message SocketOption {
+  // The full name of the socket option.  Typically this will be the upper case
+  // name, such as "SO_REUSEPORT".
+  string name = 1;
+  // The human readable value of this socket option.  At least one of value or
+  // additional will be set.
+  string value = 2;
+  // Additional data associated with the socket option.  At least one of value
+  // or additional will be set.
+  google.protobuf.Any additional = 3;
+}
+
+// For use with SocketOption's additional field.  This is primarily used for
+// SO_RCVTIMEO and SO_SNDTIMEO
+message SocketOptionTimeout {
+  google.protobuf.Duration duration = 1;
+}
+
+// For use with SocketOption's additional field.  This is primarily used for
+// SO_LINGER.
+message SocketOptionLinger {
+  // active maps to `struct linger.l_onoff`
+  bool active = 1;
+  // duration maps to `struct linger.l_linger`
+  google.protobuf.Duration duration = 2;
+}
+
+// For use with SocketOption's additional field.  Tcp info for
+// SOL_TCP and TCP_INFO.
+message SocketOptionTcpInfo {
+  uint32 tcpi_state = 1;
+
+  uint32 tcpi_ca_state = 2;
+  uint32 tcpi_retransmits = 3;
+  uint32 tcpi_probes = 4;
+  uint32 tcpi_backoff = 5;
+  uint32 tcpi_options = 6;
+  uint32 tcpi_snd_wscale = 7;
+  uint32 tcpi_rcv_wscale = 8;
+
+  uint32 tcpi_rto = 9;
+  uint32 tcpi_ato = 10;
+  uint32 tcpi_snd_mss = 11;
+  uint32 tcpi_rcv_mss = 12;
+
+  uint32 tcpi_unacked = 13;
+  uint32 tcpi_sacked = 14;
+  uint32 tcpi_lost = 15;
+  uint32 tcpi_retrans = 16;
+  uint32 tcpi_fackets = 17;
+
+  uint32 tcpi_last_data_sent = 18;
+  uint32 tcpi_last_ack_sent = 19;
+  uint32 tcpi_last_data_recv = 20;
+  uint32 tcpi_last_ack_recv = 21;
+
+  uint32 tcpi_pmtu = 22;
+  uint32 tcpi_rcv_ssthresh = 23;
+  uint32 tcpi_rtt = 24;
+  uint32 tcpi_rttvar = 25;
+  uint32 tcpi_snd_ssthresh = 26;
+  uint32 tcpi_snd_cwnd = 27;
+  uint32 tcpi_advmss = 28;
+  uint32 tcpi_reordering = 29;
+}
+
+// Channelz is a service exposed by gRPC servers that provides detailed debug
+// information.
+service Channelz {
+  // Gets all root channels (i.e. channels the application has directly
+  // created). This does not include subchannels nor non-top level channels.
+  rpc GetTopChannels(GetTopChannelsRequest) returns (GetTopChannelsResponse);
+  // Gets all servers that exist in the process.
+  rpc GetServers(GetServersRequest) returns (GetServersResponse);
+  // Returns a single Server, or else a NOT_FOUND code.
+  rpc GetServer(GetServerRequest) returns (GetServerResponse);
+  // Gets all server sockets that exist in the process.
+  rpc GetServerSockets(GetServerSocketsRequest) returns (GetServerSocketsResponse);
+  // Returns a single Channel, or else a NOT_FOUND code.
+  rpc GetChannel(GetChannelRequest) returns (GetChannelResponse);
+  // Returns a single Subchannel, or else a NOT_FOUND code.
+  rpc GetSubchannel(GetSubchannelRequest) returns (GetSubchannelResponse);
+  // Returns a single Socket or else a NOT_FOUND code.
+  rpc GetSocket(GetSocketRequest) returns (GetSocketResponse);
+}
+
+message GetTopChannelsRequest {
+  // start_channel_id indicates that only channels at or above this id should be
+  // included in the results.
+  // To request the first page, this should be set to 0. To request
+  // subsequent pages, the client generates this value by adding 1 to
+  // the highest seen result ID.
+  int64 start_channel_id = 1;
+
+  // If non-zero, the server will return a page of results containing
+  // at most this many items. If zero, the server will choose a
+  // reasonable page size.  Must never be negative.
+  int64 max_results = 2;
+}
+
+message GetTopChannelsResponse {
+  // list of channels that the connection detail service knows about.  Sorted in
+  // ascending channel_id order.
+  // Must contain at least 1 result, otherwise 'end' must be true.
+  repeated Channel channel = 1;
+  // If set, indicates that the list of channels is the final list.  Requesting
+  // more channels can only return more if they are created after this RPC
+  // completes.
+  bool end = 2;
+}
+
+message GetServersRequest {
+  // start_server_id indicates that only servers at or above this id should be
+  // included in the results.
+  // To request the first page, this must be set to 0. To request
+  // subsequent pages, the client generates this value by adding 1 to
+  // the highest seen result ID.
+  int64 start_server_id = 1;
+
+  // If non-zero, the server will return a page of results containing
+  // at most this many items. If zero, the server will choose a
+  // reasonable page size.  Must never be negative.
+  int64 max_results = 2;
+}
+
+message GetServersResponse {
+  // list of servers that the connection detail service knows about.  Sorted in
+  // ascending server_id order.
+  // Must contain at least 1 result, otherwise 'end' must be true.
+  repeated Server server = 1;
+  // If set, indicates that the list of servers is the final list.  Requesting
+  // more servers will only return more if they are created after this RPC
+  // completes.
+  bool end = 2;
+}
+
+message GetServerRequest {
+  // server_id is the identifier of the specific server to get.
+  int64 server_id = 1;
+}
+
+message GetServerResponse {
+  // The Server that corresponds to the requested server_id.  This field
+  // should be set.
+  Server server = 1;
+}
+
+message GetServerSocketsRequest {
+  int64 server_id = 1;
+  // start_socket_id indicates that only sockets at or above this id should be
+  // included in the results.
+  // To request the first page, this must be set to 0. To request
+  // subsequent pages, the client generates this value by adding 1 to
+  // the highest seen result ID.
+  int64 start_socket_id = 2;
+
+  // If non-zero, the server will return a page of results containing
+  // at most this many items. If zero, the server will choose a
+  // reasonable page size.  Must never be negative.
+  int64 max_results = 3;
+}
+
+message GetServerSocketsResponse {
+  // list of socket refs that the connection detail service knows about.  Sorted in
+  // ascending socket_id order.
+  // Must contain at least 1 result, otherwise 'end' must be true.
+  repeated SocketRef socket_ref = 1;
+  // If set, indicates that the list of sockets is the final list.  Requesting
+  // more sockets will only return more if they are created after this RPC
+  // completes.
+  bool end = 2;
+}
+
+message GetChannelRequest {
+  // channel_id is the identifier of the specific channel to get.
+  int64 channel_id = 1;
+}
+
+message GetChannelResponse {
+  // The Channel that corresponds to the requested channel_id.  This field
+  // should be set.
+  Channel channel = 1;
+}
+
+message GetSubchannelRequest {
+  // subchannel_id is the identifier of the specific subchannel to get.
+  int64 subchannel_id = 1;
+}
+
+message GetSubchannelResponse {
+  // The Subchannel that corresponds to the requested subchannel_id.  This
+  // field should be set.
+  Subchannel subchannel = 1;
+}
+
+message GetSocketRequest {
+  // socket_id is the identifier of the specific socket to get.
+  int64 socket_id = 1;
+
+  // If true, the response will contain only high level information
+  // that is inexpensive to obtain. Fields thay may be omitted are
+  // documented.
+  bool summary = 2;
+}
+
+message GetSocketResponse {
+  // The Socket that corresponds to the requested socket_id.  This field
+  // should be set.
+  Socket socket = 1;
+}

--- a/packages/grpc-js/src/admin.ts
+++ b/packages/grpc-js/src/admin.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { ServiceDefinition } from "./make-client";
+import { Server, UntypedServiceImplementation } from "./server";
+
+interface GetServiceDefinition {
+  (): ServiceDefinition;
+}
+
+interface GetHandlers {
+  (): UntypedServiceImplementation;
+}
+
+const registeredAdminServices: {getServiceDefinition: GetServiceDefinition, getHandlers: GetHandlers}[] = [];
+
+export function registerAdminService(getServiceDefinition: GetServiceDefinition, getHandlers: GetHandlers) {
+  registeredAdminServices.push({getServiceDefinition, getHandlers});
+}
+
+export function addAdminServicesToServer(server: Server): void {
+  for (const {getServiceDefinition, getHandlers} of registeredAdminServices) {
+    server.addService(getServiceDefinition(), getHandlers());
+  }
+}

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -163,6 +163,7 @@ export class ChannelImplementation implements Channel {
   private configSelector: ConfigSelector | null = null;
 
   // Channelz info
+  private originalTarget: string;
   private channelzRef: ChannelRef;
   private channelzTrace: ChannelzTrace;
   private callTracker = new ChannelzCallTracker();
@@ -196,6 +197,7 @@ export class ChannelImplementation implements Channel {
         );
       }
     }
+    this.originalTarget = target;
     const originalTargetUri = parseUri(target);
     if (originalTargetUri === null) {
       throw new Error(`Could not parse target name "${target}"`);
@@ -320,6 +322,7 @@ export class ChannelImplementation implements Channel {
 
   private getChannelzInfo(): ChannelInfo {
     return {
+      target: this.originalTarget,
       state: this.connectivityState,
       trace: this.channelzTrace,
       callTracker: this.callTracker,

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -104,6 +104,12 @@ export interface Channel {
     callback: (error?: Error) => void
   ): void;
   /**
+   * Get the channelz reference object for this channel. A request to the
+   * channelz service for the id in this object will provide information
+   * about this channel.
+   */
+  getChannelzRef(): ChannelRef;
+  /**
    * Create a call object. Call is an opaque type that is used by the Client
    * class. This function is called by the gRPC library when starting a
    * request. Implementers should return an instance of Call that is returned
@@ -243,7 +249,7 @@ export class ChannelImplementation implements Channel {
           Object.assign({}, this.options, subchannelArgs),
           this.credentials
         );
-        this.channelzTrace.addTrace('CT_INFO', 'Created or got existing subchannel', subchannel.getChannelzRef());
+        this.channelzTrace.addTrace('CT_INFO', 'Created subchannel or used existing subchannel', subchannel.getChannelzRef());
         return subchannel;
       },
       updateState: (connectivityState: ConnectivityState, picker: Picker) => {
@@ -675,6 +681,10 @@ export class ChannelImplementation implements Channel {
       timer,
     };
     this.connectivityStateWatchers.push(watcherObject);
+  }
+
+  getChannelzRef() {
+    return this.channelzRef;
   }
 
   createCall(

--- a/packages/grpc-js/src/channelz.ts
+++ b/packages/grpc-js/src/channelz.ts
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { isIPv4, isIPv6 } from "net";
+import { ConnectivityState } from "./connectivity-state";
+import { SubchannelAddress } from "./subchannel-address";
+
+export type TraceSeverity = 'CT_UNKNOWN' | 'CT_INFO' | 'CT_WARNING' | 'CT_ERROR';
+
+export interface ChannelRef {
+  kind: 'channel';
+  id: number;
+  name: string;
+}
+
+export interface SubchannelRef {
+  kind: 'subchannel';
+  id: number;
+  name: string;
+}
+
+export interface ServerRef {
+  kind: 'server';
+  id: number;
+}
+
+export interface SocketRef {
+  kind: 'socket';
+  id: number;
+  name: string;
+}
+
+interface TraceEvent {
+  description: string;
+  severity: TraceSeverity;
+  timestamp: Date;
+  childChannel?: ChannelRef;
+  childSubchannel?: SubchannelRef;
+}
+
+export class ChannelzTrace {
+  events: TraceEvent[] = [];
+  creationTimestamp: Date;
+  eventsLogged: number = 0;
+
+  constructor() {
+    this.creationTimestamp = new Date();
+  }
+
+  addTrace(severity: TraceSeverity, description: string, child?: ChannelRef | SubchannelRef) {
+    const timestamp = new Date();
+    this.events.push({
+      description: description,
+      severity: severity,
+      timestamp: timestamp,
+      childChannel: child?.kind === 'channel' ? child : undefined,
+      childSubchannel: child?.kind === 'subchannel' ? child : undefined
+    });
+    this.eventsLogged += 1;
+  }
+}
+
+export class ChannelzChildrenTracker {
+  private channelChildren: Map<number, {ref: ChannelRef, count: number}> = new Map<number, {ref: ChannelRef, count: number}>();
+  private subchannelChildren: Map<number, {ref: SubchannelRef, count: number}> = new Map<number, {ref: SubchannelRef, count: number}>();
+  private socketChildren: Map<number, {ref: SocketRef, count: number}> = new Map<number, {ref: SocketRef, count: number}>();
+
+  refChild(child: ChannelRef | SubchannelRef | SocketRef) {
+    switch (child.kind) {
+      case 'channel': {
+        let trackedChild = this.channelChildren.get(child.id) ?? {ref: child, count: 0};
+        trackedChild.count += 1;
+        this.channelChildren.set(child.id, trackedChild);
+        break;
+      }
+      case 'subchannel':{
+        let trackedChild = this.subchannelChildren.get(child.id) ?? {ref: child, count: 0};
+        trackedChild.count += 1;
+        this.subchannelChildren.set(child.id, trackedChild);
+        break;
+      }
+      case 'socket':{
+        let trackedChild = this.socketChildren.get(child.id) ?? {ref: child, count: 0};
+        trackedChild.count += 1;
+        this.socketChildren.set(child.id, trackedChild);
+        break;
+      }
+    }
+  }
+
+  unrefChild(child: ChannelRef | SubchannelRef | SocketRef) {
+    switch (child.kind) {
+      case 'channel': {
+        let trackedChild = this.channelChildren.get(child.id);
+        if (trackedChild !== undefined) {
+          trackedChild.count -= 1;
+          if (trackedChild.count === 0) {
+            this.channelChildren.delete(child.id);
+          } else {
+            this.channelChildren.set(child.id, trackedChild);
+          }
+        }
+        break;
+      }
+      case 'subchannel': {
+        let trackedChild = this.subchannelChildren.get(child.id);
+        if (trackedChild !== undefined) {
+          trackedChild.count -= 1;
+          if (trackedChild.count === 0) {
+            this.subchannelChildren.delete(child.id);
+          } else {
+            this.subchannelChildren.set(child.id, trackedChild);
+          }
+        }
+        break;
+      }
+      case 'socket': {
+        let trackedChild = this.socketChildren.get(child.id);
+        if (trackedChild !== undefined) {
+          trackedChild.count -= 1;
+          if (trackedChild.count === 0) {
+            this.socketChildren.delete(child.id);
+          } else {
+            this.socketChildren.set(child.id, trackedChild);
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  getChildLists(): ChannelzChildren {
+    const channels: ChannelRef[] = [];
+    for (const {ref} of this.channelChildren.values()) {
+      channels.push(ref);
+    }
+    const subchannels: SubchannelRef[] = [];
+    for (const {ref} of this.subchannelChildren.values()) {
+      subchannels.push(ref);
+    }
+    const sockets: SocketRef[] = [];
+    for (const {ref} of this.socketChildren.values()) {
+      sockets.push(ref);
+    }
+    return {channels, subchannels, sockets};
+  }
+}
+
+export class ChannelzCallTracker {
+  callsStarted: number = 0;
+  callsSucceeded: number = 0;
+  callsFailed: number = 0;
+  lastCallStartedTimestamp: Date | null = null;
+
+  addCallStarted() {
+    this.callsStarted += 1;
+    this.lastCallStartedTimestamp = new Date();
+  }
+  addCallSucceeded() {
+    this.callsSucceeded += 1;
+  }
+  addCallFailed() {
+    this.callsFailed += 1;
+  }
+}
+
+export interface ChannelzChildren {
+  channels: ChannelRef[];
+  subchannels: SubchannelRef[];
+  sockets: SocketRef[];
+}
+
+export interface ChannelInfo {
+  state: ConnectivityState;
+  trace: ChannelzTrace;
+  callTracker: ChannelzCallTracker;
+  children: ChannelzChildren;
+}
+
+export interface SubchannelInfo extends ChannelInfo {}
+
+export interface ServerInfo {
+  trace: ChannelzTrace;
+  callTracker: ChannelzCallTracker;
+  children: ChannelzChildren;
+}
+
+export interface TlsInfo {
+  cipherSuiteStandardName: string | null;
+  cipherSuiteOtherName: string | null;
+  localCertificate: Buffer | null;
+  remoteCertificate: Buffer | null;
+}
+
+export interface SocketInfo {
+  localAddress: SubchannelAddress;
+  remoteAddress: SubchannelAddress | null;
+  security: TlsInfo | null;
+  remoteName: string | null;
+  streamsStarted: number;
+  streamsSucceeded: number;
+  streamsFailed: number;
+  messagesSent: number;
+  messagesReceived: number;
+  keepAlivesSent: number;
+  lastLocalStreamCreatedTimestamp: Date | null;
+  lastRemoteStreamCreatedTimestamp: Date | null;
+  lastMessageSentTimestamp: Date | null;
+  lastMessageReceivedTimestamp: Date | null;
+  localFlowControlWindow: number | null;
+  remoteFlowControlWindow: number | null;
+}
+
+interface ChannelEntry {
+  ref: ChannelRef;
+  getInfo(): ChannelInfo;
+}
+
+interface SubchannelEntry {
+  ref: SubchannelRef;
+  getInfo(): SubchannelInfo;
+}
+
+interface ServerEntry {
+  ref: ServerRef;
+  getInfo(): ServerInfo;
+}
+
+interface SocketEntry {
+  ref: SocketRef;
+  getInfo(): SocketInfo;
+}
+
+let nextId = 1;
+
+function getNextId(): number {
+  return nextId++;
+}
+
+const channels: (ChannelEntry | undefined)[] = [];
+const subchannels: (SubchannelEntry | undefined)[] = [];
+const servers: (ServerEntry | undefined)[] = [];
+const sockets: (SocketEntry | undefined)[] = [];
+
+export function registerChannelzChannel(name: string, getInfo: () => ChannelInfo): ChannelRef {
+  const id = getNextId();
+  const ref: ChannelRef = {id, name, kind: 'channel'};
+  channels[id] = { ref, getInfo };
+  return ref;
+}
+
+export function registerChannelzSubchannel(name: string, getInfo:() => SubchannelInfo): SubchannelRef {
+  const id = getNextId();
+  const ref: SubchannelRef = {id, name, kind: 'subchannel'};
+  subchannels[id] = { ref, getInfo };
+  return ref;
+}
+
+export function registerChannelzServer(getInfo: () => ServerInfo): ServerRef {
+  const id = getNextId();
+  const ref: ServerRef = {id, kind: 'server'};
+  servers[id] = { ref, getInfo };
+  return ref;
+}
+
+export function registerChannelzSocket(name: string, getInfo: () => SocketInfo): SocketRef {
+  const id = getNextId();
+  const ref: SocketRef = {id, name, kind: 'socket'};
+  sockets[id] = { ref, getInfo};
+  return ref;
+}
+
+export function unregisterChannelzRef(ref: ChannelRef | SubchannelRef | ServerRef | SocketRef) {
+  switch (ref.kind) {
+    case 'channel':
+      delete channels[ref.id];
+      return;
+    case 'subchannel':
+      delete subchannels[ref.id];
+      return;
+    case 'server':
+      delete servers[ref.id];
+      return;
+    case 'socket':
+      delete sockets[ref.id];
+      return;
+  }
+}
+
+export interface ChannelzClientView {
+  updateState(connectivityState: ConnectivityState): void;
+  addTrace(severity: TraceSeverity, description: string, child?: ChannelRef | SubchannelRef): void;
+  addCallStarted(): void;
+  addCallSucceeded(): void;
+  addCallFailed(): void;
+  addChild(child: ChannelRef | SubchannelRef): void;
+  removeChild(child: ChannelRef | SubchannelRef): void;
+}
+
+export interface ChannelzSubchannelView extends ChannelzClientView {
+  getRef(): SubchannelRef;
+}
+
+/**
+ * Converts an IPv4 or IPv6 address from string representation to binary
+ * representation
+ * @param ipAddress an IP address in standard IPv4 or IPv6 text format
+ * @returns 
+ */
+function ipAddressStringToBuffer(ipAddress: string): Buffer | null {
+  if (isIPv4(ipAddress)) {
+    return Buffer.from(Uint8Array.from(ipAddress.split('.').map(segment => Number.parseInt(segment))));
+  } else if (isIPv6(ipAddress)) {
+    let leftSection: string;
+    let rightSection: string | null;
+    const doubleColonIndex = ipAddress.indexOf('::');
+    if (doubleColonIndex === -1) {
+      leftSection = ipAddress;
+      rightSection = null;
+    } else {
+      leftSection = ipAddress.substring(0, doubleColonIndex);
+      rightSection = ipAddress.substring(doubleColonIndex + 2);
+    }
+    const leftBuffer = Uint8Array.from(leftSection.split(':').map(segment => Number.parseInt(segment, 16)));
+    const rightBuffer = rightSection ? Uint8Array.from(rightSection.split(':').map(segment => Number.parseInt(segment, 16))) : new Uint8Array();
+    const middleBuffer = Buffer.alloc(16 - leftBuffer.length - rightBuffer.length, 0);
+    return Buffer.concat([leftBuffer, middleBuffer, rightBuffer]);
+  } else {
+    return null;
+  }
+}

--- a/packages/grpc-js/src/channelz.ts
+++ b/packages/grpc-js/src/channelz.ts
@@ -50,6 +50,7 @@ import { GetServerSocketsResponse } from "./generated/grpc/channelz/v1/GetServer
 import { ChannelzDefinition, ChannelzHandlers } from "./generated/grpc/channelz/v1/Channelz";
 import { ProtoGrpcType as ChannelzProtoGrpcType } from "./generated/channelz";
 import type { loadSync } from '@grpc/proto-loader';
+import { registerAdminService } from "./admin";
 
 export type TraceSeverity = 'CT_UNKNOWN' | 'CT_INFO' | 'CT_WARNING' | 'CT_ERROR';
 
@@ -713,4 +714,8 @@ export function getChannelzServiceDefinition(): ChannelzDefinition {
   }) as unknown as ChannelzProtoGrpcType;
   loadedChannelzDefinition = loadedProto.grpc.channelz.v1.Channelz.service;
   return loadedChannelzDefinition;
+}
+
+export function setup() {
+  registerAdminService(getChannelzServiceDefinition, getChannelzHandlers);
 }

--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -12,6 +12,7 @@ export {
   LoadBalancer,
   LoadBalancingConfig,
   ChannelControlHelper,
+  createChildChannelControlHelper,
   registerLoadBalancerType,
   getFirstUsableConfig,
   validateLoadBalancingConfig,

--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -32,3 +32,4 @@ export {
 export { Call as CallStream } from './call-stream';
 export { Filter, BaseFilter, FilterFactory } from './filter';
 export { FilterStackFactory } from './filter-stack';
+export { registerAdminService } from './admin';

--- a/packages/grpc-js/src/generated/channelz.ts
+++ b/packages/grpc-js/src/generated/channelz.ts
@@ -1,0 +1,73 @@
+import type * as grpc from '../index';
+import type { MessageTypeDefinition } from '@grpc/proto-loader';
+
+import type { ChannelzClient as _grpc_channelz_v1_ChannelzClient, ChannelzDefinition as _grpc_channelz_v1_ChannelzDefinition } from './grpc/channelz/v1/Channelz';
+
+type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
+  new(...args: ConstructorParameters<Constructor>): Subtype;
+};
+
+export interface ProtoGrpcType {
+  google: {
+    protobuf: {
+      Any: MessageTypeDefinition
+      BoolValue: MessageTypeDefinition
+      BytesValue: MessageTypeDefinition
+      DoubleValue: MessageTypeDefinition
+      Duration: MessageTypeDefinition
+      FloatValue: MessageTypeDefinition
+      Int32Value: MessageTypeDefinition
+      Int64Value: MessageTypeDefinition
+      StringValue: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition
+      UInt32Value: MessageTypeDefinition
+      UInt64Value: MessageTypeDefinition
+    }
+  }
+  grpc: {
+    channelz: {
+      v1: {
+        Address: MessageTypeDefinition
+        Channel: MessageTypeDefinition
+        ChannelConnectivityState: MessageTypeDefinition
+        ChannelData: MessageTypeDefinition
+        ChannelRef: MessageTypeDefinition
+        ChannelTrace: MessageTypeDefinition
+        ChannelTraceEvent: MessageTypeDefinition
+        /**
+         * Channelz is a service exposed by gRPC servers that provides detailed debug
+         * information.
+         */
+        Channelz: SubtypeConstructor<typeof grpc.Client, _grpc_channelz_v1_ChannelzClient> & { service: _grpc_channelz_v1_ChannelzDefinition }
+        GetChannelRequest: MessageTypeDefinition
+        GetChannelResponse: MessageTypeDefinition
+        GetServerRequest: MessageTypeDefinition
+        GetServerResponse: MessageTypeDefinition
+        GetServerSocketsRequest: MessageTypeDefinition
+        GetServerSocketsResponse: MessageTypeDefinition
+        GetServersRequest: MessageTypeDefinition
+        GetServersResponse: MessageTypeDefinition
+        GetSocketRequest: MessageTypeDefinition
+        GetSocketResponse: MessageTypeDefinition
+        GetSubchannelRequest: MessageTypeDefinition
+        GetSubchannelResponse: MessageTypeDefinition
+        GetTopChannelsRequest: MessageTypeDefinition
+        GetTopChannelsResponse: MessageTypeDefinition
+        Security: MessageTypeDefinition
+        Server: MessageTypeDefinition
+        ServerData: MessageTypeDefinition
+        ServerRef: MessageTypeDefinition
+        Socket: MessageTypeDefinition
+        SocketData: MessageTypeDefinition
+        SocketOption: MessageTypeDefinition
+        SocketOptionLinger: MessageTypeDefinition
+        SocketOptionTcpInfo: MessageTypeDefinition
+        SocketOptionTimeout: MessageTypeDefinition
+        SocketRef: MessageTypeDefinition
+        Subchannel: MessageTypeDefinition
+        SubchannelRef: MessageTypeDefinition
+      }
+    }
+  }
+}
+

--- a/packages/grpc-js/src/generated/google/protobuf/Any.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/Any.ts
@@ -1,0 +1,13 @@
+// Original file: null
+
+import type { AnyExtension } from '@grpc/proto-loader';
+
+export type Any = AnyExtension | {
+  type_url: string;
+  value: Buffer | Uint8Array | string;
+}
+
+export interface Any__Output {
+  'type_url': (string);
+  'value': (Buffer);
+}

--- a/packages/grpc-js/src/generated/google/protobuf/BoolValue.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/BoolValue.ts
@@ -1,0 +1,10 @@
+// Original file: null
+
+
+export interface BoolValue {
+  'value'?: (boolean);
+}
+
+export interface BoolValue__Output {
+  'value': (boolean);
+}

--- a/packages/grpc-js/src/generated/google/protobuf/BytesValue.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/BytesValue.ts
@@ -1,0 +1,10 @@
+// Original file: null
+
+
+export interface BytesValue {
+  'value'?: (Buffer | Uint8Array | string);
+}
+
+export interface BytesValue__Output {
+  'value': (Buffer);
+}

--- a/packages/grpc-js/src/generated/google/protobuf/DoubleValue.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/DoubleValue.ts
@@ -1,0 +1,10 @@
+// Original file: null
+
+
+export interface DoubleValue {
+  'value'?: (number | string);
+}
+
+export interface DoubleValue__Output {
+  'value': (number);
+}

--- a/packages/grpc-js/src/generated/google/protobuf/Duration.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/Duration.ts
@@ -1,0 +1,13 @@
+// Original file: null
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface Duration {
+  'seconds'?: (number | string | Long);
+  'nanos'?: (number);
+}
+
+export interface Duration__Output {
+  'seconds': (string);
+  'nanos': (number);
+}

--- a/packages/grpc-js/src/generated/google/protobuf/FloatValue.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/FloatValue.ts
@@ -1,0 +1,10 @@
+// Original file: null
+
+
+export interface FloatValue {
+  'value'?: (number | string);
+}
+
+export interface FloatValue__Output {
+  'value': (number);
+}

--- a/packages/grpc-js/src/generated/google/protobuf/Int32Value.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/Int32Value.ts
@@ -1,0 +1,10 @@
+// Original file: null
+
+
+export interface Int32Value {
+  'value'?: (number);
+}
+
+export interface Int32Value__Output {
+  'value': (number);
+}

--- a/packages/grpc-js/src/generated/google/protobuf/Int64Value.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/Int64Value.ts
@@ -1,0 +1,11 @@
+// Original file: null
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface Int64Value {
+  'value'?: (number | string | Long);
+}
+
+export interface Int64Value__Output {
+  'value': (string);
+}

--- a/packages/grpc-js/src/generated/google/protobuf/StringValue.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/StringValue.ts
@@ -1,0 +1,10 @@
+// Original file: null
+
+
+export interface StringValue {
+  'value'?: (string);
+}
+
+export interface StringValue__Output {
+  'value': (string);
+}

--- a/packages/grpc-js/src/generated/google/protobuf/Timestamp.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/Timestamp.ts
@@ -1,0 +1,13 @@
+// Original file: null
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface Timestamp {
+  'seconds'?: (number | string | Long);
+  'nanos'?: (number);
+}
+
+export interface Timestamp__Output {
+  'seconds': (string);
+  'nanos': (number);
+}

--- a/packages/grpc-js/src/generated/google/protobuf/UInt32Value.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/UInt32Value.ts
@@ -1,0 +1,10 @@
+// Original file: null
+
+
+export interface UInt32Value {
+  'value'?: (number);
+}
+
+export interface UInt32Value__Output {
+  'value': (number);
+}

--- a/packages/grpc-js/src/generated/google/protobuf/UInt64Value.ts
+++ b/packages/grpc-js/src/generated/google/protobuf/UInt64Value.ts
@@ -1,0 +1,11 @@
+// Original file: null
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface UInt64Value {
+  'value'?: (number | string | Long);
+}
+
+export interface UInt64Value__Output {
+  'value': (string);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Address.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Address.ts
@@ -1,0 +1,89 @@
+// Original file: proto/channelz.proto
+
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../../google/protobuf/Any';
+
+/**
+ * An address type not included above.
+ */
+export interface _grpc_channelz_v1_Address_OtherAddress {
+  /**
+   * The human readable version of the value.  This value should be set.
+   */
+  'name'?: (string);
+  /**
+   * The actual address message.
+   */
+  'value'?: (_google_protobuf_Any | null);
+}
+
+/**
+ * An address type not included above.
+ */
+export interface _grpc_channelz_v1_Address_OtherAddress__Output {
+  /**
+   * The human readable version of the value.  This value should be set.
+   */
+  'name': (string);
+  /**
+   * The actual address message.
+   */
+  'value': (_google_protobuf_Any__Output | null);
+}
+
+export interface _grpc_channelz_v1_Address_TcpIpAddress {
+  /**
+   * Either the IPv4 or IPv6 address in bytes.  Will be either 4 bytes or 16
+   * bytes in length.
+   */
+  'ip_address'?: (Buffer | Uint8Array | string);
+  /**
+   * 0-64k, or -1 if not appropriate.
+   */
+  'port'?: (number);
+}
+
+export interface _grpc_channelz_v1_Address_TcpIpAddress__Output {
+  /**
+   * Either the IPv4 or IPv6 address in bytes.  Will be either 4 bytes or 16
+   * bytes in length.
+   */
+  'ip_address': (Buffer);
+  /**
+   * 0-64k, or -1 if not appropriate.
+   */
+  'port': (number);
+}
+
+/**
+ * A Unix Domain Socket address.
+ */
+export interface _grpc_channelz_v1_Address_UdsAddress {
+  'filename'?: (string);
+}
+
+/**
+ * A Unix Domain Socket address.
+ */
+export interface _grpc_channelz_v1_Address_UdsAddress__Output {
+  'filename': (string);
+}
+
+/**
+ * Address represents the address used to create the socket.
+ */
+export interface Address {
+  'tcpip_address'?: (_grpc_channelz_v1_Address_TcpIpAddress | null);
+  'uds_address'?: (_grpc_channelz_v1_Address_UdsAddress | null);
+  'other_address'?: (_grpc_channelz_v1_Address_OtherAddress | null);
+  'address'?: "tcpip_address"|"uds_address"|"other_address";
+}
+
+/**
+ * Address represents the address used to create the socket.
+ */
+export interface Address__Output {
+  'tcpip_address'?: (_grpc_channelz_v1_Address_TcpIpAddress__Output | null);
+  'uds_address'?: (_grpc_channelz_v1_Address_UdsAddress__Output | null);
+  'other_address'?: (_grpc_channelz_v1_Address_OtherAddress__Output | null);
+  'address': "tcpip_address"|"uds_address"|"other_address";
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Channel.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Channel.ts
@@ -1,0 +1,68 @@
+// Original file: proto/channelz.proto
+
+import type { ChannelRef as _grpc_channelz_v1_ChannelRef, ChannelRef__Output as _grpc_channelz_v1_ChannelRef__Output } from '../../../grpc/channelz/v1/ChannelRef';
+import type { ChannelData as _grpc_channelz_v1_ChannelData, ChannelData__Output as _grpc_channelz_v1_ChannelData__Output } from '../../../grpc/channelz/v1/ChannelData';
+import type { SubchannelRef as _grpc_channelz_v1_SubchannelRef, SubchannelRef__Output as _grpc_channelz_v1_SubchannelRef__Output } from '../../../grpc/channelz/v1/SubchannelRef';
+import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef';
+
+/**
+ * Channel is a logical grouping of channels, subchannels, and sockets.
+ */
+export interface Channel {
+  /**
+   * The identifier for this channel. This should bet set.
+   */
+  'ref'?: (_grpc_channelz_v1_ChannelRef | null);
+  /**
+   * Data specific to this channel.
+   */
+  'data'?: (_grpc_channelz_v1_ChannelData | null);
+  /**
+   * There are no ordering guarantees on the order of channel refs.
+   * There may not be cycles in the ref graph.
+   * A channel ref may be present in more than one channel or subchannel.
+   */
+  'channel_ref'?: (_grpc_channelz_v1_ChannelRef)[];
+  /**
+   * At most one of 'channel_ref+subchannel_ref' and 'socket' is set.
+   * There are no ordering guarantees on the order of subchannel refs.
+   * There may not be cycles in the ref graph.
+   * A sub channel ref may be present in more than one channel or subchannel.
+   */
+  'subchannel_ref'?: (_grpc_channelz_v1_SubchannelRef)[];
+  /**
+   * There are no ordering guarantees on the order of sockets.
+   */
+  'socket_ref'?: (_grpc_channelz_v1_SocketRef)[];
+}
+
+/**
+ * Channel is a logical grouping of channels, subchannels, and sockets.
+ */
+export interface Channel__Output {
+  /**
+   * The identifier for this channel. This should bet set.
+   */
+  'ref': (_grpc_channelz_v1_ChannelRef__Output | null);
+  /**
+   * Data specific to this channel.
+   */
+  'data': (_grpc_channelz_v1_ChannelData__Output | null);
+  /**
+   * There are no ordering guarantees on the order of channel refs.
+   * There may not be cycles in the ref graph.
+   * A channel ref may be present in more than one channel or subchannel.
+   */
+  'channel_ref': (_grpc_channelz_v1_ChannelRef__Output)[];
+  /**
+   * At most one of 'channel_ref+subchannel_ref' and 'socket' is set.
+   * There are no ordering guarantees on the order of subchannel refs.
+   * There may not be cycles in the ref graph.
+   * A sub channel ref may be present in more than one channel or subchannel.
+   */
+  'subchannel_ref': (_grpc_channelz_v1_SubchannelRef__Output)[];
+  /**
+   * There are no ordering guarantees on the order of sockets.
+   */
+  'socket_ref': (_grpc_channelz_v1_SocketRef__Output)[];
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelConnectivityState.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelConnectivityState.ts
@@ -1,0 +1,29 @@
+// Original file: proto/channelz.proto
+
+
+// Original file: proto/channelz.proto
+
+export enum _grpc_channelz_v1_ChannelConnectivityState_State {
+  UNKNOWN = 0,
+  IDLE = 1,
+  CONNECTING = 2,
+  READY = 3,
+  TRANSIENT_FAILURE = 4,
+  SHUTDOWN = 5,
+}
+
+/**
+ * These come from the specified states in this document:
+ * https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
+ */
+export interface ChannelConnectivityState {
+  'state'?: (_grpc_channelz_v1_ChannelConnectivityState_State | keyof typeof _grpc_channelz_v1_ChannelConnectivityState_State);
+}
+
+/**
+ * These come from the specified states in this document:
+ * https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
+ */
+export interface ChannelConnectivityState__Output {
+  'state': (keyof typeof _grpc_channelz_v1_ChannelConnectivityState_State);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelData.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelData.ts
@@ -1,0 +1,76 @@
+// Original file: proto/channelz.proto
+
+import type { ChannelConnectivityState as _grpc_channelz_v1_ChannelConnectivityState, ChannelConnectivityState__Output as _grpc_channelz_v1_ChannelConnectivityState__Output } from '../../../grpc/channelz/v1/ChannelConnectivityState';
+import type { ChannelTrace as _grpc_channelz_v1_ChannelTrace, ChannelTrace__Output as _grpc_channelz_v1_ChannelTrace__Output } from '../../../grpc/channelz/v1/ChannelTrace';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
+import type { Long } from '@grpc/proto-loader';
+
+/**
+ * Channel data is data related to a specific Channel or Subchannel.
+ */
+export interface ChannelData {
+  /**
+   * The connectivity state of the channel or subchannel.  Implementations
+   * should always set this.
+   */
+  'state'?: (_grpc_channelz_v1_ChannelConnectivityState | null);
+  /**
+   * The target this channel originally tried to connect to.  May be absent
+   */
+  'target'?: (string);
+  /**
+   * A trace of recent events on the channel.  May be absent.
+   */
+  'trace'?: (_grpc_channelz_v1_ChannelTrace | null);
+  /**
+   * The number of calls started on the channel
+   */
+  'calls_started'?: (number | string | Long);
+  /**
+   * The number of calls that have completed with an OK status
+   */
+  'calls_succeeded'?: (number | string | Long);
+  /**
+   * The number of calls that have completed with a non-OK status
+   */
+  'calls_failed'?: (number | string | Long);
+  /**
+   * The last time a call was started on the channel.
+   */
+  'last_call_started_timestamp'?: (_google_protobuf_Timestamp | null);
+}
+
+/**
+ * Channel data is data related to a specific Channel or Subchannel.
+ */
+export interface ChannelData__Output {
+  /**
+   * The connectivity state of the channel or subchannel.  Implementations
+   * should always set this.
+   */
+  'state': (_grpc_channelz_v1_ChannelConnectivityState__Output | null);
+  /**
+   * The target this channel originally tried to connect to.  May be absent
+   */
+  'target': (string);
+  /**
+   * A trace of recent events on the channel.  May be absent.
+   */
+  'trace': (_grpc_channelz_v1_ChannelTrace__Output | null);
+  /**
+   * The number of calls started on the channel
+   */
+  'calls_started': (string);
+  /**
+   * The number of calls that have completed with an OK status
+   */
+  'calls_succeeded': (string);
+  /**
+   * The number of calls that have completed with a non-OK status
+   */
+  'calls_failed': (string);
+  /**
+   * The last time a call was started on the channel.
+   */
+  'last_call_started_timestamp': (_google_protobuf_Timestamp__Output | null);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelRef.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelRef.ts
@@ -1,0 +1,31 @@
+// Original file: proto/channelz.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+/**
+ * ChannelRef is a reference to a Channel.
+ */
+export interface ChannelRef {
+  /**
+   * The globally unique id for this channel.  Must be a positive number.
+   */
+  'channel_id'?: (number | string | Long);
+  /**
+   * An optional name associated with the channel.
+   */
+  'name'?: (string);
+}
+
+/**
+ * ChannelRef is a reference to a Channel.
+ */
+export interface ChannelRef__Output {
+  /**
+   * The globally unique id for this channel.  Must be a positive number.
+   */
+  'channel_id': (string);
+  /**
+   * An optional name associated with the channel.
+   */
+  'name': (string);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelTrace.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelTrace.ts
@@ -1,0 +1,45 @@
+// Original file: proto/channelz.proto
+
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
+import type { ChannelTraceEvent as _grpc_channelz_v1_ChannelTraceEvent, ChannelTraceEvent__Output as _grpc_channelz_v1_ChannelTraceEvent__Output } from '../../../grpc/channelz/v1/ChannelTraceEvent';
+import type { Long } from '@grpc/proto-loader';
+
+/**
+ * ChannelTrace represents the recent events that have occurred on the channel.
+ */
+export interface ChannelTrace {
+  /**
+   * Number of events ever logged in this tracing object. This can differ from
+   * events.size() because events can be overwritten or garbage collected by
+   * implementations.
+   */
+  'num_events_logged'?: (number | string | Long);
+  /**
+   * Time that this channel was created.
+   */
+  'creation_timestamp'?: (_google_protobuf_Timestamp | null);
+  /**
+   * List of events that have occurred on this channel.
+   */
+  'events'?: (_grpc_channelz_v1_ChannelTraceEvent)[];
+}
+
+/**
+ * ChannelTrace represents the recent events that have occurred on the channel.
+ */
+export interface ChannelTrace__Output {
+  /**
+   * Number of events ever logged in this tracing object. This can differ from
+   * events.size() because events can be overwritten or garbage collected by
+   * implementations.
+   */
+  'num_events_logged': (string);
+  /**
+   * Time that this channel was created.
+   */
+  'creation_timestamp': (_google_protobuf_Timestamp__Output | null);
+  /**
+   * List of events that have occurred on this channel.
+   */
+  'events': (_grpc_channelz_v1_ChannelTraceEvent__Output)[];
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelTraceEvent.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelTraceEvent.ts
@@ -1,0 +1,73 @@
+// Original file: proto/channelz.proto
+
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
+import type { ChannelRef as _grpc_channelz_v1_ChannelRef, ChannelRef__Output as _grpc_channelz_v1_ChannelRef__Output } from '../../../grpc/channelz/v1/ChannelRef';
+import type { SubchannelRef as _grpc_channelz_v1_SubchannelRef, SubchannelRef__Output as _grpc_channelz_v1_SubchannelRef__Output } from '../../../grpc/channelz/v1/SubchannelRef';
+
+// Original file: proto/channelz.proto
+
+/**
+ * The supported severity levels of trace events.
+ */
+export enum _grpc_channelz_v1_ChannelTraceEvent_Severity {
+  CT_UNKNOWN = 0,
+  CT_INFO = 1,
+  CT_WARNING = 2,
+  CT_ERROR = 3,
+}
+
+/**
+ * A trace event is an interesting thing that happened to a channel or
+ * subchannel, such as creation, address resolution, subchannel creation, etc.
+ */
+export interface ChannelTraceEvent {
+  /**
+   * High level description of the event.
+   */
+  'description'?: (string);
+  /**
+   * the severity of the trace event
+   */
+  'severity'?: (_grpc_channelz_v1_ChannelTraceEvent_Severity | keyof typeof _grpc_channelz_v1_ChannelTraceEvent_Severity);
+  /**
+   * When this event occurred.
+   */
+  'timestamp'?: (_google_protobuf_Timestamp | null);
+  'channel_ref'?: (_grpc_channelz_v1_ChannelRef | null);
+  'subchannel_ref'?: (_grpc_channelz_v1_SubchannelRef | null);
+  /**
+   * ref of referenced channel or subchannel.
+   * Optional, only present if this event refers to a child object. For example,
+   * this field would be filled if this trace event was for a subchannel being
+   * created.
+   */
+  'child_ref'?: "channel_ref"|"subchannel_ref";
+}
+
+/**
+ * A trace event is an interesting thing that happened to a channel or
+ * subchannel, such as creation, address resolution, subchannel creation, etc.
+ */
+export interface ChannelTraceEvent__Output {
+  /**
+   * High level description of the event.
+   */
+  'description': (string);
+  /**
+   * the severity of the trace event
+   */
+  'severity': (keyof typeof _grpc_channelz_v1_ChannelTraceEvent_Severity);
+  /**
+   * When this event occurred.
+   */
+  'timestamp': (_google_protobuf_Timestamp__Output | null);
+  'channel_ref'?: (_grpc_channelz_v1_ChannelRef__Output | null);
+  'subchannel_ref'?: (_grpc_channelz_v1_SubchannelRef__Output | null);
+  /**
+   * ref of referenced channel or subchannel.
+   * Optional, only present if this event refers to a child object. For example,
+   * this field would be filled if this trace event was for a subchannel being
+   * created.
+   */
+  'child_ref': "channel_ref"|"subchannel_ref";
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Channelz.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Channelz.ts
@@ -1,0 +1,178 @@
+// Original file: proto/channelz.proto
+
+import type * as grpc from '../../../../index'
+import type { MethodDefinition } from '@grpc/proto-loader'
+import type { GetChannelRequest as _grpc_channelz_v1_GetChannelRequest, GetChannelRequest__Output as _grpc_channelz_v1_GetChannelRequest__Output } from '../../../grpc/channelz/v1/GetChannelRequest';
+import type { GetChannelResponse as _grpc_channelz_v1_GetChannelResponse, GetChannelResponse__Output as _grpc_channelz_v1_GetChannelResponse__Output } from '../../../grpc/channelz/v1/GetChannelResponse';
+import type { GetServerRequest as _grpc_channelz_v1_GetServerRequest, GetServerRequest__Output as _grpc_channelz_v1_GetServerRequest__Output } from '../../../grpc/channelz/v1/GetServerRequest';
+import type { GetServerResponse as _grpc_channelz_v1_GetServerResponse, GetServerResponse__Output as _grpc_channelz_v1_GetServerResponse__Output } from '../../../grpc/channelz/v1/GetServerResponse';
+import type { GetServerSocketsRequest as _grpc_channelz_v1_GetServerSocketsRequest, GetServerSocketsRequest__Output as _grpc_channelz_v1_GetServerSocketsRequest__Output } from '../../../grpc/channelz/v1/GetServerSocketsRequest';
+import type { GetServerSocketsResponse as _grpc_channelz_v1_GetServerSocketsResponse, GetServerSocketsResponse__Output as _grpc_channelz_v1_GetServerSocketsResponse__Output } from '../../../grpc/channelz/v1/GetServerSocketsResponse';
+import type { GetServersRequest as _grpc_channelz_v1_GetServersRequest, GetServersRequest__Output as _grpc_channelz_v1_GetServersRequest__Output } from '../../../grpc/channelz/v1/GetServersRequest';
+import type { GetServersResponse as _grpc_channelz_v1_GetServersResponse, GetServersResponse__Output as _grpc_channelz_v1_GetServersResponse__Output } from '../../../grpc/channelz/v1/GetServersResponse';
+import type { GetSocketRequest as _grpc_channelz_v1_GetSocketRequest, GetSocketRequest__Output as _grpc_channelz_v1_GetSocketRequest__Output } from '../../../grpc/channelz/v1/GetSocketRequest';
+import type { GetSocketResponse as _grpc_channelz_v1_GetSocketResponse, GetSocketResponse__Output as _grpc_channelz_v1_GetSocketResponse__Output } from '../../../grpc/channelz/v1/GetSocketResponse';
+import type { GetSubchannelRequest as _grpc_channelz_v1_GetSubchannelRequest, GetSubchannelRequest__Output as _grpc_channelz_v1_GetSubchannelRequest__Output } from '../../../grpc/channelz/v1/GetSubchannelRequest';
+import type { GetSubchannelResponse as _grpc_channelz_v1_GetSubchannelResponse, GetSubchannelResponse__Output as _grpc_channelz_v1_GetSubchannelResponse__Output } from '../../../grpc/channelz/v1/GetSubchannelResponse';
+import type { GetTopChannelsRequest as _grpc_channelz_v1_GetTopChannelsRequest, GetTopChannelsRequest__Output as _grpc_channelz_v1_GetTopChannelsRequest__Output } from '../../../grpc/channelz/v1/GetTopChannelsRequest';
+import type { GetTopChannelsResponse as _grpc_channelz_v1_GetTopChannelsResponse, GetTopChannelsResponse__Output as _grpc_channelz_v1_GetTopChannelsResponse__Output } from '../../../grpc/channelz/v1/GetTopChannelsResponse';
+
+/**
+ * Channelz is a service exposed by gRPC servers that provides detailed debug
+ * information.
+ */
+export interface ChannelzClient extends grpc.Client {
+  /**
+   * Returns a single Channel, or else a NOT_FOUND code.
+   */
+  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetChannelResponse__Output) => void): grpc.ClientUnaryCall;
+  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetChannelResponse__Output) => void): grpc.ClientUnaryCall;
+  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetChannelResponse__Output) => void): grpc.ClientUnaryCall;
+  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetChannelResponse__Output) => void): grpc.ClientUnaryCall;
+  
+  /**
+   * Returns a single Server, or else a NOT_FOUND code.
+   */
+  GetServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServer(argument: _grpc_channelz_v1_GetServerRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServer(argument: _grpc_channelz_v1_GetServerRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
+  /**
+   * Returns a single Server, or else a NOT_FOUND code.
+   */
+  getServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
+  getServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
+  getServer(argument: _grpc_channelz_v1_GetServerRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
+  getServer(argument: _grpc_channelz_v1_GetServerRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
+  
+  /**
+   * Gets all server sockets that exist in the process.
+   */
+  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
+  /**
+   * Gets all server sockets that exist in the process.
+   */
+  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
+  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
+  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
+  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
+  
+  /**
+   * Gets all servers that exist in the process.
+   */
+  GetServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServers(argument: _grpc_channelz_v1_GetServersRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServers(argument: _grpc_channelz_v1_GetServersRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
+  /**
+   * Gets all servers that exist in the process.
+   */
+  getServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
+  getServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
+  getServers(argument: _grpc_channelz_v1_GetServersRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
+  getServers(argument: _grpc_channelz_v1_GetServersRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
+  
+  /**
+   * Returns a single Socket or else a NOT_FOUND code.
+   */
+  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
+  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
+  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
+  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
+  /**
+   * Returns a single Socket or else a NOT_FOUND code.
+   */
+  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
+  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
+  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
+  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
+  
+  /**
+   * Returns a single Subchannel, or else a NOT_FOUND code.
+   */
+  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
+  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
+  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
+  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
+  /**
+   * Returns a single Subchannel, or else a NOT_FOUND code.
+   */
+  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
+  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
+  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
+  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
+  
+  /**
+   * Gets all root channels (i.e. channels the application has directly
+   * created). This does not include subchannels nor non-top level channels.
+   */
+  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
+  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
+  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
+  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
+  /**
+   * Gets all root channels (i.e. channels the application has directly
+   * created). This does not include subchannels nor non-top level channels.
+   */
+  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
+  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
+  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
+  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
+  
+}
+
+/**
+ * Channelz is a service exposed by gRPC servers that provides detailed debug
+ * information.
+ */
+export interface ChannelzHandlers extends grpc.UntypedServiceImplementation {
+  /**
+   * Returns a single Channel, or else a NOT_FOUND code.
+   */
+  GetChannel: grpc.handleUnaryCall<_grpc_channelz_v1_GetChannelRequest__Output, _grpc_channelz_v1_GetChannelResponse>;
+  
+  /**
+   * Returns a single Server, or else a NOT_FOUND code.
+   */
+  GetServer: grpc.handleUnaryCall<_grpc_channelz_v1_GetServerRequest__Output, _grpc_channelz_v1_GetServerResponse>;
+  
+  /**
+   * Gets all server sockets that exist in the process.
+   */
+  GetServerSockets: grpc.handleUnaryCall<_grpc_channelz_v1_GetServerSocketsRequest__Output, _grpc_channelz_v1_GetServerSocketsResponse>;
+  
+  /**
+   * Gets all servers that exist in the process.
+   */
+  GetServers: grpc.handleUnaryCall<_grpc_channelz_v1_GetServersRequest__Output, _grpc_channelz_v1_GetServersResponse>;
+  
+  /**
+   * Returns a single Socket or else a NOT_FOUND code.
+   */
+  GetSocket: grpc.handleUnaryCall<_grpc_channelz_v1_GetSocketRequest__Output, _grpc_channelz_v1_GetSocketResponse>;
+  
+  /**
+   * Returns a single Subchannel, or else a NOT_FOUND code.
+   */
+  GetSubchannel: grpc.handleUnaryCall<_grpc_channelz_v1_GetSubchannelRequest__Output, _grpc_channelz_v1_GetSubchannelResponse>;
+  
+  /**
+   * Gets all root channels (i.e. channels the application has directly
+   * created). This does not include subchannels nor non-top level channels.
+   */
+  GetTopChannels: grpc.handleUnaryCall<_grpc_channelz_v1_GetTopChannelsRequest__Output, _grpc_channelz_v1_GetTopChannelsResponse>;
+  
+}
+
+export interface ChannelzDefinition extends grpc.ServiceDefinition {
+  GetChannel: MethodDefinition<_grpc_channelz_v1_GetChannelRequest, _grpc_channelz_v1_GetChannelResponse, _grpc_channelz_v1_GetChannelRequest__Output, _grpc_channelz_v1_GetChannelResponse__Output>
+  GetServer: MethodDefinition<_grpc_channelz_v1_GetServerRequest, _grpc_channelz_v1_GetServerResponse, _grpc_channelz_v1_GetServerRequest__Output, _grpc_channelz_v1_GetServerResponse__Output>
+  GetServerSockets: MethodDefinition<_grpc_channelz_v1_GetServerSocketsRequest, _grpc_channelz_v1_GetServerSocketsResponse, _grpc_channelz_v1_GetServerSocketsRequest__Output, _grpc_channelz_v1_GetServerSocketsResponse__Output>
+  GetServers: MethodDefinition<_grpc_channelz_v1_GetServersRequest, _grpc_channelz_v1_GetServersResponse, _grpc_channelz_v1_GetServersRequest__Output, _grpc_channelz_v1_GetServersResponse__Output>
+  GetSocket: MethodDefinition<_grpc_channelz_v1_GetSocketRequest, _grpc_channelz_v1_GetSocketResponse, _grpc_channelz_v1_GetSocketRequest__Output, _grpc_channelz_v1_GetSocketResponse__Output>
+  GetSubchannel: MethodDefinition<_grpc_channelz_v1_GetSubchannelRequest, _grpc_channelz_v1_GetSubchannelResponse, _grpc_channelz_v1_GetSubchannelRequest__Output, _grpc_channelz_v1_GetSubchannelResponse__Output>
+  GetTopChannels: MethodDefinition<_grpc_channelz_v1_GetTopChannelsRequest, _grpc_channelz_v1_GetTopChannelsResponse, _grpc_channelz_v1_GetTopChannelsRequest__Output, _grpc_channelz_v1_GetTopChannelsResponse__Output>
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetChannelRequest.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetChannelRequest.ts
@@ -1,0 +1,17 @@
+// Original file: proto/channelz.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface GetChannelRequest {
+  /**
+   * channel_id is the identifier of the specific channel to get.
+   */
+  'channel_id'?: (number | string | Long);
+}
+
+export interface GetChannelRequest__Output {
+  /**
+   * channel_id is the identifier of the specific channel to get.
+   */
+  'channel_id': (string);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetChannelResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetChannelResponse.ts
@@ -1,0 +1,19 @@
+// Original file: proto/channelz.proto
+
+import type { Channel as _grpc_channelz_v1_Channel, Channel__Output as _grpc_channelz_v1_Channel__Output } from '../../../grpc/channelz/v1/Channel';
+
+export interface GetChannelResponse {
+  /**
+   * The Channel that corresponds to the requested channel_id.  This field
+   * should be set.
+   */
+  'channel'?: (_grpc_channelz_v1_Channel | null);
+}
+
+export interface GetChannelResponse__Output {
+  /**
+   * The Channel that corresponds to the requested channel_id.  This field
+   * should be set.
+   */
+  'channel': (_grpc_channelz_v1_Channel__Output | null);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerRequest.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerRequest.ts
@@ -1,0 +1,17 @@
+// Original file: proto/channelz.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface GetServerRequest {
+  /**
+   * server_id is the identifier of the specific server to get.
+   */
+  'server_id'?: (number | string | Long);
+}
+
+export interface GetServerRequest__Output {
+  /**
+   * server_id is the identifier of the specific server to get.
+   */
+  'server_id': (string);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerResponse.ts
@@ -1,0 +1,19 @@
+// Original file: proto/channelz.proto
+
+import type { Server as _grpc_channelz_v1_Server, Server__Output as _grpc_channelz_v1_Server__Output } from '../../../grpc/channelz/v1/Server';
+
+export interface GetServerResponse {
+  /**
+   * The Server that corresponds to the requested server_id.  This field
+   * should be set.
+   */
+  'server'?: (_grpc_channelz_v1_Server | null);
+}
+
+export interface GetServerResponse__Output {
+  /**
+   * The Server that corresponds to the requested server_id.  This field
+   * should be set.
+   */
+  'server': (_grpc_channelz_v1_Server__Output | null);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerSocketsRequest.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerSocketsRequest.ts
@@ -1,0 +1,39 @@
+// Original file: proto/channelz.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface GetServerSocketsRequest {
+  'server_id'?: (number | string | Long);
+  /**
+   * start_socket_id indicates that only sockets at or above this id should be
+   * included in the results.
+   * To request the first page, this must be set to 0. To request
+   * subsequent pages, the client generates this value by adding 1 to
+   * the highest seen result ID.
+   */
+  'start_socket_id'?: (number | string | Long);
+  /**
+   * If non-zero, the server will return a page of results containing
+   * at most this many items. If zero, the server will choose a
+   * reasonable page size.  Must never be negative.
+   */
+  'max_results'?: (number | string | Long);
+}
+
+export interface GetServerSocketsRequest__Output {
+  'server_id': (string);
+  /**
+   * start_socket_id indicates that only sockets at or above this id should be
+   * included in the results.
+   * To request the first page, this must be set to 0. To request
+   * subsequent pages, the client generates this value by adding 1 to
+   * the highest seen result ID.
+   */
+  'start_socket_id': (string);
+  /**
+   * If non-zero, the server will return a page of results containing
+   * at most this many items. If zero, the server will choose a
+   * reasonable page size.  Must never be negative.
+   */
+  'max_results': (string);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerSocketsResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerSocketsResponse.ts
@@ -1,0 +1,33 @@
+// Original file: proto/channelz.proto
+
+import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef';
+
+export interface GetServerSocketsResponse {
+  /**
+   * list of socket refs that the connection detail service knows about.  Sorted in
+   * ascending socket_id order.
+   * Must contain at least 1 result, otherwise 'end' must be true.
+   */
+  'socket_ref'?: (_grpc_channelz_v1_SocketRef)[];
+  /**
+   * If set, indicates that the list of sockets is the final list.  Requesting
+   * more sockets will only return more if they are created after this RPC
+   * completes.
+   */
+  'end'?: (boolean);
+}
+
+export interface GetServerSocketsResponse__Output {
+  /**
+   * list of socket refs that the connection detail service knows about.  Sorted in
+   * ascending socket_id order.
+   * Must contain at least 1 result, otherwise 'end' must be true.
+   */
+  'socket_ref': (_grpc_channelz_v1_SocketRef__Output)[];
+  /**
+   * If set, indicates that the list of sockets is the final list.  Requesting
+   * more sockets will only return more if they are created after this RPC
+   * completes.
+   */
+  'end': (boolean);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetServersRequest.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetServersRequest.ts
@@ -1,0 +1,37 @@
+// Original file: proto/channelz.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface GetServersRequest {
+  /**
+   * start_server_id indicates that only servers at or above this id should be
+   * included in the results.
+   * To request the first page, this must be set to 0. To request
+   * subsequent pages, the client generates this value by adding 1 to
+   * the highest seen result ID.
+   */
+  'start_server_id'?: (number | string | Long);
+  /**
+   * If non-zero, the server will return a page of results containing
+   * at most this many items. If zero, the server will choose a
+   * reasonable page size.  Must never be negative.
+   */
+  'max_results'?: (number | string | Long);
+}
+
+export interface GetServersRequest__Output {
+  /**
+   * start_server_id indicates that only servers at or above this id should be
+   * included in the results.
+   * To request the first page, this must be set to 0. To request
+   * subsequent pages, the client generates this value by adding 1 to
+   * the highest seen result ID.
+   */
+  'start_server_id': (string);
+  /**
+   * If non-zero, the server will return a page of results containing
+   * at most this many items. If zero, the server will choose a
+   * reasonable page size.  Must never be negative.
+   */
+  'max_results': (string);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetServersResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetServersResponse.ts
@@ -1,0 +1,33 @@
+// Original file: proto/channelz.proto
+
+import type { Server as _grpc_channelz_v1_Server, Server__Output as _grpc_channelz_v1_Server__Output } from '../../../grpc/channelz/v1/Server';
+
+export interface GetServersResponse {
+  /**
+   * list of servers that the connection detail service knows about.  Sorted in
+   * ascending server_id order.
+   * Must contain at least 1 result, otherwise 'end' must be true.
+   */
+  'server'?: (_grpc_channelz_v1_Server)[];
+  /**
+   * If set, indicates that the list of servers is the final list.  Requesting
+   * more servers will only return more if they are created after this RPC
+   * completes.
+   */
+  'end'?: (boolean);
+}
+
+export interface GetServersResponse__Output {
+  /**
+   * list of servers that the connection detail service knows about.  Sorted in
+   * ascending server_id order.
+   * Must contain at least 1 result, otherwise 'end' must be true.
+   */
+  'server': (_grpc_channelz_v1_Server__Output)[];
+  /**
+   * If set, indicates that the list of servers is the final list.  Requesting
+   * more servers will only return more if they are created after this RPC
+   * completes.
+   */
+  'end': (boolean);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetSocketRequest.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetSocketRequest.ts
@@ -1,0 +1,29 @@
+// Original file: proto/channelz.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface GetSocketRequest {
+  /**
+   * socket_id is the identifier of the specific socket to get.
+   */
+  'socket_id'?: (number | string | Long);
+  /**
+   * If true, the response will contain only high level information
+   * that is inexpensive to obtain. Fields thay may be omitted are
+   * documented.
+   */
+  'summary'?: (boolean);
+}
+
+export interface GetSocketRequest__Output {
+  /**
+   * socket_id is the identifier of the specific socket to get.
+   */
+  'socket_id': (string);
+  /**
+   * If true, the response will contain only high level information
+   * that is inexpensive to obtain. Fields thay may be omitted are
+   * documented.
+   */
+  'summary': (boolean);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetSocketResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetSocketResponse.ts
@@ -1,0 +1,19 @@
+// Original file: proto/channelz.proto
+
+import type { Socket as _grpc_channelz_v1_Socket, Socket__Output as _grpc_channelz_v1_Socket__Output } from '../../../grpc/channelz/v1/Socket';
+
+export interface GetSocketResponse {
+  /**
+   * The Socket that corresponds to the requested socket_id.  This field
+   * should be set.
+   */
+  'socket'?: (_grpc_channelz_v1_Socket | null);
+}
+
+export interface GetSocketResponse__Output {
+  /**
+   * The Socket that corresponds to the requested socket_id.  This field
+   * should be set.
+   */
+  'socket': (_grpc_channelz_v1_Socket__Output | null);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetSubchannelRequest.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetSubchannelRequest.ts
@@ -1,0 +1,17 @@
+// Original file: proto/channelz.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface GetSubchannelRequest {
+  /**
+   * subchannel_id is the identifier of the specific subchannel to get.
+   */
+  'subchannel_id'?: (number | string | Long);
+}
+
+export interface GetSubchannelRequest__Output {
+  /**
+   * subchannel_id is the identifier of the specific subchannel to get.
+   */
+  'subchannel_id': (string);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetSubchannelResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetSubchannelResponse.ts
@@ -1,0 +1,19 @@
+// Original file: proto/channelz.proto
+
+import type { Subchannel as _grpc_channelz_v1_Subchannel, Subchannel__Output as _grpc_channelz_v1_Subchannel__Output } from '../../../grpc/channelz/v1/Subchannel';
+
+export interface GetSubchannelResponse {
+  /**
+   * The Subchannel that corresponds to the requested subchannel_id.  This
+   * field should be set.
+   */
+  'subchannel'?: (_grpc_channelz_v1_Subchannel | null);
+}
+
+export interface GetSubchannelResponse__Output {
+  /**
+   * The Subchannel that corresponds to the requested subchannel_id.  This
+   * field should be set.
+   */
+  'subchannel': (_grpc_channelz_v1_Subchannel__Output | null);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetTopChannelsRequest.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetTopChannelsRequest.ts
@@ -1,0 +1,37 @@
+// Original file: proto/channelz.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface GetTopChannelsRequest {
+  /**
+   * start_channel_id indicates that only channels at or above this id should be
+   * included in the results.
+   * To request the first page, this should be set to 0. To request
+   * subsequent pages, the client generates this value by adding 1 to
+   * the highest seen result ID.
+   */
+  'start_channel_id'?: (number | string | Long);
+  /**
+   * If non-zero, the server will return a page of results containing
+   * at most this many items. If zero, the server will choose a
+   * reasonable page size.  Must never be negative.
+   */
+  'max_results'?: (number | string | Long);
+}
+
+export interface GetTopChannelsRequest__Output {
+  /**
+   * start_channel_id indicates that only channels at or above this id should be
+   * included in the results.
+   * To request the first page, this should be set to 0. To request
+   * subsequent pages, the client generates this value by adding 1 to
+   * the highest seen result ID.
+   */
+  'start_channel_id': (string);
+  /**
+   * If non-zero, the server will return a page of results containing
+   * at most this many items. If zero, the server will choose a
+   * reasonable page size.  Must never be negative.
+   */
+  'max_results': (string);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetTopChannelsResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetTopChannelsResponse.ts
@@ -1,0 +1,33 @@
+// Original file: proto/channelz.proto
+
+import type { Channel as _grpc_channelz_v1_Channel, Channel__Output as _grpc_channelz_v1_Channel__Output } from '../../../grpc/channelz/v1/Channel';
+
+export interface GetTopChannelsResponse {
+  /**
+   * list of channels that the connection detail service knows about.  Sorted in
+   * ascending channel_id order.
+   * Must contain at least 1 result, otherwise 'end' must be true.
+   */
+  'channel'?: (_grpc_channelz_v1_Channel)[];
+  /**
+   * If set, indicates that the list of channels is the final list.  Requesting
+   * more channels can only return more if they are created after this RPC
+   * completes.
+   */
+  'end'?: (boolean);
+}
+
+export interface GetTopChannelsResponse__Output {
+  /**
+   * list of channels that the connection detail service knows about.  Sorted in
+   * ascending channel_id order.
+   * Must contain at least 1 result, otherwise 'end' must be true.
+   */
+  'channel': (_grpc_channelz_v1_Channel__Output)[];
+  /**
+   * If set, indicates that the list of channels is the final list.  Requesting
+   * more channels can only return more if they are created after this RPC
+   * completes.
+   */
+  'end': (boolean);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Security.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Security.ts
@@ -1,0 +1,87 @@
+// Original file: proto/channelz.proto
+
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../../google/protobuf/Any';
+
+export interface _grpc_channelz_v1_Security_OtherSecurity {
+  /**
+   * The human readable version of the value.
+   */
+  'name'?: (string);
+  /**
+   * The actual security details message.
+   */
+  'value'?: (_google_protobuf_Any | null);
+}
+
+export interface _grpc_channelz_v1_Security_OtherSecurity__Output {
+  /**
+   * The human readable version of the value.
+   */
+  'name': (string);
+  /**
+   * The actual security details message.
+   */
+  'value': (_google_protobuf_Any__Output | null);
+}
+
+export interface _grpc_channelz_v1_Security_Tls {
+  /**
+   * The cipher suite name in the RFC 4346 format:
+   * https://tools.ietf.org/html/rfc4346#appendix-C
+   */
+  'standard_name'?: (string);
+  /**
+   * Some other way to describe the cipher suite if
+   * the RFC 4346 name is not available.
+   */
+  'other_name'?: (string);
+  /**
+   * the certificate used by this endpoint.
+   */
+  'local_certificate'?: (Buffer | Uint8Array | string);
+  /**
+   * the certificate used by the remote endpoint.
+   */
+  'remote_certificate'?: (Buffer | Uint8Array | string);
+  'cipher_suite'?: "standard_name"|"other_name";
+}
+
+export interface _grpc_channelz_v1_Security_Tls__Output {
+  /**
+   * The cipher suite name in the RFC 4346 format:
+   * https://tools.ietf.org/html/rfc4346#appendix-C
+   */
+  'standard_name'?: (string);
+  /**
+   * Some other way to describe the cipher suite if
+   * the RFC 4346 name is not available.
+   */
+  'other_name'?: (string);
+  /**
+   * the certificate used by this endpoint.
+   */
+  'local_certificate': (Buffer);
+  /**
+   * the certificate used by the remote endpoint.
+   */
+  'remote_certificate': (Buffer);
+  'cipher_suite': "standard_name"|"other_name";
+}
+
+/**
+ * Security represents details about how secure the socket is.
+ */
+export interface Security {
+  'tls'?: (_grpc_channelz_v1_Security_Tls | null);
+  'other'?: (_grpc_channelz_v1_Security_OtherSecurity | null);
+  'model'?: "tls"|"other";
+}
+
+/**
+ * Security represents details about how secure the socket is.
+ */
+export interface Security__Output {
+  'tls'?: (_grpc_channelz_v1_Security_Tls__Output | null);
+  'other'?: (_grpc_channelz_v1_Security_OtherSecurity__Output | null);
+  'model': "tls"|"other";
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Server.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Server.ts
@@ -1,0 +1,45 @@
+// Original file: proto/channelz.proto
+
+import type { ServerRef as _grpc_channelz_v1_ServerRef, ServerRef__Output as _grpc_channelz_v1_ServerRef__Output } from '../../../grpc/channelz/v1/ServerRef';
+import type { ServerData as _grpc_channelz_v1_ServerData, ServerData__Output as _grpc_channelz_v1_ServerData__Output } from '../../../grpc/channelz/v1/ServerData';
+import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef';
+
+/**
+ * Server represents a single server.  There may be multiple servers in a single
+ * program.
+ */
+export interface Server {
+  /**
+   * The identifier for a Server.  This should be set.
+   */
+  'ref'?: (_grpc_channelz_v1_ServerRef | null);
+  /**
+   * The associated data of the Server.
+   */
+  'data'?: (_grpc_channelz_v1_ServerData | null);
+  /**
+   * The sockets that the server is listening on.  There are no ordering
+   * guarantees.  This may be absent.
+   */
+  'listen_socket'?: (_grpc_channelz_v1_SocketRef)[];
+}
+
+/**
+ * Server represents a single server.  There may be multiple servers in a single
+ * program.
+ */
+export interface Server__Output {
+  /**
+   * The identifier for a Server.  This should be set.
+   */
+  'ref': (_grpc_channelz_v1_ServerRef__Output | null);
+  /**
+   * The associated data of the Server.
+   */
+  'data': (_grpc_channelz_v1_ServerData__Output | null);
+  /**
+   * The sockets that the server is listening on.  There are no ordering
+   * guarantees.  This may be absent.
+   */
+  'listen_socket': (_grpc_channelz_v1_SocketRef__Output)[];
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ServerData.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ServerData.ts
@@ -1,0 +1,57 @@
+// Original file: proto/channelz.proto
+
+import type { ChannelTrace as _grpc_channelz_v1_ChannelTrace, ChannelTrace__Output as _grpc_channelz_v1_ChannelTrace__Output } from '../../../grpc/channelz/v1/ChannelTrace';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
+import type { Long } from '@grpc/proto-loader';
+
+/**
+ * ServerData is data for a specific Server.
+ */
+export interface ServerData {
+  /**
+   * A trace of recent events on the server.  May be absent.
+   */
+  'trace'?: (_grpc_channelz_v1_ChannelTrace | null);
+  /**
+   * The number of incoming calls started on the server
+   */
+  'calls_started'?: (number | string | Long);
+  /**
+   * The number of incoming calls that have completed with an OK status
+   */
+  'calls_succeeded'?: (number | string | Long);
+  /**
+   * The number of incoming calls that have a completed with a non-OK status
+   */
+  'calls_failed'?: (number | string | Long);
+  /**
+   * The last time a call was started on the server.
+   */
+  'last_call_started_timestamp'?: (_google_protobuf_Timestamp | null);
+}
+
+/**
+ * ServerData is data for a specific Server.
+ */
+export interface ServerData__Output {
+  /**
+   * A trace of recent events on the server.  May be absent.
+   */
+  'trace': (_grpc_channelz_v1_ChannelTrace__Output | null);
+  /**
+   * The number of incoming calls started on the server
+   */
+  'calls_started': (string);
+  /**
+   * The number of incoming calls that have completed with an OK status
+   */
+  'calls_succeeded': (string);
+  /**
+   * The number of incoming calls that have a completed with a non-OK status
+   */
+  'calls_failed': (string);
+  /**
+   * The last time a call was started on the server.
+   */
+  'last_call_started_timestamp': (_google_protobuf_Timestamp__Output | null);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ServerRef.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ServerRef.ts
@@ -1,0 +1,31 @@
+// Original file: proto/channelz.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+/**
+ * ServerRef is a reference to a Server.
+ */
+export interface ServerRef {
+  /**
+   * A globally unique identifier for this server.  Must be a positive number.
+   */
+  'server_id'?: (number | string | Long);
+  /**
+   * An optional name associated with the server.
+   */
+  'name'?: (string);
+}
+
+/**
+ * ServerRef is a reference to a Server.
+ */
+export interface ServerRef__Output {
+  /**
+   * A globally unique identifier for this server.  Must be a positive number.
+   */
+  'server_id': (string);
+  /**
+   * An optional name associated with the server.
+   */
+  'name': (string);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Socket.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Socket.ts
@@ -1,0 +1,70 @@
+// Original file: proto/channelz.proto
+
+import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef';
+import type { SocketData as _grpc_channelz_v1_SocketData, SocketData__Output as _grpc_channelz_v1_SocketData__Output } from '../../../grpc/channelz/v1/SocketData';
+import type { Address as _grpc_channelz_v1_Address, Address__Output as _grpc_channelz_v1_Address__Output } from '../../../grpc/channelz/v1/Address';
+import type { Security as _grpc_channelz_v1_Security, Security__Output as _grpc_channelz_v1_Security__Output } from '../../../grpc/channelz/v1/Security';
+
+/**
+ * Information about an actual connection.  Pronounced "sock-ay".
+ */
+export interface Socket {
+  /**
+   * The identifier for the Socket.
+   */
+  'ref'?: (_grpc_channelz_v1_SocketRef | null);
+  /**
+   * Data specific to this Socket.
+   */
+  'data'?: (_grpc_channelz_v1_SocketData | null);
+  /**
+   * The locally bound address.
+   */
+  'local'?: (_grpc_channelz_v1_Address | null);
+  /**
+   * The remote bound address.  May be absent.
+   */
+  'remote'?: (_grpc_channelz_v1_Address | null);
+  /**
+   * Security details for this socket.  May be absent if not available, or
+   * there is no security on the socket.
+   */
+  'security'?: (_grpc_channelz_v1_Security | null);
+  /**
+   * Optional, represents the name of the remote endpoint, if different than
+   * the original target name.
+   */
+  'remote_name'?: (string);
+}
+
+/**
+ * Information about an actual connection.  Pronounced "sock-ay".
+ */
+export interface Socket__Output {
+  /**
+   * The identifier for the Socket.
+   */
+  'ref': (_grpc_channelz_v1_SocketRef__Output | null);
+  /**
+   * Data specific to this Socket.
+   */
+  'data': (_grpc_channelz_v1_SocketData__Output | null);
+  /**
+   * The locally bound address.
+   */
+  'local': (_grpc_channelz_v1_Address__Output | null);
+  /**
+   * The remote bound address.  May be absent.
+   */
+  'remote': (_grpc_channelz_v1_Address__Output | null);
+  /**
+   * Security details for this socket.  May be absent if not available, or
+   * there is no security on the socket.
+   */
+  'security': (_grpc_channelz_v1_Security__Output | null);
+  /**
+   * Optional, represents the name of the remote endpoint, if different than
+   * the original target name.
+   */
+  'remote_name': (string);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/SocketData.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/SocketData.ts
@@ -1,0 +1,150 @@
+// Original file: proto/channelz.proto
+
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from '../../../google/protobuf/Int64Value';
+import type { SocketOption as _grpc_channelz_v1_SocketOption, SocketOption__Output as _grpc_channelz_v1_SocketOption__Output } from '../../../grpc/channelz/v1/SocketOption';
+import type { Long } from '@grpc/proto-loader';
+
+/**
+ * SocketData is data associated for a specific Socket.  The fields present
+ * are specific to the implementation, so there may be minor differences in
+ * the semantics.  (e.g. flow control windows)
+ */
+export interface SocketData {
+  /**
+   * The number of streams that have been started.
+   */
+  'streams_started'?: (number | string | Long);
+  /**
+   * The number of streams that have ended successfully:
+   * On client side, received frame with eos bit set;
+   * On server side, sent frame with eos bit set.
+   */
+  'streams_succeeded'?: (number | string | Long);
+  /**
+   * The number of streams that have ended unsuccessfully:
+   * On client side, ended without receiving frame with eos bit set;
+   * On server side, ended without sending frame with eos bit set.
+   */
+  'streams_failed'?: (number | string | Long);
+  /**
+   * The number of grpc messages successfully sent on this socket.
+   */
+  'messages_sent'?: (number | string | Long);
+  /**
+   * The number of grpc messages received on this socket.
+   */
+  'messages_received'?: (number | string | Long);
+  /**
+   * The number of keep alives sent.  This is typically implemented with HTTP/2
+   * ping messages.
+   */
+  'keep_alives_sent'?: (number | string | Long);
+  /**
+   * The last time a stream was created by this endpoint.  Usually unset for
+   * servers.
+   */
+  'last_local_stream_created_timestamp'?: (_google_protobuf_Timestamp | null);
+  /**
+   * The last time a stream was created by the remote endpoint.  Usually unset
+   * for clients.
+   */
+  'last_remote_stream_created_timestamp'?: (_google_protobuf_Timestamp | null);
+  /**
+   * The last time a message was sent by this endpoint.
+   */
+  'last_message_sent_timestamp'?: (_google_protobuf_Timestamp | null);
+  /**
+   * The last time a message was received by this endpoint.
+   */
+  'last_message_received_timestamp'?: (_google_protobuf_Timestamp | null);
+  /**
+   * The amount of window, granted to the local endpoint by the remote endpoint.
+   * This may be slightly out of date due to network latency.  This does NOT
+   * include stream level or TCP level flow control info.
+   */
+  'local_flow_control_window'?: (_google_protobuf_Int64Value | null);
+  /**
+   * The amount of window, granted to the remote endpoint by the local endpoint.
+   * This may be slightly out of date due to network latency.  This does NOT
+   * include stream level or TCP level flow control info.
+   */
+  'remote_flow_control_window'?: (_google_protobuf_Int64Value | null);
+  /**
+   * Socket options set on this socket.  May be absent if 'summary' is set
+   * on GetSocketRequest.
+   */
+  'option'?: (_grpc_channelz_v1_SocketOption)[];
+}
+
+/**
+ * SocketData is data associated for a specific Socket.  The fields present
+ * are specific to the implementation, so there may be minor differences in
+ * the semantics.  (e.g. flow control windows)
+ */
+export interface SocketData__Output {
+  /**
+   * The number of streams that have been started.
+   */
+  'streams_started': (string);
+  /**
+   * The number of streams that have ended successfully:
+   * On client side, received frame with eos bit set;
+   * On server side, sent frame with eos bit set.
+   */
+  'streams_succeeded': (string);
+  /**
+   * The number of streams that have ended unsuccessfully:
+   * On client side, ended without receiving frame with eos bit set;
+   * On server side, ended without sending frame with eos bit set.
+   */
+  'streams_failed': (string);
+  /**
+   * The number of grpc messages successfully sent on this socket.
+   */
+  'messages_sent': (string);
+  /**
+   * The number of grpc messages received on this socket.
+   */
+  'messages_received': (string);
+  /**
+   * The number of keep alives sent.  This is typically implemented with HTTP/2
+   * ping messages.
+   */
+  'keep_alives_sent': (string);
+  /**
+   * The last time a stream was created by this endpoint.  Usually unset for
+   * servers.
+   */
+  'last_local_stream_created_timestamp': (_google_protobuf_Timestamp__Output | null);
+  /**
+   * The last time a stream was created by the remote endpoint.  Usually unset
+   * for clients.
+   */
+  'last_remote_stream_created_timestamp': (_google_protobuf_Timestamp__Output | null);
+  /**
+   * The last time a message was sent by this endpoint.
+   */
+  'last_message_sent_timestamp': (_google_protobuf_Timestamp__Output | null);
+  /**
+   * The last time a message was received by this endpoint.
+   */
+  'last_message_received_timestamp': (_google_protobuf_Timestamp__Output | null);
+  /**
+   * The amount of window, granted to the local endpoint by the remote endpoint.
+   * This may be slightly out of date due to network latency.  This does NOT
+   * include stream level or TCP level flow control info.
+   */
+  'local_flow_control_window': (_google_protobuf_Int64Value__Output | null);
+  /**
+   * The amount of window, granted to the remote endpoint by the local endpoint.
+   * This may be slightly out of date due to network latency.  This does NOT
+   * include stream level or TCP level flow control info.
+   */
+  'remote_flow_control_window': (_google_protobuf_Int64Value__Output | null);
+  /**
+   * Socket options set on this socket.  May be absent if 'summary' is set
+   * on GetSocketRequest.
+   */
+  'option': (_grpc_channelz_v1_SocketOption__Output)[];
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOption.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOption.ts
@@ -1,0 +1,47 @@
+// Original file: proto/channelz.proto
+
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../../google/protobuf/Any';
+
+/**
+ * SocketOption represents socket options for a socket.  Specifically, these
+ * are the options returned by getsockopt().
+ */
+export interface SocketOption {
+  /**
+   * The full name of the socket option.  Typically this will be the upper case
+   * name, such as "SO_REUSEPORT".
+   */
+  'name'?: (string);
+  /**
+   * The human readable value of this socket option.  At least one of value or
+   * additional will be set.
+   */
+  'value'?: (string);
+  /**
+   * Additional data associated with the socket option.  At least one of value
+   * or additional will be set.
+   */
+  'additional'?: (_google_protobuf_Any | null);
+}
+
+/**
+ * SocketOption represents socket options for a socket.  Specifically, these
+ * are the options returned by getsockopt().
+ */
+export interface SocketOption__Output {
+  /**
+   * The full name of the socket option.  Typically this will be the upper case
+   * name, such as "SO_REUSEPORT".
+   */
+  'name': (string);
+  /**
+   * The human readable value of this socket option.  At least one of value or
+   * additional will be set.
+   */
+  'value': (string);
+  /**
+   * Additional data associated with the socket option.  At least one of value
+   * or additional will be set.
+   */
+  'additional': (_google_protobuf_Any__Output | null);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOptionLinger.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOptionLinger.ts
@@ -1,0 +1,33 @@
+// Original file: proto/channelz.proto
+
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../google/protobuf/Duration';
+
+/**
+ * For use with SocketOption's additional field.  This is primarily used for
+ * SO_LINGER.
+ */
+export interface SocketOptionLinger {
+  /**
+   * active maps to `struct linger.l_onoff`
+   */
+  'active'?: (boolean);
+  /**
+   * duration maps to `struct linger.l_linger`
+   */
+  'duration'?: (_google_protobuf_Duration | null);
+}
+
+/**
+ * For use with SocketOption's additional field.  This is primarily used for
+ * SO_LINGER.
+ */
+export interface SocketOptionLinger__Output {
+  /**
+   * active maps to `struct linger.l_onoff`
+   */
+  'active': (boolean);
+  /**
+   * duration maps to `struct linger.l_linger`
+   */
+  'duration': (_google_protobuf_Duration__Output | null);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOptionTcpInfo.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOptionTcpInfo.ts
@@ -1,0 +1,74 @@
+// Original file: proto/channelz.proto
+
+
+/**
+ * For use with SocketOption's additional field.  Tcp info for
+ * SOL_TCP and TCP_INFO.
+ */
+export interface SocketOptionTcpInfo {
+  'tcpi_state'?: (number);
+  'tcpi_ca_state'?: (number);
+  'tcpi_retransmits'?: (number);
+  'tcpi_probes'?: (number);
+  'tcpi_backoff'?: (number);
+  'tcpi_options'?: (number);
+  'tcpi_snd_wscale'?: (number);
+  'tcpi_rcv_wscale'?: (number);
+  'tcpi_rto'?: (number);
+  'tcpi_ato'?: (number);
+  'tcpi_snd_mss'?: (number);
+  'tcpi_rcv_mss'?: (number);
+  'tcpi_unacked'?: (number);
+  'tcpi_sacked'?: (number);
+  'tcpi_lost'?: (number);
+  'tcpi_retrans'?: (number);
+  'tcpi_fackets'?: (number);
+  'tcpi_last_data_sent'?: (number);
+  'tcpi_last_ack_sent'?: (number);
+  'tcpi_last_data_recv'?: (number);
+  'tcpi_last_ack_recv'?: (number);
+  'tcpi_pmtu'?: (number);
+  'tcpi_rcv_ssthresh'?: (number);
+  'tcpi_rtt'?: (number);
+  'tcpi_rttvar'?: (number);
+  'tcpi_snd_ssthresh'?: (number);
+  'tcpi_snd_cwnd'?: (number);
+  'tcpi_advmss'?: (number);
+  'tcpi_reordering'?: (number);
+}
+
+/**
+ * For use with SocketOption's additional field.  Tcp info for
+ * SOL_TCP and TCP_INFO.
+ */
+export interface SocketOptionTcpInfo__Output {
+  'tcpi_state': (number);
+  'tcpi_ca_state': (number);
+  'tcpi_retransmits': (number);
+  'tcpi_probes': (number);
+  'tcpi_backoff': (number);
+  'tcpi_options': (number);
+  'tcpi_snd_wscale': (number);
+  'tcpi_rcv_wscale': (number);
+  'tcpi_rto': (number);
+  'tcpi_ato': (number);
+  'tcpi_snd_mss': (number);
+  'tcpi_rcv_mss': (number);
+  'tcpi_unacked': (number);
+  'tcpi_sacked': (number);
+  'tcpi_lost': (number);
+  'tcpi_retrans': (number);
+  'tcpi_fackets': (number);
+  'tcpi_last_data_sent': (number);
+  'tcpi_last_ack_sent': (number);
+  'tcpi_last_data_recv': (number);
+  'tcpi_last_ack_recv': (number);
+  'tcpi_pmtu': (number);
+  'tcpi_rcv_ssthresh': (number);
+  'tcpi_rtt': (number);
+  'tcpi_rttvar': (number);
+  'tcpi_snd_ssthresh': (number);
+  'tcpi_snd_cwnd': (number);
+  'tcpi_advmss': (number);
+  'tcpi_reordering': (number);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOptionTimeout.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOptionTimeout.ts
@@ -1,0 +1,19 @@
+// Original file: proto/channelz.proto
+
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../google/protobuf/Duration';
+
+/**
+ * For use with SocketOption's additional field.  This is primarily used for
+ * SO_RCVTIMEO and SO_SNDTIMEO
+ */
+export interface SocketOptionTimeout {
+  'duration'?: (_google_protobuf_Duration | null);
+}
+
+/**
+ * For use with SocketOption's additional field.  This is primarily used for
+ * SO_RCVTIMEO and SO_SNDTIMEO
+ */
+export interface SocketOptionTimeout__Output {
+  'duration': (_google_protobuf_Duration__Output | null);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/SocketRef.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/SocketRef.ts
@@ -1,0 +1,31 @@
+// Original file: proto/channelz.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+/**
+ * SocketRef is a reference to a Socket.
+ */
+export interface SocketRef {
+  /**
+   * The globally unique id for this socket.  Must be a positive number.
+   */
+  'socket_id'?: (number | string | Long);
+  /**
+   * An optional name associated with the socket.
+   */
+  'name'?: (string);
+}
+
+/**
+ * SocketRef is a reference to a Socket.
+ */
+export interface SocketRef__Output {
+  /**
+   * The globally unique id for this socket.  Must be a positive number.
+   */
+  'socket_id': (string);
+  /**
+   * An optional name associated with the socket.
+   */
+  'name': (string);
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Subchannel.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Subchannel.ts
@@ -1,0 +1,70 @@
+// Original file: proto/channelz.proto
+
+import type { SubchannelRef as _grpc_channelz_v1_SubchannelRef, SubchannelRef__Output as _grpc_channelz_v1_SubchannelRef__Output } from '../../../grpc/channelz/v1/SubchannelRef';
+import type { ChannelData as _grpc_channelz_v1_ChannelData, ChannelData__Output as _grpc_channelz_v1_ChannelData__Output } from '../../../grpc/channelz/v1/ChannelData';
+import type { ChannelRef as _grpc_channelz_v1_ChannelRef, ChannelRef__Output as _grpc_channelz_v1_ChannelRef__Output } from '../../../grpc/channelz/v1/ChannelRef';
+import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef';
+
+/**
+ * Subchannel is a logical grouping of channels, subchannels, and sockets.
+ * A subchannel is load balanced over by it's ancestor
+ */
+export interface Subchannel {
+  /**
+   * The identifier for this channel.
+   */
+  'ref'?: (_grpc_channelz_v1_SubchannelRef | null);
+  /**
+   * Data specific to this channel.
+   */
+  'data'?: (_grpc_channelz_v1_ChannelData | null);
+  /**
+   * There are no ordering guarantees on the order of channel refs.
+   * There may not be cycles in the ref graph.
+   * A channel ref may be present in more than one channel or subchannel.
+   */
+  'channel_ref'?: (_grpc_channelz_v1_ChannelRef)[];
+  /**
+   * At most one of 'channel_ref+subchannel_ref' and 'socket' is set.
+   * There are no ordering guarantees on the order of subchannel refs.
+   * There may not be cycles in the ref graph.
+   * A sub channel ref may be present in more than one channel or subchannel.
+   */
+  'subchannel_ref'?: (_grpc_channelz_v1_SubchannelRef)[];
+  /**
+   * There are no ordering guarantees on the order of sockets.
+   */
+  'socket_ref'?: (_grpc_channelz_v1_SocketRef)[];
+}
+
+/**
+ * Subchannel is a logical grouping of channels, subchannels, and sockets.
+ * A subchannel is load balanced over by it's ancestor
+ */
+export interface Subchannel__Output {
+  /**
+   * The identifier for this channel.
+   */
+  'ref': (_grpc_channelz_v1_SubchannelRef__Output | null);
+  /**
+   * Data specific to this channel.
+   */
+  'data': (_grpc_channelz_v1_ChannelData__Output | null);
+  /**
+   * There are no ordering guarantees on the order of channel refs.
+   * There may not be cycles in the ref graph.
+   * A channel ref may be present in more than one channel or subchannel.
+   */
+  'channel_ref': (_grpc_channelz_v1_ChannelRef__Output)[];
+  /**
+   * At most one of 'channel_ref+subchannel_ref' and 'socket' is set.
+   * There are no ordering guarantees on the order of subchannel refs.
+   * There may not be cycles in the ref graph.
+   * A sub channel ref may be present in more than one channel or subchannel.
+   */
+  'subchannel_ref': (_grpc_channelz_v1_SubchannelRef__Output)[];
+  /**
+   * There are no ordering guarantees on the order of sockets.
+   */
+  'socket_ref': (_grpc_channelz_v1_SocketRef__Output)[];
+}

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/SubchannelRef.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/SubchannelRef.ts
@@ -1,0 +1,31 @@
+// Original file: proto/channelz.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+/**
+ * SubchannelRef is a reference to a Subchannel.
+ */
+export interface SubchannelRef {
+  /**
+   * The globally unique id for this subchannel.  Must be a positive number.
+   */
+  'subchannel_id'?: (number | string | Long);
+  /**
+   * An optional name associated with the subchannel.
+   */
+  'name'?: (string);
+}
+
+/**
+ * SubchannelRef is a reference to a Subchannel.
+ */
+export interface SubchannelRef__Output {
+  /**
+   * The globally unique id for this subchannel.  Must be a positive number.
+   */
+  'subchannel_id': (string);
+  /**
+   * An optional name associated with the subchannel.
+   */
+  'name': (string);
+}

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -249,6 +249,13 @@ export { GrpcObject } from './make-client';
 
 export { ChannelOptions } from './channel-options';
 
+export {
+  getChannelzServiceDefinition,
+  getChannelzHandlers
+} from './channelz';
+
+export { addAdminServicesToServer } from './admin';
+
 import * as experimental from './experimental';
 export { experimental };
 
@@ -257,6 +264,7 @@ import * as resolver_uds from './resolver-uds';
 import * as resolver_ip from './resolver-ip';
 import * as load_balancer_pick_first from './load-balancer-pick-first';
 import * as load_balancer_round_robin from './load-balancer-round-robin';
+import * as channelz from './channelz';
 
 (() => {
   resolver_dns.setup();
@@ -264,4 +272,5 @@ import * as load_balancer_round_robin from './load-balancer-round-robin';
   resolver_ip.setup();
   load_balancer_pick_first.setup();
   load_balancer_round_robin.setup();
+  channelz.setup();
 })();

--- a/packages/grpc-js/src/load-balancer-child-handler.ts
+++ b/packages/grpc-js/src/load-balancer-child-handler.ts
@@ -26,6 +26,7 @@ import { SubchannelAddress } from './subchannel-address';
 import { ChannelOptions } from './channel-options';
 import { ConnectivityState } from './connectivity-state';
 import { Picker } from './picker';
+import { ChannelRef, SubchannelRef } from './channelz';
 
 const TYPE_NAME = 'child_load_balancer_helper';
 
@@ -67,6 +68,13 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
     setChild(newChild: LoadBalancer) {
       this.child = newChild;
     }
+    addChannelzChild(child: ChannelRef | SubchannelRef) {
+      this.parent.channelControlHelper.addChannelzChild(child);
+    }
+    removeChannelzChild(child: ChannelRef | SubchannelRef) {
+      this.parent.channelControlHelper.removeChannelzChild(child);
+    }
+    
     private calledByPendingChild(): boolean {
       return this.child === this.parent.pendingChild;
     }

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -229,6 +229,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
         subchannel.removeConnectivityStateListener(
           this.pickedSubchannelStateListener
         );
+        this.channelControlHelper.removeChannelzChild(subchannel.getChannelzRef());
         if (this.subchannels.length > 0) {
           if (this.triedAllSubchannels) {
             let newLBState: ConnectivityState;
@@ -321,6 +322,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
     this.updateState(ConnectivityState.READY, new PickFirstPicker(subchannel));
     subchannel.addConnectivityStateListener(this.pickedSubchannelStateListener);
     subchannel.ref();
+    this.channelControlHelper.addChannelzChild(subchannel.getChannelzRef());
     this.resetSubchannelList();
     clearTimeout(this.connectionDelayTimeout);
   }
@@ -339,6 +341,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
     for (const subchannel of this.subchannels) {
       subchannel.removeConnectivityStateListener(this.subchannelStateListener);
       subchannel.unref();
+      this.channelControlHelper.removeChannelzChild(subchannel.getChannelzRef());
     }
     this.currentSubchannelIndex = 0;
     this.subchannelStateCounts = {
@@ -369,6 +372,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
     );
     for (const subchannel of this.subchannels) {
       subchannel.ref();
+      this.channelControlHelper.addChannelzChild(subchannel.getChannelzRef());
     }
     for (const subchannel of this.subchannels) {
       subchannel.addConnectivityStateListener(this.subchannelStateListener);
@@ -449,6 +453,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
       this.currentPick.removeConnectivityStateListener(
         this.pickedSubchannelStateListener
       );
+      this.channelControlHelper.removeChannelzChild(this.currentPick.getChannelzRef());
     }
   }
 

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -191,6 +191,7 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
     for (const subchannel of this.subchannels) {
       subchannel.removeConnectivityStateListener(this.subchannelStateListener);
       subchannel.unref();
+      this.channelControlHelper.removeChannelzChild(subchannel.getChannelzRef());
     }
     this.subchannelStateCounts = {
       [ConnectivityState.CONNECTING]: 0,
@@ -217,6 +218,7 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
     for (const subchannel of this.subchannels) {
       subchannel.ref();
       subchannel.addConnectivityStateListener(this.subchannelStateListener);
+      this.channelControlHelper.addChannelzChild(subchannel.getChannelzRef());
       const subchannelState = subchannel.getConnectivityState();
       this.subchannelStateCounts[subchannelState] += 1;
       if (

--- a/packages/grpc-js/src/load-balancer.ts
+++ b/packages/grpc-js/src/load-balancer.ts
@@ -20,6 +20,7 @@ import { Subchannel } from './subchannel';
 import { SubchannelAddress } from './subchannel-address';
 import { ConnectivityState } from './connectivity-state';
 import { Picker } from './picker';
+import { ChannelRef, SubchannelRef } from './channelz';
 
 /**
  * A collection of functions associated with a channel that a load balancer
@@ -47,6 +48,8 @@ export interface ChannelControlHelper {
    * Request new data from the resolver.
    */
   requestReresolution(): void;
+  addChannelzChild(child: ChannelRef | SubchannelRef): void;
+  removeChannelzChild(child: ChannelRef | SubchannelRef): void;
 }
 
 /**

--- a/packages/grpc-js/src/load-balancer.ts
+++ b/packages/grpc-js/src/load-balancer.ts
@@ -53,6 +53,24 @@ export interface ChannelControlHelper {
 }
 
 /**
+ * Create a child ChannelControlHelper that overrides some methods of the
+ * parent while letting others pass through to the parent unmodified. This
+ * allows other code to create these children without needing to know about
+ * all of the methods to be passed through.
+ * @param parent 
+ * @param overrides 
+ */
+export function createChildChannelControlHelper(parent: ChannelControlHelper, overrides: Partial<ChannelControlHelper>): ChannelControlHelper {
+  return {
+    createSubchannel: overrides.createSubchannel?.bind(overrides) ?? parent.createSubchannel.bind(parent),
+    updateState: overrides.updateState?.bind(overrides) ?? parent.updateState.bind(parent),
+    requestReresolution: overrides.requestReresolution?.bind(overrides) ?? parent.requestReresolution.bind(parent),
+    addChannelzChild: overrides.addChannelzChild?.bind(overrides) ?? parent.addChannelzChild.bind(parent),
+    removeChannelzChild: overrides.removeChannelzChild?.bind(overrides) ?? parent.removeChannelzChild.bind(parent)
+  };
+}
+
+/**
  * Tracks one or more connected subchannels and determines which subchannel
  * each request should use.
  */

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -75,7 +75,7 @@ function getDefaultConfigSelector(
     return {
       methodConfig: { name: [] },
       pickInformation: {},
-      status: Status.OK,
+      status: Status.OK
     };
   };
 }
@@ -170,6 +170,12 @@ export class ResolvingLoadBalancer implements LoadBalancer {
         this.latestChildPicker = picker;
         this.updateState(newState, picker);
       },
+      addChannelzChild: channelControlHelper.addChannelzChild.bind(
+        channelControlHelper
+      ),
+      removeChannelzChild: channelControlHelper.removeChannelzChild.bind(
+        channelControlHelper
+      )
     });
     this.innerResolver = createResolver(
       target,

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -570,7 +570,6 @@ export class Http2ServerCallStream<
       const response = this.serializeMessage(value!);
 
       this.write(response);
-      this.emit('sendMessage');
       this.sendStatus({ code: Status.OK, details: 'OK', metadata });
     } catch (err) {
       err.code = Status.INTERNAL;

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -411,6 +411,8 @@ export class Http2ServerCallStream<
       );
       this.cancelled = true;
       this.emit('cancelled', 'cancelled');
+      this.emit('streamEnd', false);
+      this.sendStatus({code: Status.CANCELLED, details: 'Cancelled by client', metadata: new Metadata()});
     });
 
     this.stream.on('drain', () => {
@@ -513,6 +515,7 @@ export class Http2ServerCallStream<
             resolve();
           }
 
+          this.emit('receiveMessage');
           resolve(this.deserializeMessage(requestBytes));
         } catch (err) {
           err.code = Status.INTERNAL;
@@ -567,6 +570,7 @@ export class Http2ServerCallStream<
       const response = this.serializeMessage(value!);
 
       this.write(response);
+      this.emit('sendMessage');
       this.sendStatus({ code: Status.OK, details: 'OK', metadata });
     } catch (err) {
       err.code = Status.INTERNAL;
@@ -575,6 +579,8 @@ export class Http2ServerCallStream<
   }
 
   sendStatus(statusObj: StatusObject) {
+    this.emit('callEnd', statusObj.code);
+    this.emit('streamEnd', statusObj.code === Status.OK);
     if (this.checkCancelled()) {
       return;
     }
@@ -609,9 +615,6 @@ export class Http2ServerCallStream<
   }
 
   sendError(error: ServerErrorResponse | ServerStatusResponse) {
-    if (this.checkCancelled()) {
-      return;
-    }
     const status: StatusObject = {
       code: Status.UNKNOWN,
       details: 'message' in error ? error.message : 'Unknown Error',
@@ -653,6 +656,7 @@ export class Http2ServerCallStream<
     }
 
     this.sendMetadata();
+    this.emit('sendMessage');
     return this.stream.write(chunk);
   }
 
@@ -688,6 +692,7 @@ export class Http2ServerCallStream<
           });
           return;
         }
+        this.emit('receiveMessage');
         this.pushOrBufferMessage(readable, message);
       }
     });

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -64,10 +64,6 @@ import { CipherNameAndProtocol, TLSSocket } from 'tls';
 
 const TRACER_NAME = 'server';
 
-function trace(text: string): void {
-  logging.trace(LogVerbosity.DEBUG, TRACER_NAME, text);
-}
-
 interface BindResult {
   port: number;
   count: number;
@@ -163,6 +159,7 @@ export class Server {
     this.options = options ?? {};
     this.channelzRef = registerChannelzServer(() => this.getChannelzInfo());
     this.channelzTrace.addTrace('CT_INFO', 'Server created');
+    this.trace('Server constructed');
   }
 
   private getChannelzInfo(): ServerInfo {
@@ -216,6 +213,11 @@ export class Server {
       return socketInfo;
     };
   }
+
+  private trace(text: string): void {
+    logging.trace(LogVerbosity.DEBUG, TRACER_NAME, '(' + this.channelzRef.id + ') ' + text);
+  }
+  
 
   addProtoService(): void {
     throw new Error('Not implemented. Use addService() instead');
@@ -372,7 +374,7 @@ export class Server {
       }
       return Promise.all(
         addressList.map((address) => {
-          trace('Attempting to bind ' + subchannelAddressToString(address));
+          this.trace('Attempting to bind ' + subchannelAddressToString(address));
           let addr: SubchannelAddress;
           if (isTcpSubchannelAddress(address)) {
             addr = {
@@ -426,7 +428,7 @@ export class Server {
               });
               this.listenerChildrenTracker.refChild(channelzRef);
               this.http2ServerList.push({server: http2Server, channelzRef: channelzRef});
-              trace('Successfully bound ' + subchannelAddressToString(boundSubchannelAddress));
+              this.trace('Successfully bound ' + subchannelAddressToString(boundSubchannelAddress));
               resolve('port' in boundSubchannelAddress ? boundSubchannelAddress.port : portNum);
               http2Server.removeListener('error', onError);
             });
@@ -494,7 +496,7 @@ export class Server {
           });
           this.listenerChildrenTracker.refChild(channelzRef);
           this.http2ServerList.push({server: http2Server, channelzRef: channelzRef});
-          trace('Successfully bound ' + subchannelAddressToString(boundSubchannelAddress));
+          this.trace('Successfully bound ' + subchannelAddressToString(boundSubchannelAddress));
           resolve(
             bindSpecificPort(
               addressList.slice(1),
@@ -727,7 +729,7 @@ export class Server {
                 serverAddress.address + ':' + serverAddress.port;
             }
           }
-          trace(
+          this.trace(
             'Received call to method ' +
               path +
               ' at address ' +
@@ -736,7 +738,7 @@ export class Server {
           const handler = this.handlers.get(path);
 
           if (handler === undefined) {
-            trace(
+            this.trace(
               'No handler registered for method ' +
                 path +
                 '. Sending UNIMPLEMENTED status.'

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -188,7 +188,7 @@ export class Server {
         const peerCertificate = tlsSocket.getPeerCertificate();
         tlsInfo = {
           cipherSuiteStandardName: cipherInfo.standardName ?? null,
-          cipherSuiteOtherName: cipherInfo.standardName ? cipherInfo.name: null,
+          cipherSuiteOtherName: cipherInfo.standardName ? null : cipherInfo.name,
           localCertificate: (certificate && 'raw' in certificate) ? certificate.raw : null,
           remoteCertificate: (peerCertificate && 'raw' in peerCertificate) ? peerCertificate.raw : null
         };
@@ -424,6 +424,7 @@ export class Server {
                   remoteFlowControlWindow: null
                 };
               });
+              this.listenerChildrenTracker.refChild(channelzRef);
               this.http2ServerList.push({server: http2Server, channelzRef: channelzRef});
               trace('Successfully bound ' + subchannelAddressToString(boundSubchannelAddress));
               resolve('port' in boundSubchannelAddress ? boundSubchannelAddress.port : portNum);
@@ -491,6 +492,7 @@ export class Server {
               remoteFlowControlWindow: null
             };
           });
+          this.listenerChildrenTracker.refChild(channelzRef);
           this.http2ServerList.push({server: http2Server, channelzRef: channelzRef});
           trace('Successfully bound ' + subchannelAddressToString(boundSubchannelAddress));
           resolve(
@@ -674,6 +676,10 @@ export class Server {
 
   addHttp2Port(): void {
     throw new Error('Not yet implemented');
+  }
+
+  getChannelzRef() {
+    return this.channelzRef;
   }
 
   private _setupHandlers(

--- a/packages/grpc-js/src/subchannel-address.ts
+++ b/packages/grpc-js/src/subchannel-address.ts
@@ -15,6 +15,8 @@
  *
  */
 
+import { isIP } from "net";
+
 export interface TcpSubchannelAddress {
   port: number;
   host: string;
@@ -58,5 +60,20 @@ export function subchannelAddressToString(address: SubchannelAddress): string {
     return address.host + ':' + address.port;
   } else {
     return address.path;
+  }
+}
+
+const DEFAULT_PORT = 443;
+
+export function stringToSubchannelAddress(addressString: string, port?: number): SubchannelAddress {
+  if (isIP(addressString)) {
+    return {
+      host: addressString,
+      port: port ?? DEFAULT_PORT
+    };
+  } else {
+    return {
+      path: addressString
+    };
   }
 }

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -18,23 +18,25 @@
 import * as http2 from 'http2';
 import { ChannelCredentials } from './channel-credentials';
 import { Metadata } from './metadata';
-import { Http2CallStream } from './call-stream';
+import { Call, Http2CallStream, WriteObject } from './call-stream';
 import { ChannelOptions } from './channel-options';
-import { PeerCertificate, checkServerIdentity } from 'tls';
+import { PeerCertificate, checkServerIdentity, TLSSocket, CipherNameAndProtocol } from 'tls';
 import { ConnectivityState } from './connectivity-state';
 import { BackoffTimeout, BackoffOptions } from './backoff-timeout';
 import { getDefaultAuthority } from './resolver';
 import * as logging from './logging';
-import { LogVerbosity } from './constants';
+import { LogVerbosity, Status } from './constants';
 import { getProxiedConnection, ProxyConnectionResult } from './http_proxy';
 import * as net from 'net';
 import { GrpcUri, parseUri, splitHostPort, uriToString } from './uri-parser';
 import { ConnectionOptions } from 'tls';
-import { FilterFactory, Filter } from './filter';
+import { FilterFactory, Filter, BaseFilter } from './filter';
 import {
+  stringToSubchannelAddress,
   SubchannelAddress,
   subchannelAddressToString,
 } from './subchannel-address';
+import { SubchannelRef, ChannelzTrace, ChannelzChildrenTracker, SubchannelInfo, registerChannelzSubchannel, ChannelzCallTracker, SocketInfo, SocketRef, unregisterChannelzRef, registerChannelzSocket, TlsInfo } from './channelz';
 
 const clientVersion = require('../../package.json').version;
 
@@ -157,6 +159,53 @@ export class Subchannel {
    */
   private subchannelAddressString: string;
 
+  // Channelz info
+  private channelzRef: SubchannelRef;
+  private channelzTrace: ChannelzTrace;
+  private callTracker = new ChannelzCallTracker();
+  private childrenTracker = new ChannelzChildrenTracker();
+
+  // Channelz socket info
+  private channelzSocketRef: SocketRef | null = null;
+  /**
+   * Name of the remote server, if it is not the same as the subchannel
+   * address, i.e. if connecting through an HTTP CONNECT proxy.
+   */
+  private remoteName: string | null = null;
+  private streamTracker = new ChannelzCallTracker();
+  private keepalivesSent = 0;
+  private messagesSent = 0;
+  private messagesReceived = 0;
+  private lastMessageSentTimestamp: Date | null = null;
+  private lastMessageReceivedTimestamp: Date | null = null;
+  private MessageCountFilter = class extends BaseFilter implements Filter {
+    private session: http2.ClientHttp2Session;
+    constructor(private parent: Subchannel) {
+      super();
+      this.session = parent.session!;
+    }
+    sendMessage(message: Promise<WriteObject>): Promise<WriteObject> {
+      if (this.parent.session === this.session) {
+        this.parent.messagesSent += 1;
+        this.parent.lastMessageSentTimestamp = new Date();
+      }
+      return message;
+    }
+    receiveMessage(message: Promise<Buffer>): Promise<Buffer> {
+      if (this.parent.session === this.session) {
+        this.parent.messagesReceived += 1;
+        this.parent.lastMessageReceivedTimestamp = new Date();
+      }
+      return message;
+    }
+  };
+  private MessageCountFilterFactory = class implements FilterFactory<Filter> {
+    constructor(private parent: Subchannel) {}
+    createFilter(callStream: Call): Filter {
+      return new this.parent.MessageCountFilter(this.parent);
+    }
+  }
+
   /**
    * A class representing a connection to a single backend.
    * @param channelTarget The target string for the channel as a whole
@@ -206,6 +255,77 @@ export class Subchannel {
       this.handleBackoffTimer();
     }, backoffOptions);
     this.subchannelAddressString = subchannelAddressToString(subchannelAddress);
+
+    this.channelzRef = registerChannelzSubchannel(this.subchannelAddressString, () => this.getChannelzInfo());
+    this.channelzTrace = new ChannelzTrace();
+    this.channelzTrace.addTrace('CT_INFO', 'Subchannel created');
+  }
+
+  private getChannelzInfo(): SubchannelInfo {
+    return {
+      state: this.connectivityState,
+      trace: this.channelzTrace,
+      callTracker: this.callTracker,
+      children: this.childrenTracker.getChildLists()
+    };
+  }
+
+  private getChannelzSocketInfo(): SocketInfo | null {
+    if (this.session === null) {
+      return null;
+    }
+    const sessionSocket = this.session.socket;
+    const remoteAddress = sessionSocket.remoteAddress ? stringToSubchannelAddress(sessionSocket.remoteAddress, sessionSocket.remotePort) : null;
+    const localAddress = stringToSubchannelAddress(sessionSocket.localAddress, sessionSocket.localPort);
+    let tlsInfo: TlsInfo | null;
+    if (this.session.encrypted) {
+      const tlsSocket: TLSSocket = sessionSocket as TLSSocket;
+      const cipherInfo: CipherNameAndProtocol & {standardName?: string} = tlsSocket.getCipher();
+      const certificate = tlsSocket.getCertificate();
+      const peerCertificate = tlsSocket.getPeerCertificate();
+      tlsInfo = {
+        cipherSuiteStandardName: cipherInfo.standardName ?? null,
+        cipherSuiteOtherName: cipherInfo.standardName ? cipherInfo.name: null,
+        localCertificate: (certificate && 'raw' in certificate) ? certificate.raw : null,
+        remoteCertificate: (peerCertificate && 'raw' in peerCertificate) ? peerCertificate.raw : null
+      };
+    } else {
+      tlsInfo = null;
+    }
+    const socketInfo: SocketInfo = {
+      remoteAddress: remoteAddress,
+      localAddress: localAddress,
+      security: tlsInfo,
+      remoteName: this.remoteName,
+      streamsStarted: this.streamTracker.callsStarted,
+      streamsSucceeded: this.streamTracker.callsSucceeded,
+      streamsFailed: this.streamTracker.callsFailed,
+      messagesSent: this.messagesSent,
+      messagesReceived: this.messagesReceived,
+      keepAlivesSent: this.keepalivesSent,
+      lastLocalStreamCreatedTimestamp: this.streamTracker.lastCallStartedTimestamp,
+      lastRemoteStreamCreatedTimestamp: null,
+      lastMessageSentTimestamp: this.lastMessageSentTimestamp,
+      lastMessageReceivedTimestamp: this.lastMessageReceivedTimestamp,
+      localFlowControlWindow: this.session.state.localWindowSize ?? null,
+      remoteFlowControlWindow: this.session.state.remoteWindowSize ?? null
+    };
+    return socketInfo;
+  }
+
+  private resetChannelzSocketInfo() {
+    if (this.channelzSocketRef) {
+      unregisterChannelzRef(this.channelzSocketRef);
+      this.childrenTracker.unrefChild(this.channelzSocketRef);
+      this.channelzSocketRef = null;
+    }
+    this.remoteName = null;
+    this.streamTracker = new ChannelzCallTracker();
+    this.keepalivesSent = 0;
+    this.messagesSent = 0;
+    this.messagesReceived = 0;
+    this.lastMessageSentTimestamp = null;
+    this.lastMessageReceivedTimestamp = null;
   }
 
   private handleBackoffTimer() {
@@ -235,6 +355,7 @@ export class Subchannel {
   }
 
   private sendPing() {
+    this.keepalivesSent += 1;
     logging.trace(
       LogVerbosity.DEBUG,
       'keepalive',
@@ -266,6 +387,11 @@ export class Subchannel {
   }
 
   private createSession(proxyConnectionResult: ProxyConnectionResult) {
+    if (proxyConnectionResult.realTarget) {
+      this.remoteName = uriToString(proxyConnectionResult.realTarget);
+    } else {
+      this.remoteName = null;
+    }
     const targetAuthority = getDefaultAuthority(
       proxyConnectionResult.realTarget ?? this.channelTarget
     );
@@ -353,6 +479,8 @@ export class Subchannel {
       connectionOptions
     );
     this.session = session;
+    this.channelzSocketRef = registerChannelzSocket(this.subchannelAddressString, () => this.getChannelzSocketInfo()!);
+    this.childrenTracker.refChild(this.channelzSocketRef);
     session.unref();
     /* For all of these events, check if the session at the time of the event
      * is the same one currently attached to this subchannel, to ensure that
@@ -425,6 +553,7 @@ export class Subchannel {
           (error as Error).message
       );
     });
+    registerChannelzSocket(this.subchannelAddressString, () => this.getChannelzSocketInfo()!);
   }
 
   private startConnectingInternal() {
@@ -506,6 +635,7 @@ export class Subchannel {
         ' -> ' +
         ConnectivityState[newState]
     );
+    this.channelzTrace.addTrace('CT_INFO', ConnectivityState[this.connectivityState] + ' -> ' + ConnectivityState[newState]);
     const previousState = this.connectivityState;
     this.connectivityState = newState;
     switch (newState) {
@@ -530,6 +660,7 @@ export class Subchannel {
           this.session.close();
         }
         this.session = null;
+        this.resetChannelzSocketInfo();
         this.stopKeepalivePings();
         /* If the backoff timer has already ended by the time we get to the
          * TRANSIENT_FAILURE state, we want to immediately transition out of
@@ -545,6 +676,7 @@ export class Subchannel {
           this.session.close();
         }
         this.session = null;
+        this.resetChannelzSocketInfo();
         this.stopKeepalivePings();
         break;
       default:
@@ -566,10 +698,12 @@ export class Subchannel {
     /* If no calls, channels, or subchannel pools have any more references to
      * this subchannel, we can be sure it will never be used again. */
     if (this.callRefcount === 0 && this.refcount === 0) {
+      this.channelzTrace.addTrace('CT_INFO', 'Shutting down');
       this.transitionToState(
         [ConnectivityState.CONNECTING, ConnectivityState.READY],
         ConnectivityState.TRANSIENT_FAILURE
       );
+      unregisterChannelzRef(this.channelzRef);
     }
   }
 
@@ -694,6 +828,26 @@ export class Subchannel {
         ' with headers\n' +
         headersString
     );
+    this.callTracker.addCallStarted();
+    callStream.addStatusWatcher(status => {
+      if (status.code === Status.OK) {
+        this.callTracker.addCallSucceeded();
+      } else {
+        this.callTracker.addCallFailed();
+      }
+    });
+    const streamSession = this.session;
+    this.streamTracker.addCallStarted();
+    callStream.addStreamEndWatcher(success => {
+      if (streamSession === this.session) {
+        if (success) {
+          this.streamTracker.addCallSucceeded();
+        } else {
+          this.streamTracker.addCallFailed();
+        }
+      }
+    });
+    extraFilterFactories.push(new this.MessageCountFilterFactory(this));
     callStream.attachHttp2Stream(http2Stream, this, extraFilterFactories);
   }
 
@@ -772,5 +926,9 @@ export class Subchannel {
 
   getAddress(): string {
     return this.subchannelAddressString;
+  }
+
+  getChannelzRef(): SubchannelRef {
+    return this.channelzRef;
   }
 }

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -266,7 +266,8 @@ export class Subchannel {
       state: this.connectivityState,
       trace: this.channelzTrace,
       callTracker: this.callTracker,
-      children: this.childrenTracker.getChildLists()
+      children: this.childrenTracker.getChildLists(),
+      target: this.subchannelAddressString
     };
   }
 
@@ -285,7 +286,7 @@ export class Subchannel {
       const peerCertificate = tlsSocket.getPeerCertificate();
       tlsInfo = {
         cipherSuiteStandardName: cipherInfo.standardName ?? null,
-        cipherSuiteOtherName: cipherInfo.standardName ? cipherInfo.name: null,
+        cipherSuiteOtherName: cipherInfo.standardName ? null : cipherInfo.name,
         localCertificate: (certificate && 'raw' in certificate) ? certificate.raw : null,
         remoteCertificate: (peerCertificate && 'raw' in peerCertificate) ? peerCertificate.raw : null
       };

--- a/packages/grpc-js/test/test-channelz.ts
+++ b/packages/grpc-js/test/test-channelz.ts
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import * as assert from 'assert';
+import * as protoLoader from '@grpc/proto-loader';
+import * as grpc from '../src';
+
+import { ProtoGrpcType } from '../src/generated/channelz'
+import { ChannelzClient } from '../src/generated/grpc/channelz/v1/Channelz';
+import { Channel__Output } from '../src/generated/grpc/channelz/v1/Channel';
+import { Server__Output } from '../src/generated/grpc/channelz/v1/Server';
+import { ServiceClient, ServiceClientConstructor } from '../src/make-client';
+import { loadProtoFile } from './common';
+
+const loadedChannelzProto = protoLoader.loadSync('channelz.proto', {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+  includeDirs: [
+    `${__dirname}/../../proto`
+  ]
+});
+const channelzGrpcObject = grpc.loadPackageDefinition(loadedChannelzProto) as unknown as ProtoGrpcType;
+
+const TestServiceClient = loadProtoFile(`${__dirname}/fixtures/test_service.proto`).TestService as ServiceClientConstructor;
+
+const testServiceImpl: grpc.UntypedServiceImplementation = {
+  unary(call: grpc.ServerUnaryCall<any, any>, callback: grpc.sendUnaryData<any>) {
+    if (call.request.error) {
+      setTimeout(() => {
+        callback({
+          code: grpc.status.INVALID_ARGUMENT,
+          details: call.request.message
+        });
+      }, call.request.errorAfter)
+    } else {
+      callback(null, {count: 1});
+    }
+  }
+}
+
+describe('Channelz', () => {
+  let channelzServer: grpc.Server;
+  let channelzClient: ChannelzClient;
+  let testServer: grpc.Server;
+  let testClient: ServiceClient;
+
+  before((done) => {
+    channelzServer = new grpc.Server();
+    channelzServer.addService(grpc.getChannelzServiceDefinition(), grpc.getChannelzHandlers());
+    channelzServer.bindAsync('localhost:0', grpc.ServerCredentials.createInsecure(), (error, port) => {
+      if (error) {
+        done(error);
+        return;
+      }
+      channelzServer.start();
+      channelzClient = new channelzGrpcObject.grpc.channelz.v1.Channelz(`localhost:${port}`, grpc.credentials.createInsecure());
+      done();
+    });
+  });
+
+  after(() => {
+    channelzClient.close();
+    channelzServer.forceShutdown();
+  });
+
+  beforeEach((done) => {
+    testServer = new grpc.Server();
+    testServer.addService(TestServiceClient.service, testServiceImpl);
+    testServer.bindAsync('localhost:0', grpc.ServerCredentials.createInsecure(), (error, port) => {
+      if (error) {
+        done(error);
+        return;
+      }
+      testServer.start();
+      testClient = new TestServiceClient(`localhost:${port}`, grpc.credentials.createInsecure());
+      done();
+    });
+  });
+
+  afterEach(() => {
+    testClient.close();
+    testServer.forceShutdown();
+  });
+
+  it('should see a newly created channel', (done) => {
+    // Test that the specific test client channel info can be retrieved
+    channelzClient.GetChannel({channel_id: testClient.getChannel().getChannelzRef().id}, (error, result) => {
+      assert.ifError(error);
+      assert(result);
+      assert(result.channel);
+      assert(result.channel.ref);
+      assert.strictEqual(+result.channel.ref.channel_id, testClient.getChannel().getChannelzRef().id);
+      // Test that the channel is in the list of top channels
+      channelzClient.getTopChannels({start_channel_id: testClient.getChannel().getChannelzRef().id, max_results:1}, (error, result) => {
+        assert.ifError(error);
+        assert(result);
+        assert.strictEqual(result.channel.length, 1);
+        assert(result.channel[0].ref);
+        assert.strictEqual(+result.channel[0].ref.channel_id, testClient.getChannel().getChannelzRef().id);
+        done();
+      });
+    });
+  });
+
+  it('should see a newly created server', (done) => {
+    // Test that the specific test server info can be retrieved
+    channelzClient.getServer({server_id: testServer.getChannelzRef().id}, (error, result) => {
+      assert.ifError(error);
+      assert(result);
+      assert(result.server);
+      assert(result.server.ref);
+      assert.strictEqual(+result.server.ref.server_id, testServer.getChannelzRef().id);
+      // Test that the server is in the list of servers
+      channelzClient.getServers({start_server_id: testServer.getChannelzRef().id, max_results: 1}, (error, result) => {
+        assert.ifError(error);
+        assert(result);
+        assert.strictEqual(result.server.length, 1);
+        assert(result.server[0].ref);
+        assert.strictEqual(+result.server[0].ref.server_id, testServer.getChannelzRef().id);
+        done();
+      });
+    });
+  });
+
+  it('should count successful calls', (done) => {
+    testClient.unary({}, (error: grpc.ServiceError, value: unknown) => {
+      assert.ifError(error);
+      // Channel data tests
+      channelzClient.GetChannel({channel_id: testClient.getChannel().getChannelzRef().id}, (error, channelResult) => {
+        assert.ifError(error);
+        assert(channelResult);
+        assert(channelResult.channel);
+        assert(channelResult.channel.ref);
+        assert(channelResult.channel.data);
+        assert.strictEqual(+channelResult.channel.data.calls_started, 1);
+        assert.strictEqual(+channelResult.channel.data.calls_succeeded, 1);
+        assert.strictEqual(+channelResult.channel.data.calls_failed, 0);
+        assert.strictEqual(channelResult.channel.subchannel_ref.length, 1);
+        channelzClient.getSubchannel({subchannel_id: channelResult.channel.subchannel_ref[0].subchannel_id}, (error, subchannelResult) => {
+          assert.ifError(error);
+          assert(subchannelResult);
+          assert(subchannelResult.subchannel);
+          assert(subchannelResult.subchannel.ref);
+          assert(subchannelResult.subchannel.data);
+          assert.strictEqual(subchannelResult.subchannel.ref.subchannel_id, channelResult.channel!.subchannel_ref[0].subchannel_id);
+          assert.strictEqual(+subchannelResult.subchannel.data.calls_started, 1);
+          assert.strictEqual(+subchannelResult.subchannel.data.calls_succeeded, 1);
+          assert.strictEqual(+subchannelResult.subchannel.data.calls_failed, 0);
+          assert.strictEqual(subchannelResult.subchannel.socket_ref.length, 1);
+          channelzClient.getSocket({socket_id: subchannelResult.subchannel.socket_ref[0].socket_id}, (error, socketResult) => {
+            assert.ifError(error);
+            assert(socketResult);
+            assert(socketResult.socket);
+            assert(socketResult.socket.ref);
+            assert(socketResult.socket.data);
+            assert.strictEqual(socketResult.socket.ref.socket_id, subchannelResult.subchannel!.socket_ref[0].socket_id);
+            assert.strictEqual(+socketResult.socket.data.streams_started, 1);
+            assert.strictEqual(+socketResult.socket.data.streams_succeeded, 1);
+            assert.strictEqual(+socketResult.socket.data.streams_failed, 0);
+            assert.strictEqual(+socketResult.socket.data.messages_received, 1);
+            assert.strictEqual(+socketResult.socket.data.messages_sent, 1);
+            // Server data tests
+            channelzClient.getServer({server_id: testServer.getChannelzRef().id}, (error, serverResult) => {
+              assert.ifError(error);
+              assert(serverResult);
+              assert(serverResult.server);
+              assert(serverResult.server.ref);
+              assert(serverResult.server.data);
+              assert.strictEqual(+serverResult.server.ref.server_id, testServer.getChannelzRef().id);
+              assert.strictEqual(+serverResult.server.data.calls_started, 1);
+              assert.strictEqual(+serverResult.server.data.calls_succeeded, 1);
+              assert.strictEqual(+serverResult.server.data.calls_failed, 0);
+              channelzClient.getServerSockets({server_id: testServer.getChannelzRef().id}, (error, socketsResult) => {
+                assert.ifError(error);
+                assert(socketsResult);
+                assert.strictEqual(socketsResult.socket_ref.length, 1);
+                channelzClient.getSocket({socket_id: socketsResult.socket_ref[0].socket_id}, (error, serverSocketResult) => {
+                  assert.ifError(error);
+                  assert(serverSocketResult);
+                  assert(serverSocketResult.socket);
+                  assert(serverSocketResult.socket.ref);
+                  assert(serverSocketResult.socket.data);
+                  assert.strictEqual(serverSocketResult.socket.ref.socket_id, socketsResult.socket_ref[0].socket_id);
+                  assert.strictEqual(+serverSocketResult.socket.data.streams_started, 1);
+                  assert.strictEqual(+serverSocketResult.socket.data.streams_succeeded, 1);
+                  assert.strictEqual(+serverSocketResult.socket.data.streams_failed, 0);
+                  assert.strictEqual(+serverSocketResult.socket.data.messages_received, 1);
+                  assert.strictEqual(+serverSocketResult.socket.data.messages_sent, 1);
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  it('should count failed calls', (done) => {
+    testClient.unary({error: true}, (error: grpc.ServiceError, value: unknown) => {
+      assert(error);
+      // Channel data tests
+      channelzClient.GetChannel({channel_id: testClient.getChannel().getChannelzRef().id}, (error, channelResult) => {
+        assert.ifError(error);
+        assert(channelResult);
+        assert(channelResult.channel);
+        assert(channelResult.channel.ref);
+        assert(channelResult.channel.data);
+        assert.strictEqual(+channelResult.channel.data.calls_started, 1);
+        assert.strictEqual(+channelResult.channel.data.calls_succeeded, 0);
+        assert.strictEqual(+channelResult.channel.data.calls_failed, 1);
+        assert.strictEqual(channelResult.channel.subchannel_ref.length, 1);
+        channelzClient.getSubchannel({subchannel_id: channelResult.channel.subchannel_ref[0].subchannel_id}, (error, subchannelResult) => {
+          assert.ifError(error);
+          assert(subchannelResult);
+          assert(subchannelResult.subchannel);
+          assert(subchannelResult.subchannel.ref);
+          assert(subchannelResult.subchannel.data);
+          assert.strictEqual(subchannelResult.subchannel.ref.subchannel_id, channelResult.channel!.subchannel_ref[0].subchannel_id);
+          assert.strictEqual(+subchannelResult.subchannel.data.calls_started, 1);
+          assert.strictEqual(+subchannelResult.subchannel.data.calls_succeeded, 0);
+          assert.strictEqual(+subchannelResult.subchannel.data.calls_failed, 1);
+          assert.strictEqual(subchannelResult.subchannel.socket_ref.length, 1);
+          channelzClient.getSocket({socket_id: subchannelResult.subchannel.socket_ref[0].socket_id}, (error, socketResult) => {
+            assert.ifError(error);
+            assert(socketResult);
+            assert(socketResult.socket);
+            assert(socketResult.socket.ref);
+            assert(socketResult.socket.data);
+            assert.strictEqual(socketResult.socket.ref.socket_id, subchannelResult.subchannel!.socket_ref[0].socket_id);
+            assert.strictEqual(+socketResult.socket.data.streams_started, 1);
+            assert.strictEqual(+socketResult.socket.data.streams_succeeded, 1);
+            assert.strictEqual(+socketResult.socket.data.streams_failed, 0);
+            assert.strictEqual(+socketResult.socket.data.messages_received, 0);
+            assert.strictEqual(+socketResult.socket.data.messages_sent, 1);
+            // Server data tests
+            channelzClient.getServer({server_id: testServer.getChannelzRef().id}, (error, serverResult) => {
+              assert.ifError(error);
+              assert(serverResult);
+              assert(serverResult.server);
+              assert(serverResult.server.ref);
+              assert(serverResult.server.data);
+              assert.strictEqual(+serverResult.server.ref.server_id, testServer.getChannelzRef().id);
+              assert.strictEqual(+serverResult.server.data.calls_started, 1);
+              assert.strictEqual(+serverResult.server.data.calls_succeeded, 0);
+              assert.strictEqual(+serverResult.server.data.calls_failed, 1);
+              channelzClient.getServerSockets({server_id: testServer.getChannelzRef().id}, (error, socketsResult) => {
+                assert.ifError(error);
+                assert(socketsResult);
+                assert.strictEqual(socketsResult.socket_ref.length, 1);
+                channelzClient.getSocket({socket_id: socketsResult.socket_ref[0].socket_id}, (error, serverSocketResult) => {
+                  assert.ifError(error);
+                  assert(serverSocketResult);
+                  assert(serverSocketResult.socket);
+                  assert(serverSocketResult.socket.ref);
+                  assert(serverSocketResult.socket.data);
+                  assert.strictEqual(serverSocketResult.socket.ref.socket_id, socketsResult.socket_ref[0].socket_id);
+                  assert.strictEqual(+serverSocketResult.socket.data.streams_started, 1);
+                  assert.strictEqual(+serverSocketResult.socket.data.streams_succeeded, 0);
+                  assert.strictEqual(+serverSocketResult.socket.data.streams_failed, 1);
+                  assert.strictEqual(+serverSocketResult.socket.data.messages_received, 1);
+                  assert.strictEqual(+serverSocketResult.socket.data.messages_sent, 0);
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/channelz/channelz_manual_test.js
+++ b/test/channelz/channelz_manual_test.js
@@ -1,0 +1,73 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+'use strict';
+
+require('../fixtures/js_js');
+const interopClient = require('../interop/interop_client');
+const interopServer = require('../interop/interop_server');
+const serverGrpc = require('../any_grpc').server;
+
+const hostOverride = 'foo.test.google.fr';
+
+const testCases = [
+  'empty_unary',
+  'large_unary',
+  'client_streaming',
+  'server_streaming',
+  'ping_pong',
+  'empty_stream',
+  'cancel_after_begin',
+  'cancel_after_first_response',
+  'timeout_on_sleeping_server',
+  'custom_metadata',
+  'status_code_and_message',
+  'special_status_message',
+  'unimplemented_service',
+  'unimplemented_method'
+];
+
+function getRandomTest() {
+  return testCases[(Math.random() * testCases.length) | 0];
+}
+
+let testCompleteCount = 0;
+
+interopServer.getServer('0', true, (error, result) => {
+  if (error) {
+    throw error;
+  }
+  const channelzServer = new serverGrpc.Server();
+  channelzServer.bindAsync('localhost:0', serverGrpc.ServerCredentials.createInsecure(), (error, port) => {
+    if (error) {
+      throw error;
+    }
+    console.log(`Serving channelz at port ${port}`);
+    serverGrpc.addAdminServicesToServer(channelzServer);
+    channelzServer.start();
+    result.server.start();
+    setInterval(() => {
+      interopClient.runTest(`localhost:${result.port}`, hostOverride, getRandomTest(), true, true, () => {
+        testCompleteCount += 1;
+        if (testCompleteCount % 100 === 0) {
+          console.log(`Completed ${testCompleteCount} tests`);
+        }
+      });
+    }, 100);
+  });
+})

--- a/test/interop/interop_server.js
+++ b/test/interop/interop_server.js
@@ -200,7 +200,7 @@ function handleHalfDuplex(call) {
  * Get a server object bound to the given port
  * @param {string} port Port to which to bind
  * @param {boolean} tls Indicates that the bound port should use TLS
- * @param {function(Error, {{server: Server, port: number}})} callback Callback
+ * @param {function(Error, {server: Server, port: number})} callback Callback
  *     to call with result or error
  * @param {object?} options Optional additional options to use when
  *     constructing the server


### PR DESCRIPTION
Add channelz functionality to grpc-js (see [gRFC A14](https://github.com/grpc/proposal/blob/master/A14-channelz.md)), along with the admin interface (see [gRFC A38](https://github.com/grpc/proposal/blob/master/A38-admin-interface-api.md)).

There are three main parts of this change:

 - The channelz bookkeeping logic, which is spread among the first part of `channelz.ts`, `channel.ts`, `subchannel.ts`, and `server.ts`, with small parts in `call-stream.ts` and `server-call.ts` to count messages.
 - The channelz service handler code, which all lives in the second part of `channelz.ts`.
 - The admin interface, which is simply a registry of service definitions and corresponding service handlers to be added to a server as a group using the `addAdminServicesToServer` function. The registration function takes getters instead of plain objects to support retrieving those things lazily, which allows us to load the channelz service lazily so that we do not need to load `protobufjs` in applications that do not use channelz.

This change adds the following public APIs:

 - `getChannelzServiceDefinition(): ServiceDefinition`
 - `getChannelzHandlers(): ServiceHandler`
 - `addAdminServicesToServer(server: Server): void`
 - `Channel#getChannelzRef(): ChannelRef`
 - `Server#getChannelzRef(): ServerRef`

The intended use is for a user to do one of the following to serve the channelz service:

```ts
const server = new grpc.Server();
server.addService(grpc.getChannelzServiceDefinition(), grpc.getChannelzHandlers());
```

OR

```ts
const server = new grpc.Server();
grpc.addAdminServicesToServer(server);
```

In addition, I modified the channel, subchannel, and server trace logs to include the channelz ID to make them easier to cross-reference.

The new `channelz_manual_test.js` file just starts a server and a client that continuously makes requests to that server, and starts another server serving the channelz service, for a separate channelz client to examine.