### PR TITLE
grpc-js-xds: Add envoy/extensions files in 1.5.x

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -60,6 +60,7 @@
     "deps/envoy-api/envoy/service/**/*.proto",
     "deps/envoy-api/envoy/type/**/*.proto",
     "deps/envoy-api/envoy/annotations/**/*.proto",
+    "deps/envoy-api/envoy/extensions/**/*.proto",
     "deps/googleapis/google/api/**/*.proto",
     "deps/googleapis/google/protobuf/**/*.proto",
     "deps/googleapis/google/rpc/**/*.proto",

--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {


### PR DESCRIPTION
Backport #2018 to the 1.5.x branch to publish a patch.