### PR TITLE
grpc-js-xds: Don't stop backoff timers for LRS streams

### DIFF
--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -781,7 +781,6 @@ export class XdsClient {
     trace('Received LRS response');
     /* Once we get any response from the server, we assume that the stream is
      * in a good state, so we can reset the backoff timer. */
-    this.lrsBackoff.stop();
     this.lrsBackoff.reset();
     if (
       !this.receivedLrsSettingsForCurrentStream ||


### PR DESCRIPTION
#2077 for LRS.