### PR TITLE
grpc-js: Fix mean calculation in outlier detection LB policy

### DIFF
--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -429,7 +429,7 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
     }
 
     // Step 2
-    const successRateMean = successRates.reduce((a, b) => a + b);
+    const successRateMean = successRates.reduce((a, b) => a + b) / successRates.length;
     let successRateVariance = 0;
     for (const rate of successRates) {
       const deviation = rate - successRateMean;


### PR DESCRIPTION
sum !== mean