### PR TITLE
grpc-js: Fix handling of calls after resolution failure

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/channel.ts
+++ b/packages/grpc-js/src/channel.ts
@@ -20,6 +20,7 @@ import {
   Call,
   Http2CallStream,
   CallStreamOptions,
+  StatusObject,
 } from './call-stream';
 import { ChannelCredentials } from './channel-credentials';
 import { ChannelOptions } from './channel-options';
@@ -170,6 +171,14 @@ export class ChannelImplementation implements Channel {
    */
   private callRefTimer: NodeJS.Timer;
   private configSelector: ConfigSelector | null = null;
+  /**
+   * This is the error from the name resolver if it failed most recently. It
+   * is only used to end calls that start while there is no config selector
+   * and the name resolver is in backoff, so it should be nulled if
+   * configSelector becomes set or the channel state becomes anything other
+   * than TRANSIENT_FAILURE.
+   */
+  private currentResolutionError: StatusObject | null = null;
 
   // Channelz info
   private readonly channelzEnabled: boolean = true;
@@ -290,6 +299,7 @@ export class ChannelImplementation implements Channel {
           this.channelzTrace.addTrace('CT_INFO', 'Address resolution succeeded');
         }
         this.configSelector = configSelector;
+        this.currentResolutionError = null;
         /* We process the queue asynchronously to ensure that the corresponding
          * load balancer update has completed. */
         process.nextTick(() => {
@@ -308,6 +318,9 @@ export class ChannelImplementation implements Channel {
         }
         if (this.configSelectionQueue.length > 0) {
           this.trace('Name resolution failed with calls queued for config selection');
+        }
+        if (this.configSelector === null) {
+          this.currentResolutionError = status;
         }
         const localQueue = this.configSelectionQueue;
         this.configSelectionQueue = [];
@@ -591,6 +604,9 @@ export class ChannelImplementation implements Channel {
         watcherObject.callback();
       }
     }
+    if (newState !== ConnectivityState.TRANSIENT_FAILURE) {
+      this.currentResolutionError = null;
+    }
   }
 
   private tryGetConfig(stream: Http2CallStream, metadata: Metadata) {
@@ -605,11 +621,15 @@ export class ChannelImplementation implements Channel {
        * ResolvingLoadBalancer may be idle and if so it needs to be kicked
        * because it now has a pending request. */
       this.resolvingLoadBalancer.exitIdle();
-      this.configSelectionQueue.push({
-        callStream: stream,
-        callMetadata: metadata,
-      });
-      this.callRefTimerRef();
+      if (this.currentResolutionError && !metadata.getOptions().waitForReady) {
+        stream.cancelWithStatus(this.currentResolutionError.code, this.currentResolutionError.details);
+      } else {
+        this.configSelectionQueue.push({
+          callStream: stream,
+          callMetadata: metadata,
+        });
+        this.callRefTimerRef();
+      }
     } else {
       const callConfig = this.configSelector(stream.getMethod(), metadata);
       if (callConfig.status === Status.OK) {

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -268,6 +268,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
     if (this.currentState === ConnectivityState.IDLE) {
       this.updateState(ConnectivityState.CONNECTING, new QueuePicker(this));
     }
+    this.backoffTimeout.runOnce();
   }
 
   private updateState(connectivityState: ConnectivityState, picker: Picker) {
@@ -294,18 +295,16 @@ export class ResolvingLoadBalancer implements LoadBalancer {
       );
       this.onFailedResolution(error);
     }
-    this.backoffTimeout.runOnce();
   }
 
   exitIdle() {
     this.childLoadBalancer.exitIdle();
-    if (this.currentState === ConnectivityState.IDLE) {
+    if (this.currentState === ConnectivityState.IDLE || this.currentState === ConnectivityState.TRANSIENT_FAILURE) {
       if (this.backoffTimeout.isRunning()) {
         this.continueResolving = true;
       } else {
         this.updateResolution();
       }
-      this.updateState(ConnectivityState.CONNECTING, new QueuePicker(this));
     }
   }
 


### PR DESCRIPTION
This fixes #2090. The change to the channel here is just to track name resolution errors so that if a call comes in while the channel is in TRANSIENT_FAILURE, backing off waiting to resolve again, we end the call with an error, the same as if the LB policy was in TRANSIENT_FAILURE. The change to the resolving load balancer just lets the `exitIdle` schedule another name resolution attempt if the state is TRANSIENT_FAILURE, which is consistent with handling of `exitIdle` and backoffs in other places. I removed the state transition from there because it is redundant with the one in `updateResolution`, and inappropriate when not calling that function immediately. I also moved the backoff timer start to the start of name resolution instead of the end, for consistency with other backoff timers.