### PR TITLE
grpc-js: Fix server trace function inconsistency

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -391,8 +391,8 @@ export class Server {
 
           const http2Server = setupServer();
           return new Promise<number | Error>((resolve, reject) => {
-            function onError(err: Error): void {
-              trace('Failed to bind ' + subchannelAddressToString(address) + ' with error ' + err.message);
+            const onError = (err: Error) => {
+              this.trace('Failed to bind ' + subchannelAddressToString(address) + ' with error ' + err.message);
               resolve(err);
             }
 
@@ -467,8 +467,8 @@ export class Server {
       const address = addressList[0];
       const http2Server = setupServer();
       return new Promise<BindResult>((resolve, reject) => {
-        function onError(err: Error): void {
-          trace('Failed to bind ' + subchannelAddressToString(address) + ' with error ' + err.message);
+        const onError = (err: Error) => {
+          this.trace('Failed to bind ' + subchannelAddressToString(address) + ' with error ' + err.message);
           resolve(bindWildcardPort(addressList.slice(1)));
         }
 


### PR DESCRIPTION
This fixes an incompatibility between `trace` calls that were added in #1917 and upmerged in #1924, and changes to the `trace` function in #1915. `onError` needs to be changed to an arrow function so that `this` refers to the server instance.