### PR TITLE
grpc-js: Disable per-session memory limit by default

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -407,6 +407,12 @@ export class Subchannel {
       connectionOptions.maxSessionMemory = this.options[
         'grpc-node.max_session_memory'
       ];
+    } else {
+      /* By default, set a very large max session memory limit, to effectively
+       * disable enforcement of the limit. Some testing indicates that Node's
+       * behavior degrades badly when this limit is reached, so we solve that
+       * by disabling the check entirely. */
+      connectionOptions.maxSessionMemory = Number.MAX_SAFE_INTEGER;
     }
     let addressScheme = 'http://';
     if ('secureContext' in connectionOptions) {


### PR DESCRIPTION
The `grpc-node.max_session_memory` option was added in #1666 to configure Node's per-session memory limit. Recent testing related to https://github.com/googleapis/nodejs-firestore/issues/1023#issuecomment-1079149229 indicate that Node's behavior degrades in an undesirable and possibly buggy way when this limit is reached. To fix that behavior this change disables that limit by default.