### PR TITLE
grpc-js: Specify "types" option for TypeScript

### DIFF
--- a/packages/grpc-js/tsconfig.json
+++ b/packages/grpc-js/tsconfig.json
@@ -6,7 +6,8 @@
     "target": "es2017",
     "module": "commonjs",
     "resolveJsonModule": true,
-    "incremental": true
+    "incremental": true,
+    "types": ["mocha"]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
This has the effect of eliding triple-slash references for type imports such as `import type { Long } from '@grpc/proto-loader'` in the emitted type definitions.

According to https://github.com/microsoft/TypeScript/pull/22752 they are supposed to be elided anyway, but maybe there's a bug. I found this workaround via the discussion in https://github.com/microsoft/TypeScript/issues/19874.

Test Plan: Ran `npm run compile` in `packages/grpc-js`. Verified that `packages/grpc-js/build/src/generated/google/protobuf/Int64Value.d.ts` does not contain `/// <reference types="long" />`.

Fixes #2030