### PR TITLE
grpc-js: Specify 'types' option in tsconfig file

### DIFF
--- a/packages/grpc-js/tsconfig.json
+++ b/packages/grpc-js/tsconfig.json
@@ -6,7 +6,8 @@
     "target": "es2017",
     "module": "commonjs",
     "resolveJsonModule": true,
-    "incremental": true
+    "incremental": true,
+    "types": ["mocha"]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
This is the same as #2121, redone with permission of the author, because of CLA problems. This change prevents the TypeScript compiler from generating `/// <reference types="long" />` from `import type { Long } from '@grpc/proto-loader'`, which causes problems when users have other dependencies on `long`.

Fixes #2030.