### PR TITLE
grpc-js: Fix compatibility with @types/node 17.0.6 (1.2.x)

### DIFF
--- a/packages/grpc-js/src/object-stream.ts
+++ b/packages/grpc-js/src/object-stream.ts
@@ -36,9 +36,9 @@ export interface IntermediateObjectWritable<T> extends Writable {
   write(chunk: any & T, cb?: WriteCallback): boolean;
   write(chunk: any & T, encoding?: any, cb?: WriteCallback): boolean;
   setDefaultEncoding(encoding: string): this;
-  end(): void;
-  end(chunk: any & T, cb?: Function): void;
-  end(chunk: any & T, encoding?: any, cb?: Function): void;
+  end(): ReturnType<Writable['end']> extends Writable ? this : void;
+  end(chunk: any & T, cb?: Function): ReturnType<Writable['end']> extends Writable ? this : void;
+  end(chunk: any & T, encoding?: any, cb?: Function): ReturnType<Writable['end']> extends Writable ? this : void;
 }
 
 export interface ObjectWritable<T> extends IntermediateObjectWritable<T> {
@@ -46,20 +46,7 @@ export interface ObjectWritable<T> extends IntermediateObjectWritable<T> {
   write(chunk: T, cb?: Function): boolean;
   write(chunk: T, encoding?: any, cb?: Function): boolean;
   setDefaultEncoding(encoding: string): this;
-  end(): void;
-  end(chunk: T, cb?: Function): void;
-  end(chunk: T, encoding?: any, cb?: Function): void;
+  end(): ReturnType<Writable['end']> extends Writable ? this : void;
+  end(chunk: T, cb?: Function): ReturnType<Writable['end']> extends Writable ? this : void;
+  end(chunk: T, encoding?: any, cb?: Function): ReturnType<Writable['end']> extends Writable ? this : void;
 }
-
-export type ObjectDuplex<T, U> = {
-  read(size?: number): U;
-
-  _write(chunk: T, encoding: string, callback: Function): void;
-  write(chunk: T, cb?: Function): boolean;
-  write(chunk: T, encoding?: any, cb?: Function): boolean;
-  end(): void;
-  end(chunk: T, cb?: Function): void;
-  end(chunk: T, encoding?: any, cb?: Function): void;
-} & Duplex &
-  ObjectWritable<T> &
-  ObjectReadable<U>;

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -235,7 +235,7 @@ export class ServerWritableStreamImpl<RequestType, ResponseType>
       this.trailingMetadata = metadata;
     }
 
-    super.end();
+    return super.end();
   }
 }
 
@@ -280,7 +280,7 @@ export class ServerDuplexStreamImpl<RequestType, ResponseType> extends Duplex
       this.trailingMetadata = metadata;
     }
 
-    super.end();
+    return super.end();
   }
 }
 
@@ -290,7 +290,6 @@ ServerDuplexStreamImpl.prototype._write =
   ServerWritableStreamImpl.prototype._write;
 ServerDuplexStreamImpl.prototype._final =
   ServerWritableStreamImpl.prototype._final;
-ServerDuplexStreamImpl.prototype.end = ServerWritableStreamImpl.prototype.end;
 
 // Unary response callback signature.
 export type sendUnaryData<ResponseType> = (


### PR DESCRIPTION
Same as #2011, but for 1.2.x.