### PR TITLE
Decrease dependency to yargs 16 for compatibility with Node <12

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -768,7 +768,7 @@ async function writeAllFiles(protoFiles: string[], options: GeneratorOptions) {
 }
 
 async function runScript() {
-  const argv = await yargs
+  const argv = yargs
     .parserConfiguration({
       'parse-positional-numbers': false
     })

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -49,14 +49,14 @@
     "lodash.camelcase": "^4.3.0",
     "long": "^4.0.0",
     "protobufjs": "^6.10.0",
-    "yargs": "^17.3.1"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "@types/lodash.camelcase": "^4.3.4",
     "@types/mkdirp": "^1.0.1",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.26",
-    "@types/yargs": "^17.0.8",
+    "@types/yargs": "^16.0.4",
     "clang-format": "^1.2.2",
     "gts": "^1.1.0",
     "rimraf": "^3.0.2",

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "author": "Google Inc.",
   "contributors": [
     {


### PR DESCRIPTION
This is mostly reversing #2006, but I put a tighter version range on `yargs` this time. `yargs` 17 drops compatibility with Node 10, which causes problems because we test on Node 10. #1995 is still fixed: `npm audit` shows no problems with this new dependency.