### PR TITLE
proto-loader: Switch `long` dependency back to 4.x

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "author": "Google Inc.",
   "contributors": [
     {
@@ -47,7 +47,7 @@
   "dependencies": {
     "@types/long": "^4.0.1",
     "lodash.camelcase": "^4.3.0",
-    "long": "^4.0.0 || ^5.2.0",
+    "long": "^4.0.0",
     "protobufjs": "^6.10.0",
     "yargs": "^16.2.0"
   },


### PR DESCRIPTION
This puts it back to the way it was before I started changing this, but leaves the change to the `import` line intact so that it is still compatible with 5.x. When I started this, I didn't realize that `long` 4.x actually has a separate `@types/long` package, but 5.x includes its types. TypeScript seems to prefer the included type information, so the types in 5.x would override the types for 4.x even if the user explicitly declared a dependency on `@types/long` 4.x.

This should fix #2113.