### PR TITLE
grpc-js: Set provided class options to generated class

### DIFF
--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -91,6 +91,7 @@ export interface ServiceClientConstructor {
     options?: Partial<ChannelOptions>
   ): ServiceClient;
   service: ServiceDefinition;
+  serviceName: string;
 }
 
 /**
@@ -127,6 +128,7 @@ export function makeClientConstructor(
 
   class ServiceClientImpl extends Client implements ServiceClient {
     static service: ServiceDefinition;
+    static serviceName: string;
     [methodName: string]: Function;
   }
 
@@ -171,6 +173,7 @@ export function makeClientConstructor(
   });
 
   ServiceClientImpl.service = methods;
+  ServiceClientImpl.serviceName = serviceName;
 
   return ServiceClientImpl;
 }


### PR DESCRIPTION
Currently neither `serviceName` nor `classOptions` are not used in `makeClientConstructor` at all. In some cases it is very handy to access at least `serviceName` in generated class to identify which service exactly generated class belongs to.