### PR TITLE
grpc-js: Fix trailers-only response handling

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -524,6 +524,10 @@ export class Http2CallStream implements Call {
         }
 
         if (flags & http2.constants.NGHTTP2_FLAG_END_STREAM) {
+          /* NGHTTP2_FLAG_END_STREAM indicates that this is a trailers-only
+           * response, so we know that we will not be receiving any messages
+           * after this. */
+          this.readsClosed = true;
           this.handleTrailers(headers);
         } else {
           let metadata: Metadata;
@@ -561,6 +565,7 @@ export class Http2CallStream implements Call {
         }
       });
       stream.on('end', () => {
+        this.trace('finished receiving HTTP/2 data frames');
         this.readsClosed = true;
         this.maybeOutputStatus();
       });


### PR DESCRIPTION
We received a user report that when receiving a server stream with no messages from a Java server in particular, users would not get an `end` event from the call. Java servers send trailers-only responses, so this seems like a bug in the trailers-only response handling. The only thing I can think of causing this is the `ClientHttp2Stream` not emitting an `end` event when receiving a trailers-only response, causing the `readsClosed` flag to never be set and the `Http2CallStream` to never output a status, because of [this check](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/call-stream.ts#L343-L351). So, this change sets that flag and adds logging to the `ClientHttp2Stream` `end` event to verify what is happening.