### PR TITLE
grpc-js: Improve coverage of channelzEnabled checks in server code

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
When I originally added the `channelzEnabled` option, it looks like I missed having it guard some code in the server for some reason. I did a more exhaustive search this time and I'm pretty sure I got everything. This should fix #2068 in particular with the bottom change: that `registerChannelzSocket` call was unguarded, but the corresponding `unregisterChannelzRef` call was guarded, which meant that registered sockets would pile up indefinitely.