### PR TITLE
bugfix: handle disconnectListeners in reverse to allow listener removal in loop

### DIFF
--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -646,7 +646,8 @@ export class Subchannel {
     this.transitionToState(
       [ConnectivityState.READY],
       ConnectivityState.TRANSIENT_FAILURE);
-    for (const listener of this.disconnectListeners) {
+    for (let i = this.disconnectListeners.length - 1; i >= 0; i--) {
+      const listener = this.disconnectListeners[i];
       listener();
     }
   }

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -108,7 +108,7 @@ export class Subchannel {
    * socket disconnects. Used for ending active calls with an UNAVAILABLE
    * status.
    */
-  private disconnectListeners: Array<() => void> = [];
+  private disconnectListeners: Set<() => void> = new Set();
 
   private backoffTimeout: BackoffTimeout;
 
@@ -646,8 +646,7 @@ export class Subchannel {
     this.transitionToState(
       [ConnectivityState.READY],
       ConnectivityState.TRANSIENT_FAILURE);
-    for (let i = this.disconnectListeners.length - 1; i >= 0; i--) {
-      const listener = this.disconnectListeners[i];
+    for (const listener of this.disconnectListeners.values()) {
       listener();
     }
   }
@@ -972,14 +971,11 @@ export class Subchannel {
   }
 
   addDisconnectListener(listener: () => void) {
-    this.disconnectListeners.push(listener);
+    this.disconnectListeners.add(listener);
   }
 
   removeDisconnectListener(listener: () => void) {
-    const listenerIndex = this.disconnectListeners.indexOf(listener);
-    if (listenerIndex > -1) {
-      this.disconnectListeners.splice(listenerIndex, 1);
-    }
+    this.disconnectListeners.delete(listener);
   }
 
   /**


### PR DESCRIPTION
I had a situation with 1 subchannel for multiple streams. If a keepalive timeout occured, it would not trigger a 'Connection dropped' for each stream.

I found a bug in the code that handles the disconnect listeners. The listener function itself can [remove itself from the array](https://github.com/bartslinger/grpc-node/blob/0a0e13eedecedb31e91ad2d250c5fca6f31e46b6/packages/grpc-js/src/call-stream.ts#L334). The removal [uses splice](https://github.com/bartslinger/grpc-node/blob/0a0e13eedecedb31e91ad2d250c5fca6f31e46b6/packages/grpc-js/src/subchannel.ts#L981). Thereby, the next item shifts one place and will not be called from the loop. This is a common problem and is usually handled by looping in reverse.