### PR TITLE
grpc-js: Add outlier detection tracing and enable it in interop tests, plus some other changes

### DIFF
--- a/packages/grpc-js-xds/interop/Dockerfile
+++ b/packages/grpc-js-xds/interop/Dockerfile
@@ -33,6 +33,6 @@ COPY --from=build /node/src/grpc-node/packages/grpc-js ./packages/grpc-js/
 COPY --from=build /node/src/grpc-node/packages/grpc-js-xds ./packages/grpc-js-xds/
 
 ENV GRPC_VERBOSITY="DEBUG"
-ENV GRPC_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver,fault_injection,http_filter,csds
+ENV GRPC_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver,fault_injection,http_filter,csds,outlier_detection
 
 ENTRYPOINT [ "node", "/node/src/grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client" ]

--- a/packages/grpc-js-xds/src/load-balancer-cds.ts
+++ b/packages/grpc-js-xds/src/load-balancer-cds.ts
@@ -79,9 +79,8 @@ function translateOutlierDetectionConfig(outlierDetection: OutlierDetection__Out
     return undefined;
   }
   if (!outlierDetection) {
-    /* No-op outlier detection config, with max possible interval and no
-     * ejection criteria configured. */
-    return new OutlierDetectionLoadBalancingConfig(~(1<<31), null, null, null, null, null, []);
+    /* No-op outlier detection config, with all fields unset. */
+    return new OutlierDetectionLoadBalancingConfig(null, null, null, null, null, null, []);
   }
   let successRateConfig: Partial<SuccessRateEjectionConfig> | null = null;
   /* Success rate ejection is enabled by default, so we only disable it if

--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -357,7 +357,10 @@ class OutlierDetectionPicker implements Picker {
           extraFilterFactories: extraFilterFactories
         };
       } else {
-        return wrappedPick;
+        return {
+          ...wrappedPick,
+          subchannel: subchannelWrapper.getWrappedSubchannel()
+        }
       }
     } else {
       return wrappedPick;
@@ -619,6 +622,10 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
       trace('Counting disabled. Cancelling timer.');
       this.timerStartTime = null;
       clearTimeout(this.ejectionTimer);
+      for (const mapEntry of this.addressMap.values()) {
+        this.uneject(mapEntry);
+        mapEntry.ejectionTimeMultiplier = 0;
+      }
     }
 
     this.latestConfig = lbConfig;


### PR DESCRIPTION
The main change here is adding trace logging, modeled heavily on the logs added to the core implementation in grpc/grpc#30239. I also made the changes described in grpc/proposal#315, and I made the unwrapping of the subchannel in the wrapper more consistent.