### PR TITLE
grpc-js: Handle undefined `socket.localAddress` (1.4.x)

### DIFF
--- a/packages/grpc-js/src/channelz.ts
+++ b/packages/grpc-js/src/channelz.ts
@@ -298,7 +298,7 @@ export interface TlsInfo {
 }
 
 export interface SocketInfo {
-  localAddress: SubchannelAddress;
+  localAddress: SubchannelAddress | null;
   remoteAddress: SubchannelAddress | null;
   security: TlsInfo | null;
   remoteName: string | null;
@@ -629,7 +629,7 @@ function GetSocket(call: ServerUnaryCall<GetSocketRequest__Output, GetSocketResp
   } : null;
   const socketMessage: SocketMessage = {
     ref: socketRefToMessage(socketEntry.ref),
-    local: subchannelAddressToAddressMessage(resolvedInfo.localAddress),
+    local: resolvedInfo.localAddress ? subchannelAddressToAddressMessage(resolvedInfo.localAddress) : null,
     remote: resolvedInfo.remoteAddress ? subchannelAddressToAddressMessage(resolvedInfo.remoteAddress) : null,
     remote_name: resolvedInfo.remoteName ?? undefined,
     security: securityMessage,

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -188,7 +188,7 @@ export class Server {
       const sessionInfo = this.sessions.get(session)!;
       const sessionSocket = session.socket;
       const remoteAddress = sessionSocket.remoteAddress ? stringToSubchannelAddress(sessionSocket.remoteAddress, sessionSocket.remotePort) : null;
-      const localAddress = stringToSubchannelAddress(sessionSocket.localAddress, sessionSocket.localPort);
+      const localAddress = sessionSocket.localAddress ? stringToSubchannelAddress(sessionSocket.localAddress!, sessionSocket.localPort) : null;
       let tlsInfo: TlsInfo | null;
       if (session.encrypted) {
         const tlsSocket: TLSSocket = sessionSocket as TLSSocket;

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -261,7 +261,7 @@ export class Subchannel {
     }
     const sessionSocket = this.session.socket;
     const remoteAddress = sessionSocket.remoteAddress ? stringToSubchannelAddress(sessionSocket.remoteAddress, sessionSocket.remotePort) : null;
-    const localAddress = stringToSubchannelAddress(sessionSocket.localAddress, sessionSocket.localPort);
+    const localAddress = sessionSocket.localAddress ? stringToSubchannelAddress(sessionSocket.localAddress, sessionSocket.localPort) : null;
     let tlsInfo: TlsInfo | null;
     if (this.session.encrypted) {
       const tlsSocket: TLSSocket = sessionSocket as TLSSocket;


### PR DESCRIPTION
Backport of #1953.