### PR TITLE
grpc-js: Remove an extra call to registerChannelzSocket

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -555,7 +555,6 @@ export class Subchannel {
           (error as Error).message
       );
     });
-    registerChannelzSocket(this.subchannelAddressString, () => this.getChannelzSocketInfo()!);
   }
 
   private startConnectingInternal() {


### PR DESCRIPTION
That line shouldn't be there at all. It just creates an orphaned socket reference that can never be cleaned up.