### PR TITLE
proto-loader: Update protobufjs dependency to 7.x

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.6.13",
+  "version": "0.7.0",
   "author": "Google Inc.",
   "contributors": [
     {
@@ -48,7 +48,7 @@
     "@types/long": "^4.0.1",
     "lodash.camelcase": "^4.3.0",
     "long": "^4.0.0",
-    "protobufjs": "^6.11.3",
+    "protobufjs": "^7.0.0",
     "yargs": "^16.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Protobuf.js version 7.0.0 was released very recently, so this change picks it up. Note: for 0.x versions, the minor version acts like a major version, and users will need to explicitly change their dependencies to get the new version. I changed the minor version in this case because the proto-loader library delegates a lot of functionality to Protobuf.js, so there is a lot of potential for delegated breakage.