### PR TITLE
Add credentials scope in oauth2_auth_token interop test

### DIFF
--- a/test/interop/interop_client.js
+++ b/test/interop/interop_client.js
@@ -484,7 +484,7 @@ function getApplicationCreds(scope, callback) {
 }
 
 function getOauth2Creds(scope, callback) {
-  (new GoogleAuth()).getAccessToken().then((token) => {
+  (new GoogleAuth({scopes: scope})).getAccessToken().then((token) => {
     var updateMd = function(service_url, callback) {
       var metadata = new grpc.Metadata();
       metadata.add('authorization', 'Bearer ' + token);


### PR DESCRIPTION
This might be related to the failure we're seeing in the latest test in grpc/grpc#29062 (https://source.cloud.google.com/results/invocations/db79eb34-916d-4c37-b14b-42aac68fc5b4/targets/grpc%2Fcore%2Fpull_request%2Flinux%2Fgrpc_interop_toprod/log). This change matches the code on line 483 of the same file.