### PR TITLE
grpc-js-xds: A few fixes for xDS tests

### DIFF
--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -59,7 +59,7 @@ GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weigh
     --gcp_suffix=$(date '+%s') \
     --verbose \
     ${XDS_V3_OPT-} \
-    --client_cmd="$(which node) grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client \
+    --client_cmd="$(which node) --enable-source-maps grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client \
       --server=xds:///{server_uri} \
       --stats_port={stats_port} \
       --qps={qps} \

--- a/packages/grpc-js-xds/src/xds-bootstrap.ts
+++ b/packages/grpc-js-xds/src/xds-bootstrap.ts
@@ -109,7 +109,7 @@ function validateXdsServerConfig(obj: any): XdsServerConfig {
   return {
     serverUri: obj.server_uri,
     channelCreds: obj.channel_creds.map(validateChannelCredsConfig),
-    serverFeatures: obj.server_features
+    serverFeatures: obj.server_features ?? []
   };
 }
 

--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -341,6 +341,16 @@ export class XdsClient {
           return;
         }
         trace('Loaded bootstrap info: ' + JSON.stringify(bootstrapInfo, undefined, 2));
+        if (bootstrapInfo.xdsServers.length < 1) {
+          trace('Failed to initialize xDS Client. No servers provided in bootstrap info.');
+          // Bubble this error up to any listeners
+          this.reportStreamError({
+            code: status.INTERNAL,
+            details: 'Failed to initialize xDS Client. No servers provided in bootstrap info.',
+            metadata: new Metadata(),
+          });
+          return;
+        }
         if (bootstrapInfo.xdsServers[0].serverFeatures.indexOf('xds_v3') >= 0) {
           this.apiVersion = XdsApiVersion.V3;
         } else {
@@ -425,8 +435,7 @@ export class XdsClient {
           {channelOverride: channel}
         );
         this.maybeStartLrsStream();
-      },
-      (error) => {
+      }).catch((error) => {
         trace('Failed to initialize xDS Client. ' + error.message);
         // Bubble this error up to any listeners
         this.reportStreamError({

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -309,6 +309,7 @@ export class Server {
           const http2Server = setupServer();
           return new Promise<number | Error>((resolve, reject) => {
             function onError(err: Error): void {
+              trace('Failed to bind ' + subchannelAddressToString(address) + ' with error ' + err.message);
               resolve(err);
             }
 
@@ -356,6 +357,7 @@ export class Server {
       const http2Server = setupServer();
       return new Promise<BindResult>((resolve, reject) => {
         function onError(err: Error): void {
+          trace('Failed to bind ' + subchannelAddressToString(address) + ' with error ' + err.message);
           resolve(bindWildcardPort(addressList.slice(1)));
         }
 

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -268,6 +268,10 @@ export class Server {
       };
     }
 
+    const deferredCallback = (error: Error | null, port: number) => {
+      process.nextTick(() => callback(error, port));
+    }
+
     const setupServer = (): http2.Http2Server | http2.Http2SecureServer => {
       let http2Server: http2.Http2Server | http2.Http2SecureServer;
       if (creds._isSecure()) {
@@ -386,7 +390,7 @@ export class Server {
         // We only want one resolution result. Discard all future results
         resolverListener.onSuccessfulResolution = () => {};
         if (addressList.length === 0) {
-          callback(new Error(`No addresses resolved for port ${port}`), 0);
+          deferredCallback(new Error(`No addresses resolved for port ${port}`), 0);
           return;
         }
         let bindResultPromise: Promise<BindResult>;
@@ -409,7 +413,7 @@ export class Server {
             if (bindResult.count === 0) {
               const errorString = `No address added out of total ${addressList.length} resolved`;
               logging.log(LogVerbosity.ERROR, errorString);
-              callback(new Error(errorString), 0);
+              deferredCallback(new Error(errorString), 0);
             } else {
               if (bindResult.count < addressList.length) {
                 logging.log(
@@ -417,18 +421,18 @@ export class Server {
                   `WARNING Only ${bindResult.count} addresses added out of total ${addressList.length} resolved`
                 );
               }
-              callback(null, bindResult.port);
+              deferredCallback(null, bindResult.port);
             }
           },
           (error) => {
             const errorString = `No address added out of total ${addressList.length} resolved`;
             logging.log(LogVerbosity.ERROR, errorString);
-            callback(new Error(errorString), 0);
+            deferredCallback(new Error(errorString), 0);
           }
         );
       },
       onError: (error) => {
-        callback(new Error(error.details), 0);
+        deferredCallback(new Error(error.details), 0);
       },
     };
 


### PR DESCRIPTION
This fixes a few different things for the xDS tests:

 - Enable source maps, so that error messages point to TS file lines.
 - Ensure that the `serverFeatures` field in the bootstrap file is always set, as the type specifies
 - Improve error handling and reporting in the xDS client async initialization code
 - Report specific errors when servers fail to bind ports.