### PR TITLE
grpc-js: Add session state logging at call start

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -36,8 +36,9 @@ can be set.
   - `server` - Traces high-level server events
   - `server_call` - Traces server handling of individual requests
   - `subchannel` - Traces subchannel connectivity state and errors
-  - `subchannel_refcount` - Traces subchannel refcount changes
-  - `subchannel_flowctrl` - Traces HTTP/2 flow control
+  - `subchannel_refcount` - Traces subchannel refcount changes. Includes per-call logs.
+  - `subchannel_flowctrl` - Traces HTTP/2 flow control. Includes per-call logs.
+  - `subchannel_internals` - Traces HTTP/2 session state. Includes per-call logs.
 
   The following tracers are added by the `@grpc/grpc-js-xds` library:
   - `cds_balancer` - Traces the CDS load balancing policy

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -329,6 +329,10 @@ export class Subchannel {
     logging.trace(LogVerbosity.DEBUG, FLOW_CONTROL_TRACER_NAME, '(' + this.channelzRef.id + ') ' + this.subchannelAddressString + ' ' + text);
   }
 
+  private internalsTrace(text: string): void {
+    logging.trace(LogVerbosity.DEBUG, 'subchannel_internals', '(' + this.channelzRef.id + ') ' + this.subchannelAddressString + ' ' + text);
+  }
+
   private handleBackoffTimer() {
     if (this.continueConnecting) {
       this.transitionToState(
@@ -860,6 +864,13 @@ export class Subchannel {
         this.session!.state.remoteWindowSize
     );
     const streamSession = this.session;
+    this.internalsTrace(
+      'session.closed=' + 
+      streamSession!.closed + 
+      ' session.destroyed=' + 
+      streamSession!.destroyed + 
+      ' session.socket.destroyed=' + 
+      streamSession!.socket.destroyed);
     let statsTracker: SubchannelCallStatsTracker;
     if (this.channelzEnabled) {
       this.callTracker.addCallStarted();


### PR DESCRIPTION
This adds yet another `subchannel_*` tracer, and they could probably be consolidated, but for now I just want to get this out. This will test a guess I have about the cause of #2049.