### PR TITLE
Expose MetadataOptions interface in grpc-js.

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -119,7 +119,7 @@ export const credentials = {
 
 /**** Metadata ****/
 
-export { Metadata, MetadataValue };
+export { Metadata, MetadataOptions, MetadataValue };
 
 /**** Constants ****/
 

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -48,7 +48,7 @@ import {
   ServiceClientConstructor,
   ServiceDefinition,
 } from './make-client';
-import { Metadata, MetadataValue } from './metadata';
+import { Metadata, MetadataOptions, MetadataValue } from './metadata';
 import {
   Server,
   UntypedHandleCall,


### PR DESCRIPTION
Since Metadata is exposed and its constructor takes MetadataOptions, those should also be exposed.