### PR TITLE
proto-loader: Make serializers reject arrays

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "author": "Google Inc.",
   "contributors": [
     {

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -212,6 +212,9 @@ function createDeserializer(
 
 function createSerializer(cls: Protobuf.Type): Serialize<object> {
   return function serialize(arg: object): Buffer {
+    if (Array.isArray(arg)) {
+      throw new Error(`Failed to serialize message: expected object with ${cls.name} structure, got array instead`);
+    }
     const message = cls.fromObject(arg);
     return cls.encode(message).finish() as Buffer;
   };


### PR DESCRIPTION
I keep seeing a very specific mistake where people define a message type with a single repeated field and then try to send a message of that type by sending an array that matches that field's type. This never works, in the sense that it never sends a message with the intended information to the remote end, so this change just makes it fail faster and more clearly.