### PR TITLE
grpc-js: Preserve state when recreating subchannel wrappers

### DIFF
--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -199,12 +199,13 @@ export class OutlierDetectionLoadBalancingConfig implements LoadBalancingConfig 
 }
 
 class OutlierDetectionSubchannelWrapper extends BaseSubchannelWrapper implements SubchannelInterface {
-  private childSubchannelState: ConnectivityState = ConnectivityState.IDLE;
+  private childSubchannelState: ConnectivityState;
   private stateListeners: ConnectivityStateListener[] = [];
   private ejected: boolean = false;
   private refCount: number = 0;
   constructor(childSubchannel: SubchannelInterface, private mapEntry?: MapEntry) {
     super(childSubchannel);
+    this.childSubchannelState = childSubchannel.getConnectivityState();
     childSubchannel.addConnectivityStateListener((subchannel, previousState, newState) => {
       this.childSubchannelState = newState;
       if (!this.ejected) {

--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -391,6 +391,10 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
         const originalSubchannel = channelControlHelper.createSubchannel(subchannelAddress, subchannelArgs);
         const mapEntry = this.addressMap.get(subchannelAddressToString(subchannelAddress));
         const subchannelWrapper = new OutlierDetectionSubchannelWrapper(originalSubchannel, mapEntry);
+        if (mapEntry?.currentEjectionTimestamp !== null) {
+          // If the address is ejected, propagate that to the new subchannel wrapper
+          subchannelWrapper.eject();
+        }
         mapEntry?.subchannelWrappers.push(subchannelWrapper);
         return subchannelWrapper;
       },


### PR DESCRIPTION
When the address list is updated, the child will probably request new subchannels for the addresses, and if the addresses are unchanged, the same subchannels will be provided but the outlier detection LB policy will still recreate the wrapper objects. I made two changes here to preserve the state when that happens:

 - Construct the wrapper using the subchannel's reported state instead of defaulting to the `IDLE` state, so that the wrapper reports the correct state immediately, before the subchannel's state changes.
 - If the address is already ejected, propagate that state to the new subchannel wrapper.