### PR TITLE
grpc-js: Don't use http_proxy for uds connections

### DIFF
--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -136,6 +136,9 @@ export function mapProxyName(
   if ((options['grpc.enable_http_proxy'] ?? 1) === 0) {
     return noProxyResult;
   }
+  if (target.scheme === 'unix') {
+    return noProxyResult;
+  }
   const proxyInfo = getProxyInfo();
   if (!proxyInfo.address) {
     return noProxyResult;


### PR DESCRIPTION
The environment variable `http_proxy` will be used for UDS connections which prevents the connection from working. Since UDS runs on the local machine there's no use for a sending it through a proxy. This pull request adds a check which disables the http proxy if the target is a Unix Domain Socket.