### PR TITLE
Remove `grpc` dependency

### DIFF
--- a/packages/grpc-health-check/health.js
+++ b/packages/grpc-health-check/health.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var grpc = require('grpc');
-
 var _get = require('lodash.get');
 var _clone = require('lodash.clone')
 
 var health_messages = require('./v1/health_pb');
 var health_service = require('./v1/health_grpc_pb');
+
+// https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/constants.ts
+const NOT_FOUND_STATUS_CODE = 5;
 
 function HealthImplementation(statusMap) {
   this.statusMap = _clone(statusMap);
@@ -38,8 +39,7 @@ HealthImplementation.prototype.check = function(call, callback){
   var service = call.request.getService();
   var status = _get(this.statusMap, service, null);
   if (status === null) {
-    // TODO(murgatroid99): Do this without an explicit reference to grpc.
-    callback({code:grpc.status.NOT_FOUND});
+    callback({ code: NOT_FOUND_STATUS_CODE });
   } else {
     var response = new health_messages.HealthCheckResponse();
     response.setStatus(status);

--- a/packages/grpc-health-check/package.json
+++ b/packages/grpc-health-check/package.json
@@ -16,7 +16,6 @@
   ],
   "dependencies": {
     "google-protobuf": "^3.4.0",
-    "grpc": "^1.6.0",
     "lodash.clone": "^4.5.0",
     "lodash.get": "^4.4.2"
   },

--- a/packages/grpc-health-check/package.json
+++ b/packages/grpc-health-check/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "google-protobuf": "^3.4.0",
+    "grpc": "^1.6.0",
     "lodash.clone": "^4.5.0",
     "lodash.get": "^4.4.2"
   },


### PR DESCRIPTION
Hard code the `NOT_FOUND` status code from the `grpc` library (deprecated).

The enum `grpc.status` has not been changed in 5 years from viewing the git blame and IMO likely won't. Further, when people download this package from NPM they could see a warning in the console saying that a package has been deprecated since `grpc-health-check` relies on `grpc`.

---

Actually, can't fully remove the `grpc` dependency from the `package.json` since the https://github.com/grpc/grpc-node/blob/master/packages/grpc-health-check/v1/health_grpc_pb.js uses it for the `makeGenericClientConstructor` function - which doesn't look like it would be a simple copy to this repository if that would even be desirable.