### PR TITLE
grpc-js: Fix shutting down subchannels in separate pools

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/subchannel-pool.ts
+++ b/packages/grpc-js/src/subchannel-pool.ts
@@ -49,10 +49,8 @@ export class SubchannelPool {
   /**
    * A pool of subchannels use for making connections. Subchannels with the
    * exact same parameters will be reused.
-   * @param global If true, this is the global subchannel pool. Otherwise, it
-   * is the pool for a single channel.
    */
-  constructor(private global: boolean) {}
+  constructor() {}
 
   /**
    * Unrefs all unused subchannels and cancels the cleanup task if all
@@ -95,7 +93,7 @@ export class SubchannelPool {
    * Ensures that the cleanup task is spawned.
    */
   ensureCleanupTask(): void {
-    if (this.global && this.cleanupTimer === null) {
+    if (this.cleanupTimer === null) {
       this.cleanupTimer = setInterval(() => {
         this.unrefUnusedSubchannels();
       }, REF_CHECK_INTERVAL);
@@ -156,14 +154,12 @@ export class SubchannelPool {
       channelCredentials,
       subchannel,
     });
-    if (this.global) {
-      subchannel.ref();
-    }
+    subchannel.ref();
     return subchannel;
   }
 }
 
-const globalSubchannelPool = new SubchannelPool(true);
+const globalSubchannelPool = new SubchannelPool();
 
 /**
  * Get either the global subchannel pool, or a new subchannel pool.
@@ -173,6 +169,6 @@ export function getSubchannelPool(global: boolean): SubchannelPool {
   if (global) {
     return globalSubchannelPool;
   } else {
-    return new SubchannelPool(false);
+    return new SubchannelPool();
   }
 }

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -741,7 +741,7 @@ export class Subchannel {
       }
       this.transitionToState(
         [ConnectivityState.CONNECTING, ConnectivityState.READY],
-        ConnectivityState.TRANSIENT_FAILURE
+        ConnectivityState.IDLE
       );
       if (this.channelzEnabled) {
         unregisterChannelzRef(this.channelzRef);


### PR DESCRIPTION
This change makes the subchannel pool behave the same whether they are global or local. The main issue was that not calling `subchannel.ref` when creating the subchannel resulted in the subchannel shutting down but staying in the pool when its refcount reached 0, and then the pool could still use it. This is counter to the intention that a subchannel should only be shut down when it will never be used again. Once that is removed, the cleanup timer becomes useful to avoid filling the pool up with unused subchannels, and the result is that the `global` constructor parameter doesn't do anything anymore.

I also changed the subchannel shutdown behavior to transition to IDLE instead of TRANSIENT_FAILURE. In theory, both of those should be fine there because the important thing is closing and discarding the connection, but TRANSIENT_FAILURE is more disruptive if the shutdown is in error.