### PR TITLE
grpc-js: Transition subchannel to TRANSIENT_FAILURE when the socket closes

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -669,9 +669,15 @@ export class Subchannel {
     switch (newState) {
       case ConnectivityState.READY:
         this.stopBackoff();
-        this.session!.socket.once('close', () => {
-          for (const listener of this.disconnectListeners) {
-            listener();
+        const session = this.session!;
+        session.socket.once('close', () => {
+          if (this.session === session) {
+            this.transitionToState(
+              [ConnectivityState.READY],
+              ConnectivityState.TRANSIENT_FAILURE);
+            for (const listener of this.disconnectListeners) {
+              listener();
+            }
           }
         });
         if (this.keepaliveWithoutCalls) {


### PR DESCRIPTION
Both log files in #2409 show calls ending with the message "Connection dropped", which is triggered by the socket's `'close'` event. I think this means that the socket closes and then something ends up in a bad state. The simplest way to address that is to discard the connection when that event is emitted. The `if (this.session === session)` condition I added is one that appears in a few other places in the subchannel implementation. It avoids a race where a connection is discarded and a new connection is created, and then events from the old connection get emitted and get applied to the new connection.