### PR TITLE
grpc-js: Implement getConnectivityState in subchannel wrapper

### DIFF
--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -215,6 +215,14 @@ class OutlierDetectionSubchannelWrapper extends BaseSubchannelWrapper implements
     });
   }
 
+  getConnectivityState(): connectivityState {
+    if (this.ejected) {
+      return ConnectivityState.TRANSIENT_FAILURE;
+    } else {
+      return this.childSubchannelState;
+    }
+  }
+
   /**
    * Add a listener function to be called whenever the wrapper's
    * connectivity state changes.


### PR DESCRIPTION
The `ejected` state overrides the reported connectivity state. The existing implementation implements that correctly when handling the connectivity state update event, but it does not implement `getConnectivityState`, so that falls back to the default implementation which just proxies the result from the `childSubchannel`. This matters because the `round_robin` LB policy uses `getConnectivityState` instead of just tracking the state update events.
