### PR TITLE
grpc-js-xds: Bump to 1.3.2

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {


### PR DESCRIPTION
I think #1910 and #1921 are worth publishing as a patch.