### PR TITLE
grpc-js: Don't use http_proxy for uds connections

### DIFF
--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -136,6 +136,9 @@ export function mapProxyName(
   if ((options['grpc.enable_http_proxy'] ?? 1) === 0) {
     return noProxyResult;
   }
+  if (target.scheme === 'unix') {
+    return noProxyResult;
+  }
   const proxyInfo = getProxyInfo();
   if (!proxyInfo.address) {
     return noProxyResult;


### PR DESCRIPTION
Backport of #2022 to 1.5.x