### PR TITLE
grpc-js: Return never from functions that always throw

### DIFF
--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -173,7 +173,7 @@ class InsecureChannelCredentialsImpl extends ChannelCredentials {
     super(callCredentials);
   }
 
-  compose(callCredentials: CallCredentials): ChannelCredentials {
+  compose(callCredentials: CallCredentials): never {
     throw new Error('Cannot compose insecure credentials');
   }
 

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -207,13 +207,13 @@ export type Call =
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export const loadObject = (value: any, options: any) => {
+export const loadObject = (value: any, options: any): never => {
   throw new Error(
     'Not available in this library. Use @grpc/proto-loader and loadPackageDefinition instead'
   );
 };
 
-export const load = (filename: any, format: any, options: any) => {
+export const load = (filename: any, format: any, options: any): never => {
   throw new Error(
     'Not available in this library. Use @grpc/proto-loader and loadPackageDefinition instead'
   );

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -312,7 +312,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   updateAddressList(
     addressList: SubchannelAddress[],
     lbConfig: LoadBalancingConfig | null
-  ) {
+  ): never {
     throw new Error('updateAddressList not supported on ResolvingLoadBalancer');
   }
 

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -231,7 +231,7 @@ export class Server {
   }
   
 
-  addProtoService(): void {
+  addProtoService(): never {
     throw new Error('Not implemented. Use addService() instead');
   }
 
@@ -311,7 +311,7 @@ export class Server {
     });
   }
 
-  bind(port: string, creds: ServerCredentials): void {
+  bind(port: string, creds: ServerCredentials): never {
     throw new Error('Not implemented. Use bindAsync() instead');
   }
 
@@ -696,7 +696,7 @@ export class Server {
     }
   }
 
-  addHttp2Port(): void {
+  addHttp2Port(): never {
     throw new Error('Not yet implemented');
   }
 


### PR DESCRIPTION
Migrating from `grpc` to `@grpc/grpc-js` I missed the part where `Server.bind` was not implemented. The TypeScript type-checker would've caught my mistake if the return type was set as `never`.

I think it would be accurate to have their return types be `never` until implemented https://www.typescriptlang.org/docs/handbook/2/functions.html#never