### PR TITLE
grpc-js: Allow users to disable channelz

### DIFF
--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -36,6 +36,7 @@ export interface ChannelOptions {
   'grpc.enable_http_proxy'?: number;
   'grpc.http_connect_target'?: string;
   'grpc.http_connect_creds'?: string;
+  'grpc.enable_channelz'?: number;
   'grpc-node.max_session_memory'?: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
@@ -61,6 +62,7 @@ export const recognizedOptions = {
   'grpc.max_send_message_length': true,
   'grpc.max_receive_message_length': true,
   'grpc.enable_http_proxy': true,
+  'grpc.enable_channelz': true,
   'grpc-node.max_session_memory': true,
 };
 


### PR DESCRIPTION
This change enables the functionality of the channel option [`grpc.enable_channelz`](https://grpc.github.io/grpc/core/group__grpc__arg__keys.html#ga169f04dc1fa795c27b0daeda33c16999), which allows users to disable channelz stats gathering and tracing in a channel or server.