### PR TITLE
Add envoy/extensions files

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -60,6 +60,7 @@
     "deps/envoy-api/envoy/service/**/*.proto",
     "deps/envoy-api/envoy/type/**/*.proto",
     "deps/envoy-api/envoy/annotations/**/*.proto",
+    "deps/envoy-api/envoy/extensions/**/*.proto",
     "deps/googleapis/google/api/**/*.proto",
     "deps/googleapis/google/protobuf/**/*.proto",
     "deps/googleapis/google/rpc/**/*.proto",


### PR DESCRIPTION
Extension files are also referenced in the grpc-js-xds code https://github.com/grpc/grpc-node/blob/master/packages/grpc-js-xds/src/resources.ts#L68, so they need to be included when grpc-js-xds is installed as a dependency. 