### PR TITLE
HTTP/2 flow control tracing

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -37,6 +37,7 @@ can be set.
   - `server_call` - Traces server handling of individual requests
   - `subchannel` - Traces subchannel connectivity state and errors
   - `subchannel_refcount` - Traces subchannel refcount changes
+  - `subchannel_flowctrl` - Traces HTTP/2 flow control
 
   The following tracers are added by the `@grpc/grpc-js-xds` library:
   - `cds_balancer` - Traces the CDS load balancing policy

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -41,6 +41,7 @@ import { SubchannelRef, ChannelzTrace, ChannelzChildrenTracker, SubchannelInfo, 
 const clientVersion = require('../../package.json').version;
 
 const TRACER_NAME = 'subchannel';
+const FLOW_CONTROL_TRACER_NAME = 'subchannel_flowctrl';
 
 const MIN_CONNECT_TIMEOUT_MS = 20000;
 const INITIAL_BACKOFF_MS = 1000;
@@ -322,6 +323,10 @@ export class Subchannel {
 
   private refTrace(text: string): void {
     logging.trace(LogVerbosity.DEBUG, 'subchannel_refcount', '(' + this.channelzRef.id + ') ' + this.subchannelAddressString + ' ' + text);
+  }
+
+  private flowControlTrace(text: string): void {
+    logging.trace(LogVerbosity.DEBUG, FLOW_CONTROL_TRACER_NAME, '(' + this.channelzRef.id + ') ' + this.subchannelAddressString + ' ' + text);
   }
 
   private handleBackoffTimer() {
@@ -847,6 +852,12 @@ export class Subchannel {
         this.subchannelAddressString +
         ' with headers\n' +
         headersString
+    );
+    this.flowControlTrace(
+      'local window size: ' +
+        this.session!.state.localWindowSize +
+        ' remote window size: ' +
+        this.session!.state.remoteWindowSize
     );
     const streamSession = this.session;
     let statsTracker: SubchannelCallStatsTracker;


### PR DESCRIPTION
subchannel_flowctrl tracer, if enabled, logs local and remote window sizes of a subchannel's HTTP2 session to debug log on the start of every call.