### PR TITLE
grpc-js: Loosen requirements on channel option types

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -177,18 +177,8 @@ export class ChannelImplementation implements Channel {
       );
     }
     if (options) {
-      if (
-        typeof options !== 'object' ||
-        !Object.values(options).every(
-          (value) =>
-            typeof value === 'string' ||
-            typeof value === 'number' ||
-            typeof value === 'undefined'
-        )
-      ) {
-        throw new TypeError(
-          'Channel options must be an object with string or number values'
-        );
+      if (typeof options !== 'object') {
+        throw new TypeError('Channel options must be an object');
       }
     }
     const originalTargetUri = parseUri(target);


### PR DESCRIPTION
The original reason for having this requirement in the old library was for compatibility with the corresponding core type. That got carried over, but there's no real reason now to keep enforcing it, and the presence of this requirement creates a restriction that is unusual in JavaScript that prevents a wrapping library from blindly passing along an options object so that the lower-level library can simply use any options that it considers relevant. In fact, gRPC channel options are already deliberately namespaced, which makes blindly passing options even more reasonable.

In short, I want to eliminate the need for code like in googleapis/gax-nodejs#1115