### PR TITLE
 added grpc-node.max_session_memory to js docs

### DIFF
--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -56,6 +56,7 @@ Many channel arguments supported in `grpc` are not supported in `@grpc/grpc-js`.
   - `grpc.max_send_message_length`
   - `grpc.max_receive_message_length`
   - `grpc.enable_http_proxy`
+  - `grpc-node.max_session_memory`
   - `channelOverride`
   - `channelFactoryOverride`
 


### PR DESCRIPTION
I found the [doc](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js#supported-channel-options) is outdated,  the `grpc-node.max_session_memory` options is missing.

_Originally posted by @NeoyeElf in https://github.com/grpc/grpc-node/issues/1666#issuecomment-1007093753_