### PR TITLE
grpc-js: Fix double resolver calls in DNS resolver

### DIFF
--- a/packages/grpc-js/src/backoff-timeout.ts
+++ b/packages/grpc-js/src/backoff-timeout.ts
@@ -100,6 +100,7 @@ export class BackoffTimeout {
   }
 
   private runTimer(delay: number) {
+    clearTimeout(this.timerId);
     this.timerId = setTimeout(() => {
       this.callback();
       this.running = false;

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -158,7 +158,6 @@ class DnsResolver implements Resolver {
     if (this.ipResult !== null) {
       trace('Returning IP address for target ' + uriToString(this.target));
       setImmediate(() => {
-        this.backoff.reset();
         this.listener.onSuccessfulResolution(
           this.ipResult!,
           null,
@@ -167,6 +166,8 @@ class DnsResolver implements Resolver {
           {}
         );
       });
+      this.backoff.stop();
+      this.backoff.reset();
       return;
     }
     if (this.dnsHostname === null) {
@@ -178,7 +179,11 @@ class DnsResolver implements Resolver {
           metadata: new Metadata(),
         });
       });
+      this.stopNextResolutionTimer();
     } else {
+      if (this.pendingLookupPromise !== null) {
+        return;
+      }
       trace('Looking up DNS hostname ' + this.dnsHostname);
       /* We clear out latestLookupResult here to ensure that it contains the
        * latest result since the last time we started resolving. That way, the
@@ -299,6 +304,7 @@ class DnsResolver implements Resolver {
   }
 
   private startNextResolutionTimer() {
+    clearTimeout(this.nextResolutionTimer);
     this.nextResolutionTimer = setTimeout(() => {
       this.stopNextResolutionTimer();
       if (this.continueResolving) {
@@ -314,10 +320,12 @@ class DnsResolver implements Resolver {
   }
 
   private startResolutionWithBackoff() {
+    if (this.pendingLookupPromise === null) {
       this.continueResolving = false;
       this.startResolution();
       this.backoff.runOnce();
       this.startNextResolutionTimer();
+    }
   }
 
   updateResolution() {


### PR DESCRIPTION
As pointed out in https://github.com/grpc/grpc-node/issues/2080#issuecomment-1102136143, in some cases the backoff timer and next resolution timer could both trigger, causing double resolver attempts, double backoff timers, etc., which can then cause further proliferation of requests. So the fix here is to more consistently prevent new DNS requests while any DNS request is already running, and also clear timers before setting new ones.