### PR TITLE
grpc-js: Limit the number of retained channelz trace events

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
This limits the number of trace events that can be retained at any one time per channel/subchannel/server, in an attempt to limit the total memory usage and hopefully fix #1941.

[channelz.proto has the following comment](https://github.com/grpc/grpc-proto/blob/master/grpc/channelz/v1/channelz.proto#L148-L150) on the `num_events_logged` field of the `ChannelTrace` message:

> Number of events ever logged in this tracing object. This can differ from events.size() because events can be overwritten or garbage collected by implementations.

I am interpreting this as permission to discard old events when the implementation decides it is necessary.