### PR TITLE
Disable source maps in build

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -46,6 +46,7 @@
     "build": "npm run compile",
     "clean": "rimraf ./build",
     "compile": "tsc -p .",
+    "dev": "tsc -p . --project tsconfig.dev.json",
     "format": "clang-format -i -style=\"{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}\" src/*.ts test/*.ts",
     "lint": "npm run check",
     "prepare": "npm run generate-types && npm run compile",

--- a/packages/grpc-js/tsconfig.dev.json
+++ b/packages/grpc-js/tsconfig.dev.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "lib": ["es2017"],
+    "outDir": "build",
+    "target": "es2017",
+    "module": "commonjs",
+    "resolveJsonModule": true,
+    "incremental": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/packages/grpc-js/tsconfig.json
+++ b/packages/grpc-js/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2017"],
     "outDir": "build",
     "target": "es2017",
+    "sourceMap": false,
     "module": "commonjs",
     "resolveJsonModule": true,
     "incremental": true

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -16,6 +16,7 @@
     "build": "npm run compile",
     "clean": "rimraf ./build",
     "compile": "tsc -p .",
+    "dev": "tsc -p . --project tsconfig.dev.json",
     "format": "clang-format -i -style=\"{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}\" src/*.ts test/*.ts",
     "lint": "tslint -c node_modules/google-ts-style/tslint.json -p . -t codeFrame --type-check",
     "prepare": "npm run compile",

--- a/packages/proto-loader/tsconfig.dev.json
+++ b/packages/proto-loader/tsconfig.dev.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "lib": ["es2017"],
+    "target": "es2017"
+  },
+  "include": [
+    "bin/**/*.ts",
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/packages/proto-loader/tsconfig.json
+++ b/packages/proto-loader/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
+    "sourceMap": false,
     "lib": ["es2017"],
     "target": "es2017"
   },


### PR DESCRIPTION
This PR disables source maps by default when building `grpc-js` and `proto-loader` packages, by setting `compilerOptions.sourceMap = false` in the packages' `tsconfig.json` files.

Since `.map` files are not bundled in the `npm` release, this would solve missing source map errors when using the package. (See issue #2170)

Previous `tsconfig.json` files are moved to `tsconfig.dev.json` and a new script: `npm run dev` is added that performs a build with source maps.