### PR TITLE
grpc-js: Fix `exitIdle` propagation and DNS IP result backoff

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-child-handler.ts
+++ b/packages/grpc-js/src/load-balancer-child-handler.ts
@@ -125,9 +125,9 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
   }
   exitIdle(): void {
     if (this.currentChild) {
-      this.currentChild.resetBackoff();
+      this.currentChild.exitIdle();
       if (this.pendingChild) {
-        this.pendingChild.resetBackoff();
+        this.pendingChild.exitIdle();
       }
     }
   }

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -144,6 +144,7 @@ class DnsResolver implements Resolver {
     if (this.ipResult !== null) {
       trace('Returning IP address for target ' + uriToString(this.target));
       setImmediate(() => {
+        this.backoff.reset();
         this.listener.onSuccessfulResolution(
           this.ipResult!,
           null,


### PR DESCRIPTION
This should fix #2031. The main issue was the code in `load-balancer-child-handler.ts`: it's just a copy/paste error, and the result is that calls to `exitIdle` would not be propagated to child LB policies. That meant that when a new call tried to kick an IDLE LB policy, it would not happen, and it would only eventually leave IDLE when it got a new address list from the resolver. This problem was exacerbated by the missing `backoff.reset` call in `dns-resolver.ts`. The backoff is meant to wait an increasing amount of time after each failure, but because it was not reset there it would also wait an increasing amount of time after each successful IP address resolution.