### PR TITLE
grpc-js-xds: Refactor xDS stream state and add resource timer

### DIFF
--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -309,7 +309,7 @@ export class XdsClient {
     const edsState = new EdsState(() => {
       this.updateNames('eds');
     });
-    const cdsState = new CdsState(edsState, () => {
+    const cdsState = new CdsState(() => {
       this.updateNames('cds');
     });
     const rdsState = new RdsState(() => {
@@ -630,6 +630,7 @@ export class XdsClient {
           this.updateNames(service);
         }
       }
+      this.reportAdsStreamStarted();
     }
   }
 
@@ -775,6 +776,13 @@ export class XdsClient {
     this.adsState.cds.reportStreamError(status);
     this.adsState.rds.reportStreamError(status);
     this.adsState.lds.reportStreamError(status);
+  }
+
+  private reportAdsStreamStarted() {
+    this.adsState.eds.reportAdsStreamStart();
+    this.adsState.cds.reportAdsStreamStart();
+    this.adsState.rds.reportAdsStreamStart();
+    this.adsState.lds.reportAdsStreamStart();
   }
 
   private handleLrsResponse(message: LoadStatsResponse__Output) {

--- a/packages/grpc-js-xds/src/xds-stream-state/eds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/eds-state.ts
@@ -19,7 +19,7 @@ import { experimental, logVerbosity, StatusObject } from "@grpc/grpc-js";
 import { isIPv4, isIPv6 } from "net";
 import { ClusterLoadAssignment__Output } from "../generated/envoy/config/endpoint/v3/ClusterLoadAssignment";
 import { Any__Output } from "../generated/google/protobuf/Any";
-import { HandleResponseResult, RejectedResourceEntry, ResourcePair, Watcher, XdsStreamState } from "./xds-stream-state";
+import { BaseXdsStreamState, HandleResponseResult, RejectedResourceEntry, ResourcePair, Watcher, XdsStreamState } from "./xds-stream-state";
 
 const TRACER_NAME = 'xds_client';
 
@@ -27,83 +27,15 @@ function trace(text: string): void {
   experimental.trace(logVerbosity.DEBUG, TRACER_NAME, text);
 }
 
-export class EdsState implements XdsStreamState<ClusterLoadAssignment__Output> {
-  public versionInfo = '';
-  public nonce = '';
-
-  private watchers: Map<
-    string,
-    Watcher<ClusterLoadAssignment__Output>[]
-  > = new Map<string, Watcher<ClusterLoadAssignment__Output>[]>();
-
-  private latestResponses: ClusterLoadAssignment__Output[] = [];
-  private latestIsV2 = false;
-
-  constructor(private updateResourceNames: () => void) {}
-
-  /**
-   * Add the watcher to the watcher list. Returns true if the list of resource
-   * names has changed, and false otherwise.
-   * @param edsServiceName
-   * @param watcher
-   */
-  addWatcher(
-    edsServiceName: string,
-    watcher: Watcher<ClusterLoadAssignment__Output>
-  ): void {
-    let watchersEntry = this.watchers.get(edsServiceName);
-    let addedServiceName = false;
-    if (watchersEntry === undefined) {
-      addedServiceName = true;
-      watchersEntry = [];
-      this.watchers.set(edsServiceName, watchersEntry);
-    }
-    trace('Adding EDS watcher (' + watchersEntry.length + ' ->' + (watchersEntry.length + 1) + ') for edsServiceName ' + edsServiceName);
-    watchersEntry.push(watcher);
-
-    /* If we have already received an update for the requested edsServiceName,
-     * immediately pass that update along to the watcher */
-    const isV2 = this.latestIsV2;
-    for (const message of this.latestResponses) {
-      if (message.cluster_name === edsServiceName) {
-        /* These updates normally occur asynchronously, so we ensure that
-         * the same happens here */
-        process.nextTick(() => {
-          trace('Reporting existing EDS update for new watcher for edsServiceName ' + edsServiceName);
-          watcher.onValidUpdate(message, isV2);
-        });
-      }
-    }
-    if (addedServiceName) {
-      this.updateResourceNames();
-    }
+export class EdsState extends BaseXdsStreamState<ClusterLoadAssignment__Output> implements XdsStreamState<ClusterLoadAssignment__Output> {
+  protected getResourceName(resource: ClusterLoadAssignment__Output): string {
+    return resource.cluster_name;
   }
-
-  removeWatcher(
-    edsServiceName: string,
-    watcher: Watcher<ClusterLoadAssignment__Output>
-  ): void {
-    trace('Removing EDS watcher for edsServiceName ' + edsServiceName);
-    const watchersEntry = this.watchers.get(edsServiceName);
-    let removedServiceName = false;
-    if (watchersEntry !== undefined) {
-      const entryIndex = watchersEntry.indexOf(watcher);
-      if (entryIndex >= 0) {
-        trace('Removed EDS watcher (' + watchersEntry.length + ' -> ' + (watchersEntry.length - 1) + ') for edsServiceName ' + edsServiceName);
-        watchersEntry.splice(entryIndex, 1);
-      }
-      if (watchersEntry.length === 0) {
-        removedServiceName = true;
-        this.watchers.delete(edsServiceName);
-      }
-    }
-    if (removedServiceName) {
-      this.updateResourceNames();
-    }
+  protected getProtocolName(): string {
+    return 'EDS';
   }
-
-  getResourceNames(): string[] {
-    return Array.from(this.watchers.keys());
+  protected isStateOfTheWorld(): boolean {
+    return false;
   }
 
   /**
@@ -111,7 +43,7 @@ export class EdsState implements XdsStreamState<ClusterLoadAssignment__Output> {
    * https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md#clusterloadassignment-proto
    * @param message
    */
-  private validateResponse(message: ClusterLoadAssignment__Output) {
+  public validateResponse(message: ClusterLoadAssignment__Output) {
     for (const endpoint of message.endpoints) {
       for (const lb of endpoint.lb_endpoints) {
         const socketAddress = lb.endpoint?.address?.socket_address;
@@ -127,49 +59,5 @@ export class EdsState implements XdsStreamState<ClusterLoadAssignment__Output> {
       }
     }
     return true;
-  }
-
-  handleResponses(responses: ResourcePair<ClusterLoadAssignment__Output>[], isV2: boolean): HandleResponseResult {
-    const validResponses: ClusterLoadAssignment__Output[] = [];
-    let result: HandleResponseResult = {
-      accepted: [],
-      rejected: [],
-      missing: []
-    }
-    for (const {resource, raw} of responses) {
-      if (this.validateResponse(resource)) {
-        validResponses.push(resource);
-        result.accepted.push({
-          name: resource.cluster_name,
-          raw: raw});
-      } else {
-        trace('EDS validation failed for message ' + JSON.stringify(resource));
-        result.rejected.push({
-          name: resource.cluster_name, 
-          raw: raw,
-          error: `ClusterLoadAssignment validation failed for resource ${resource.cluster_name}`
-        });
-      }
-    }
-    this.latestResponses = validResponses;
-    this.latestIsV2 = isV2;
-    const allClusterNames: Set<string> = new Set<string>();
-    for (const message of validResponses) {
-      allClusterNames.add(message.cluster_name);
-      const watchers = this.watchers.get(message.cluster_name) ?? [];
-      for (const watcher of watchers) {
-        watcher.onValidUpdate(message, isV2);
-      }
-    }
-    trace('Received EDS updates for cluster names [' + Array.from(allClusterNames) + ']');
-    return result;
-  }
-
-  reportStreamError(status: StatusObject): void {
-    for (const watcherList of this.watchers.values()) {
-      for (const watcher of watcherList) {
-        watcher.onTransientError(status);
-      }
-    }
   }
 }

--- a/packages/grpc-js-xds/src/xds-stream-state/xds-stream-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/xds-stream-state.ts
@@ -15,8 +15,10 @@
  *
  */
 
-import { StatusObject } from "@grpc/grpc-js";
+import { experimental, logVerbosity, StatusObject } from "@grpc/grpc-js";
 import { Any__Output } from "../generated/google/protobuf/Any";
+
+const TRACER_NAME = 'xds_client';
 
 export interface Watcher<UpdateType> {
   /* Including the isV2 flag here is a bit of a kludge. It would probably be
@@ -63,4 +65,189 @@ export interface XdsStreamState<ResponseType> {
   handleResponses(responses: ResourcePair<ResponseType>[], isV2: boolean): HandleResponseResult;
 
   reportStreamError(status: StatusObject): void;
+  reportAdsStreamStart(): void;
+
+  addWatcher(name: string, watcher: Watcher<ResponseType>): void;
+  removeWatcher(resourceName: string, watcher: Watcher<ResponseType>): void;
+}
+
+interface SubscriptionEntry<ResponseType> {
+  watchers: Watcher<ResponseType>[];
+  cachedResponse: ResponseType | null;
+  resourceTimer: NodeJS.Timer;
+}
+
+const RESOURCE_TIMEOUT_MS = 15_000;
+
+export abstract class BaseXdsStreamState<ResponseType> implements XdsStreamState<ResponseType> {
+  versionInfo = '';
+  nonce = '';
+
+  private subscriptions: Map<string, SubscriptionEntry<ResponseType>> = new Map<string, SubscriptionEntry<ResponseType>>();
+  private latestIsV2 = false;
+  private isAdsStreamRunning = false;
+
+  constructor(private updateResourceNames: () => void) {}
+
+  protected trace(text: string) {
+    experimental.trace(logVerbosity.DEBUG, TRACER_NAME, this.getProtocolName() + ' | ' + text);
+  }
+
+  private startResourceTimer(subscriptionEntry: SubscriptionEntry<ResponseType>) {
+    clearTimeout(subscriptionEntry.resourceTimer);
+    subscriptionEntry.resourceTimer = setTimeout(() => {
+      for (const watcher of subscriptionEntry.watchers) {
+        watcher.onResourceDoesNotExist();
+      }
+    }, RESOURCE_TIMEOUT_MS);
+  }
+
+  addWatcher(name: string, watcher: Watcher<ResponseType>): void {
+    this.trace('Adding watcher for name ' + name);
+    let subscriptionEntry = this.subscriptions.get(name);
+    let addedName = false;
+    if (subscriptionEntry === undefined) {
+      addedName = true;
+      subscriptionEntry = {
+        watchers: [],
+        cachedResponse: null,
+        resourceTimer: setTimeout(() => {}, 0)
+      };
+      this.startResourceTimer(subscriptionEntry);
+      this.subscriptions.set(name, subscriptionEntry);
+    }
+    subscriptionEntry.watchers.push(watcher);
+    if (subscriptionEntry.cachedResponse !== null) {
+      const cachedResponse = subscriptionEntry.cachedResponse;
+      /* These updates normally occur asynchronously, so we ensure that
+       * the same happens here */
+      process.nextTick(() => {
+        this.trace('Reporting existing update for new watcher for name ' + name);
+        watcher.onValidUpdate(cachedResponse, this.latestIsV2);
+      });
+    }
+    if (addedName) {
+      this.updateResourceNames();
+    }
+  }
+  removeWatcher(resourceName: string, watcher: Watcher<ResponseType>): void {
+    this.trace('Removing watcher for name ' + resourceName);
+    const subscriptionEntry = this.subscriptions.get(resourceName);
+    if (subscriptionEntry !== undefined) {
+      const entryIndex = subscriptionEntry.watchers.indexOf(watcher);
+      if (entryIndex >= 0) {
+        subscriptionEntry.watchers.splice(entryIndex, 1);
+      }
+      if (subscriptionEntry.watchers.length === 0) {
+        clearTimeout(subscriptionEntry.resourceTimer);
+        this.subscriptions.delete(resourceName);
+        this.updateResourceNames();
+      }
+    }
+  }
+
+  getResourceNames(): string[] {
+    return Array.from(this.subscriptions.keys());
+  }
+  handleResponses(responses: ResourcePair<ResponseType>[], isV2: boolean): HandleResponseResult {
+    const validResponses: ResponseType[] = [];
+    let result: HandleResponseResult = {
+      accepted: [],
+      rejected: [],
+      missing: []
+    }
+    for (const {resource, raw} of responses) {
+      const resourceName = this.getResourceName(resource);
+      if (this.validateResponse(resource, isV2)) {
+        validResponses.push(resource);
+        result.accepted.push({
+          name: resourceName,
+          raw: raw});
+      } else {
+        this.trace('Validation failed for message ' + JSON.stringify(resource));
+        result.rejected.push({
+          name: resourceName, 
+          raw: raw,
+          error: `Validation failed for resource ${resourceName}`
+        });
+      }
+    }
+    this.latestIsV2 = isV2;
+    const allResourceNames = new Set<string>();
+    for (const resource of validResponses) {
+      const resourceName = this.getResourceName(resource);
+      allResourceNames.add(resourceName);
+      const subscriptionEntry = this.subscriptions.get(resourceName);
+      if (subscriptionEntry) {
+        const watchers = subscriptionEntry.watchers;
+        for (const watcher of watchers) {
+          watcher.onValidUpdate(resource, isV2);
+        }
+        clearTimeout(subscriptionEntry.resourceTimer);
+        subscriptionEntry.cachedResponse = resource;
+      }
+    }
+    result.missing = this.handleMissingNames(allResourceNames);
+    this.trace('Received response with resource names [' + Array.from(allResourceNames) + ']');
+    return result;
+  }
+  reportStreamError(status: StatusObject): void {
+    for (const subscriptionEntry of this.subscriptions.values()) {
+      for (const watcher of subscriptionEntry.watchers) {
+        watcher.onTransientError(status);
+      }
+      clearTimeout(subscriptionEntry.resourceTimer);
+    }
+    this.isAdsStreamRunning = false;
+  }
+
+  reportAdsStreamStart() {
+    this.isAdsStreamRunning = true;
+    for (const subscriptionEntry of this.subscriptions.values()) {
+      if (subscriptionEntry.cachedResponse === null) {
+        this.startResourceTimer(subscriptionEntry);
+      }
+    }
+  }
+
+  private handleMissingNames(allResponseNames: Set<String>): string[] {
+    if (this.isStateOfTheWorld()) {
+      const missingNames: string[] = [];
+      for (const [resourceName, subscriptionEntry] of this.subscriptions.entries()) {
+        if (!allResponseNames.has(resourceName) && subscriptionEntry.cachedResponse !== null) {
+          this.trace('Reporting resource does not exist named ' + resourceName);
+          missingNames.push(resourceName);
+          for (const watcher of subscriptionEntry.watchers) {
+            watcher.onResourceDoesNotExist();
+          }
+        }
+      }
+      return missingNames;
+    } else {
+      return [];
+    }
+  }
+
+  /**
+   * Apply the validation rules for this resource type to this resource
+   * instance.
+   * This function is public so that the LDS validateResponse can call into
+   * the RDS validateResponse.
+   * @param resource The resource object sent by the xDS server
+   * @param isV2 If true, the resource is an xDS V2 resource instead of xDS V3
+   */
+  public abstract validateResponse(resource: ResponseType, isV2: boolean): boolean;
+  /**
+   * Get the name of a resource object. The name is some field of the object, so
+   * getting it depends on the specific type.
+   * @param resource 
+   */
+  protected abstract getResourceName(resource: ResponseType): string;
+  protected abstract getProtocolName(): string;
+  /**
+   * Indicates whether responses are "state of the world", i.e. that they
+   * contain all resources and that omitted previously-seen resources should
+   * be treated as removed.
+   */
+  protected abstract isStateOfTheWorld(): boolean;
 }

--- a/packages/grpc-js-xds/src/xds-stream-state/xds-stream-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/xds-stream-state.ts
@@ -113,7 +113,9 @@ export abstract class BaseXdsStreamState<ResponseType> implements XdsStreamState
         cachedResponse: null,
         resourceTimer: setTimeout(() => {}, 0)
       };
-      this.startResourceTimer(subscriptionEntry);
+      if (this.isAdsStreamRunning) {
+        this.startResourceTimer(subscriptionEntry);
+      }
       this.subscriptions.set(name, subscriptionEntry);
     }
     subscriptionEntry.watchers.push(watcher);

--- a/packages/grpc-js-xds/src/xds-stream-state/xds-stream-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/xds-stream-state.ts
@@ -201,6 +201,7 @@ export abstract class BaseXdsStreamState<ResponseType> implements XdsStreamState
       clearTimeout(subscriptionEntry.resourceTimer);
     }
     this.isAdsStreamRunning = false;
+    this.nonce = '';
   }
 
   reportAdsStreamStart() {

--- a/test/kokoro/linux.cfg
+++ b/test/kokoro/linux.cfg
@@ -14,10 +14,10 @@
 # Config file for Kokoro (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc-node/packages/grpc-js-xds/scripts/xds.sh"
-timeout_mins: 360
+build_file: "grpc-node/test/kokoro.sh"
+timeout_mins: 60
 action {
   define_artifacts {
-    regex: "github/grpc/reports/**"
+    regex: "github/grpc-node/reports/**/sponge_log.xml"
   }
 }

--- a/test/kokoro/linux.cfg
+++ b/test/kokoro/linux.cfg
@@ -14,10 +14,10 @@
 # Config file for Kokoro (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc-node/test/kokoro.sh"
-timeout_mins: 60
+build_file: "grpc-node/packages/grpc-js-xds/scripts/xds.sh"
+timeout_mins: 360
 action {
   define_artifacts {
-    regex: "github/grpc-node/reports/**/sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }


### PR DESCRIPTION
The main goal of this change is to add the resource timer, which is described in [this section of the xDS docs](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#knowing-when-a-requested-resource-does-not-exist). Essentially, the protocol does not consistently tell us when a resource does not exist, so we assume that the server will respond to any request within 15 seconds, and if the client does not get the requested resource in that time, it assumes that it does not exist. Since the timer is watching server response latency, we only run it while we have an active ADS stream. The specific algorithm is as follows:

 - When a watcher subscribes to a new resource name, if the ADS stream is alive, start the timer for that resource name.
 - When the ADS stream dies, cancel all timers.
 - When a new ADS stream starts, start the timer for all resource names for which we do not have a cached response.
 - When we receive a resource, cancel its timer.
 - When the timer fires, report that the resource does not exist.

Some significant changes were needed to the watchers structure to implement this in a reasonable way, and the simplest way to do that was to refactor most of the logic into the new `BaseXdsStreamState` abstract class. This refactor ended up slightly modifying the nonexistent resource reporting for LDS and CDS, to account for whether we already have a cached response. Otherwise I think it should all be functionally the same.

I also added a change to clear the nonce when the ADS stream ends, because apparently we're supposed to do that too. It's not really related to this change but I was touching that part of the code anyway and it's a quick change.