### PR TITLE
grpc-js: Fix handling of grpc.enable_channelz option

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -832,6 +832,7 @@ export class Subchannel {
         headersString
     );
     const streamSession = this.session;
+    let statsTracker: SubchannelCallStatsTracker;
     if (this.channelzEnabled) {
       this.callTracker.addCallStarted();
       callStream.addStatusWatcher(status => {
@@ -851,7 +852,7 @@ export class Subchannel {
           }
         }
       });
-      callStream.attachHttp2Stream(http2Stream, this, extraFilters, {
+      statsTracker = {
         addMessageSent: () => {
           this.messagesSent += 1;
           this.lastMessageSentTimestamp = new Date();
@@ -859,8 +860,14 @@ export class Subchannel {
         addMessageReceived: () => {
           this.messagesReceived += 1;
         }
-      });
+      }
+    } else {
+      statsTracker = {
+        addMessageSent: () => {},
+        addMessageReceived: () => {}
+      }
     }
+    callStream.attachHttp2Stream(http2Stream, this, extraFilters, statsTracker);
   }
 
   /**


### PR DESCRIPTION
When I added support for that option I was a little overzealous with making code conditional and I accidentally made attaching an http2 stream to a call conditional on channelz being enabled. There is now a test that the basic functionality still works with that option set.