### PR TITLE
grpc-js: Add tracing of channel options in channel and subchannel constructors

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -290,6 +290,7 @@ export class ChannelImplementation implements Channel {
       new MaxMessageSizeFilterFactory(this.options),
       new CompressionFilterFactory(this),
     ]);
+    trace(LogVerbosity.DEBUG, 'channel', 'Channel constructed with options ' + JSON.stringify(options, undefined, 2));
   }
 
   private callRefTimerRef() {

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -247,6 +247,7 @@ export class Subchannel {
       this.handleBackoffTimer();
     }, backoffOptions);
     this.subchannelAddressString = subchannelAddressToString(subchannelAddress);
+    trace('Subchannel constructed with options ' + JSON.stringify(options, undefined, 2));
   }
 
   private handleBackoffTimer() {


### PR DESCRIPTION
This can help debugging whether options get passed down from wrapping libraries to channels (and subchannels).