### PR TITLE
grpc-js-xds: Handle all ways control-plane streams can end (1.3.x)

### DIFF
--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -459,18 +459,22 @@ export class XdsClient {
     this.adsCall.on('data', (message: DiscoveryResponse__Output) => {
       this.handleAdsResponse(message);
     });
-    this.adsCall.on('error', (error: ServiceError) => {
+    this.adsCall.on('status', (streamStatus: StatusObject) => {
       trace(
-        'ADS stream ended. code=' + error.code + ' details= ' + error.details
+        'ADS stream ended. code=' + streamStatus.code + ' details= ' + streamStatus.details
       );
       this.adsCall = null;
-      this.reportStreamError(error);
+      if (streamStatus.code !== status.OK) {
+        this.reportStreamError(streamStatus);
+      }
       /* If the backoff timer is no longer running, we do not need to wait any
        * more to start the new call. */
       if (!this.adsBackoff.isRunning()) {
         this.maybeStartAdsStream();
       }
+
     });
+    this.adsCall.on('error', () => {});
 
     const allTypeUrls: AdsTypeUrl[] = [
       EDS_TYPE_URL,
@@ -611,9 +615,9 @@ export class XdsClient {
       this.latestLrsSettings = message;
       receivedSettingsForThisStream = true;
     });
-    this.lrsCall.on('error', (error: ServiceError) => {
+    this.lrsCall.on('status', (streamStatus: StatusObject) => {
       trace(
-        'LRS stream ended. code=' + error.code + ' details= ' + error.details
+        'LRS stream ended. code=' + streamStatus.code + ' details= ' + streamStatus.details
       );
       this.lrsCall = null;
       clearInterval(this.statsTimer);
@@ -623,6 +627,7 @@ export class XdsClient {
         this.maybeStartLrsStream();
       }
     });
+    this.lrsCall.on('error', () => {});
     /* Send buffered stats information when starting LRS stream. If there is no
      * buffered stats information, it will still send the node field. */
     this.sendStats();


### PR DESCRIPTION
Same as #1920, but for 1.3.x.