### PR TITLE
proto-loader: Don't force long@5

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "author": "Google Inc.",
   "contributors": [
     {
@@ -47,7 +47,7 @@
   "dependencies": {
     "@types/long": "^4.0.1",
     "lodash.camelcase": "^4.3.0",
-    "long": "^5.2.0",
+    "long": "^4.0.0 || ^5.2.0",
     "protobufjs": "^6.10.0",
     "yargs": "^16.2.0"
   },


### PR DESCRIPTION
This fixes #2111. I tested this with long version 4 and 5 and it imports the same thing in both cases.