### PR TITLE
grpc-js: Don't clear ping timeout when still connected

### DIFF
--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -384,6 +384,11 @@ export class Subchannel {
      * sending pings should also involve some network activity. */
   }
 
+  /**
+   * Stop keepalive pings when terminating a connection. This discards the
+   * outstanding ping timeout, so it should not be called if the same
+   * connection will still be used.
+   */
   private stopKeepalivePings() {
     clearInterval(this.keepaliveIntervalId);
     clearTimeout(this.keepaliveTimeoutId);

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -773,7 +773,7 @@ export class Subchannel {
       }
       this.backoffTimeout.unref();
       if (!this.keepaliveWithoutCalls) {
-        this.stopKeepalivePings();
+        clearInterval(this.keepaliveIntervalId);
       }
       this.checkBothRefcounts();
     }


### PR DESCRIPTION
By default, we don't send pings when there are no active streams because some servers don't like that. But that doesn't mean that existing pending pings should be invalidated when the last stream ends. This change fixes that. I changed this line instead of changing `stopKeepalivePings` because there are two other call sites of `stopKeepalivePings` that should have the other behavior.