### PR TITLE
feat(client): export `ServiceClientConstructor` type 

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -42,7 +42,9 @@ import {
   loadPackageDefinition,
   makeClientConstructor,
   MethodDefinition,
+  ProtobufTypeDefinition,
   Serialize,
+  ServiceClientConstructor,
   ServiceDefinition,
 } from './make-client';
 import { Metadata, MetadataValue } from './metadata';
@@ -245,7 +247,11 @@ export {
   InterceptorConfigurationError,
 } from './client-interceptors';
 
-export { GrpcObject } from './make-client';
+export {
+  GrpcObject,
+  ServiceClientConstructor,
+  ProtobufTypeDefinition
+} from './make-client';
 
 export { ChannelOptions } from './channel-options';
 


### PR DESCRIPTION
export `ServiceClientConstructor,  ProtobufTypeDefinition` .

When writing a server configured with [dynamic_codegen](https://github.com/grpc/grpc/blob/v1.41.0/examples/node/dynamic_codegen/greeter_server.js#L31) in TypeScript, it is necessary to TypeHint the value read from proto, and being able to annotate with this type helps it be a bit more seamless

# example dynamic_codegen ts code diff
orig: https://github.com/grpc/grpc/blob/v1.41.0/examples/node/dynamic_codegen/greeter_server.js
```diff
var PROTO_PATH = __dirname + '/../../../examples/proto/helloworld.proto';

import * as grpc from '@grpc/grpc-js'
- import {ServiceClientConstructor} from '@grpc/grpc-js/build/src/make-client'
import * as protoLoader from '@grpc/proto-loader'

const packageDefinition = protoLoader.loadSync(
    PROTO_PATH,
    {keepCase: true,
      longs: String,
      enums: String,
      defaults: true,
      oneofs: true
    });
const hello_proto = grpc.loadPackageDefinition(packageDefinition).helloworld as grpc.GrpcObject;

/**
 * Implements the SayHello RPC method.
 */
function sayHello(call: any, callback: any) {
  callback(null, {message: 'Hello ' + call.request.name});
}

/**
 * Starts an RPC server that receives requests for the Greeter service at the
 * sample server port
 */
function main() {
  var server = new grpc.Server();
-  server.addService((hello_proto.Greeter as ServiceClientConstructor).service, {sayHello: sayHello});
+  server.addService((hello_proto.Greeter as grpc.ServiceClientConstructor).service, {sayHello: sayHello});
  server.bindAsync('localhost:50051', grpc.ServerCredentials.createInsecure(), () => {
    server.start();
  });
}

main();

```
