### PR TITLE
grpc-js: Add channel construction stacktrace traces

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -39,6 +39,7 @@ can be set.
   - `subchannel_refcount` - Traces subchannel refcount changes. Includes per-call logs.
   - `subchannel_flowctrl` - Traces HTTP/2 flow control. Includes per-call logs.
   - `subchannel_internals` - Traces HTTP/2 session state. Includes per-call logs.
+  - `channel_stacktrace` - Traces channel construction events with stack traces.
 
   The following tracers are added by the `@grpc/grpc-js-xds` library:
   - `cds_balancer` - Traces the CDS load balancing policy

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -335,6 +335,8 @@ export class ChannelImplementation implements Channel {
       new CompressionFilterFactory(this, this.options),
     ]);
     this.trace('Channel constructed with options ' + JSON.stringify(options, undefined, 2));
+    const error = new Error();
+    trace(LogVerbosity.DEBUG, 'channel_stacktrace', '(' + this.channelzRef.id + ') ' + 'Channel constructed \n' + error.stack?.substring(error.stack.indexOf('\n')+1));
   }
 
   private getChannelzInfo(): ChannelInfo {


### PR DESCRIPTION
We want to figure out what is constructing all of the channels that are in use in a certain user's code, and this seems like the simplest way to do that.