### PR TITLE
grpc-js: Report error when no message received for unary response

### DIFF
--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -338,7 +338,15 @@ export class Client {
         }
         receivedStatus = true;
         if (status.code === Status.OK) {
-          callProperties.callback!(null, responseMessage!);
+          if (responseMessage === null) {
+            callProperties.callback!(callErrorFromStatus({
+              code: Status.INTERNAL,
+              details: 'No message received',
+              metadata: status.metadata
+            }));
+          } else {
+            callProperties.callback!(null, responseMessage);
+          }
         } else {
           callProperties.callback!(callErrorFromStatus(status));
         }
@@ -455,7 +463,15 @@ export class Client {
         }
         receivedStatus = true;
         if (status.code === Status.OK) {
-          callProperties.callback!(null, responseMessage!);
+          if (responseMessage === null) {
+            callProperties.callback!(callErrorFromStatus({
+              code: Status.INTERNAL,
+              details: 'No message received',
+              metadata: status.metadata
+            }));
+          } else {
+            callProperties.callback!(null, responseMessage);
+          }
         } else {
           callProperties.callback!(callErrorFromStatus(status));
         }


### PR DESCRIPTION
For unary and client streaming requests, the client expects to get exactly one response message. We already report an error when the client receives more than one message. This change adds an error when the client receives 0 messages.

This addresses #2065 and #2101.