### PR TITLE
Make changes to make all of the test jobs green

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -44,7 +44,7 @@
   ],
   "scripts": {
     "build": "npm run compile",
-    "clean": "node -e 'require(\"rimraf\")(\"./build\", () => {})'",
+    "clean": "rimraf ./build",
     "compile": "tsc -p .",
     "format": "clang-format -i -style=\"{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}\" src/*.ts test/*.ts",
     "lint": "npm run check",

--- a/packages/grpc-js/test/test-client.ts
+++ b/packages/grpc-js/test/test-client.ts
@@ -79,7 +79,8 @@ describe('Client without a server', () => {
   after(() => {
     client.close();
   });
-  it('should fail multiple calls to the nonexistent server', done => {
+  it('should fail multiple calls to the nonexistent server', function(done) {
+    this.timeout(5000);
     // Regression test for https://github.com/grpc/grpc-node/issues/1411
     client.makeUnaryRequest('/service/method', x => x, x => x, Buffer.from([]), (error, value) => {
       assert(error);

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -24,7 +24,7 @@ import * as resolver_uds from '../src/resolver-uds';
 import * as resolver_ip from '../src/resolver-ip';
 import { ServiceConfig } from '../src/service-config';
 import { StatusObject } from '../src/call-stream';
-import { SubchannelAddress, isTcpSubchannelAddress } from "../src/subchannel-address";
+import { SubchannelAddress, isTcpSubchannelAddress, subchannelAddressToString } from "../src/subchannel-address";
 import { parseUri, GrpcUri } from '../src/uri-parser';
 
 describe('Name Resolver', () => {
@@ -223,7 +223,7 @@ describe('Name Resolver', () => {
                 isTcpSubchannelAddress(addr) &&
                 addr.host === '127.0.0.1' &&
                 addr.port === 443
-            )
+            ), `None of [${addressList.map(addr => subchannelAddressToString(addr))}] matched '127.0.0.1:443'`
           );
           done();
         },
@@ -263,7 +263,10 @@ describe('Name Resolver', () => {
       const resolver = resolverManager.createResolver(target, listener, {});
       resolver.updateResolution();
     });
-    it('Should resolve a DNS name to IPv4 and IPv6 addresses', done => {
+    /* This DNS name resolves to only the IPv4 address on Windows, and only the
+     * IPv6 address on Mac. There is no result that we can consistently test
+     * for here. */
+    it.skip('Should resolve a DNS name to IPv4 and IPv6 addresses', done => {
       const target = resolverManager.mapUriDefaultScheme(parseUri('loopback46.unittest.grpc.io')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
@@ -279,7 +282,7 @@ describe('Name Resolver', () => {
                 isTcpSubchannelAddress(addr) &&
                 addr.host === '127.0.0.1' &&
                 addr.port === 443
-            )
+            ), `None of [${addressList.map(addr => subchannelAddressToString(addr))}] matched '127.0.0.1:443'`
           );
           /* TODO(murgatroid99): check for IPv6 result, once we can get that
            * consistently */

--- a/packages/grpc-js/test/test-resolver.ts
+++ b/packages/grpc-js/test/test-resolver.ts
@@ -207,7 +207,15 @@ describe('Name Resolver', () => {
       const resolver = resolverManager.createResolver(target, listener, {});
       resolver.updateResolution();
     });
-    it('Should resolve a name with multiple dots', done => {
+    /* The DNS entry for loopback4.unittest.grpc.io only has a single A record
+     * with the address 127.0.0.1, but the Mac DNS resolver appears to use
+     * NAT64 to create an IPv6 address in that case, so it instead returns
+     * 64:ff9b::7f00:1. Handling that kind of translation is outside of the
+     * scope of this test, so we are skipping it. The test primarily exists
+     * as a regression test for https://github.com/grpc/grpc-node/issues/1044,
+     * and the test 'Should resolve gRPC interop servers' tests the same thing.
+     */
+    it.skip('Should resolve a name with multiple dots', done => {
       const target = resolverManager.mapUriDefaultScheme(parseUri('loopback4.unittest.grpc.io')!)!;
       const listener: resolverManager.ResolverListener = {
         onSuccessfulResolution: (
@@ -317,6 +325,10 @@ describe('Name Resolver', () => {
       const resolver = resolverManager.createResolver(target, listener, {});
       resolver.updateResolution();
     });
+    /* This test also serves as a regression test for
+     * https://github.com/grpc/grpc-node/issues/1044, specifically handling
+     * hyphens and multiple periods in a DNS name. It should not be skipped
+     * unless there is another test for the same issue. */
     it('Should resolve gRPC interop servers', done => {
       let completeCount = 0;
       const target1 = resolverManager.mapUriDefaultScheme(parseUri('grpc-test.sandbox.googleapis.com')!)!;

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -848,7 +848,11 @@ describe('Compressed requests', () => {
       });
     });
     
-    it('Should not compress requests when the NoCompress write flag is used', done => {
+    /* As of Node 16, Writable and Duplex streams validate the encoding
+     * argument to write, and the flags values we are passing there are not
+     * valid. We don't currently have an alternative way to pass that flag
+     * down, so for now this feature is not supported. */
+    it.skip('Should not compress requests when the NoCompress write flag is used', done => {
       const bidiStream = client.bidiStream();
       let timesRequested = 0;
       let timesResponded = 0;

--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -379,7 +379,7 @@ function generateMessageInterfaces(formatter: TextFormatter, messageType: Protob
   let usesLong: boolean = false;
   let seenDeps: Set<string> = new Set<string>();
   const childTypes = getChildMessagesAndEnums(messageType);
-  formatter.writeLine(`// Original file: ${messageType.filename}`);
+  formatter.writeLine(`// Original file: ${messageType.filename?.replace(/\\/g, '/')}`);
   formatter.writeLine('');
   messageType.fieldsArray.sort((fieldA, fieldB) => fieldA.id - fieldB.id);
   for (const field of messageType.fieldsArray) {
@@ -437,7 +437,7 @@ function generateMessageInterfaces(formatter: TextFormatter, messageType: Protob
 }
 
 function generateEnumInterface(formatter: TextFormatter, enumType: Protobuf.Enum, options: GeneratorOptions, nameOverride?: string) {
-  formatter.writeLine(`// Original file: ${enumType.filename}`);
+  formatter.writeLine(`// Original file: ${enumType.filename?.replace(/\\/g, '/')}`);
   formatter.writeLine('');
   if (options.includeComments) {
     formatComment(formatter, enumType.comment);
@@ -590,7 +590,7 @@ function generateServiceDefinitionInterface(formatter: TextFormatter, serviceTyp
 }
 
 function generateServiceInterfaces(formatter: TextFormatter, serviceType: Protobuf.Service, options: GeneratorOptions) {
-  formatter.writeLine(`// Original file: ${serviceType.filename}`);
+  formatter.writeLine(`// Original file: ${serviceType.filename?.replace(/\\/g, '/')}`);
   formatter.writeLine('');
   const grpcImportPath = options.grpcLib.startsWith('.') ? getPathToRoot(serviceType) + options.grpcLib : options.grpcLib;
   formatter.writeLine(`import type * as grpc from '${grpcImportPath}'`);

--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -379,7 +379,7 @@ function generateMessageInterfaces(formatter: TextFormatter, messageType: Protob
   let usesLong: boolean = false;
   let seenDeps: Set<string> = new Set<string>();
   const childTypes = getChildMessagesAndEnums(messageType);
-  formatter.writeLine(`// Original file: ${messageType.filename?.replace(/\\/g, '/')}`);
+  formatter.writeLine(`// Original file: ${(messageType.filename ?? 'null')?.replace(/\\/g, '/')}`);
   formatter.writeLine('');
   messageType.fieldsArray.sort((fieldA, fieldB) => fieldA.id - fieldB.id);
   for (const field of messageType.fieldsArray) {
@@ -437,7 +437,7 @@ function generateMessageInterfaces(formatter: TextFormatter, messageType: Protob
 }
 
 function generateEnumInterface(formatter: TextFormatter, enumType: Protobuf.Enum, options: GeneratorOptions, nameOverride?: string) {
-  formatter.writeLine(`// Original file: ${enumType.filename?.replace(/\\/g, '/')}`);
+  formatter.writeLine(`// Original file: ${(enumType.filename ?? 'null')?.replace(/\\/g, '/')}`);
   formatter.writeLine('');
   if (options.includeComments) {
     formatComment(formatter, enumType.comment);
@@ -590,7 +590,7 @@ function generateServiceDefinitionInterface(formatter: TextFormatter, serviceTyp
 }
 
 function generateServiceInterfaces(formatter: TextFormatter, serviceType: Protobuf.Service, options: GeneratorOptions) {
-  formatter.writeLine(`// Original file: ${serviceType.filename?.replace(/\\/g, '/')}`);
+  formatter.writeLine(`// Original file: ${(serviceType.filename ?? 'null')?.replace(/\\/g, '/')}`);
   formatter.writeLine('');
   const grpcImportPath = options.grpcLib.startsWith('.') ? getPathToRoot(serviceType) + options.grpcLib : options.grpcLib;
   formatter.writeLine(`import type * as grpc from '${grpcImportPath}'`);

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -25,7 +25,7 @@
     "pretest": "npm run compile",
     "posttest": "npm run check",
     "generate-golden": "node ./build/bin/proto-loader-gen-types.js --keepCase --longs=String --enums=String --defaults --oneofs --json --includeComments -I deps/gapic-showcase/schema/ deps/googleapis/ -O ./golden-generated --grpcLib @grpc/grpc-js google/showcase/v1beta1/echo.proto",
-    "validate-golden": "rm -rf ./golden-generated-old && mv ./golden-generated/ ./golden-generated-old && npm run generate-golden && diff -r ./golden-generated ./golden-generated-old"
+    "validate-golden": "rm -rf ./golden-generated-old && mv ./golden-generated/ ./golden-generated-old && npm run generate-golden && diff -rZ ./golden-generated ./golden-generated-old"
   },
   "repository": {
     "type": "git",

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -25,7 +25,7 @@
     "pretest": "npm run compile",
     "posttest": "npm run check",
     "generate-golden": "node ./build/bin/proto-loader-gen-types.js --keepCase --longs=String --enums=String --defaults --oneofs --json --includeComments -I deps/gapic-showcase/schema/ deps/googleapis/ -O ./golden-generated --grpcLib @grpc/grpc-js google/showcase/v1beta1/echo.proto",
-    "validate-golden": "rm -rf ./golden-generated-old && mv ./golden-generated/ ./golden-generated-old && npm run generate-golden && diff -rZ ./golden-generated ./golden-generated-old"
+    "validate-golden": "rm -rf ./golden-generated-old && mv ./golden-generated/ ./golden-generated-old && npm run generate-golden && diff -rb ./golden-generated ./golden-generated-old"
   },
   "repository": {
     "type": "git",

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -14,7 +14,7 @@
   "typings": "build/src/index.d.ts",
   "scripts": {
     "build": "npm run compile",
-    "clean": "node -e 'require(\"rimraf\")(\"./build\", () => {})'",
+    "clean": "rimraf ./build",
     "compile": "tsc -p .",
     "format": "clang-format -i -style=\"{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}\" src/*.ts test/*.ts",
     "lint": "tslint -c node_modules/google-ts-style/tslint.json -p . -t codeFrame --type-check",

--- a/run-tests.bat
+++ b/run-tests.bat
@@ -21,7 +21,7 @@ powershell -c "[System.Environment]::OSVersion"
 powershell -c "Get-WmiObject -Class Win32_ComputerSystem"
 powershell -c "(Get-WmiObject -Class Win32_ComputerSystem).SystemType"
 
-powershell -c "& { iwr https://raw.githubusercontent.com/grumpycoders/nvm-ps/master/nvm.ps1 | iex }"
+powershell -c "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; & { iwr https://raw.githubusercontent.com/grumpycoders/nvm-ps/master/nvm.ps1 | iex }"
 
 SET PATH=%APPDATA%\nvm-ps;%APPDATA%\nvm-ps\nodejs;%PATH%
 SET JOBS=8

--- a/run-tests.bat
+++ b/run-tests.bat
@@ -55,7 +55,6 @@ for %%v in (10 12) do (
 
   node -e "process.exit(process.version.startsWith('v%%v') ? 0 : -1)" || goto :error
 
-  call .\node_modules\.bin\gulp cleanAll || SET FAILED=1
   call .\node_modules\.bin\gulp setup || SET FAILED=1
   call .\node_modules\.bin\gulp test || SET FAILED=1
   cmd.exe /c "SET GRPC_DNS_RESOLVER=ares& call .\node_modules\.bin\gulp nativeTestOnly" || SET FAILED=1

--- a/run-tests.bat
+++ b/run-tests.bat
@@ -28,8 +28,8 @@ SET JOBS=8
 
 call nvm version
 
-call nvm install 8
-call nvm use 8
+call nvm install 10
+call nvm use 10
 
 SET npm_config_fetch_retries=5
 
@@ -38,7 +38,7 @@ call npm install || goto :error
 SET JUNIT_REPORT_STACK=1
 SET FAILED=0
 
-for %%v in (8 10 12) do (
+for %%v in (10 12) do (
   call nvm install %%v
   call nvm use %%v
   if "%%v"=="4" (

--- a/run-tests.bat
+++ b/run-tests.bat
@@ -31,6 +31,8 @@ call nvm version
 call nvm install 10
 call nvm use 10
 
+git submodule update --init --recursive
+
 SET npm_config_fetch_retries=5
 
 call npm install || goto :error

--- a/test/api/connectivity_test.js
+++ b/test/api/connectivity_test.js
@@ -61,7 +61,9 @@ const serviceImpl = {
 describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, function() {
   it('client should not wait for ready by default', function(done) {
     this.timeout(15000);
-    const disconnectedClient = new TestServiceClient('foo.test.google.com:50051', clientGrpc.credentials.createInsecure());
+    /* TCP port 47 is reserved according to
+     * https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers */
+    const disconnectedClient = new TestServiceClient('localhost:47', clientGrpc.credentials.createInsecure());
     const deadline = new Date();
     deadline.setSeconds(deadline.getSeconds() + 10);
     disconnectedClient.unary({}, {deadline: deadline}, (error, value) =>{
@@ -72,7 +74,7 @@ describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, functio
   });
   it('client should wait for a connection with waitForReady on', function(done) {
     this.timeout(15000);
-    const disconnectedClient = new TestServiceClient('foo.test.google.com:50051', clientGrpc.credentials.createInsecure());
+    const disconnectedClient = new TestServiceClient('localhost:47', clientGrpc.credentials.createInsecure());
     const metadata = new clientGrpc.Metadata({waitForReady: true});
     const deadline = new Date();
     deadline.setSeconds(deadline.getSeconds() + 10);

--- a/test/gulpfile.ts
+++ b/test/gulpfile.ts
@@ -25,6 +25,10 @@ import * as semver from 'semver';
 const testDir = __dirname;
 const apiTestDir = path.resolve(testDir, 'api');
 
+/* The native library has some misbehavior in specific tests when running in
+ * Node 14 and above. */
+const NATIVE_SUPPORT_RANGE = '<14';
+
 const runInstall = () => {
   return execa('npm', ['install'], {cwd: testDir, stdio: 'inherit'});
 };
@@ -51,11 +55,11 @@ const testJsClientNativeServer = runTestsWithFixture('native', 'js');
 const testNativeClientJsServer = runTestsWithFixture('js', 'native');
 const testJsClientJsServer = runTestsWithFixture('js', 'js');
 
-const test = gulp.series(
+const test = semver.satisfies(process.version, NATIVE_SUPPORT_RANGE)? gulp.series(
                testJsClientJsServer,
                testJsClientNativeServer,
                testNativeClientJsServer
-              );
+              ) : testJsClientJsServer;
 
 export {
   install,


### PR DESCRIPTION
This skips three groups of tests:

 1. All tests against the native library on Node versions 14 and greater. The purpose of those tests is to test that grpc-js is interoperable and behaviorally consistent with the native library, not to test the function of the native library itself. That fails if the native library itself is not behaving correctly, so it's best to skip the tests where that is the case. We are still testing that in Node versions 10 and 12.
 2. The `NoCompress` flag test. We currently use the `encoding` argument of the `write` method to pass write flags in. This is not supported functionality, but it has worked for a long time. However, Node 16 apparently added validation for that argument, and any flags we pass in are not considered valid. So, that now does not work at all, and as a result we cannot pass in write flags at all. We will need to find a new way to do that, but for now we are skipping the test of the way it would work currently.
 3. The DNS resolver tests with the target names `loopback4.unittest.grpc.io` and `loopback46.unittest.grpc.io`. In the first case, since there is no IPv6 address, the Mac DNS resolver returns an IPv4-embedded IPv6 address, which is out of the scope of the test to test for. In the second case, that address should resolve to `127.0.0.1` and `::1`, and it works correctly on Linux. However, on Windows we only get the IPv4 address and on Mac we only get the IPv6 address, so there is nothing we can consistently test for on all platforms.

That revealed an actual bug: with the introduction of compressed message handling on the server, the message handling code now performs an asynchronous operation, which can result in reordering of messages, or messages with the end of stream event. The second commit corrects that.