### PR TITLE
grpc-js-xds: Use valid resources when NACKing messages

### DIFF
--- a/packages/grpc-js-xds/src/xds-stream-state/cds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/cds-state.ts
@@ -137,17 +137,21 @@ export class CdsState implements XdsStreamState<Cluster__Output> {
   }
 
   handleResponses(responses: Cluster__Output[], isV2: boolean): string | null {
+    const validResponses: Cluster__Output[] = [];
+    let errorMessage: string | null = null;
     for (const message of responses) {
-      if (!this.validateResponse(message)) {
+      if (this.validateResponse(message)) {
+        validResponses.push(message);
+      } else {
         trace('CDS validation failed for message ' + JSON.stringify(message));
-        return 'CDS Error: Cluster validation failed';
+        errorMessage = 'CDS Error: Cluster validation failed';
       }
     }
-    this.latestResponses = responses;
+    this.latestResponses = validResponses;
     this.latestIsV2 = isV2;
     const allEdsServiceNames: Set<string> = new Set<string>();
     const allClusterNames: Set<string> = new Set<string>();
-    for (const message of responses) {
+    for (const message of validResponses) {
       allClusterNames.add(message.name);
       const edsServiceName = message.eds_cluster_config?.service_name ?? '';
       allEdsServiceNames.add(
@@ -161,7 +165,7 @@ export class CdsState implements XdsStreamState<Cluster__Output> {
     trace('Received CDS updates for cluster names ' + Array.from(allClusterNames));
     this.handleMissingNames(allClusterNames);
     this.edsState.handleMissingNames(allEdsServiceNames);
-    return null;
+    return errorMessage;
   }
 
   reportStreamError(status: StatusObject): void {

--- a/packages/grpc-js-xds/src/xds-stream-state/eds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/eds-state.ts
@@ -146,16 +146,20 @@ export class EdsState implements XdsStreamState<ClusterLoadAssignment__Output> {
   }
 
   handleResponses(responses: ClusterLoadAssignment__Output[], isV2: boolean) {
+    const validResponses: ClusterLoadAssignment__Output[] = [];
+    let errorMessage: string | null = null;
     for (const message of responses) {
-      if (!this.validateResponse(message)) {
+      if (this.validateResponse(message)) {
+        validResponses.push(message);
+      } else {
         trace('EDS validation failed for message ' + JSON.stringify(message));
-        return 'EDS Error: ClusterLoadAssignment validation failed';
+        errorMessage = 'EDS Error: ClusterLoadAssignment validation failed';
       }
     }
-    this.latestResponses = responses;
+    this.latestResponses = validResponses;
     this.latestIsV2 = isV2;
     const allClusterNames: Set<string> = new Set<string>();
-    for (const message of responses) {
+    for (const message of validResponses) {
       allClusterNames.add(message.cluster_name);
       const watchers = this.watchers.get(message.cluster_name) ?? [];
       for (const watcher of watchers) {
@@ -163,7 +167,7 @@ export class EdsState implements XdsStreamState<ClusterLoadAssignment__Output> {
       }
     }
     trace('Received EDS updates for cluster names ' + Array.from(allClusterNames));
-    return null;
+    return errorMessage;
   }
 
   reportStreamError(status: StatusObject): void {


### PR DESCRIPTION
In accordance with [A46: xDS NACK Semantics Improvement](https://github.com/grpc/proposal/blob/master/A46-xds-nack-semantics-improvement.md), when NACKing response messages because some resources failed validation, use any other resources that passed validation, instead of discarding them.