### PR TITLE
grpc-js: Use real channelz IDs when channelz is disabled

### DIFF
--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -219,16 +219,9 @@ export class ChannelImplementation implements Channel {
     }
 
     this.channelzTrace = new ChannelzTrace();
+    this.channelzRef = registerChannelzChannel(target, () => this.getChannelzInfo(), this.channelzEnabled);
     if (this.channelzEnabled) {
-      this.channelzRef = registerChannelzChannel(target, () => this.getChannelzInfo());
       this.channelzTrace.addTrace('CT_INFO', 'Channel created');
-    } else {
-      // Dummy channelz ref that will never be used
-      this.channelzRef = {
-        kind: 'channel',
-        id: -1,
-        name: ''
-      };
     }
 
     if (this.options['grpc.default_authority']) {

--- a/packages/grpc-js/src/channelz.ts
+++ b/packages/grpc-js/src/channelz.ts
@@ -347,31 +347,39 @@ const subchannels: (SubchannelEntry | undefined)[] = [];
 const servers: (ServerEntry | undefined)[] = [];
 const sockets: (SocketEntry | undefined)[] = [];
 
-export function registerChannelzChannel(name: string, getInfo: () => ChannelInfo): ChannelRef {
+export function registerChannelzChannel(name: string, getInfo: () => ChannelInfo, channelzEnabled: boolean): ChannelRef {
   const id = getNextId();
   const ref: ChannelRef = {id, name, kind: 'channel'};
-  channels[id] = { ref, getInfo };
+  if (channelzEnabled) {
+    channels[id] = { ref, getInfo };
+  }
   return ref;
 }
 
-export function registerChannelzSubchannel(name: string, getInfo:() => SubchannelInfo): SubchannelRef {
+export function registerChannelzSubchannel(name: string, getInfo:() => SubchannelInfo, channelzEnabled: boolean): SubchannelRef {
   const id = getNextId();
   const ref: SubchannelRef = {id, name, kind: 'subchannel'};
-  subchannels[id] = { ref, getInfo };
+  if (channelzEnabled) {
+    subchannels[id] = { ref, getInfo };
+  }
   return ref;
 }
 
-export function registerChannelzServer(getInfo: () => ServerInfo): ServerRef {
+export function registerChannelzServer(getInfo: () => ServerInfo, channelzEnabled: boolean): ServerRef {
   const id = getNextId();
   const ref: ServerRef = {id, kind: 'server'};
-  servers[id] = { ref, getInfo };
+  if (channelzEnabled) {
+    servers[id] = { ref, getInfo };
+  }
   return ref;
 }
 
-export function registerChannelzSocket(name: string, getInfo: () => SocketInfo): SocketRef {
+export function registerChannelzSocket(name: string, getInfo: () => SocketInfo, channelzEnabled: boolean): SocketRef {
   const id = getNextId();
   const ref: SocketRef = {id, name, kind: 'socket'};
-  sockets[id] = { ref, getInfo};
+  if (channelzEnabled) {
+    sockets[id] = { ref, getInfo};
+  }
   return ref;
 }
 

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -161,17 +161,11 @@ export class Server {
     if (this.options['grpc.enable_channelz'] === 0) {
       this.channelzEnabled = false;
     }
+    this.channelzRef = registerChannelzServer(() => this.getChannelzInfo(), this.channelzEnabled);
     if (this.channelzEnabled) {
-      this.channelzRef = registerChannelzServer(() => this.getChannelzInfo());
       this.channelzTrace.addTrace('CT_INFO', 'Server created');
-      this.trace('Server constructed');
-    } else {
-      // Dummy channelz ref that will never be used
-      this.channelzRef = {
-        kind: 'server',
-        id: -1
-      };
     }
+    this.trace('Server constructed');
   }
 
   private getChannelzInfo(): ServerInfo {
@@ -431,34 +425,28 @@ export class Server {
                 }
               }
               let channelzRef: SocketRef;
-              if (this.channelzEnabled) {
-                channelzRef = registerChannelzSocket(subchannelAddressToString(boundSubchannelAddress), () => {
-                  return {
-                    localAddress: boundSubchannelAddress,
-                    remoteAddress: null,
-                    security: null,
-                    remoteName: null,
-                    streamsStarted: 0,
-                    streamsSucceeded: 0,
-                    streamsFailed: 0,
-                    messagesSent: 0,
-                    messagesReceived: 0,
-                    keepAlivesSent: 0,
-                    lastLocalStreamCreatedTimestamp: null,
-                    lastRemoteStreamCreatedTimestamp: null,
-                    lastMessageSentTimestamp: null,
-                    lastMessageReceivedTimestamp: null,
-                    localFlowControlWindow: null,
-                    remoteFlowControlWindow: null
-                  };
-                });
-                this.listenerChildrenTracker.refChild(channelzRef);
-              } else {
-                channelzRef = {
-                  kind: 'socket',
-                  id: -1,
-                  name: ''
+              channelzRef = registerChannelzSocket(subchannelAddressToString(boundSubchannelAddress), () => {
+                return {
+                  localAddress: boundSubchannelAddress,
+                  remoteAddress: null,
+                  security: null,
+                  remoteName: null,
+                  streamsStarted: 0,
+                  streamsSucceeded: 0,
+                  streamsFailed: 0,
+                  messagesSent: 0,
+                  messagesReceived: 0,
+                  keepAlivesSent: 0,
+                  lastLocalStreamCreatedTimestamp: null,
+                  lastRemoteStreamCreatedTimestamp: null,
+                  lastMessageSentTimestamp: null,
+                  lastMessageReceivedTimestamp: null,
+                  localFlowControlWindow: null,
+                  remoteFlowControlWindow: null
                 };
+              }, this.channelzEnabled);
+              if (this.channelzEnabled) {
+                this.listenerChildrenTracker.refChild(channelzRef);
               }
               this.http2ServerList.push({server: http2Server, channelzRef: channelzRef});
               this.trace('Successfully bound ' + subchannelAddressToString(boundSubchannelAddress));
@@ -509,34 +497,28 @@ export class Server {
             port: boundAddress.port
           };
           let channelzRef: SocketRef;
-          if (this.channelzEnabled) {
-            channelzRef = registerChannelzSocket(subchannelAddressToString(boundSubchannelAddress), () => {
-              return {
-                localAddress: boundSubchannelAddress,
-                remoteAddress: null,
-                security: null,
-                remoteName: null,
-                streamsStarted: 0,
-                streamsSucceeded: 0,
-                streamsFailed: 0,
-                messagesSent: 0,
-                messagesReceived: 0,
-                keepAlivesSent: 0,
-                lastLocalStreamCreatedTimestamp: null,
-                lastRemoteStreamCreatedTimestamp: null,
-                lastMessageSentTimestamp: null,
-                lastMessageReceivedTimestamp: null,
-                localFlowControlWindow: null,
-                remoteFlowControlWindow: null
-              };
-            });
-            this.listenerChildrenTracker.refChild(channelzRef);
-          } else {
-            channelzRef = {
-              kind: 'socket',
-              id: -1,
-              name: ''
+          channelzRef = registerChannelzSocket(subchannelAddressToString(boundSubchannelAddress), () => {
+            return {
+              localAddress: boundSubchannelAddress,
+              remoteAddress: null,
+              security: null,
+              remoteName: null,
+              streamsStarted: 0,
+              streamsSucceeded: 0,
+              streamsFailed: 0,
+              messagesSent: 0,
+              messagesReceived: 0,
+              keepAlivesSent: 0,
+              lastLocalStreamCreatedTimestamp: null,
+              lastRemoteStreamCreatedTimestamp: null,
+              lastMessageSentTimestamp: null,
+              lastMessageReceivedTimestamp: null,
+              localFlowControlWindow: null,
+              remoteFlowControlWindow: null
             };
+          }, this.channelzEnabled);
+          if (this.channelzEnabled) {
+            this.listenerChildrenTracker.refChild(channelzRef);
           }
           this.http2ServerList.push({server: http2Server, channelzRef: channelzRef});
           this.trace('Successfully bound ' + subchannelAddressToString(boundSubchannelAddress));
@@ -893,15 +875,7 @@ export class Server {
       }
 
       let channelzRef: SocketRef;
-      if (this.channelzEnabled) {
-        channelzRef = registerChannelzSocket(session.socket.remoteAddress ?? 'unknown', this.getChannelzSessionInfoGetter(session));
-      } else {
-        channelzRef = {
-          kind: 'socket',
-          id: -1,
-          name: ''
-        }
-      }
+      channelzRef = registerChannelzSocket(session.socket.remoteAddress ?? 'unknown', this.getChannelzSessionInfoGetter(session), this.channelzEnabled);
 
       const channelzSessionInfo: ChannelzSessionInfo = {
         ref: channelzRef,

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -227,16 +227,9 @@ export class Subchannel {
       this.channelzEnabled = false;
     }
     this.channelzTrace = new ChannelzTrace();
+    this.channelzRef = registerChannelzSubchannel(this.subchannelAddressString, () => this.getChannelzInfo(), this.channelzEnabled);
     if (this.channelzEnabled) {
-      this.channelzRef = registerChannelzSubchannel(this.subchannelAddressString, () => this.getChannelzInfo());
       this.channelzTrace.addTrace('CT_INFO', 'Subchannel created');
-    } else {
-      // Dummy channelz ref that will never be used
-      this.channelzRef = {
-        kind: 'subchannel',
-        id: -1,
-        name: ''
-      };
     }
     this.trace('Subchannel constructed with options ' + JSON.stringify(options, undefined, 2));
   }
@@ -484,8 +477,8 @@ export class Subchannel {
       connectionOptions
     );
     this.session = session;
+    this.channelzSocketRef = registerChannelzSocket(this.subchannelAddressString, () => this.getChannelzSocketInfo()!, this.channelzEnabled);
     if (this.channelzEnabled) {
-      this.channelzSocketRef = registerChannelzSocket(this.subchannelAddressString, () => this.getChannelzSocketInfo()!);
       this.childrenTracker.refChild(this.channelzSocketRef);
     }
     session.unref();


### PR DESCRIPTION
Channelz IDs for channels, subchannels, and servers also serve as entity IDs in trace logs. The current behavior creates a dummy ref with the ID -1 when channelz is disabled, but that makes different entities indistinguishable in trace logs. With this change, instead a channelz ref is created as usual but no corresponding channelz data is created or stored.