### PR TITLE
grpc-js-xds: Improve received resource list logging

### DIFF
--- a/packages/grpc-js-xds/src/xds-stream-state/cds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/cds-state.ts
@@ -158,7 +158,7 @@ export class CdsState implements XdsStreamState<Cluster__Output> {
         watcher.onValidUpdate(message, isV2);
       }
     }
-    trace('Received CDS updates for cluster names ' + Array.from(allClusterNames));
+    trace('Received CDS updates for cluster names [' + Array.from(allClusterNames) + ']');
     this.handleMissingNames(allClusterNames);
     this.edsState.handleMissingNames(allEdsServiceNames);
     return null;

--- a/packages/grpc-js-xds/src/xds-stream-state/eds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/eds-state.ts
@@ -162,7 +162,7 @@ export class EdsState implements XdsStreamState<ClusterLoadAssignment__Output> {
         watcher.onValidUpdate(message, isV2);
       }
     }
-    trace('Received EDS updates for cluster names ' + Array.from(allClusterNames));
+    trace('Received EDS updates for cluster names [' + Array.from(allClusterNames) + ']');
     return null;
   }
 

--- a/packages/grpc-js-xds/src/xds-stream-state/lds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/lds-state.ts
@@ -175,7 +175,7 @@ export class LdsState implements XdsStreamState<Listener__Output> {
         watcher.onValidUpdate(message, isV2);
       }
     }
-    trace('Received RDS response with route config names ' + Array.from(allTargetNames));
+    trace('Received LDS response with listener names [' + Array.from(allTargetNames) + ']');
     this.handleMissingNames(allTargetNames);
     this.rdsState.handleMissingNames(allRouteConfigNames);
     return null;

--- a/packages/grpc-js-xds/src/xds-stream-state/rds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/rds-state.ts
@@ -199,7 +199,7 @@ export class RdsState implements XdsStreamState<RouteConfiguration__Output> {
         watcher.onValidUpdate(message, isV2);
       }
     }
-    trace('Received RDS response with route config names ' + Array.from(allRouteConfigNames));
+    trace('Received RDS response with route config names [' + Array.from(allRouteConfigNames) + ']');
     return null;
   }
 


### PR DESCRIPTION
First, this adds square brackets around the list of received names so that if the list is empty, it's clear that something was supposed to be there, and second, this fixes the LDS resource log to actually say "LDS" instead of "RDS".