### PR TITLE
include `.map` files in proto-loader npm package

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -38,7 +38,7 @@
   "files": [
     "LICENSE",
     "build/src/*.d.ts",
-    "build/src/*.js",
+    "build/src/*.{js,js.map}",
     "build/bin/*.js"
   ],
   "bin": {

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -39,7 +39,7 @@
     "LICENSE",
     "build/src/*.d.ts",
     "build/src/*.{js,js.map}",
-    "build/bin/*.js"
+    "build/bin/*.{js,js.map}"
   ],
   "bin": {
     "proto-loader-gen-types": "./build/bin/proto-loader-gen-types.js"


### PR DESCRIPTION
This PR updates `proto-loader` package.json to include `.js.map` files.

Fixes #2170 