### PR TITLE
Clone submodules in xds k8s url map script

### DIFF
--- a/packages/grpc-js-xds/scripts/xds_k8s_url_map.sh
+++ b/packages/grpc-js-xds/scripts/xds_k8s_url_map.sh
@@ -133,6 +133,10 @@ main() {
   local script_dir
   script_dir="$(dirname "$0")"
 
+  cd "${script_dir}"
+
+  git submodule update --init --recursive
+
   # Source the test driver from the master branch.
   echo "Sourcing test driver install script from: ${TEST_DRIVER_INSTALL_SCRIPT_URL}"
   source /dev/stdin <<< "$(curl -s "${TEST_DRIVER_INSTALL_SCRIPT_URL}")"


### PR DESCRIPTION
These lines are copied from the other script. Without this the docker image ends up broken.