### PR TITLE
bump protobufjs to "^6.11.3"

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -48,7 +48,7 @@
     "@types/long": "^4.0.1",
     "lodash.camelcase": "^4.3.0",
     "long": "^4.0.0",
-    "protobufjs": "^6.10.0",
+    "protobufjs": "^6.11.3",
     "yargs": "^16.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The package protobufjs before 6.11.3 are vulnerable to Prototype Pollution which can allow an attacker to add/modify properties of the Object.prototype.

This vulnerability can occur in multiple ways:

1. by providing untrusted user input to util.setProperty or to ReflectionObject.setParsedOption functions
2. by parsing/loading .proto files
Publish Date: 2022-05-27

URL: [CVE-2022-25878](https://vuln.whitesourcesoftware.com/vulnerability/CVE-2022-25878)