### PR TITLE
grpc-js-xds: Don't stop backoff timers for ADS streams

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {

--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -688,7 +688,6 @@ export class XdsClient {
   ack(serviceKind: AdsServiceKind) {
     /* An ack is the best indication of a successful interaction between the
      * client and the server, so we can reset the backoff timer here. */
-    this.adsBackoff.stop();
     this.adsBackoff.reset();
 
     this.updateNames(serviceKind);


### PR DESCRIPTION
This means that the client will always back off from starting a new ADS stream by the base backoff time.