### PR TITLE
grpc-js: Consistently re-resolve when idle

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -298,7 +298,6 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   }
 
   exitIdle() {
-    this.childLoadBalancer.exitIdle();
     if (this.currentState === ConnectivityState.IDLE || this.currentState === ConnectivityState.TRANSIENT_FAILURE) {
       if (this.backoffTimeout.isRunning()) {
         this.continueResolving = true;
@@ -306,6 +305,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
         this.updateResolution();
       }
     }
+    this.childLoadBalancer.exitIdle();
   }
 
   updateAddressList(


### PR DESCRIPTION
This fixes #2094. `childLoadBalancer.exitIdle()` can cause a state change, which results in failing the check to re-resolve.

There is another problem that `PickFirstLoadBalancer` has a code path to call `requestReresolution`, but it may actually be unreachable because the logic there is kind of convoluted. It would be good to fix that, but for now, it's worth getting this quick fix out.