### PR TITLE
grpc-js-xds: Include additional paths when loading csds protos

### DIFF
--- a/packages/grpc-js-xds/src/csds.ts
+++ b/packages/grpc-js-xds/src/csds.ts
@@ -205,6 +205,8 @@ const loadedProto = loadSync('envoy/service/status/v3/csds.proto', {
     // Paths are relative to src/build
     __dirname + '/../../deps/envoy-api/',
     __dirname + '/../../deps/xds/',
+    __dirname + '/../../deps/protoc-gen-validate/',
+    __dirname + '/../../deps/googleapis/'
   ],
 });
 


### PR DESCRIPTION
The absence of those paths was causing warnings but not errors.