### PR TITLE
proto-loader: Update yargs to version 17

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -767,8 +767,8 @@ async function writeAllFiles(protoFiles: string[], options: GeneratorOptions) {
   }
 }
 
-function runScript() {
-  const argv = yargs
+async function runScript() {
+  const argv = await yargs
     .parserConfiguration({
       'parse-positional-numbers': false
     })

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -49,14 +49,14 @@
     "lodash.camelcase": "^4.3.0",
     "long": "^4.0.0",
     "protobufjs": "^6.10.0",
-    "yargs": "^16.1.1"
+    "yargs": "^17.3.1"
   },
   "devDependencies": {
     "@types/lodash.camelcase": "^4.3.4",
     "@types/mkdirp": "^1.0.1",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.26",
-    "@types/yargs": "^15.0.5",
+    "@types/yargs": "^17.0.8",
     "clang-format": "^1.2.2",
     "gts": "^1.1.0",
     "rimraf": "^3.0.2",

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "author": "Google Inc.",
   "contributors": [
     {


### PR DESCRIPTION
This fixes #1995. Yargs 17 makes the `argv` object possibly a `Promise`, and the simplest way to make TypeScript OK with accessing its properties is to `await` it.