### PR TITLE
grpc-js: Don't pass undefined checkServerIdentity

### DIFF
--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -183,9 +183,12 @@ class SecureChannelCredentialsImpl extends ChannelCredentials {
       ciphers: CIPHER_SUITES,
     });
     this.connectionOptions = { 
-      secureContext,
-      checkServerIdentity: verifyOptions?.checkServerIdentity
+      secureContext
     };
+    // Node asserts that this option is a function, so we cannot pass undefined
+    if (verifyOptions?.checkServerIdentity) {
+      this.connectionOptions.checkServerIdentity = verifyOptions.checkServerIdentity;
+    }
   }
 
   compose(callCredentials: CallCredentials): ChannelCredentials {


### PR DESCRIPTION
This is a fix for #1968. Unconditionally setting the option to `verifyOptions?.checkServerIdentity` sets the value to `undefined` if the original value is unset. Node (at least in version 10) asserts that the value is a function if it is set, so this causes an assertion error.