### PR TITLE
Add HTTP/2 settings frame tracing

### DIFF
--- a/packages/grpc-js/src/logging.ts
+++ b/packages/grpc-js/src/logging.ts
@@ -108,10 +108,12 @@ export function trace(
   tracer: string,
   text: string
 ): void {
-  if (
-    !disabledTracers.has(tracer) &&
-    (allEnabled || enabledTracers.has(tracer))
-  ) {
+  if (isTracerEnabled(tracer)) {
     log(severity, new Date().toISOString() + ' | ' + tracer + ' | ' + text);
   }
+}
+
+export function isTracerEnabled(tracer: string): boolean {
+  return !disabledTracers.has(tracer) &&
+    (allEnabled || enabledTracers.has(tracer));
 }

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -555,6 +555,24 @@ export class Subchannel {
           (error as Error).message
       );
     });
+    if (logging.isTracerEnabled(TRACER_NAME)) {
+      session.on('remoteSettings', (settings: http2.Settings) => {
+        this.trace(
+          'new settings received' +
+            (this.session !== session ? ' on the old connection' : '') +
+            ': ' +
+            JSON.stringify(settings)
+        );
+      });
+      session.on('localSettings', (settings: http2.Settings) => {
+        this.trace(
+          'local settings acknowledged by remote' +
+            (this.session !== session ? ' on the old connection' : '') +
+            ': ' +
+            JSON.stringify(settings)
+        );
+      });
+    }
   }
 
   private startConnectingInternal() {


### PR DESCRIPTION
This adds HTTP/2 settings frame information to debug logs.
HTTP/2 settings frame contains important information like max_concurrent_streams and initial_window_size useful for debugging concurrency, latency, and throughput issues.