### PR TITLE
grpc-js: Transparently retry session destroyed error

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -466,9 +466,9 @@ export class ChannelImplementation implements Channel {
                     callConfig.onCommitted?.();
                     pickResult.onCallStarted?.();
                   } catch (error) {
-                    if (
-                      (error as NodeJS.ErrnoException).code ===
-                      'ERR_HTTP2_GOAWAY_SESSION'
+                    const errorCode = (error as NodeJS.ErrnoException).code;
+                    if (errorCode === 'ERR_HTTP2_GOAWAY_SESSION' ||
+                        errorCode === 'ERR_HTTP2_INVALID_SESSION'
                     ) {
                       /* An error here indicates that something went wrong with
                        * the picked subchannel's http2 stream right before we


### PR DESCRIPTION
This adds transparent retry for the error "The session has been destroyed" when starting a call on a subchannel. The correspondence between that string and the error code in this code comes from https://github.com/nodejs/node/blob/a01302b8dfaa9aa6290cd6bee552c4ce30dca34c/lib/internal/errors.js#L1031