### PR TITLE
grpc-js: End calls when keepalive pings time out

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
We assume that when a keepalive ping times out, that means that the connection is gone. So we should also not expect that any existing calls will make progress, so we should just end them instead of waiting for their deadlines to expire, if they even have one. This change matches the behavior of other languages like Java: https://github.com/grpc/grpc-java/blob/d4fa0ecc07495097453b0a2848765f076b9e714c/core/src/main/java/io/grpc/internal/KeepAliveManager.java#L287-L289.