### PR TITLE
grpc-js-xds: Remove LDS and CDS code for removing RDS and EDS entries

### DIFF
--- a/packages/grpc-js-xds/src/xds-stream-state/cds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/cds-state.ts
@@ -149,14 +149,9 @@ export class CdsState implements XdsStreamState<Cluster__Output> {
     }
     this.latestResponses = validResponses;
     this.latestIsV2 = isV2;
-    const allEdsServiceNames: Set<string> = new Set<string>();
     const allClusterNames: Set<string> = new Set<string>();
     for (const message of validResponses) {
       allClusterNames.add(message.name);
-      const edsServiceName = message.eds_cluster_config?.service_name ?? '';
-      allEdsServiceNames.add(
-        edsServiceName === '' ? message.name : edsServiceName
-      );
       const watchers = this.watchers.get(message.name) ?? [];
       for (const watcher of watchers) {
         watcher.onValidUpdate(message, isV2);
@@ -164,7 +159,6 @@ export class CdsState implements XdsStreamState<Cluster__Output> {
     }
     trace('Received CDS updates for cluster names ' + Array.from(allClusterNames));
     this.handleMissingNames(allClusterNames);
-    this.edsState.handleMissingNames(allEdsServiceNames);
     return errorMessage;
   }
 

--- a/packages/grpc-js-xds/src/xds-stream-state/eds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/eds-state.ts
@@ -128,23 +128,6 @@ export class EdsState implements XdsStreamState<ClusterLoadAssignment__Output> {
     return true;
   }
 
-  /**
-   * Given a list of edsServiceNames (which may actually be the cluster name),
-   * for each watcher watching a name not on the list, call that watcher's
-   * onResourceDoesNotExist method.
-   * @param allClusterNames
-   */
-  handleMissingNames(allEdsServiceNames: Set<string>) {
-    for (const [edsServiceName, watcherList] of this.watchers.entries()) {
-      if (!allEdsServiceNames.has(edsServiceName)) {
-        trace('Reporting EDS resource does not exist for edsServiceName ' + edsServiceName);
-        for (const watcher of watcherList) {
-          watcher.onResourceDoesNotExist();
-        }
-      }
-    }
-  }
-
   handleResponses(responses: ClusterLoadAssignment__Output[], isV2: boolean) {
     const validResponses: ClusterLoadAssignment__Output[] = [];
     let errorMessage: string | null = null;

--- a/packages/grpc-js-xds/src/xds-stream-state/lds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/lds-state.ts
@@ -167,13 +167,8 @@ export class LdsState implements XdsStreamState<Listener__Output> {
     this.latestResponses = validResponses;
     this.latestIsV2 = isV2;
     const allTargetNames = new Set<string>();
-    const allRouteConfigNames = new Set<string>();
     for (const message of validResponses) {
       allTargetNames.add(message.name);
-      const httpConnectionManager = decodeSingleResource(HTTP_CONNECTION_MANGER_TYPE_URL_V3, message.api_listener!.api_listener!.value);
-      if (httpConnectionManager.rds) {
-        allRouteConfigNames.add(httpConnectionManager.rds.route_config_name);
-      }
       const watchers = this.watchers.get(message.name) ?? [];
       for (const watcher of watchers) {
         watcher.onValidUpdate(message, isV2);
@@ -181,7 +176,6 @@ export class LdsState implements XdsStreamState<Listener__Output> {
     }
     trace('Received RDS response with route config names ' + Array.from(allTargetNames));
     this.handleMissingNames(allTargetNames);
-    this.rdsState.handleMissingNames(allRouteConfigNames);
     return errorMessage;
   }
 

--- a/packages/grpc-js-xds/src/xds-stream-state/rds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/rds-state.ts
@@ -172,16 +172,6 @@ export class RdsState implements XdsStreamState<RouteConfiguration__Output> {
     return true;
   }
 
-  handleMissingNames(allRouteConfigNames: Set<string>) {
-    for (const [routeConfigName, watcherList] of this.watchers.entries()) {
-      if (!allRouteConfigNames.has(routeConfigName)) {
-        for (const watcher of watcherList) {
-          watcher.onResourceDoesNotExist();
-        }
-      }
-    }
-  }
-
   handleResponses(responses: RouteConfiguration__Output[], isV2: boolean): string | null {
     const validResponses: RouteConfiguration__Output[] = [];
     let errorMessage: string | null = null;


### PR DESCRIPTION
This is the Node version of grpc/grpc#28128. The code that is being removed here is redundant with the code that removes a resource when its last watcher is removed, which will happen anyway in situations when the parent resource no longer refers to it.