### PR TITLE
Drop testing on Node 8, add 14 and 16

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,7 +28,7 @@ cd $ROOT
 git submodule update --init --recursive
 
 if [ ! -n "$node_versions" ] ; then
-  node_versions="8 10 12"
+  node_versions="10 12 14 16"
 fi
 
 set +ex


### PR DESCRIPTION
Now that grpc-js setup generates code for channelz, our test setup no longer runs on Node 8, so testing on Node 8 is too much of a hassle. Since Node 8 is well past EOL, the number of people who may be impacted by not having these tests should be very small.

Since I was changing that list anyway, I figured we might as well add 14 and 16.