### PR TITLE
grpc-js: Add support for `grpc.dns_min_time_between_resolutions_ms` channel arg

### DIFF
--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -58,6 +58,7 @@ Many channel arguments supported in `grpc` are not supported in `@grpc/grpc-js`.
   - `grpc.enable_http_proxy`
   - `grpc.default_compression_algorithm`
   - `grpc.enable_channelz`
+  - `grpc.dns_min_time_between_resolutions_ms`
   - `grpc-node.max_session_memory`
   - `channelOverride`
   - `channelFactoryOverride`

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -43,6 +43,7 @@ export interface ChannelOptions {
   'grpc.http_connect_creds'?: string;
   'grpc.default_compression_algorithm'?: CompressionAlgorithms;
   'grpc.enable_channelz'?: number;
+  'grpc.dns_min_time_between_resolutions_ms'?: number;
   'grpc-node.max_session_memory'?: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
@@ -69,6 +70,7 @@ export const recognizedOptions = {
   'grpc.max_receive_message_length': true,
   'grpc.enable_http_proxy': true,
   'grpc.enable_channelz': true,
+  'grpc.dns_min_time_between_resolutions_ms': true,
   'grpc-node.max_session_memory': true,
 };
 


### PR DESCRIPTION
This adds a delay after a successful DNS request before another DNS request can be started, configurable with the `grpc.dns_min_time_between_resolutions_ms` channel arg, defaulting to 30 seconds. This all matches the current behavior of the C core.