### PR TITLE
Fix ts errors with typescript 4.6.3 #2107

### DIFF
--- a/packages/grpc-js/src/call-credentials-filter.ts
+++ b/packages/grpc-js/src/call-credentials-filter.ts
@@ -54,7 +54,7 @@ export class CallCredentialsFilter extends BaseFilter implements Filter {
     const resultMetadata = await metadata;
     try {
       resultMetadata.merge(await credsMetadata);
-    } catch (error) {
+    } catch (error: any) {
       this.stream.cancelWithStatus(
         Status.UNAUTHENTICATED,
         `Failed to retrieve auth metadata with error: ${error.message}`

--- a/packages/grpc-js/src/call-credentials.ts
+++ b/packages/grpc-js/src/call-credentials.ts
@@ -115,7 +115,7 @@ export abstract class CallCredentials {
                 reject(err);
                 return;
               }
-              resolve(headers);
+              resolve(headers || {});
             }
           );
         });

--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -553,7 +553,7 @@ export class Http2CallStream implements Call {
           let metadata: Metadata;
           try {
             metadata = Metadata.fromHttp2Headers(headers);
-          } catch (error) {
+          } catch (error: any) {
             this.endCall({
               code: Status.UNKNOWN,
               details: error.message,
@@ -564,7 +564,7 @@ export class Http2CallStream implements Call {
           try {
             const finalMetadata = this.filterStack.receiveMetadata(metadata);
             this.listener?.onReceiveMetadata(finalMetadata);
-          } catch (error) {
+          } catch (error: any) {
             this.endCall({
               code: Status.UNKNOWN,
               details: error.message,
@@ -700,7 +700,7 @@ export class Http2CallStream implements Call {
         );
         try {
           this.writeMessageToStream(this.pendingWrite, this.pendingWriteCallback);
-        } catch (error) {
+        } catch (error: any) {
           this.endCall({
             code: Status.UNAVAILABLE,
             details: `Write failed with error ${error.message}`,
@@ -862,7 +862,7 @@ export class Http2CallStream implements Call {
         this.trace('sending data chunk of length ' + message.message.length);
         try {
         this.writeMessageToStream(message.message, cb);
-        }  catch (error) {
+        }  catch (error: any) {
           this.endCall({
             code: Status.UNAVAILABLE,
             details: `Write failed with error ${error.message}`,

--- a/packages/grpc-js/src/client-interceptors.ts
+++ b/packages/grpc-js/src/client-interceptors.ts
@@ -379,7 +379,7 @@ class BaseInterceptingCall implements InterceptingCallInterface {
     let serialized: Buffer;
     try {
       serialized = this.methodDefinition.requestSerialize(message);
-    } catch (e) {
+    } catch (e: any) {
       this.call.cancelWithStatus(
         Status.INTERNAL,
         `Request message serialization failure: ${e.message}`
@@ -406,7 +406,7 @@ class BaseInterceptingCall implements InterceptingCallInterface {
         let deserialized: any;
         try {
           deserialized = this.methodDefinition.responseDeserialize(message);
-        } catch (e) {
+        } catch (e: any) {
           readError = {
             code: Status.INTERNAL,
             details: `Response message parsing error: ${e.message}`,

--- a/packages/grpc-js/src/metadata.ts
+++ b/packages/grpc-js/src/metadata.ts
@@ -293,7 +293,7 @@ export class Metadata {
             result.add(key, values);
           }
         }
-      } catch (error) {
+      } catch (error: any) {
         const message = `Failed to add metadata entry ${key}: ${values}. ${error.message}. For more information see https://github.com/grpc/grpc-node/issues/1173`;
         log(LogVerbosity.ERROR, message);
       }

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -215,7 +215,7 @@ export class ServerWritableStreamImpl<RequestType, ResponseType>
         this.call.once('drain', callback);
         return;
       }
-    } catch (err) {
+    } catch (err: any) {
       err.code = Status.INTERNAL;
       this.emit('error', err);
     }
@@ -444,7 +444,7 @@ export class Http2ServerCallStream<
   private getDecompressedMessage(message: Buffer, encoding: string) {
     switch (encoding) {
       case 'deflate': {
-        return new Promise<Buffer | undefined>((resolve, reject) => {
+        return new Promise<Buffer | undefined | void>((resolve, reject) => {
           zlib.inflate(message.slice(5), (err, output) => {
             if (err) {
               this.sendError({
@@ -460,7 +460,7 @@ export class Http2ServerCallStream<
       }
   
       case 'gzip': {
-        return new Promise<Buffer | undefined>((resolve, reject) => {
+        return new Promise<Buffer | undefined | void>((resolve, reject) => {
           zlib.unzip(message.slice(5), (err, output) => {
             if (err) {
               this.sendError({
@@ -539,7 +539,7 @@ export class Http2ServerCallStream<
     return metadata;
   }
 
-  receiveUnaryMessage(encoding: string): Promise<RequestType> {
+  receiveUnaryMessage(encoding: string): Promise<RequestType|void> {
     return new Promise((resolve, reject) => {
       const stream = this.stream;
       const chunks: Buffer[] = [];
@@ -578,7 +578,7 @@ export class Http2ServerCallStream<
           else {
             resolve(this.deserializeMessage(decompressedMessage));
           }
-        } catch (err) {
+        } catch (err: any) {
           err.code = Status.INTERNAL;
           this.sendError(err);
           resolve();
@@ -629,7 +629,7 @@ export class Http2ServerCallStream<
 
       this.write(response);
       this.sendStatus({ code: Status.OK, details: 'OK', metadata });
-    } catch (err) {
+    } catch (err: any) {
       err.code = Status.INTERNAL;
       this.sendError(err);
     }
@@ -853,7 +853,7 @@ export class Http2ServerCallStream<
       } else {
         this.messagesToPush.push(deserialized);
       }
-    } catch (error) {
+    } catch (error: any) {
       // Ignore any remaining messages when errors occur.
       this.bufferedMessages.length = 0;
 

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -868,7 +868,7 @@ export class Server {
             default:
               throw new Error(`Unknown handler type: ${handler.type}`);
           }
-        } catch (err) {
+        } catch (err: any) {
           if (!call) {
             call = new Http2ServerCallStream(stream, null!, this.options);
             if (this.channelzEnabled) {


### PR DESCRIPTION
This fixes couple typescript files failing to transpile with typescript 4.6.x. Typescript 4.6 enforces object's default type to be 'unknown', instead of 'any' and no implicit the argument value for the resolve call.

The transpilation errors under typescript 4.6:
a. Object is of type 'unknown'
b. Argument of type 'unknown' is not assignable to parameter of type XYZ
c. Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?

To repro:
1. cd packages/grpc-js
2. npm install
3. npm install typescript@4.6.3
4. npm run build