### PR TITLE
grpc-js: Add tracing of channel options in channel and subchannel constructors

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -311,7 +311,7 @@ export class ChannelImplementation implements Channel {
       new MaxMessageSizeFilterFactory(this.options),
       new CompressionFilterFactory(this),
     ]);
-    this.trace('Constructed channel');
+    this.trace('Channel constructed with options ' + JSON.stringify(options, undefined, 2));
   }
 
   private getChannelzInfo(): ChannelInfo {

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -229,7 +229,7 @@ export class Subchannel {
     this.channelzRef = registerChannelzSubchannel(this.subchannelAddressString, () => this.getChannelzInfo());
     this.channelzTrace = new ChannelzTrace();
     this.channelzTrace.addTrace('CT_INFO', 'Subchannel created');
-    this.trace('Subchannel constructed');
+    this.trace('Subchannel constructed with options ' + JSON.stringify(options, undefined, 2));
   }
 
   private getChannelzInfo(): SubchannelInfo {


### PR DESCRIPTION
Same as #1932, but on 1.4.x, with the modified tracing APIs