### PR TITLE
grpc-js: DNS: unset continueResolving when starting a resolution attempt

### DIFF
--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -314,6 +314,7 @@ class DnsResolver implements Resolver {
   }
 
   private startResolutionWithBackoff() {
+      this.continueResolving = false;
       this.startResolution();
       this.backoff.runOnce();
       this.startNextResolutionTimer();


### PR DESCRIPTION
The purpose of that field is to indicate that a request to update the name resolution has come in while the resolver is in a period when it is waiting before making the next resolution attempt, so that when it is done waiting, it starts the next attempt immediately. It needs to be unset then so that it can have the correct meaning in the next waiting period.

Pointed out in https://github.com/grpc/grpc-node/issues/2080#issuecomment-1100763866