### PR TITLE
grpc-js: Document recently-added channel options

### DIFF
--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -56,6 +56,9 @@ Many channel arguments supported in `grpc` are not supported in `@grpc/grpc-js`.
   - `grpc.max_send_message_length`
   - `grpc.max_receive_message_length`
   - `grpc.enable_http_proxy`
+  - `grpc.default_compression_algorithm`
+  - `grpc.enable_channelz`
+  - `grpc-node.max_session_memory`
   - `channelOverride`
   - `channelFactoryOverride`
 

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -36,6 +36,9 @@ export interface ChannelOptions {
   'grpc.max_send_message_length'?: number;
   'grpc.max_receive_message_length'?: number;
   'grpc.enable_http_proxy'?: number;
+  /* http_connect_target and http_connect_creds are used for passing data
+   * around internally, and should not be documented as public-facing options
+   */
   'grpc.http_connect_target'?: string;
   'grpc.http_connect_creds'?: string;
   'grpc.default_compression_algorithm'?: CompressionAlgorithms;


### PR DESCRIPTION
This is an expansion on #2015 to include other options that were added but not added to the documentation.