### PR TITLE
grpc-js: Trace call end when actually ending the call

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -312,6 +312,13 @@ export class Http2CallStream implements Call {
       const filteredStatus = this.filterStack.receiveTrailers(
         this.finalStatus!
       );
+      this.trace(
+        'ended with status: code=' +
+          filteredStatus.code +
+          ' details="' +
+          filteredStatus.details +
+          '"'
+      );
       this.statusWatchers.forEach(watcher => watcher(filteredStatus));
       /* We delay the actual action of bubbling up the status to insulate the
        * cleanup code in this class from any errors that may be thrown in the
@@ -346,13 +353,6 @@ export class Http2CallStream implements Call {
     /* If the status is OK and a new status comes in (e.g. from a
      * deserialization failure), that new status takes priority */
     if (this.finalStatus === null || this.finalStatus.code === Status.OK) {
-      this.trace(
-        'ended with status: code=' +
-          status.code +
-          ' details="' +
-          status.details +
-          '"'
-      );
       this.finalStatus = status;
       this.maybeOutputStatus();
     }


### PR DESCRIPTION
The current code can output a spurious extra trace if a call is cancelled after it succeeds. That extra trace is misleading because the call does not actually end with that second status code.