### PR TITLE
grpc-js: Add secureConnection error handling in server

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -371,6 +371,13 @@ export class Server {
           creds._getSettings()!
         );
         http2Server = http2.createSecureServer(secureServerOptions);
+        http2Server.on('secureConnection', (socket: TLSSocket) => {
+          /* These errors need to be handled by the user of Http2SecureServer,
+           * according to https://github.com/nodejs/node/issues/35824 */
+          socket.on('error', (e: Error) => {
+            this.trace('An incoming TLS connection closed with error: ' + e.message);
+          });
+        });
       } else {
         http2Server = http2.createServer(serverOptions);
       }


### PR DESCRIPTION
This fixes #2026. nodejs/node#35824 indicates that this is not handled internally by Node, and that we have to handle this error.