### PR TITLE
proto-loader-gen-types Typename templates

### DIFF
--- a/packages/proto-loader/README.md
+++ b/packages/proto-loader/README.md
@@ -88,6 +88,10 @@ Options:
   -O, --outDir           Directory in which to output files  [string] [required]
       --grpcLib          The gRPC implementation library that these types will
                          be used with                        [string] [required]
+      --inputTemplate    Template for mapping input or "permissive" type names
+                                                        [string] [default: "%s"]
+      --outputTemplate   Template for mapping output or "restricted" type names
+                                                [string] [default: "%s__Output"]
 ```
 
 ### Example Usage

--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -26,12 +26,25 @@ import * as yargs from 'yargs';
 import camelCase = require('lodash.camelcase');
 import { loadProtosWithOptions, addCommonProtos } from '../src/util';
 
+const templateStr = "%s";
+const useNameFmter = ({outputTemplate, inputTemplate}: GeneratorOptions) => {
+  if (outputTemplate === inputTemplate) {
+    throw new Error('inputTemplate and outputTemplate must differ')
+  }
+  return {
+    outputName: (n: string) => outputTemplate.replace(templateStr, n),
+    inputName: (n: string) => inputTemplate.replace(templateStr, n)
+  };
+}
+
 type GeneratorOptions = Protobuf.IParseOptions & Protobuf.IConversionOptions & {
   includeDirs?: string[];
   grpcLib: string;
   outDir: string;
   verbose?: boolean;
   includeComments?: boolean;
+  inputTemplate: string;
+  outputTemplate: string;
 }
 
 class TextFormatter {
@@ -114,15 +127,16 @@ function getTypeInterfaceName(type: Protobuf.Type | Protobuf.Enum | Protobuf.Ser
   return type.fullName.replace(/\./g, '_');
 }
 
-function getImportLine(dependency: Protobuf.Type | Protobuf.Enum | Protobuf.Service, from?: Protobuf.Type | Protobuf.Service) {
+function getImportLine(dependency: Protobuf.Type | Protobuf.Enum | Protobuf.Service, from: Protobuf.Type | Protobuf.Service | undefined, options: GeneratorOptions) {
   const filePath = from === undefined ? './' + getImportPath(dependency) : getRelativeImportPath(from, dependency);
+  const {outputName, inputName} = useNameFmter(options);
   const typeInterfaceName = getTypeInterfaceName(dependency);
   let importedTypes: string;
   /* If the dependency is defined within a message, it will be generated in that
    * message's file and exported using its typeInterfaceName. */
   if (dependency.parent instanceof Protobuf.Type) {
     if (dependency instanceof Protobuf.Type) {
-      importedTypes = `${typeInterfaceName}, ${typeInterfaceName}__Output`;
+      importedTypes = `${inputName(typeInterfaceName)}, ${outputName(typeInterfaceName)}`;
     } else if (dependency instanceof Protobuf.Enum) {
       importedTypes = `${typeInterfaceName}`;
     } else if (dependency instanceof Protobuf.Service) {
@@ -132,7 +146,7 @@ function getImportLine(dependency: Protobuf.Type | Protobuf.Enum | Protobuf.Serv
     }
   } else {
     if (dependency instanceof Protobuf.Type) {
-      importedTypes = `${dependency.name} as ${typeInterfaceName}, ${dependency.name}__Output as ${typeInterfaceName}__Output`;
+      importedTypes = `${inputName(dependency.name)} as ${inputName(typeInterfaceName)}, ${outputName(dependency.name)} as ${outputName(typeInterfaceName)}`;
     } else if (dependency instanceof Protobuf.Enum) {
       importedTypes = `${dependency.name} as ${typeInterfaceName}`;
     } else if (dependency instanceof Protobuf.Service) {
@@ -170,7 +184,8 @@ function formatComment(formatter: TextFormatter, comment?: string | null) {
 
 // GENERATOR FUNCTIONS
 
-function getTypeNamePermissive(fieldType: string, resolvedType: Protobuf.Type | Protobuf.Enum | null, repeated: boolean, map: boolean): string {
+function getTypeNamePermissive(fieldType: string, resolvedType: Protobuf.Type | Protobuf.Enum | null, repeated: boolean, map: boolean, options: GeneratorOptions): string {
+  const {inputName} = useNameFmter(options);
   switch (fieldType) {
     case 'double':
     case 'float':
@@ -200,9 +215,9 @@ function getTypeNamePermissive(fieldType: string, resolvedType: Protobuf.Type | 
       const typeInterfaceName = getTypeInterfaceName(resolvedType);
       if (resolvedType instanceof Protobuf.Type) {
         if (repeated || map) {
-          return typeInterfaceName;
+          return inputName(typeInterfaceName);
         } else {
-          return `${typeInterfaceName} | null`;
+          return `${inputName(typeInterfaceName)} | null`;
         }
       } else {
         return `${typeInterfaceName} | keyof typeof ${typeInterfaceName}`;
@@ -210,8 +225,8 @@ function getTypeNamePermissive(fieldType: string, resolvedType: Protobuf.Type | 
   }
 }
 
-function getFieldTypePermissive(field: Protobuf.FieldBase): string {
-  const valueType = getTypeNamePermissive(field.type, field.resolvedType, field.repeated, field.map);
+function getFieldTypePermissive(field: Protobuf.FieldBase, options: GeneratorOptions): string {
+  const valueType = getTypeNamePermissive(field.type, field.resolvedType, field.repeated, field.map, options);
   if (field instanceof Protobuf.MapField) {
     const keyType = field.keyType === 'string' ? 'string' : 'number';
     return `{[key: ${keyType}]: ${valueType}}`;
@@ -221,23 +236,24 @@ function getFieldTypePermissive(field: Protobuf.FieldBase): string {
 }
 
 function generatePermissiveMessageInterface(formatter: TextFormatter, messageType: Protobuf.Type, options: GeneratorOptions, nameOverride?: string) {
+  const {inputName} = useNameFmter(options);
   if (options.includeComments) {
     formatComment(formatter, messageType.comment);
   }
   if (messageType.fullName === '.google.protobuf.Any') {
     /* This describes the behavior of the Protobuf.js Any wrapper fromObject
      * replacement function */
-    formatter.writeLine('export type Any = AnyExtension | {');
+    formatter.writeLine(`export type ${inputName('Any')} = AnyExtension | {`);
     formatter.writeLine('  type_url: string;');
     formatter.writeLine('  value: Buffer | Uint8Array | string;');
     formatter.writeLine('}');
     return;
   }
-  formatter.writeLine(`export interface ${nameOverride ?? messageType.name} {`);
+  formatter.writeLine(`export interface ${inputName(nameOverride ?? messageType.name)} {`);
   formatter.indent();
   for (const field of messageType.fieldsArray) {
     const repeatedString = field.repeated ? '[]' : '';
-    const type: string = getFieldTypePermissive(field);
+    const type: string = getFieldTypePermissive(field, options);
     if (options.includeComments) {
       formatComment(formatter, field.comment);
     }
@@ -255,6 +271,7 @@ function generatePermissiveMessageInterface(formatter: TextFormatter, messageTyp
 }
 
 function getTypeNameRestricted(fieldType: string, resolvedType: Protobuf.Type | Protobuf.Enum | null, repeated: boolean, map: boolean, options: GeneratorOptions): string {
+  const {outputName} = useNameFmter(options);
   switch (fieldType) {
     case 'double':
     case 'float':
@@ -302,9 +319,9 @@ function getTypeNameRestricted(fieldType: string, resolvedType: Protobuf.Type | 
         /* null is only used to represent absent message values if the defaults
          * option is set, and only for non-repeated, non-map fields. */
         if (options.defaults && !repeated && !map) {
-          return `${typeInterfaceName}__Output | null`;
+          return `${outputName(typeInterfaceName)} | null`;
         } else {
-          return `${typeInterfaceName}__Output`;
+          return `${outputName(typeInterfaceName)}`;
         }
       } else {
         if (options.enums == String) {
@@ -327,6 +344,7 @@ function getFieldTypeRestricted(field: Protobuf.FieldBase, options: GeneratorOpt
 }
 
 function generateRestrictedMessageInterface(formatter: TextFormatter, messageType: Protobuf.Type, options: GeneratorOptions, nameOverride?: string) {
+  const {outputName} = useNameFmter(options);
   if (options.includeComments) {
     formatComment(formatter, messageType.comment);
   }
@@ -334,13 +352,13 @@ function generateRestrictedMessageInterface(formatter: TextFormatter, messageTyp
     /* This describes the behavior of the Protobuf.js Any wrapper toObject
      * replacement function */
     let optionalString = options.defaults ? '' : '?';
-    formatter.writeLine('export type Any__Output = AnyExtension | {');
+    formatter.writeLine(`export type ${outputName('Any')} = AnyExtension | {`);
     formatter.writeLine(`  type_url${optionalString}: string;`);
     formatter.writeLine(`  value${optionalString}: ${getTypeNameRestricted('bytes', null, false, false, options)};`);
     formatter.writeLine('}');
     return;
   }
-  formatter.writeLine(`export interface ${nameOverride ?? messageType.name}__Output {`);
+  formatter.writeLine(`export interface ${outputName(nameOverride ?? messageType.name)} {`);
   formatter.indent();
   for (const field of messageType.fieldsArray) {
     let fieldGuaranteed: boolean;
@@ -389,7 +407,7 @@ function generateMessageInterfaces(formatter: TextFormatter, messageType: Protob
         continue;
       }
       seenDeps.add(dependency.fullName);
-      formatter.writeLine(getImportLine(dependency, messageType));
+      formatter.writeLine(getImportLine(dependency, messageType, options));
     }
     if (field.type.indexOf('64') >= 0) {
       usesLong = true;
@@ -404,7 +422,7 @@ function generateMessageInterfaces(formatter: TextFormatter, messageType: Protob
             continue;
           }
           seenDeps.add(dependency.fullName);
-          formatter.writeLine(getImportLine(dependency, messageType));
+          formatter.writeLine(getImportLine(dependency, messageType, options));
         }
         if (field.type.indexOf('64') >= 0) {
           usesLong = true;
@@ -487,6 +505,7 @@ const CLIENT_RESERVED_METHOD_NAMES = new Set([
 ]);
 
 function generateServiceClientInterface(formatter: TextFormatter, serviceType: Protobuf.Service, options: GeneratorOptions) {
+  const {outputName, inputName} = useNameFmter(options);
   if (options.includeComments) {
     formatComment(formatter, serviceType.comment);
   }
@@ -501,8 +520,8 @@ function generateServiceClientInterface(formatter: TextFormatter, serviceType: P
       if (options.includeComments) {
         formatComment(formatter, method.comment);
       }
-      const requestType = getTypeInterfaceName(method.resolvedRequestType!);
-      const responseType = getTypeInterfaceName(method.resolvedResponseType!) + '__Output';
+      const requestType = inputName(getTypeInterfaceName(method.resolvedRequestType!));
+      const responseType = outputName(getTypeInterfaceName(method.resolvedResponseType!));
       const callbackType = `grpc.requestCallback<${responseType}>`;
       if (method.requestStream) {
         if (method.responseStream) {
@@ -541,6 +560,7 @@ function generateServiceClientInterface(formatter: TextFormatter, serviceType: P
 }
 
 function generateServiceHandlerInterface(formatter: TextFormatter, serviceType: Protobuf.Service, options: GeneratorOptions) {
+  const {inputName, outputName} = useNameFmter(options);
   if (options.includeComments) {
     formatComment(formatter, serviceType.comment);
   }
@@ -551,8 +571,8 @@ function generateServiceHandlerInterface(formatter: TextFormatter, serviceType: 
     if (options.includeComments) {
       formatComment(formatter, method.comment);
     }
-    const requestType = getTypeInterfaceName(method.resolvedRequestType!) + '__Output';
-    const responseType = getTypeInterfaceName(method.resolvedResponseType!);
+    const requestType = outputName(getTypeInterfaceName(method.resolvedRequestType!));
+    const responseType = inputName(getTypeInterfaceName(method.resolvedResponseType!));
     if (method.requestStream) {
       if (method.responseStream) {
         // Bidi streaming
@@ -576,14 +596,15 @@ function generateServiceHandlerInterface(formatter: TextFormatter, serviceType: 
   formatter.writeLine('}');
 }
 
-function generateServiceDefinitionInterface(formatter: TextFormatter, serviceType: Protobuf.Service) {
+function generateServiceDefinitionInterface(formatter: TextFormatter, serviceType: Protobuf.Service, options: GeneratorOptions) {
+  const {inputName, outputName} = useNameFmter(options);
   formatter.writeLine(`export interface ${serviceType.name}Definition extends grpc.ServiceDefinition {`);
   formatter.indent();
   for (const methodName of Object.keys(serviceType.methods).sort()) {
     const method = serviceType.methods[methodName];
     const requestType = getTypeInterfaceName(method.resolvedRequestType!);
     const responseType = getTypeInterfaceName(method.resolvedResponseType!);
-    formatter.writeLine(`${methodName}: MethodDefinition<${requestType}, ${responseType}, ${requestType}__Output, ${responseType}__Output>`);
+    formatter.writeLine(`${methodName}: MethodDefinition<${inputName(requestType)}, ${inputName(responseType)}, ${outputName(requestType)}, ${outputName(responseType)}>`);
   }
   formatter.unindent();
   formatter.writeLine('}')
@@ -601,7 +622,7 @@ function generateServiceInterfaces(formatter: TextFormatter, serviceType: Protob
     dependencies.add(method.resolvedResponseType!);
   }
   for (const dep of Array.from(dependencies.values()).sort(compareName)) {
-    formatter.writeLine(getImportLine(dep, serviceType));
+    formatter.writeLine(getImportLine(dep, serviceType, options));
   }
   formatter.writeLine('');
 
@@ -611,7 +632,7 @@ function generateServiceInterfaces(formatter: TextFormatter, serviceType: Protob
   generateServiceHandlerInterface(formatter, serviceType, options);
   formatter.writeLine('');
 
-  generateServiceDefinitionInterface(formatter, serviceType);
+  generateServiceDefinitionInterface(formatter, serviceType, options);
 }
 
 function containsDefinition(definitionType: typeof Protobuf.Type | typeof Protobuf.Enum, namespace: Protobuf.NamespaceBase): boolean {
@@ -645,7 +666,7 @@ function generateDefinitionImports(formatter: TextFormatter, namespace: Protobuf
 function generateServiceImports(formatter: TextFormatter, namespace: Protobuf.NamespaceBase, options: GeneratorOptions) {
   for (const nested of namespace.nestedArray.sort(compareName)) {
     if (nested instanceof Protobuf.Service) {
-      formatter.writeLine(getImportLine(nested));
+      formatter.writeLine(getImportLine(nested, undefined, options));
     } else if (isNamespaceBase(nested) && !(nested instanceof Protobuf.Type) && !(nested instanceof Protobuf.Enum)) {
       generateServiceImports(formatter, nested, options);
     }
@@ -776,7 +797,7 @@ async function runScript() {
     .normalize(['includeDirs', 'outDir'])
     .array('includeDirs')
     .boolean(['keepCase', 'defaults', 'arrays', 'objects', 'oneofs', 'json', 'verbose', 'includeComments'])
-    .string(['longs', 'enums', 'bytes'])
+    .string(['longs', 'enums', 'bytes', 'inputTemplate', 'outputTemplate'])
     .default('keepCase', false)
     .default('defaults', false)
     .default('arrays', false)
@@ -787,6 +808,8 @@ async function runScript() {
     .default('longs', 'Long')
     .default('enums', 'number')
     .default('bytes', 'Buffer')
+    .default('inputTemplate', `${templateStr}`)
+    .default('outputTemplate', `${templateStr}__Output`)
     .coerce('longs', value => {
       switch (value) {
         case 'String': return String;
@@ -805,7 +828,8 @@ async function runScript() {
         case 'String': return String;
         default: return undefined;
       }
-    }).alias({
+    })
+    .alias({
       includeDirs: 'I',
       outDir: 'O',
       verbose: 'v'
@@ -822,7 +846,9 @@ async function runScript() {
       includeComments: 'Generate doc comments from comments in the original files',
       includeDirs: 'Directories to search for included files',
       outDir: 'Directory in which to output files',
-      grpcLib: 'The gRPC implementation library that these types will be used with'
+      grpcLib: 'The gRPC implementation library that these types will be used with',
+      inputTemplate: 'Template for mapping input or "permissive" type names',
+      outputTemplate: 'Template for mapping output or "restricted" type names',
     }).demandOption(['outDir', 'grpcLib'])
     .demand(1)
     .usage('$0 [options] filenames...')

--- a/packages/proto-loader/golden-generated/google/api/CustomHttpPattern.ts
+++ b/packages/proto-loader/golden-generated/google/api/CustomHttpPattern.ts
@@ -4,7 +4,7 @@
 /**
  * A custom pattern is used for defining custom HTTP verb.
  */
-export interface CustomHttpPattern {
+export interface ICustomHttpPattern {
   /**
    * The name of this custom HTTP verb.
    */
@@ -18,7 +18,7 @@ export interface CustomHttpPattern {
 /**
  * A custom pattern is used for defining custom HTTP verb.
  */
-export interface CustomHttpPattern__Output {
+export interface OCustomHttpPattern {
   /**
    * The name of this custom HTTP verb.
    */

--- a/packages/proto-loader/golden-generated/google/api/Http.ts
+++ b/packages/proto-loader/golden-generated/google/api/Http.ts
@@ -1,19 +1,19 @@
 // Original file: deps/googleapis/google/api/http.proto
 
-import type { HttpRule as _google_api_HttpRule, HttpRule__Output as _google_api_HttpRule__Output } from '../../google/api/HttpRule';
+import type { IHttpRule as I_google_api_HttpRule, OHttpRule as O_google_api_HttpRule } from '../../google/api/HttpRule';
 
 /**
  * Defines the HTTP configuration for an API service. It contains a list of
  * [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
  * to one or more HTTP REST API methods.
  */
-export interface Http {
+export interface IHttp {
   /**
    * A list of HTTP configuration rules that apply to individual API methods.
    * 
    * **NOTE:** All service configuration rules follow "last one wins" order.
    */
-  'rules'?: (_google_api_HttpRule)[];
+  'rules'?: (I_google_api_HttpRule)[];
   /**
    * When set to true, URL path parameters will be fully URI-decoded except in
    * cases of single segment matches in reserved expansion, where "%2F" will be
@@ -30,13 +30,13 @@ export interface Http {
  * [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
  * to one or more HTTP REST API methods.
  */
-export interface Http__Output {
+export interface OHttp {
   /**
    * A list of HTTP configuration rules that apply to individual API methods.
    * 
    * **NOTE:** All service configuration rules follow "last one wins" order.
    */
-  'rules': (_google_api_HttpRule__Output)[];
+  'rules': (O_google_api_HttpRule)[];
   /**
    * When set to true, URL path parameters will be fully URI-decoded except in
    * cases of single segment matches in reserved expansion, where "%2F" will be

--- a/packages/proto-loader/golden-generated/google/api/HttpRule.ts
+++ b/packages/proto-loader/golden-generated/google/api/HttpRule.ts
@@ -1,7 +1,7 @@
 // Original file: deps/googleapis/google/api/http.proto
 
-import type { CustomHttpPattern as _google_api_CustomHttpPattern, CustomHttpPattern__Output as _google_api_CustomHttpPattern__Output } from '../../google/api/CustomHttpPattern';
-import type { HttpRule as _google_api_HttpRule, HttpRule__Output as _google_api_HttpRule__Output } from '../../google/api/HttpRule';
+import type { ICustomHttpPattern as I_google_api_CustomHttpPattern, OCustomHttpPattern as O_google_api_CustomHttpPattern } from '../../google/api/CustomHttpPattern';
+import type { IHttpRule as I_google_api_HttpRule, OHttpRule as O_google_api_HttpRule } from '../../google/api/HttpRule';
 
 /**
  * # gRPC Transcoding
@@ -274,7 +274,7 @@ import type { HttpRule as _google_api_HttpRule, HttpRule__Output as _google_api_
  * the request or response body to a repeated field. However, some gRPC
  * Transcoding implementations may not support this feature.
  */
-export interface HttpRule {
+export interface IHttpRule {
   /**
    * Selects a method to which this rule applies.
    * 
@@ -317,13 +317,13 @@ export interface HttpRule {
    * HTTP method unspecified for this rule. The wild-card rule is useful
    * for services that provide content to Web (HTML) clients.
    */
-  'custom'?: (_google_api_CustomHttpPattern | null);
+  'custom'?: (I_google_api_CustomHttpPattern | null);
   /**
    * Additional HTTP bindings for the selector. Nested bindings must
    * not contain an `additional_bindings` field themselves (that is,
    * the nesting may only be one level deep).
    */
-  'additional_bindings'?: (_google_api_HttpRule)[];
+  'additional_bindings'?: (I_google_api_HttpRule)[];
   /**
    * Optional. The name of the response field whose value is mapped to the HTTP
    * response body. When omitted, the entire response message will be used
@@ -612,7 +612,7 @@ export interface HttpRule {
  * the request or response body to a repeated field. However, some gRPC
  * Transcoding implementations may not support this feature.
  */
-export interface HttpRule__Output {
+export interface OHttpRule {
   /**
    * Selects a method to which this rule applies.
    * 
@@ -655,13 +655,13 @@ export interface HttpRule__Output {
    * HTTP method unspecified for this rule. The wild-card rule is useful
    * for services that provide content to Web (HTML) clients.
    */
-  'custom'?: (_google_api_CustomHttpPattern__Output | null);
+  'custom'?: (O_google_api_CustomHttpPattern | null);
   /**
    * Additional HTTP bindings for the selector. Nested bindings must
    * not contain an `additional_bindings` field themselves (that is,
    * the nesting may only be one level deep).
    */
-  'additional_bindings': (_google_api_HttpRule__Output)[];
+  'additional_bindings': (O_google_api_HttpRule)[];
   /**
    * Optional. The name of the response field whose value is mapped to the HTTP
    * response body. When omitted, the entire response message will be used

--- a/packages/proto-loader/golden-generated/google/longrunning/CancelOperationRequest.ts
+++ b/packages/proto-loader/golden-generated/google/longrunning/CancelOperationRequest.ts
@@ -4,7 +4,7 @@
 /**
  * The request message for [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
  */
-export interface CancelOperationRequest {
+export interface ICancelOperationRequest {
   /**
    * The name of the operation resource to be cancelled.
    */
@@ -14,7 +14,7 @@ export interface CancelOperationRequest {
 /**
  * The request message for [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
  */
-export interface CancelOperationRequest__Output {
+export interface OCancelOperationRequest {
   /**
    * The name of the operation resource to be cancelled.
    */

--- a/packages/proto-loader/golden-generated/google/longrunning/DeleteOperationRequest.ts
+++ b/packages/proto-loader/golden-generated/google/longrunning/DeleteOperationRequest.ts
@@ -4,7 +4,7 @@
 /**
  * The request message for [Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation].
  */
-export interface DeleteOperationRequest {
+export interface IDeleteOperationRequest {
   /**
    * The name of the operation resource to be deleted.
    */
@@ -14,7 +14,7 @@ export interface DeleteOperationRequest {
 /**
  * The request message for [Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation].
  */
-export interface DeleteOperationRequest__Output {
+export interface ODeleteOperationRequest {
   /**
    * The name of the operation resource to be deleted.
    */

--- a/packages/proto-loader/golden-generated/google/longrunning/GetOperationRequest.ts
+++ b/packages/proto-loader/golden-generated/google/longrunning/GetOperationRequest.ts
@@ -4,7 +4,7 @@
 /**
  * The request message for [Operations.GetOperation][google.longrunning.Operations.GetOperation].
  */
-export interface GetOperationRequest {
+export interface IGetOperationRequest {
   /**
    * The name of the operation resource.
    */
@@ -14,7 +14,7 @@ export interface GetOperationRequest {
 /**
  * The request message for [Operations.GetOperation][google.longrunning.Operations.GetOperation].
  */
-export interface GetOperationRequest__Output {
+export interface OGetOperationRequest {
   /**
    * The name of the operation resource.
    */

--- a/packages/proto-loader/golden-generated/google/longrunning/ListOperationsRequest.ts
+++ b/packages/proto-loader/golden-generated/google/longrunning/ListOperationsRequest.ts
@@ -4,7 +4,7 @@
 /**
  * The request message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
  */
-export interface ListOperationsRequest {
+export interface IListOperationsRequest {
   /**
    * The standard list filter.
    */
@@ -26,7 +26,7 @@ export interface ListOperationsRequest {
 /**
  * The request message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
  */
-export interface ListOperationsRequest__Output {
+export interface OListOperationsRequest {
   /**
    * The standard list filter.
    */

--- a/packages/proto-loader/golden-generated/google/longrunning/ListOperationsResponse.ts
+++ b/packages/proto-loader/golden-generated/google/longrunning/ListOperationsResponse.ts
@@ -1,15 +1,15 @@
 // Original file: deps/googleapis/google/longrunning/operations.proto
 
-import type { Operation as _google_longrunning_Operation, Operation__Output as _google_longrunning_Operation__Output } from '../../google/longrunning/Operation';
+import type { IOperation as I_google_longrunning_Operation, OOperation as O_google_longrunning_Operation } from '../../google/longrunning/Operation';
 
 /**
  * The response message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
  */
-export interface ListOperationsResponse {
+export interface IListOperationsResponse {
   /**
    * A list of operations that matches the specified filter in the request.
    */
-  'operations'?: (_google_longrunning_Operation)[];
+  'operations'?: (I_google_longrunning_Operation)[];
   /**
    * The standard List next-page token.
    */
@@ -19,11 +19,11 @@ export interface ListOperationsResponse {
 /**
  * The response message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
  */
-export interface ListOperationsResponse__Output {
+export interface OListOperationsResponse {
   /**
    * A list of operations that matches the specified filter in the request.
    */
-  'operations': (_google_longrunning_Operation__Output)[];
+  'operations': (O_google_longrunning_Operation)[];
   /**
    * The standard List next-page token.
    */

--- a/packages/proto-loader/golden-generated/google/longrunning/Operation.ts
+++ b/packages/proto-loader/golden-generated/google/longrunning/Operation.ts
@@ -1,13 +1,13 @@
 // Original file: deps/googleapis/google/longrunning/operations.proto
 
-import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../google/protobuf/Any';
-import type { Status as _google_rpc_Status, Status__Output as _google_rpc_Status__Output } from '../../google/rpc/Status';
+import type { IAny as I_google_protobuf_Any, OAny as O_google_protobuf_Any } from '../../google/protobuf/Any';
+import type { IStatus as I_google_rpc_Status, OStatus as O_google_rpc_Status } from '../../google/rpc/Status';
 
 /**
  * This resource represents a long-running operation that is the result of a
  * network API call.
  */
-export interface Operation {
+export interface IOperation {
   /**
    * The server-assigned name, which is only unique within the same service that
    * originally returns it. If you use the default HTTP mapping, the
@@ -20,7 +20,7 @@ export interface Operation {
    * Some services might not provide such metadata.  Any method that returns a
    * long-running operation should document the metadata type, if any.
    */
-  'metadata'?: (_google_protobuf_Any | null);
+  'metadata'?: (I_google_protobuf_Any | null);
   /**
    * If the value is `false`, it means the operation is still in progress.
    * If `true`, the operation is completed, and either `error` or `response` is
@@ -30,7 +30,7 @@ export interface Operation {
   /**
    * The error result of the operation in case of failure or cancellation.
    */
-  'error'?: (_google_rpc_Status | null);
+  'error'?: (I_google_rpc_Status | null);
   /**
    * The normal response of the operation in case of success.  If the original
    * method returns no data on success, such as `Delete`, the response is
@@ -41,7 +41,7 @@ export interface Operation {
    * is `TakeSnapshot()`, the inferred response type is
    * `TakeSnapshotResponse`.
    */
-  'response'?: (_google_protobuf_Any | null);
+  'response'?: (I_google_protobuf_Any | null);
   /**
    * The operation result, which can be either an `error` or a valid `response`.
    * If `done` == `false`, neither `error` nor `response` is set.
@@ -54,7 +54,7 @@ export interface Operation {
  * This resource represents a long-running operation that is the result of a
  * network API call.
  */
-export interface Operation__Output {
+export interface OOperation {
   /**
    * The server-assigned name, which is only unique within the same service that
    * originally returns it. If you use the default HTTP mapping, the
@@ -67,7 +67,7 @@ export interface Operation__Output {
    * Some services might not provide such metadata.  Any method that returns a
    * long-running operation should document the metadata type, if any.
    */
-  'metadata': (_google_protobuf_Any__Output | null);
+  'metadata': (O_google_protobuf_Any | null);
   /**
    * If the value is `false`, it means the operation is still in progress.
    * If `true`, the operation is completed, and either `error` or `response` is
@@ -77,7 +77,7 @@ export interface Operation__Output {
   /**
    * The error result of the operation in case of failure or cancellation.
    */
-  'error'?: (_google_rpc_Status__Output | null);
+  'error'?: (O_google_rpc_Status | null);
   /**
    * The normal response of the operation in case of success.  If the original
    * method returns no data on success, such as `Delete`, the response is
@@ -88,7 +88,7 @@ export interface Operation__Output {
    * is `TakeSnapshot()`, the inferred response type is
    * `TakeSnapshotResponse`.
    */
-  'response'?: (_google_protobuf_Any__Output | null);
+  'response'?: (O_google_protobuf_Any | null);
   /**
    * The operation result, which can be either an `error` or a valid `response`.
    * If `done` == `false`, neither `error` nor `response` is set.

--- a/packages/proto-loader/golden-generated/google/longrunning/OperationInfo.ts
+++ b/packages/proto-loader/golden-generated/google/longrunning/OperationInfo.ts
@@ -14,7 +14,7 @@
  * };
  * }
  */
-export interface OperationInfo {
+export interface IOperationInfo {
   /**
    * Required. The message name of the primary return type for this
    * long-running operation.
@@ -51,7 +51,7 @@ export interface OperationInfo {
  * };
  * }
  */
-export interface OperationInfo__Output {
+export interface OOperationInfo {
   /**
    * Required. The message name of the primary return type for this
    * long-running operation.

--- a/packages/proto-loader/golden-generated/google/longrunning/Operations.ts
+++ b/packages/proto-loader/golden-generated/google/longrunning/Operations.ts
@@ -2,14 +2,14 @@
 
 import type * as grpc from '@grpc/grpc-js'
 import type { MethodDefinition } from '@grpc/proto-loader'
-import type { CancelOperationRequest as _google_longrunning_CancelOperationRequest, CancelOperationRequest__Output as _google_longrunning_CancelOperationRequest__Output } from '../../google/longrunning/CancelOperationRequest';
-import type { DeleteOperationRequest as _google_longrunning_DeleteOperationRequest, DeleteOperationRequest__Output as _google_longrunning_DeleteOperationRequest__Output } from '../../google/longrunning/DeleteOperationRequest';
-import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from '../../google/protobuf/Empty';
-import type { GetOperationRequest as _google_longrunning_GetOperationRequest, GetOperationRequest__Output as _google_longrunning_GetOperationRequest__Output } from '../../google/longrunning/GetOperationRequest';
-import type { ListOperationsRequest as _google_longrunning_ListOperationsRequest, ListOperationsRequest__Output as _google_longrunning_ListOperationsRequest__Output } from '../../google/longrunning/ListOperationsRequest';
-import type { ListOperationsResponse as _google_longrunning_ListOperationsResponse, ListOperationsResponse__Output as _google_longrunning_ListOperationsResponse__Output } from '../../google/longrunning/ListOperationsResponse';
-import type { Operation as _google_longrunning_Operation, Operation__Output as _google_longrunning_Operation__Output } from '../../google/longrunning/Operation';
-import type { WaitOperationRequest as _google_longrunning_WaitOperationRequest, WaitOperationRequest__Output as _google_longrunning_WaitOperationRequest__Output } from '../../google/longrunning/WaitOperationRequest';
+import type { ICancelOperationRequest as I_google_longrunning_CancelOperationRequest, OCancelOperationRequest as O_google_longrunning_CancelOperationRequest } from '../../google/longrunning/CancelOperationRequest';
+import type { IDeleteOperationRequest as I_google_longrunning_DeleteOperationRequest, ODeleteOperationRequest as O_google_longrunning_DeleteOperationRequest } from '../../google/longrunning/DeleteOperationRequest';
+import type { IEmpty as I_google_protobuf_Empty, OEmpty as O_google_protobuf_Empty } from '../../google/protobuf/Empty';
+import type { IGetOperationRequest as I_google_longrunning_GetOperationRequest, OGetOperationRequest as O_google_longrunning_GetOperationRequest } from '../../google/longrunning/GetOperationRequest';
+import type { IListOperationsRequest as I_google_longrunning_ListOperationsRequest, OListOperationsRequest as O_google_longrunning_ListOperationsRequest } from '../../google/longrunning/ListOperationsRequest';
+import type { IListOperationsResponse as I_google_longrunning_ListOperationsResponse, OListOperationsResponse as O_google_longrunning_ListOperationsResponse } from '../../google/longrunning/ListOperationsResponse';
+import type { IOperation as I_google_longrunning_Operation, OOperation as O_google_longrunning_Operation } from '../../google/longrunning/Operation';
+import type { IWaitOperationRequest as I_google_longrunning_WaitOperationRequest, OWaitOperationRequest as O_google_longrunning_WaitOperationRequest } from '../../google/longrunning/WaitOperationRequest';
 
 /**
  * Manages long-running operations with an API service.
@@ -35,10 +35,10 @@ export interface OperationsClient extends grpc.Client {
    * an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
    * corresponding to `Code.CANCELLED`.
    */
-  CancelOperation(argument: _google_longrunning_CancelOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  CancelOperation(argument: _google_longrunning_CancelOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  CancelOperation(argument: _google_longrunning_CancelOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  CancelOperation(argument: _google_longrunning_CancelOperationRequest, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
+  CancelOperation(argument: I_google_longrunning_CancelOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  CancelOperation(argument: I_google_longrunning_CancelOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  CancelOperation(argument: I_google_longrunning_CancelOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  CancelOperation(argument: I_google_longrunning_CancelOperationRequest, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
   /**
    * Starts asynchronous cancellation on a long-running operation.  The server
    * makes a best effort to cancel the operation, but success is not
@@ -51,10 +51,10 @@ export interface OperationsClient extends grpc.Client {
    * an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
    * corresponding to `Code.CANCELLED`.
    */
-  cancelOperation(argument: _google_longrunning_CancelOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  cancelOperation(argument: _google_longrunning_CancelOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  cancelOperation(argument: _google_longrunning_CancelOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  cancelOperation(argument: _google_longrunning_CancelOperationRequest, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
+  cancelOperation(argument: I_google_longrunning_CancelOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  cancelOperation(argument: I_google_longrunning_CancelOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  cancelOperation(argument: I_google_longrunning_CancelOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  cancelOperation(argument: I_google_longrunning_CancelOperationRequest, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
   
   /**
    * Deletes a long-running operation. This method indicates that the client is
@@ -62,39 +62,39 @@ export interface OperationsClient extends grpc.Client {
    * operation. If the server doesn't support this method, it returns
    * `google.rpc.Code.UNIMPLEMENTED`.
    */
-  DeleteOperation(argument: _google_longrunning_DeleteOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  DeleteOperation(argument: _google_longrunning_DeleteOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  DeleteOperation(argument: _google_longrunning_DeleteOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  DeleteOperation(argument: _google_longrunning_DeleteOperationRequest, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
+  DeleteOperation(argument: I_google_longrunning_DeleteOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  DeleteOperation(argument: I_google_longrunning_DeleteOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  DeleteOperation(argument: I_google_longrunning_DeleteOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  DeleteOperation(argument: I_google_longrunning_DeleteOperationRequest, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
   /**
    * Deletes a long-running operation. This method indicates that the client is
    * no longer interested in the operation result. It does not cancel the
    * operation. If the server doesn't support this method, it returns
    * `google.rpc.Code.UNIMPLEMENTED`.
    */
-  deleteOperation(argument: _google_longrunning_DeleteOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  deleteOperation(argument: _google_longrunning_DeleteOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  deleteOperation(argument: _google_longrunning_DeleteOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
-  deleteOperation(argument: _google_longrunning_DeleteOperationRequest, callback: grpc.requestCallback<_google_protobuf_Empty__Output>): grpc.ClientUnaryCall;
+  deleteOperation(argument: I_google_longrunning_DeleteOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  deleteOperation(argument: I_google_longrunning_DeleteOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  deleteOperation(argument: I_google_longrunning_DeleteOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
+  deleteOperation(argument: I_google_longrunning_DeleteOperationRequest, callback: grpc.requestCallback<O_google_protobuf_Empty>): grpc.ClientUnaryCall;
   
   /**
    * Gets the latest state of a long-running operation.  Clients can use this
    * method to poll the operation result at intervals as recommended by the API
    * service.
    */
-  GetOperation(argument: _google_longrunning_GetOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  GetOperation(argument: _google_longrunning_GetOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  GetOperation(argument: _google_longrunning_GetOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  GetOperation(argument: _google_longrunning_GetOperationRequest, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
+  GetOperation(argument: I_google_longrunning_GetOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  GetOperation(argument: I_google_longrunning_GetOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  GetOperation(argument: I_google_longrunning_GetOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  GetOperation(argument: I_google_longrunning_GetOperationRequest, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
   /**
    * Gets the latest state of a long-running operation.  Clients can use this
    * method to poll the operation result at intervals as recommended by the API
    * service.
    */
-  getOperation(argument: _google_longrunning_GetOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  getOperation(argument: _google_longrunning_GetOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  getOperation(argument: _google_longrunning_GetOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  getOperation(argument: _google_longrunning_GetOperationRequest, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
+  getOperation(argument: I_google_longrunning_GetOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  getOperation(argument: I_google_longrunning_GetOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  getOperation(argument: I_google_longrunning_GetOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  getOperation(argument: I_google_longrunning_GetOperationRequest, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
   
   /**
    * Lists operations that match the specified filter in the request. If the
@@ -108,10 +108,10 @@ export interface OperationsClient extends grpc.Client {
    * collection id, however overriding users must ensure the name binding
    * is the parent resource, without the operations collection id.
    */
-  ListOperations(argument: _google_longrunning_ListOperationsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_ListOperationsResponse__Output>): grpc.ClientUnaryCall;
-  ListOperations(argument: _google_longrunning_ListOperationsRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_longrunning_ListOperationsResponse__Output>): grpc.ClientUnaryCall;
-  ListOperations(argument: _google_longrunning_ListOperationsRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_ListOperationsResponse__Output>): grpc.ClientUnaryCall;
-  ListOperations(argument: _google_longrunning_ListOperationsRequest, callback: grpc.requestCallback<_google_longrunning_ListOperationsResponse__Output>): grpc.ClientUnaryCall;
+  ListOperations(argument: I_google_longrunning_ListOperationsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_ListOperationsResponse>): grpc.ClientUnaryCall;
+  ListOperations(argument: I_google_longrunning_ListOperationsRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_longrunning_ListOperationsResponse>): grpc.ClientUnaryCall;
+  ListOperations(argument: I_google_longrunning_ListOperationsRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_ListOperationsResponse>): grpc.ClientUnaryCall;
+  ListOperations(argument: I_google_longrunning_ListOperationsRequest, callback: grpc.requestCallback<O_google_longrunning_ListOperationsResponse>): grpc.ClientUnaryCall;
   /**
    * Lists operations that match the specified filter in the request. If the
    * server doesn't support this method, it returns `UNIMPLEMENTED`.
@@ -124,10 +124,10 @@ export interface OperationsClient extends grpc.Client {
    * collection id, however overriding users must ensure the name binding
    * is the parent resource, without the operations collection id.
    */
-  listOperations(argument: _google_longrunning_ListOperationsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_ListOperationsResponse__Output>): grpc.ClientUnaryCall;
-  listOperations(argument: _google_longrunning_ListOperationsRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_longrunning_ListOperationsResponse__Output>): grpc.ClientUnaryCall;
-  listOperations(argument: _google_longrunning_ListOperationsRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_ListOperationsResponse__Output>): grpc.ClientUnaryCall;
-  listOperations(argument: _google_longrunning_ListOperationsRequest, callback: grpc.requestCallback<_google_longrunning_ListOperationsResponse__Output>): grpc.ClientUnaryCall;
+  listOperations(argument: I_google_longrunning_ListOperationsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_ListOperationsResponse>): grpc.ClientUnaryCall;
+  listOperations(argument: I_google_longrunning_ListOperationsRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_longrunning_ListOperationsResponse>): grpc.ClientUnaryCall;
+  listOperations(argument: I_google_longrunning_ListOperationsRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_ListOperationsResponse>): grpc.ClientUnaryCall;
+  listOperations(argument: I_google_longrunning_ListOperationsRequest, callback: grpc.requestCallback<O_google_longrunning_ListOperationsResponse>): grpc.ClientUnaryCall;
   
   /**
    * Waits for the specified long-running operation until it is done or reaches
@@ -140,10 +140,10 @@ export interface OperationsClient extends grpc.Client {
    * state before the specified timeout (including immediately), meaning even an
    * immediate response is no guarantee that the operation is done.
    */
-  WaitOperation(argument: _google_longrunning_WaitOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  WaitOperation(argument: _google_longrunning_WaitOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  WaitOperation(argument: _google_longrunning_WaitOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  WaitOperation(argument: _google_longrunning_WaitOperationRequest, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
+  WaitOperation(argument: I_google_longrunning_WaitOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  WaitOperation(argument: I_google_longrunning_WaitOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  WaitOperation(argument: I_google_longrunning_WaitOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  WaitOperation(argument: I_google_longrunning_WaitOperationRequest, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
   /**
    * Waits for the specified long-running operation until it is done or reaches
    * at most a specified timeout, returning the latest state.  If the operation
@@ -155,10 +155,10 @@ export interface OperationsClient extends grpc.Client {
    * state before the specified timeout (including immediately), meaning even an
    * immediate response is no guarantee that the operation is done.
    */
-  waitOperation(argument: _google_longrunning_WaitOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  waitOperation(argument: _google_longrunning_WaitOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  waitOperation(argument: _google_longrunning_WaitOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  waitOperation(argument: _google_longrunning_WaitOperationRequest, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
+  waitOperation(argument: I_google_longrunning_WaitOperationRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  waitOperation(argument: I_google_longrunning_WaitOperationRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  waitOperation(argument: I_google_longrunning_WaitOperationRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  waitOperation(argument: I_google_longrunning_WaitOperationRequest, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
   
 }
 
@@ -186,7 +186,7 @@ export interface OperationsHandlers extends grpc.UntypedServiceImplementation {
    * an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
    * corresponding to `Code.CANCELLED`.
    */
-  CancelOperation: grpc.handleUnaryCall<_google_longrunning_CancelOperationRequest__Output, _google_protobuf_Empty>;
+  CancelOperation: grpc.handleUnaryCall<O_google_longrunning_CancelOperationRequest, I_google_protobuf_Empty>;
   
   /**
    * Deletes a long-running operation. This method indicates that the client is
@@ -194,14 +194,14 @@ export interface OperationsHandlers extends grpc.UntypedServiceImplementation {
    * operation. If the server doesn't support this method, it returns
    * `google.rpc.Code.UNIMPLEMENTED`.
    */
-  DeleteOperation: grpc.handleUnaryCall<_google_longrunning_DeleteOperationRequest__Output, _google_protobuf_Empty>;
+  DeleteOperation: grpc.handleUnaryCall<O_google_longrunning_DeleteOperationRequest, I_google_protobuf_Empty>;
   
   /**
    * Gets the latest state of a long-running operation.  Clients can use this
    * method to poll the operation result at intervals as recommended by the API
    * service.
    */
-  GetOperation: grpc.handleUnaryCall<_google_longrunning_GetOperationRequest__Output, _google_longrunning_Operation>;
+  GetOperation: grpc.handleUnaryCall<O_google_longrunning_GetOperationRequest, I_google_longrunning_Operation>;
   
   /**
    * Lists operations that match the specified filter in the request. If the
@@ -215,7 +215,7 @@ export interface OperationsHandlers extends grpc.UntypedServiceImplementation {
    * collection id, however overriding users must ensure the name binding
    * is the parent resource, without the operations collection id.
    */
-  ListOperations: grpc.handleUnaryCall<_google_longrunning_ListOperationsRequest__Output, _google_longrunning_ListOperationsResponse>;
+  ListOperations: grpc.handleUnaryCall<O_google_longrunning_ListOperationsRequest, I_google_longrunning_ListOperationsResponse>;
   
   /**
    * Waits for the specified long-running operation until it is done or reaches
@@ -228,14 +228,14 @@ export interface OperationsHandlers extends grpc.UntypedServiceImplementation {
    * state before the specified timeout (including immediately), meaning even an
    * immediate response is no guarantee that the operation is done.
    */
-  WaitOperation: grpc.handleUnaryCall<_google_longrunning_WaitOperationRequest__Output, _google_longrunning_Operation>;
+  WaitOperation: grpc.handleUnaryCall<O_google_longrunning_WaitOperationRequest, I_google_longrunning_Operation>;
   
 }
 
 export interface OperationsDefinition extends grpc.ServiceDefinition {
-  CancelOperation: MethodDefinition<_google_longrunning_CancelOperationRequest, _google_protobuf_Empty, _google_longrunning_CancelOperationRequest__Output, _google_protobuf_Empty__Output>
-  DeleteOperation: MethodDefinition<_google_longrunning_DeleteOperationRequest, _google_protobuf_Empty, _google_longrunning_DeleteOperationRequest__Output, _google_protobuf_Empty__Output>
-  GetOperation: MethodDefinition<_google_longrunning_GetOperationRequest, _google_longrunning_Operation, _google_longrunning_GetOperationRequest__Output, _google_longrunning_Operation__Output>
-  ListOperations: MethodDefinition<_google_longrunning_ListOperationsRequest, _google_longrunning_ListOperationsResponse, _google_longrunning_ListOperationsRequest__Output, _google_longrunning_ListOperationsResponse__Output>
-  WaitOperation: MethodDefinition<_google_longrunning_WaitOperationRequest, _google_longrunning_Operation, _google_longrunning_WaitOperationRequest__Output, _google_longrunning_Operation__Output>
+  CancelOperation: MethodDefinition<I_google_longrunning_CancelOperationRequest, I_google_protobuf_Empty, O_google_longrunning_CancelOperationRequest, O_google_protobuf_Empty>
+  DeleteOperation: MethodDefinition<I_google_longrunning_DeleteOperationRequest, I_google_protobuf_Empty, O_google_longrunning_DeleteOperationRequest, O_google_protobuf_Empty>
+  GetOperation: MethodDefinition<I_google_longrunning_GetOperationRequest, I_google_longrunning_Operation, O_google_longrunning_GetOperationRequest, O_google_longrunning_Operation>
+  ListOperations: MethodDefinition<I_google_longrunning_ListOperationsRequest, I_google_longrunning_ListOperationsResponse, O_google_longrunning_ListOperationsRequest, O_google_longrunning_ListOperationsResponse>
+  WaitOperation: MethodDefinition<I_google_longrunning_WaitOperationRequest, I_google_longrunning_Operation, O_google_longrunning_WaitOperationRequest, O_google_longrunning_Operation>
 }

--- a/packages/proto-loader/golden-generated/google/longrunning/WaitOperationRequest.ts
+++ b/packages/proto-loader/golden-generated/google/longrunning/WaitOperationRequest.ts
@@ -1,11 +1,11 @@
 // Original file: deps/googleapis/google/longrunning/operations.proto
 
-import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../google/protobuf/Duration';
+import type { IDuration as I_google_protobuf_Duration, ODuration as O_google_protobuf_Duration } from '../../google/protobuf/Duration';
 
 /**
  * The request message for [Operations.WaitOperation][google.longrunning.Operations.WaitOperation].
  */
-export interface WaitOperationRequest {
+export interface IWaitOperationRequest {
   /**
    * The name of the operation resource to wait on.
    */
@@ -15,13 +15,13 @@ export interface WaitOperationRequest {
    * will be at most the time permitted by the underlying HTTP/RPC protocol.
    * If RPC context deadline is also specified, the shorter one will be used.
    */
-  'timeout'?: (_google_protobuf_Duration | null);
+  'timeout'?: (I_google_protobuf_Duration | null);
 }
 
 /**
  * The request message for [Operations.WaitOperation][google.longrunning.Operations.WaitOperation].
  */
-export interface WaitOperationRequest__Output {
+export interface OWaitOperationRequest {
   /**
    * The name of the operation resource to wait on.
    */
@@ -31,5 +31,5 @@ export interface WaitOperationRequest__Output {
    * will be at most the time permitted by the underlying HTTP/RPC protocol.
    * If RPC context deadline is also specified, the shorter one will be used.
    */
-  'timeout': (_google_protobuf_Duration__Output | null);
+  'timeout': (O_google_protobuf_Duration | null);
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/Any.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/Any.ts
@@ -2,12 +2,12 @@
 
 import type { AnyExtension } from '@grpc/proto-loader';
 
-export type Any = AnyExtension | {
+export type IAny = AnyExtension | {
   type_url: string;
   value: Buffer | Uint8Array | string;
 }
 
-export type Any__Output = AnyExtension | {
+export type OAny = AnyExtension | {
   type_url: string;
   value: Buffer;
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/DescriptorProto.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/DescriptorProto.ts
@@ -1,53 +1,53 @@
 // Original file: null
 
-import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from '../../google/protobuf/FieldDescriptorProto';
-import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from '../../google/protobuf/DescriptorProto';
-import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from '../../google/protobuf/EnumDescriptorProto';
-import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from '../../google/protobuf/MessageOptions';
-import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from '../../google/protobuf/OneofDescriptorProto';
+import type { IFieldDescriptorProto as I_google_protobuf_FieldDescriptorProto, OFieldDescriptorProto as O_google_protobuf_FieldDescriptorProto } from '../../google/protobuf/FieldDescriptorProto';
+import type { IDescriptorProto as I_google_protobuf_DescriptorProto, ODescriptorProto as O_google_protobuf_DescriptorProto } from '../../google/protobuf/DescriptorProto';
+import type { IEnumDescriptorProto as I_google_protobuf_EnumDescriptorProto, OEnumDescriptorProto as O_google_protobuf_EnumDescriptorProto } from '../../google/protobuf/EnumDescriptorProto';
+import type { IMessageOptions as I_google_protobuf_MessageOptions, OMessageOptions as O_google_protobuf_MessageOptions } from '../../google/protobuf/MessageOptions';
+import type { IOneofDescriptorProto as I_google_protobuf_OneofDescriptorProto, OOneofDescriptorProto as O_google_protobuf_OneofDescriptorProto } from '../../google/protobuf/OneofDescriptorProto';
 
-export interface _google_protobuf_DescriptorProto_ExtensionRange {
+export interface I_google_protobuf_DescriptorProto_ExtensionRange {
   'start'?: (number);
   'end'?: (number);
 }
 
-export interface _google_protobuf_DescriptorProto_ExtensionRange__Output {
+export interface O_google_protobuf_DescriptorProto_ExtensionRange {
   'start': (number);
   'end': (number);
 }
 
-export interface _google_protobuf_DescriptorProto_ReservedRange {
+export interface I_google_protobuf_DescriptorProto_ReservedRange {
   'start'?: (number);
   'end'?: (number);
 }
 
-export interface _google_protobuf_DescriptorProto_ReservedRange__Output {
+export interface O_google_protobuf_DescriptorProto_ReservedRange {
   'start': (number);
   'end': (number);
 }
 
-export interface DescriptorProto {
+export interface IDescriptorProto {
   'name'?: (string);
-  'field'?: (_google_protobuf_FieldDescriptorProto)[];
-  'nestedType'?: (_google_protobuf_DescriptorProto)[];
-  'enumType'?: (_google_protobuf_EnumDescriptorProto)[];
-  'extensionRange'?: (_google_protobuf_DescriptorProto_ExtensionRange)[];
-  'extension'?: (_google_protobuf_FieldDescriptorProto)[];
-  'options'?: (_google_protobuf_MessageOptions | null);
-  'oneofDecl'?: (_google_protobuf_OneofDescriptorProto)[];
-  'reservedRange'?: (_google_protobuf_DescriptorProto_ReservedRange)[];
+  'field'?: (I_google_protobuf_FieldDescriptorProto)[];
+  'nestedType'?: (I_google_protobuf_DescriptorProto)[];
+  'enumType'?: (I_google_protobuf_EnumDescriptorProto)[];
+  'extensionRange'?: (I_google_protobuf_DescriptorProto_ExtensionRange)[];
+  'extension'?: (I_google_protobuf_FieldDescriptorProto)[];
+  'options'?: (I_google_protobuf_MessageOptions | null);
+  'oneofDecl'?: (I_google_protobuf_OneofDescriptorProto)[];
+  'reservedRange'?: (I_google_protobuf_DescriptorProto_ReservedRange)[];
   'reservedName'?: (string)[];
 }
 
-export interface DescriptorProto__Output {
+export interface ODescriptorProto {
   'name': (string);
-  'field': (_google_protobuf_FieldDescriptorProto__Output)[];
-  'nestedType': (_google_protobuf_DescriptorProto__Output)[];
-  'enumType': (_google_protobuf_EnumDescriptorProto__Output)[];
-  'extensionRange': (_google_protobuf_DescriptorProto_ExtensionRange__Output)[];
-  'extension': (_google_protobuf_FieldDescriptorProto__Output)[];
-  'options': (_google_protobuf_MessageOptions__Output | null);
-  'oneofDecl': (_google_protobuf_OneofDescriptorProto__Output)[];
-  'reservedRange': (_google_protobuf_DescriptorProto_ReservedRange__Output)[];
+  'field': (O_google_protobuf_FieldDescriptorProto)[];
+  'nestedType': (O_google_protobuf_DescriptorProto)[];
+  'enumType': (O_google_protobuf_EnumDescriptorProto)[];
+  'extensionRange': (O_google_protobuf_DescriptorProto_ExtensionRange)[];
+  'extension': (O_google_protobuf_FieldDescriptorProto)[];
+  'options': (O_google_protobuf_MessageOptions | null);
+  'oneofDecl': (O_google_protobuf_OneofDescriptorProto)[];
+  'reservedRange': (O_google_protobuf_DescriptorProto_ReservedRange)[];
   'reservedName': (string)[];
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/Duration.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/Duration.ts
@@ -2,12 +2,12 @@
 
 import type { Long } from '@grpc/proto-loader';
 
-export interface Duration {
+export interface IDuration {
   'seconds'?: (number | string | Long);
   'nanos'?: (number);
 }
 
-export interface Duration__Output {
+export interface ODuration {
   'seconds': (string);
   'nanos': (number);
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/Empty.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/Empty.ts
@@ -1,8 +1,8 @@
 // Original file: null
 
 
-export interface Empty {
+export interface IEmpty {
 }
 
-export interface Empty__Output {
+export interface OEmpty {
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/EnumDescriptorProto.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/EnumDescriptorProto.ts
@@ -1,16 +1,16 @@
 // Original file: null
 
-import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from '../../google/protobuf/EnumValueDescriptorProto';
-import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from '../../google/protobuf/EnumOptions';
+import type { IEnumValueDescriptorProto as I_google_protobuf_EnumValueDescriptorProto, OEnumValueDescriptorProto as O_google_protobuf_EnumValueDescriptorProto } from '../../google/protobuf/EnumValueDescriptorProto';
+import type { IEnumOptions as I_google_protobuf_EnumOptions, OEnumOptions as O_google_protobuf_EnumOptions } from '../../google/protobuf/EnumOptions';
 
-export interface EnumDescriptorProto {
+export interface IEnumDescriptorProto {
   'name'?: (string);
-  'value'?: (_google_protobuf_EnumValueDescriptorProto)[];
-  'options'?: (_google_protobuf_EnumOptions | null);
+  'value'?: (I_google_protobuf_EnumValueDescriptorProto)[];
+  'options'?: (I_google_protobuf_EnumOptions | null);
 }
 
-export interface EnumDescriptorProto__Output {
+export interface OEnumDescriptorProto {
   'name': (string);
-  'value': (_google_protobuf_EnumValueDescriptorProto__Output)[];
-  'options': (_google_protobuf_EnumOptions__Output | null);
+  'value': (O_google_protobuf_EnumValueDescriptorProto)[];
+  'options': (O_google_protobuf_EnumOptions | null);
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/EnumOptions.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/EnumOptions.ts
@@ -1,15 +1,15 @@
 // Original file: null
 
-import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
+import type { IUninterpretedOption as I_google_protobuf_UninterpretedOption, OUninterpretedOption as O_google_protobuf_UninterpretedOption } from '../../google/protobuf/UninterpretedOption';
 
-export interface EnumOptions {
+export interface IEnumOptions {
   'allowAlias'?: (boolean);
   'deprecated'?: (boolean);
-  'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
+  'uninterpretedOption'?: (I_google_protobuf_UninterpretedOption)[];
 }
 
-export interface EnumOptions__Output {
+export interface OEnumOptions {
   'allowAlias': (boolean);
   'deprecated': (boolean);
-  'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
+  'uninterpretedOption': (O_google_protobuf_UninterpretedOption)[];
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/EnumValueDescriptorProto.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/EnumValueDescriptorProto.ts
@@ -1,15 +1,15 @@
 // Original file: null
 
-import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from '../../google/protobuf/EnumValueOptions';
+import type { IEnumValueOptions as I_google_protobuf_EnumValueOptions, OEnumValueOptions as O_google_protobuf_EnumValueOptions } from '../../google/protobuf/EnumValueOptions';
 
-export interface EnumValueDescriptorProto {
+export interface IEnumValueDescriptorProto {
   'name'?: (string);
   'number'?: (number);
-  'options'?: (_google_protobuf_EnumValueOptions | null);
+  'options'?: (I_google_protobuf_EnumValueOptions | null);
 }
 
-export interface EnumValueDescriptorProto__Output {
+export interface OEnumValueDescriptorProto {
   'name': (string);
   'number': (number);
-  'options': (_google_protobuf_EnumValueOptions__Output | null);
+  'options': (O_google_protobuf_EnumValueOptions | null);
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/EnumValueOptions.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/EnumValueOptions.ts
@@ -1,13 +1,13 @@
 // Original file: null
 
-import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
+import type { IUninterpretedOption as I_google_protobuf_UninterpretedOption, OUninterpretedOption as O_google_protobuf_UninterpretedOption } from '../../google/protobuf/UninterpretedOption';
 
-export interface EnumValueOptions {
+export interface IEnumValueOptions {
   'deprecated'?: (boolean);
-  'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
+  'uninterpretedOption'?: (I_google_protobuf_UninterpretedOption)[];
 }
 
-export interface EnumValueOptions__Output {
+export interface OEnumValueOptions {
   'deprecated': (boolean);
-  'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
+  'uninterpretedOption': (O_google_protobuf_UninterpretedOption)[];
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/FieldDescriptorProto.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/FieldDescriptorProto.ts
@@ -1,6 +1,6 @@
 // Original file: null
 
-import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from '../../google/protobuf/FieldOptions';
+import type { IFieldOptions as I_google_protobuf_FieldOptions, OFieldOptions as O_google_protobuf_FieldOptions } from '../../google/protobuf/FieldOptions';
 
 // Original file: null
 
@@ -33,7 +33,7 @@ export enum _google_protobuf_FieldDescriptorProto_Type {
   TYPE_SINT64 = 18,
 }
 
-export interface FieldDescriptorProto {
+export interface IFieldDescriptorProto {
   'name'?: (string);
   'extendee'?: (string);
   'number'?: (number);
@@ -41,12 +41,12 @@ export interface FieldDescriptorProto {
   'type'?: (_google_protobuf_FieldDescriptorProto_Type | keyof typeof _google_protobuf_FieldDescriptorProto_Type);
   'typeName'?: (string);
   'defaultValue'?: (string);
-  'options'?: (_google_protobuf_FieldOptions | null);
+  'options'?: (I_google_protobuf_FieldOptions | null);
   'oneofIndex'?: (number);
   'jsonName'?: (string);
 }
 
-export interface FieldDescriptorProto__Output {
+export interface OFieldDescriptorProto {
   'name': (string);
   'extendee': (string);
   'number': (number);
@@ -54,7 +54,7 @@ export interface FieldDescriptorProto__Output {
   'type': (keyof typeof _google_protobuf_FieldDescriptorProto_Type);
   'typeName': (string);
   'defaultValue': (string);
-  'options': (_google_protobuf_FieldOptions__Output | null);
+  'options': (O_google_protobuf_FieldOptions | null);
   'oneofIndex': (number);
   'jsonName': (string);
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/FieldOptions.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/FieldOptions.ts
@@ -1,6 +1,6 @@
 // Original file: null
 
-import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
+import type { IUninterpretedOption as I_google_protobuf_UninterpretedOption, OUninterpretedOption as O_google_protobuf_UninterpretedOption } from '../../google/protobuf/UninterpretedOption';
 import type { FieldBehavior as _google_api_FieldBehavior } from '../../google/api/FieldBehavior';
 
 // Original file: null
@@ -19,24 +19,24 @@ export enum _google_protobuf_FieldOptions_JSType {
   JS_NUMBER = 2,
 }
 
-export interface FieldOptions {
+export interface IFieldOptions {
   'ctype'?: (_google_protobuf_FieldOptions_CType | keyof typeof _google_protobuf_FieldOptions_CType);
   'packed'?: (boolean);
   'deprecated'?: (boolean);
   'lazy'?: (boolean);
   'jstype'?: (_google_protobuf_FieldOptions_JSType | keyof typeof _google_protobuf_FieldOptions_JSType);
   'weak'?: (boolean);
-  'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
+  'uninterpretedOption'?: (I_google_protobuf_UninterpretedOption)[];
   '.google.api.field_behavior'?: (_google_api_FieldBehavior | keyof typeof _google_api_FieldBehavior)[];
 }
 
-export interface FieldOptions__Output {
+export interface OFieldOptions {
   'ctype': (keyof typeof _google_protobuf_FieldOptions_CType);
   'packed': (boolean);
   'deprecated': (boolean);
   'lazy': (boolean);
   'jstype': (keyof typeof _google_protobuf_FieldOptions_JSType);
   'weak': (boolean);
-  'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
+  'uninterpretedOption': (O_google_protobuf_UninterpretedOption)[];
   '.google.api.field_behavior': (keyof typeof _google_api_FieldBehavior)[];
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/FileDescriptorProto.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/FileDescriptorProto.ts
@@ -1,37 +1,37 @@
 // Original file: null
 
-import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from '../../google/protobuf/DescriptorProto';
-import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from '../../google/protobuf/EnumDescriptorProto';
-import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from '../../google/protobuf/ServiceDescriptorProto';
-import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from '../../google/protobuf/FieldDescriptorProto';
-import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from '../../google/protobuf/FileOptions';
-import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from '../../google/protobuf/SourceCodeInfo';
+import type { IDescriptorProto as I_google_protobuf_DescriptorProto, ODescriptorProto as O_google_protobuf_DescriptorProto } from '../../google/protobuf/DescriptorProto';
+import type { IEnumDescriptorProto as I_google_protobuf_EnumDescriptorProto, OEnumDescriptorProto as O_google_protobuf_EnumDescriptorProto } from '../../google/protobuf/EnumDescriptorProto';
+import type { IServiceDescriptorProto as I_google_protobuf_ServiceDescriptorProto, OServiceDescriptorProto as O_google_protobuf_ServiceDescriptorProto } from '../../google/protobuf/ServiceDescriptorProto';
+import type { IFieldDescriptorProto as I_google_protobuf_FieldDescriptorProto, OFieldDescriptorProto as O_google_protobuf_FieldDescriptorProto } from '../../google/protobuf/FieldDescriptorProto';
+import type { IFileOptions as I_google_protobuf_FileOptions, OFileOptions as O_google_protobuf_FileOptions } from '../../google/protobuf/FileOptions';
+import type { ISourceCodeInfo as I_google_protobuf_SourceCodeInfo, OSourceCodeInfo as O_google_protobuf_SourceCodeInfo } from '../../google/protobuf/SourceCodeInfo';
 
-export interface FileDescriptorProto {
+export interface IFileDescriptorProto {
   'name'?: (string);
   'package'?: (string);
   'dependency'?: (string)[];
-  'messageType'?: (_google_protobuf_DescriptorProto)[];
-  'enumType'?: (_google_protobuf_EnumDescriptorProto)[];
-  'service'?: (_google_protobuf_ServiceDescriptorProto)[];
-  'extension'?: (_google_protobuf_FieldDescriptorProto)[];
-  'options'?: (_google_protobuf_FileOptions | null);
-  'sourceCodeInfo'?: (_google_protobuf_SourceCodeInfo | null);
+  'messageType'?: (I_google_protobuf_DescriptorProto)[];
+  'enumType'?: (I_google_protobuf_EnumDescriptorProto)[];
+  'service'?: (I_google_protobuf_ServiceDescriptorProto)[];
+  'extension'?: (I_google_protobuf_FieldDescriptorProto)[];
+  'options'?: (I_google_protobuf_FileOptions | null);
+  'sourceCodeInfo'?: (I_google_protobuf_SourceCodeInfo | null);
   'publicDependency'?: (number)[];
   'weakDependency'?: (number)[];
   'syntax'?: (string);
 }
 
-export interface FileDescriptorProto__Output {
+export interface OFileDescriptorProto {
   'name': (string);
   'package': (string);
   'dependency': (string)[];
-  'messageType': (_google_protobuf_DescriptorProto__Output)[];
-  'enumType': (_google_protobuf_EnumDescriptorProto__Output)[];
-  'service': (_google_protobuf_ServiceDescriptorProto__Output)[];
-  'extension': (_google_protobuf_FieldDescriptorProto__Output)[];
-  'options': (_google_protobuf_FileOptions__Output | null);
-  'sourceCodeInfo': (_google_protobuf_SourceCodeInfo__Output | null);
+  'messageType': (O_google_protobuf_DescriptorProto)[];
+  'enumType': (O_google_protobuf_EnumDescriptorProto)[];
+  'service': (O_google_protobuf_ServiceDescriptorProto)[];
+  'extension': (O_google_protobuf_FieldDescriptorProto)[];
+  'options': (O_google_protobuf_FileOptions | null);
+  'sourceCodeInfo': (O_google_protobuf_SourceCodeInfo | null);
   'publicDependency': (number)[];
   'weakDependency': (number)[];
   'syntax': (string);

--- a/packages/proto-loader/golden-generated/google/protobuf/FileDescriptorSet.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/FileDescriptorSet.ts
@@ -1,11 +1,11 @@
 // Original file: null
 
-import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from '../../google/protobuf/FileDescriptorProto';
+import type { IFileDescriptorProto as I_google_protobuf_FileDescriptorProto, OFileDescriptorProto as O_google_protobuf_FileDescriptorProto } from '../../google/protobuf/FileDescriptorProto';
 
-export interface FileDescriptorSet {
-  'file'?: (_google_protobuf_FileDescriptorProto)[];
+export interface IFileDescriptorSet {
+  'file'?: (I_google_protobuf_FileDescriptorProto)[];
 }
 
-export interface FileDescriptorSet__Output {
-  'file': (_google_protobuf_FileDescriptorProto__Output)[];
+export interface OFileDescriptorSet {
+  'file': (O_google_protobuf_FileDescriptorProto)[];
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/FileOptions.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/FileOptions.ts
@@ -1,6 +1,6 @@
 // Original file: null
 
-import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
+import type { IUninterpretedOption as I_google_protobuf_UninterpretedOption, OUninterpretedOption as O_google_protobuf_UninterpretedOption } from '../../google/protobuf/UninterpretedOption';
 
 // Original file: null
 
@@ -10,7 +10,7 @@ export enum _google_protobuf_FileOptions_OptimizeMode {
   LITE_RUNTIME = 3,
 }
 
-export interface FileOptions {
+export interface IFileOptions {
   'javaPackage'?: (string);
   'javaOuterClassname'?: (string);
   'optimizeFor'?: (_google_protobuf_FileOptions_OptimizeMode | keyof typeof _google_protobuf_FileOptions_OptimizeMode);
@@ -25,10 +25,10 @@ export interface FileOptions {
   'ccEnableArenas'?: (boolean);
   'objcClassPrefix'?: (string);
   'csharpNamespace'?: (string);
-  'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
+  'uninterpretedOption'?: (I_google_protobuf_UninterpretedOption)[];
 }
 
-export interface FileOptions__Output {
+export interface OFileOptions {
   'javaPackage': (string);
   'javaOuterClassname': (string);
   'optimizeFor': (keyof typeof _google_protobuf_FileOptions_OptimizeMode);
@@ -43,5 +43,5 @@ export interface FileOptions__Output {
   'ccEnableArenas': (boolean);
   'objcClassPrefix': (string);
   'csharpNamespace': (string);
-  'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
+  'uninterpretedOption': (O_google_protobuf_UninterpretedOption)[];
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/GeneratedCodeInfo.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/GeneratedCodeInfo.ts
@@ -1,24 +1,24 @@
 // Original file: null
 
 
-export interface _google_protobuf_GeneratedCodeInfo_Annotation {
+export interface I_google_protobuf_GeneratedCodeInfo_Annotation {
   'path'?: (number)[];
   'sourceFile'?: (string);
   'begin'?: (number);
   'end'?: (number);
 }
 
-export interface _google_protobuf_GeneratedCodeInfo_Annotation__Output {
+export interface O_google_protobuf_GeneratedCodeInfo_Annotation {
   'path': (number)[];
   'sourceFile': (string);
   'begin': (number);
   'end': (number);
 }
 
-export interface GeneratedCodeInfo {
-  'annotation'?: (_google_protobuf_GeneratedCodeInfo_Annotation)[];
+export interface IGeneratedCodeInfo {
+  'annotation'?: (I_google_protobuf_GeneratedCodeInfo_Annotation)[];
 }
 
-export interface GeneratedCodeInfo__Output {
-  'annotation': (_google_protobuf_GeneratedCodeInfo_Annotation__Output)[];
+export interface OGeneratedCodeInfo {
+  'annotation': (O_google_protobuf_GeneratedCodeInfo_Annotation)[];
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/MessageOptions.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/MessageOptions.ts
@@ -1,19 +1,19 @@
 // Original file: null
 
-import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
+import type { IUninterpretedOption as I_google_protobuf_UninterpretedOption, OUninterpretedOption as O_google_protobuf_UninterpretedOption } from '../../google/protobuf/UninterpretedOption';
 
-export interface MessageOptions {
+export interface IMessageOptions {
   'messageSetWireFormat'?: (boolean);
   'noStandardDescriptorAccessor'?: (boolean);
   'deprecated'?: (boolean);
   'mapEntry'?: (boolean);
-  'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
+  'uninterpretedOption'?: (I_google_protobuf_UninterpretedOption)[];
 }
 
-export interface MessageOptions__Output {
+export interface OMessageOptions {
   'messageSetWireFormat': (boolean);
   'noStandardDescriptorAccessor': (boolean);
   'deprecated': (boolean);
   'mapEntry': (boolean);
-  'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
+  'uninterpretedOption': (O_google_protobuf_UninterpretedOption)[];
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/MethodDescriptorProto.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/MethodDescriptorProto.ts
@@ -1,21 +1,21 @@
 // Original file: null
 
-import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from '../../google/protobuf/MethodOptions';
+import type { IMethodOptions as I_google_protobuf_MethodOptions, OMethodOptions as O_google_protobuf_MethodOptions } from '../../google/protobuf/MethodOptions';
 
-export interface MethodDescriptorProto {
+export interface IMethodDescriptorProto {
   'name'?: (string);
   'inputType'?: (string);
   'outputType'?: (string);
-  'options'?: (_google_protobuf_MethodOptions | null);
+  'options'?: (I_google_protobuf_MethodOptions | null);
   'clientStreaming'?: (boolean);
   'serverStreaming'?: (boolean);
 }
 
-export interface MethodDescriptorProto__Output {
+export interface OMethodDescriptorProto {
   'name': (string);
   'inputType': (string);
   'outputType': (string);
-  'options': (_google_protobuf_MethodOptions__Output | null);
+  'options': (O_google_protobuf_MethodOptions | null);
   'clientStreaming': (boolean);
   'serverStreaming': (boolean);
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/MethodOptions.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/MethodOptions.ts
@@ -1,21 +1,21 @@
 // Original file: null
 
-import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
-import type { OperationInfo as _google_longrunning_OperationInfo, OperationInfo__Output as _google_longrunning_OperationInfo__Output } from '../../google/longrunning/OperationInfo';
-import type { HttpRule as _google_api_HttpRule, HttpRule__Output as _google_api_HttpRule__Output } from '../../google/api/HttpRule';
+import type { IUninterpretedOption as I_google_protobuf_UninterpretedOption, OUninterpretedOption as O_google_protobuf_UninterpretedOption } from '../../google/protobuf/UninterpretedOption';
+import type { IOperationInfo as I_google_longrunning_OperationInfo, OOperationInfo as O_google_longrunning_OperationInfo } from '../../google/longrunning/OperationInfo';
+import type { IHttpRule as I_google_api_HttpRule, OHttpRule as O_google_api_HttpRule } from '../../google/api/HttpRule';
 
-export interface MethodOptions {
+export interface IMethodOptions {
   'deprecated'?: (boolean);
-  'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
-  '.google.longrunning.operation_info'?: (_google_longrunning_OperationInfo | null);
+  'uninterpretedOption'?: (I_google_protobuf_UninterpretedOption)[];
+  '.google.longrunning.operation_info'?: (I_google_longrunning_OperationInfo | null);
   '.google.api.method_signature'?: (string)[];
-  '.google.api.http'?: (_google_api_HttpRule | null);
+  '.google.api.http'?: (I_google_api_HttpRule | null);
 }
 
-export interface MethodOptions__Output {
+export interface OMethodOptions {
   'deprecated': (boolean);
-  'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
-  '.google.longrunning.operation_info': (_google_longrunning_OperationInfo__Output | null);
+  'uninterpretedOption': (O_google_protobuf_UninterpretedOption)[];
+  '.google.longrunning.operation_info': (O_google_longrunning_OperationInfo | null);
   '.google.api.method_signature': (string)[];
-  '.google.api.http': (_google_api_HttpRule__Output | null);
+  '.google.api.http': (O_google_api_HttpRule | null);
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/OneofDescriptorProto.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/OneofDescriptorProto.ts
@@ -1,13 +1,13 @@
 // Original file: null
 
-import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from '../../google/protobuf/OneofOptions';
+import type { IOneofOptions as I_google_protobuf_OneofOptions, OOneofOptions as O_google_protobuf_OneofOptions } from '../../google/protobuf/OneofOptions';
 
-export interface OneofDescriptorProto {
+export interface IOneofDescriptorProto {
   'name'?: (string);
-  'options'?: (_google_protobuf_OneofOptions | null);
+  'options'?: (I_google_protobuf_OneofOptions | null);
 }
 
-export interface OneofDescriptorProto__Output {
+export interface OOneofDescriptorProto {
   'name': (string);
-  'options': (_google_protobuf_OneofOptions__Output | null);
+  'options': (O_google_protobuf_OneofOptions | null);
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/OneofOptions.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/OneofOptions.ts
@@ -1,11 +1,11 @@
 // Original file: null
 
-import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
+import type { IUninterpretedOption as I_google_protobuf_UninterpretedOption, OUninterpretedOption as O_google_protobuf_UninterpretedOption } from '../../google/protobuf/UninterpretedOption';
 
-export interface OneofOptions {
-  'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
+export interface IOneofOptions {
+  'uninterpretedOption'?: (I_google_protobuf_UninterpretedOption)[];
 }
 
-export interface OneofOptions__Output {
-  'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
+export interface OOneofOptions {
+  'uninterpretedOption': (O_google_protobuf_UninterpretedOption)[];
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/ServiceDescriptorProto.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/ServiceDescriptorProto.ts
@@ -1,16 +1,16 @@
 // Original file: null
 
-import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from '../../google/protobuf/MethodDescriptorProto';
-import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from '../../google/protobuf/ServiceOptions';
+import type { IMethodDescriptorProto as I_google_protobuf_MethodDescriptorProto, OMethodDescriptorProto as O_google_protobuf_MethodDescriptorProto } from '../../google/protobuf/MethodDescriptorProto';
+import type { IServiceOptions as I_google_protobuf_ServiceOptions, OServiceOptions as O_google_protobuf_ServiceOptions } from '../../google/protobuf/ServiceOptions';
 
-export interface ServiceDescriptorProto {
+export interface IServiceDescriptorProto {
   'name'?: (string);
-  'method'?: (_google_protobuf_MethodDescriptorProto)[];
-  'options'?: (_google_protobuf_ServiceOptions | null);
+  'method'?: (I_google_protobuf_MethodDescriptorProto)[];
+  'options'?: (I_google_protobuf_ServiceOptions | null);
 }
 
-export interface ServiceDescriptorProto__Output {
+export interface OServiceDescriptorProto {
   'name': (string);
-  'method': (_google_protobuf_MethodDescriptorProto__Output)[];
-  'options': (_google_protobuf_ServiceOptions__Output | null);
+  'method': (O_google_protobuf_MethodDescriptorProto)[];
+  'options': (O_google_protobuf_ServiceOptions | null);
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/ServiceOptions.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/ServiceOptions.ts
@@ -1,17 +1,17 @@
 // Original file: null
 
-import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from '../../google/protobuf/UninterpretedOption';
+import type { IUninterpretedOption as I_google_protobuf_UninterpretedOption, OUninterpretedOption as O_google_protobuf_UninterpretedOption } from '../../google/protobuf/UninterpretedOption';
 
-export interface ServiceOptions {
+export interface IServiceOptions {
   'deprecated'?: (boolean);
-  'uninterpretedOption'?: (_google_protobuf_UninterpretedOption)[];
+  'uninterpretedOption'?: (I_google_protobuf_UninterpretedOption)[];
   '.google.api.default_host'?: (string);
   '.google.api.oauth_scopes'?: (string);
 }
 
-export interface ServiceOptions__Output {
+export interface OServiceOptions {
   'deprecated': (boolean);
-  'uninterpretedOption': (_google_protobuf_UninterpretedOption__Output)[];
+  'uninterpretedOption': (O_google_protobuf_UninterpretedOption)[];
   '.google.api.default_host': (string);
   '.google.api.oauth_scopes': (string);
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/SourceCodeInfo.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/SourceCodeInfo.ts
@@ -1,7 +1,7 @@
 // Original file: null
 
 
-export interface _google_protobuf_SourceCodeInfo_Location {
+export interface I_google_protobuf_SourceCodeInfo_Location {
   'path'?: (number)[];
   'span'?: (number)[];
   'leadingComments'?: (string);
@@ -9,7 +9,7 @@ export interface _google_protobuf_SourceCodeInfo_Location {
   'leadingDetachedComments'?: (string)[];
 }
 
-export interface _google_protobuf_SourceCodeInfo_Location__Output {
+export interface O_google_protobuf_SourceCodeInfo_Location {
   'path': (number)[];
   'span': (number)[];
   'leadingComments': (string);
@@ -17,10 +17,10 @@ export interface _google_protobuf_SourceCodeInfo_Location__Output {
   'leadingDetachedComments': (string)[];
 }
 
-export interface SourceCodeInfo {
-  'location'?: (_google_protobuf_SourceCodeInfo_Location)[];
+export interface ISourceCodeInfo {
+  'location'?: (I_google_protobuf_SourceCodeInfo_Location)[];
 }
 
-export interface SourceCodeInfo__Output {
-  'location': (_google_protobuf_SourceCodeInfo_Location__Output)[];
+export interface OSourceCodeInfo {
+  'location': (O_google_protobuf_SourceCodeInfo_Location)[];
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/Timestamp.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/Timestamp.ts
@@ -2,12 +2,12 @@
 
 import type { Long } from '@grpc/proto-loader';
 
-export interface Timestamp {
+export interface ITimestamp {
   'seconds'?: (number | string | Long);
   'nanos'?: (number);
 }
 
-export interface Timestamp__Output {
+export interface OTimestamp {
   'seconds': (string);
   'nanos': (number);
 }

--- a/packages/proto-loader/golden-generated/google/protobuf/UninterpretedOption.ts
+++ b/packages/proto-loader/golden-generated/google/protobuf/UninterpretedOption.ts
@@ -2,18 +2,18 @@
 
 import type { Long } from '@grpc/proto-loader';
 
-export interface _google_protobuf_UninterpretedOption_NamePart {
+export interface I_google_protobuf_UninterpretedOption_NamePart {
   'namePart'?: (string);
   'isExtension'?: (boolean);
 }
 
-export interface _google_protobuf_UninterpretedOption_NamePart__Output {
+export interface O_google_protobuf_UninterpretedOption_NamePart {
   'namePart': (string);
   'isExtension': (boolean);
 }
 
-export interface UninterpretedOption {
-  'name'?: (_google_protobuf_UninterpretedOption_NamePart)[];
+export interface IUninterpretedOption {
+  'name'?: (I_google_protobuf_UninterpretedOption_NamePart)[];
   'identifierValue'?: (string);
   'positiveIntValue'?: (number | string | Long);
   'negativeIntValue'?: (number | string | Long);
@@ -22,8 +22,8 @@ export interface UninterpretedOption {
   'aggregateValue'?: (string);
 }
 
-export interface UninterpretedOption__Output {
-  'name': (_google_protobuf_UninterpretedOption_NamePart__Output)[];
+export interface OUninterpretedOption {
+  'name': (O_google_protobuf_UninterpretedOption_NamePart)[];
   'identifierValue': (string);
   'positiveIntValue': (string);
   'negativeIntValue': (string);

--- a/packages/proto-loader/golden-generated/google/rpc/Status.ts
+++ b/packages/proto-loader/golden-generated/google/rpc/Status.ts
@@ -1,6 +1,6 @@
 // Original file: deps/googleapis/google/rpc/status.proto
 
-import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../google/protobuf/Any';
+import type { IAny as I_google_protobuf_Any, OAny as O_google_protobuf_Any } from '../../google/protobuf/Any';
 
 /**
  * The `Status` type defines a logical error model that is suitable for
@@ -11,7 +11,7 @@ import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__
  * You can find out more about this error model and how to work with it in the
  * [API Design Guide](https://cloud.google.com/apis/design/errors).
  */
-export interface Status {
+export interface IStatus {
   /**
    * The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
    */
@@ -26,7 +26,7 @@ export interface Status {
    * A list of messages that carry the error details.  There is a common set of
    * message types for APIs to use.
    */
-  'details'?: (_google_protobuf_Any)[];
+  'details'?: (I_google_protobuf_Any)[];
 }
 
 /**
@@ -38,7 +38,7 @@ export interface Status {
  * You can find out more about this error model and how to work with it in the
  * [API Design Guide](https://cloud.google.com/apis/design/errors).
  */
-export interface Status__Output {
+export interface OStatus {
   /**
    * The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
    */
@@ -53,5 +53,5 @@ export interface Status__Output {
    * A list of messages that carry the error details.  There is a common set of
    * message types for APIs to use.
    */
-  'details': (_google_protobuf_Any__Output)[];
+  'details': (O_google_protobuf_Any)[];
 }

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/BlockRequest.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/BlockRequest.ts
@@ -1,45 +1,45 @@
 // Original file: deps/gapic-showcase/schema/google/showcase/v1beta1/echo.proto
 
-import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../google/protobuf/Duration';
-import type { Status as _google_rpc_Status, Status__Output as _google_rpc_Status__Output } from '../../../google/rpc/Status';
-import type { BlockResponse as _google_showcase_v1beta1_BlockResponse, BlockResponse__Output as _google_showcase_v1beta1_BlockResponse__Output } from '../../../google/showcase/v1beta1/BlockResponse';
+import type { IDuration as I_google_protobuf_Duration, ODuration as O_google_protobuf_Duration } from '../../../google/protobuf/Duration';
+import type { IStatus as I_google_rpc_Status, OStatus as O_google_rpc_Status } from '../../../google/rpc/Status';
+import type { IBlockResponse as I_google_showcase_v1beta1_BlockResponse, OBlockResponse as O_google_showcase_v1beta1_BlockResponse } from '../../../google/showcase/v1beta1/BlockResponse';
 
 /**
  * The request for Block method.
  */
-export interface BlockRequest {
+export interface IBlockRequest {
   /**
    * The amount of time to block before returning a response.
    */
-  'response_delay'?: (_google_protobuf_Duration | null);
+  'response_delay'?: (I_google_protobuf_Duration | null);
   /**
    * The error that will be returned by the server. If this code is specified
    * to be the OK rpc code, an empty response will be returned.
    */
-  'error'?: (_google_rpc_Status | null);
+  'error'?: (I_google_rpc_Status | null);
   /**
    * The response to be returned that will signify successful method call.
    */
-  'success'?: (_google_showcase_v1beta1_BlockResponse | null);
+  'success'?: (I_google_showcase_v1beta1_BlockResponse | null);
   'response'?: "error"|"success";
 }
 
 /**
  * The request for Block method.
  */
-export interface BlockRequest__Output {
+export interface OBlockRequest {
   /**
    * The amount of time to block before returning a response.
    */
-  'response_delay': (_google_protobuf_Duration__Output | null);
+  'response_delay': (O_google_protobuf_Duration | null);
   /**
    * The error that will be returned by the server. If this code is specified
    * to be the OK rpc code, an empty response will be returned.
    */
-  'error'?: (_google_rpc_Status__Output | null);
+  'error'?: (O_google_rpc_Status | null);
   /**
    * The response to be returned that will signify successful method call.
    */
-  'success'?: (_google_showcase_v1beta1_BlockResponse__Output | null);
+  'success'?: (O_google_showcase_v1beta1_BlockResponse | null);
   'response': "error"|"success";
 }

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/BlockResponse.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/BlockResponse.ts
@@ -4,7 +4,7 @@
 /**
  * The response for Block method.
  */
-export interface BlockResponse {
+export interface IBlockResponse {
   /**
    * This content can contain anything, the server will not depend on a value
    * here.
@@ -15,7 +15,7 @@ export interface BlockResponse {
 /**
  * The response for Block method.
  */
-export interface BlockResponse__Output {
+export interface OBlockResponse {
   /**
    * This content can contain anything, the server will not depend on a value
    * here.

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/Echo.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/Echo.ts
@@ -2,15 +2,15 @@
 
 import type * as grpc from '@grpc/grpc-js'
 import type { MethodDefinition } from '@grpc/proto-loader'
-import type { BlockRequest as _google_showcase_v1beta1_BlockRequest, BlockRequest__Output as _google_showcase_v1beta1_BlockRequest__Output } from '../../../google/showcase/v1beta1/BlockRequest';
-import type { BlockResponse as _google_showcase_v1beta1_BlockResponse, BlockResponse__Output as _google_showcase_v1beta1_BlockResponse__Output } from '../../../google/showcase/v1beta1/BlockResponse';
-import type { EchoRequest as _google_showcase_v1beta1_EchoRequest, EchoRequest__Output as _google_showcase_v1beta1_EchoRequest__Output } from '../../../google/showcase/v1beta1/EchoRequest';
-import type { EchoResponse as _google_showcase_v1beta1_EchoResponse, EchoResponse__Output as _google_showcase_v1beta1_EchoResponse__Output } from '../../../google/showcase/v1beta1/EchoResponse';
-import type { ExpandRequest as _google_showcase_v1beta1_ExpandRequest, ExpandRequest__Output as _google_showcase_v1beta1_ExpandRequest__Output } from '../../../google/showcase/v1beta1/ExpandRequest';
-import type { Operation as _google_longrunning_Operation, Operation__Output as _google_longrunning_Operation__Output } from '../../../google/longrunning/Operation';
-import type { PagedExpandRequest as _google_showcase_v1beta1_PagedExpandRequest, PagedExpandRequest__Output as _google_showcase_v1beta1_PagedExpandRequest__Output } from '../../../google/showcase/v1beta1/PagedExpandRequest';
-import type { PagedExpandResponse as _google_showcase_v1beta1_PagedExpandResponse, PagedExpandResponse__Output as _google_showcase_v1beta1_PagedExpandResponse__Output } from '../../../google/showcase/v1beta1/PagedExpandResponse';
-import type { WaitRequest as _google_showcase_v1beta1_WaitRequest, WaitRequest__Output as _google_showcase_v1beta1_WaitRequest__Output } from '../../../google/showcase/v1beta1/WaitRequest';
+import type { IBlockRequest as I_google_showcase_v1beta1_BlockRequest, OBlockRequest as O_google_showcase_v1beta1_BlockRequest } from '../../../google/showcase/v1beta1/BlockRequest';
+import type { IBlockResponse as I_google_showcase_v1beta1_BlockResponse, OBlockResponse as O_google_showcase_v1beta1_BlockResponse } from '../../../google/showcase/v1beta1/BlockResponse';
+import type { IEchoRequest as I_google_showcase_v1beta1_EchoRequest, OEchoRequest as O_google_showcase_v1beta1_EchoRequest } from '../../../google/showcase/v1beta1/EchoRequest';
+import type { IEchoResponse as I_google_showcase_v1beta1_EchoResponse, OEchoResponse as O_google_showcase_v1beta1_EchoResponse } from '../../../google/showcase/v1beta1/EchoResponse';
+import type { IExpandRequest as I_google_showcase_v1beta1_ExpandRequest, OExpandRequest as O_google_showcase_v1beta1_ExpandRequest } from '../../../google/showcase/v1beta1/ExpandRequest';
+import type { IOperation as I_google_longrunning_Operation, OOperation as O_google_longrunning_Operation } from '../../../google/longrunning/Operation';
+import type { IPagedExpandRequest as I_google_showcase_v1beta1_PagedExpandRequest, OPagedExpandRequest as O_google_showcase_v1beta1_PagedExpandRequest } from '../../../google/showcase/v1beta1/PagedExpandRequest';
+import type { IPagedExpandResponse as I_google_showcase_v1beta1_PagedExpandResponse, OPagedExpandResponse as O_google_showcase_v1beta1_PagedExpandResponse } from '../../../google/showcase/v1beta1/PagedExpandResponse';
+import type { IWaitRequest as I_google_showcase_v1beta1_WaitRequest, OWaitRequest as O_google_showcase_v1beta1_WaitRequest } from '../../../google/showcase/v1beta1/WaitRequest';
 
 /**
  * This service is used showcase the four main types of rpcs - unary, server
@@ -25,115 +25,115 @@ export interface EchoClient extends grpc.Client {
    * and then return the response or error.
    * This method showcases how a client handles delays or retries.
    */
-  Block(argument: _google_showcase_v1beta1_BlockRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_BlockResponse__Output>): grpc.ClientUnaryCall;
-  Block(argument: _google_showcase_v1beta1_BlockRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_showcase_v1beta1_BlockResponse__Output>): grpc.ClientUnaryCall;
-  Block(argument: _google_showcase_v1beta1_BlockRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_BlockResponse__Output>): grpc.ClientUnaryCall;
-  Block(argument: _google_showcase_v1beta1_BlockRequest, callback: grpc.requestCallback<_google_showcase_v1beta1_BlockResponse__Output>): grpc.ClientUnaryCall;
+  Block(argument: I_google_showcase_v1beta1_BlockRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_BlockResponse>): grpc.ClientUnaryCall;
+  Block(argument: I_google_showcase_v1beta1_BlockRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_showcase_v1beta1_BlockResponse>): grpc.ClientUnaryCall;
+  Block(argument: I_google_showcase_v1beta1_BlockRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_BlockResponse>): grpc.ClientUnaryCall;
+  Block(argument: I_google_showcase_v1beta1_BlockRequest, callback: grpc.requestCallback<O_google_showcase_v1beta1_BlockResponse>): grpc.ClientUnaryCall;
   /**
    * This method will block (wait) for the requested amount of time
    * and then return the response or error.
    * This method showcases how a client handles delays or retries.
    */
-  block(argument: _google_showcase_v1beta1_BlockRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_BlockResponse__Output>): grpc.ClientUnaryCall;
-  block(argument: _google_showcase_v1beta1_BlockRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_showcase_v1beta1_BlockResponse__Output>): grpc.ClientUnaryCall;
-  block(argument: _google_showcase_v1beta1_BlockRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_BlockResponse__Output>): grpc.ClientUnaryCall;
-  block(argument: _google_showcase_v1beta1_BlockRequest, callback: grpc.requestCallback<_google_showcase_v1beta1_BlockResponse__Output>): grpc.ClientUnaryCall;
+  block(argument: I_google_showcase_v1beta1_BlockRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_BlockResponse>): grpc.ClientUnaryCall;
+  block(argument: I_google_showcase_v1beta1_BlockRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_showcase_v1beta1_BlockResponse>): grpc.ClientUnaryCall;
+  block(argument: I_google_showcase_v1beta1_BlockRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_BlockResponse>): grpc.ClientUnaryCall;
+  block(argument: I_google_showcase_v1beta1_BlockRequest, callback: grpc.requestCallback<O_google_showcase_v1beta1_BlockResponse>): grpc.ClientUnaryCall;
   
   /**
    * This method, upon receiving a request on the stream, the same content will
    * be passed  back on the stream. This method showcases bidirectional
    * streaming rpcs.
    */
-  Chat(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_google_showcase_v1beta1_EchoRequest, _google_showcase_v1beta1_EchoResponse__Output>;
-  Chat(options?: grpc.CallOptions): grpc.ClientDuplexStream<_google_showcase_v1beta1_EchoRequest, _google_showcase_v1beta1_EchoResponse__Output>;
+  Chat(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<I_google_showcase_v1beta1_EchoRequest, O_google_showcase_v1beta1_EchoResponse>;
+  Chat(options?: grpc.CallOptions): grpc.ClientDuplexStream<I_google_showcase_v1beta1_EchoRequest, O_google_showcase_v1beta1_EchoResponse>;
   /**
    * This method, upon receiving a request on the stream, the same content will
    * be passed  back on the stream. This method showcases bidirectional
    * streaming rpcs.
    */
-  chat(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_google_showcase_v1beta1_EchoRequest, _google_showcase_v1beta1_EchoResponse__Output>;
-  chat(options?: grpc.CallOptions): grpc.ClientDuplexStream<_google_showcase_v1beta1_EchoRequest, _google_showcase_v1beta1_EchoResponse__Output>;
+  chat(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<I_google_showcase_v1beta1_EchoRequest, O_google_showcase_v1beta1_EchoResponse>;
+  chat(options?: grpc.CallOptions): grpc.ClientDuplexStream<I_google_showcase_v1beta1_EchoRequest, O_google_showcase_v1beta1_EchoResponse>;
   
   /**
    * This method will collect the words given to it. When the stream is closed
    * by the client, this method will return the a concatenation of the strings
    * passed to it. This method showcases client-side streaming rpcs.
    */
-  Collect(metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientWritableStream<_google_showcase_v1beta1_EchoRequest>;
-  Collect(metadata: grpc.Metadata, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientWritableStream<_google_showcase_v1beta1_EchoRequest>;
-  Collect(options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientWritableStream<_google_showcase_v1beta1_EchoRequest>;
-  Collect(callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientWritableStream<_google_showcase_v1beta1_EchoRequest>;
+  Collect(metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientWritableStream<I_google_showcase_v1beta1_EchoRequest>;
+  Collect(metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientWritableStream<I_google_showcase_v1beta1_EchoRequest>;
+  Collect(options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientWritableStream<I_google_showcase_v1beta1_EchoRequest>;
+  Collect(callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientWritableStream<I_google_showcase_v1beta1_EchoRequest>;
   /**
    * This method will collect the words given to it. When the stream is closed
    * by the client, this method will return the a concatenation of the strings
    * passed to it. This method showcases client-side streaming rpcs.
    */
-  collect(metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientWritableStream<_google_showcase_v1beta1_EchoRequest>;
-  collect(metadata: grpc.Metadata, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientWritableStream<_google_showcase_v1beta1_EchoRequest>;
-  collect(options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientWritableStream<_google_showcase_v1beta1_EchoRequest>;
-  collect(callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientWritableStream<_google_showcase_v1beta1_EchoRequest>;
+  collect(metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientWritableStream<I_google_showcase_v1beta1_EchoRequest>;
+  collect(metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientWritableStream<I_google_showcase_v1beta1_EchoRequest>;
+  collect(options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientWritableStream<I_google_showcase_v1beta1_EchoRequest>;
+  collect(callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientWritableStream<I_google_showcase_v1beta1_EchoRequest>;
   
   /**
    * This method simply echos the request. This method is showcases unary rpcs.
    */
-  Echo(argument: _google_showcase_v1beta1_EchoRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientUnaryCall;
-  Echo(argument: _google_showcase_v1beta1_EchoRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientUnaryCall;
-  Echo(argument: _google_showcase_v1beta1_EchoRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientUnaryCall;
-  Echo(argument: _google_showcase_v1beta1_EchoRequest, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientUnaryCall;
+  Echo(argument: I_google_showcase_v1beta1_EchoRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientUnaryCall;
+  Echo(argument: I_google_showcase_v1beta1_EchoRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientUnaryCall;
+  Echo(argument: I_google_showcase_v1beta1_EchoRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientUnaryCall;
+  Echo(argument: I_google_showcase_v1beta1_EchoRequest, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientUnaryCall;
   /**
    * This method simply echos the request. This method is showcases unary rpcs.
    */
-  echo(argument: _google_showcase_v1beta1_EchoRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientUnaryCall;
-  echo(argument: _google_showcase_v1beta1_EchoRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientUnaryCall;
-  echo(argument: _google_showcase_v1beta1_EchoRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientUnaryCall;
-  echo(argument: _google_showcase_v1beta1_EchoRequest, callback: grpc.requestCallback<_google_showcase_v1beta1_EchoResponse__Output>): grpc.ClientUnaryCall;
+  echo(argument: I_google_showcase_v1beta1_EchoRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientUnaryCall;
+  echo(argument: I_google_showcase_v1beta1_EchoRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientUnaryCall;
+  echo(argument: I_google_showcase_v1beta1_EchoRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientUnaryCall;
+  echo(argument: I_google_showcase_v1beta1_EchoRequest, callback: grpc.requestCallback<O_google_showcase_v1beta1_EchoResponse>): grpc.ClientUnaryCall;
   
   /**
    * This method split the given content into words and will pass each word back
    * through the stream. This method showcases server-side streaming rpcs.
    */
-  Expand(argument: _google_showcase_v1beta1_ExpandRequest, metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientReadableStream<_google_showcase_v1beta1_EchoResponse__Output>;
-  Expand(argument: _google_showcase_v1beta1_ExpandRequest, options?: grpc.CallOptions): grpc.ClientReadableStream<_google_showcase_v1beta1_EchoResponse__Output>;
+  Expand(argument: I_google_showcase_v1beta1_ExpandRequest, metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientReadableStream<O_google_showcase_v1beta1_EchoResponse>;
+  Expand(argument: I_google_showcase_v1beta1_ExpandRequest, options?: grpc.CallOptions): grpc.ClientReadableStream<O_google_showcase_v1beta1_EchoResponse>;
   /**
    * This method split the given content into words and will pass each word back
    * through the stream. This method showcases server-side streaming rpcs.
    */
-  expand(argument: _google_showcase_v1beta1_ExpandRequest, metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientReadableStream<_google_showcase_v1beta1_EchoResponse__Output>;
-  expand(argument: _google_showcase_v1beta1_ExpandRequest, options?: grpc.CallOptions): grpc.ClientReadableStream<_google_showcase_v1beta1_EchoResponse__Output>;
+  expand(argument: I_google_showcase_v1beta1_ExpandRequest, metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientReadableStream<O_google_showcase_v1beta1_EchoResponse>;
+  expand(argument: I_google_showcase_v1beta1_ExpandRequest, options?: grpc.CallOptions): grpc.ClientReadableStream<O_google_showcase_v1beta1_EchoResponse>;
   
   /**
    * This is similar to the Expand method but instead of returning a stream of
    * expanded words, this method returns a paged list of expanded words.
    */
-  PagedExpand(argument: _google_showcase_v1beta1_PagedExpandRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_PagedExpandResponse__Output>): grpc.ClientUnaryCall;
-  PagedExpand(argument: _google_showcase_v1beta1_PagedExpandRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_showcase_v1beta1_PagedExpandResponse__Output>): grpc.ClientUnaryCall;
-  PagedExpand(argument: _google_showcase_v1beta1_PagedExpandRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_PagedExpandResponse__Output>): grpc.ClientUnaryCall;
-  PagedExpand(argument: _google_showcase_v1beta1_PagedExpandRequest, callback: grpc.requestCallback<_google_showcase_v1beta1_PagedExpandResponse__Output>): grpc.ClientUnaryCall;
+  PagedExpand(argument: I_google_showcase_v1beta1_PagedExpandRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_PagedExpandResponse>): grpc.ClientUnaryCall;
+  PagedExpand(argument: I_google_showcase_v1beta1_PagedExpandRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_showcase_v1beta1_PagedExpandResponse>): grpc.ClientUnaryCall;
+  PagedExpand(argument: I_google_showcase_v1beta1_PagedExpandRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_PagedExpandResponse>): grpc.ClientUnaryCall;
+  PagedExpand(argument: I_google_showcase_v1beta1_PagedExpandRequest, callback: grpc.requestCallback<O_google_showcase_v1beta1_PagedExpandResponse>): grpc.ClientUnaryCall;
   /**
    * This is similar to the Expand method but instead of returning a stream of
    * expanded words, this method returns a paged list of expanded words.
    */
-  pagedExpand(argument: _google_showcase_v1beta1_PagedExpandRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_PagedExpandResponse__Output>): grpc.ClientUnaryCall;
-  pagedExpand(argument: _google_showcase_v1beta1_PagedExpandRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_showcase_v1beta1_PagedExpandResponse__Output>): grpc.ClientUnaryCall;
-  pagedExpand(argument: _google_showcase_v1beta1_PagedExpandRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_showcase_v1beta1_PagedExpandResponse__Output>): grpc.ClientUnaryCall;
-  pagedExpand(argument: _google_showcase_v1beta1_PagedExpandRequest, callback: grpc.requestCallback<_google_showcase_v1beta1_PagedExpandResponse__Output>): grpc.ClientUnaryCall;
+  pagedExpand(argument: I_google_showcase_v1beta1_PagedExpandRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_PagedExpandResponse>): grpc.ClientUnaryCall;
+  pagedExpand(argument: I_google_showcase_v1beta1_PagedExpandRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_showcase_v1beta1_PagedExpandResponse>): grpc.ClientUnaryCall;
+  pagedExpand(argument: I_google_showcase_v1beta1_PagedExpandRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_showcase_v1beta1_PagedExpandResponse>): grpc.ClientUnaryCall;
+  pagedExpand(argument: I_google_showcase_v1beta1_PagedExpandRequest, callback: grpc.requestCallback<O_google_showcase_v1beta1_PagedExpandResponse>): grpc.ClientUnaryCall;
   
   /**
    * This method will wait the requested amount of and then return.
    * This method showcases how a client handles a request timing out.
    */
-  Wait(argument: _google_showcase_v1beta1_WaitRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  Wait(argument: _google_showcase_v1beta1_WaitRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  Wait(argument: _google_showcase_v1beta1_WaitRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  Wait(argument: _google_showcase_v1beta1_WaitRequest, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
+  Wait(argument: I_google_showcase_v1beta1_WaitRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  Wait(argument: I_google_showcase_v1beta1_WaitRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  Wait(argument: I_google_showcase_v1beta1_WaitRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  Wait(argument: I_google_showcase_v1beta1_WaitRequest, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
   /**
    * This method will wait the requested amount of and then return.
    * This method showcases how a client handles a request timing out.
    */
-  wait(argument: _google_showcase_v1beta1_WaitRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  wait(argument: _google_showcase_v1beta1_WaitRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  wait(argument: _google_showcase_v1beta1_WaitRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
-  wait(argument: _google_showcase_v1beta1_WaitRequest, callback: grpc.requestCallback<_google_longrunning_Operation__Output>): grpc.ClientUnaryCall;
+  wait(argument: I_google_showcase_v1beta1_WaitRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  wait(argument: I_google_showcase_v1beta1_WaitRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  wait(argument: I_google_showcase_v1beta1_WaitRequest, options: grpc.CallOptions, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
+  wait(argument: I_google_showcase_v1beta1_WaitRequest, callback: grpc.requestCallback<O_google_longrunning_Operation>): grpc.ClientUnaryCall;
   
 }
 
@@ -150,53 +150,53 @@ export interface EchoHandlers extends grpc.UntypedServiceImplementation {
    * and then return the response or error.
    * This method showcases how a client handles delays or retries.
    */
-  Block: grpc.handleUnaryCall<_google_showcase_v1beta1_BlockRequest__Output, _google_showcase_v1beta1_BlockResponse>;
+  Block: grpc.handleUnaryCall<O_google_showcase_v1beta1_BlockRequest, I_google_showcase_v1beta1_BlockResponse>;
   
   /**
    * This method, upon receiving a request on the stream, the same content will
    * be passed  back on the stream. This method showcases bidirectional
    * streaming rpcs.
    */
-  Chat: grpc.handleBidiStreamingCall<_google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse>;
+  Chat: grpc.handleBidiStreamingCall<O_google_showcase_v1beta1_EchoRequest, I_google_showcase_v1beta1_EchoResponse>;
   
   /**
    * This method will collect the words given to it. When the stream is closed
    * by the client, this method will return the a concatenation of the strings
    * passed to it. This method showcases client-side streaming rpcs.
    */
-  Collect: grpc.handleClientStreamingCall<_google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse>;
+  Collect: grpc.handleClientStreamingCall<O_google_showcase_v1beta1_EchoRequest, I_google_showcase_v1beta1_EchoResponse>;
   
   /**
    * This method simply echos the request. This method is showcases unary rpcs.
    */
-  Echo: grpc.handleUnaryCall<_google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse>;
+  Echo: grpc.handleUnaryCall<O_google_showcase_v1beta1_EchoRequest, I_google_showcase_v1beta1_EchoResponse>;
   
   /**
    * This method split the given content into words and will pass each word back
    * through the stream. This method showcases server-side streaming rpcs.
    */
-  Expand: grpc.handleServerStreamingCall<_google_showcase_v1beta1_ExpandRequest__Output, _google_showcase_v1beta1_EchoResponse>;
+  Expand: grpc.handleServerStreamingCall<O_google_showcase_v1beta1_ExpandRequest, I_google_showcase_v1beta1_EchoResponse>;
   
   /**
    * This is similar to the Expand method but instead of returning a stream of
    * expanded words, this method returns a paged list of expanded words.
    */
-  PagedExpand: grpc.handleUnaryCall<_google_showcase_v1beta1_PagedExpandRequest__Output, _google_showcase_v1beta1_PagedExpandResponse>;
+  PagedExpand: grpc.handleUnaryCall<O_google_showcase_v1beta1_PagedExpandRequest, I_google_showcase_v1beta1_PagedExpandResponse>;
   
   /**
    * This method will wait the requested amount of and then return.
    * This method showcases how a client handles a request timing out.
    */
-  Wait: grpc.handleUnaryCall<_google_showcase_v1beta1_WaitRequest__Output, _google_longrunning_Operation>;
+  Wait: grpc.handleUnaryCall<O_google_showcase_v1beta1_WaitRequest, I_google_longrunning_Operation>;
   
 }
 
 export interface EchoDefinition extends grpc.ServiceDefinition {
-  Block: MethodDefinition<_google_showcase_v1beta1_BlockRequest, _google_showcase_v1beta1_BlockResponse, _google_showcase_v1beta1_BlockRequest__Output, _google_showcase_v1beta1_BlockResponse__Output>
-  Chat: MethodDefinition<_google_showcase_v1beta1_EchoRequest, _google_showcase_v1beta1_EchoResponse, _google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse__Output>
-  Collect: MethodDefinition<_google_showcase_v1beta1_EchoRequest, _google_showcase_v1beta1_EchoResponse, _google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse__Output>
-  Echo: MethodDefinition<_google_showcase_v1beta1_EchoRequest, _google_showcase_v1beta1_EchoResponse, _google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse__Output>
-  Expand: MethodDefinition<_google_showcase_v1beta1_ExpandRequest, _google_showcase_v1beta1_EchoResponse, _google_showcase_v1beta1_ExpandRequest__Output, _google_showcase_v1beta1_EchoResponse__Output>
-  PagedExpand: MethodDefinition<_google_showcase_v1beta1_PagedExpandRequest, _google_showcase_v1beta1_PagedExpandResponse, _google_showcase_v1beta1_PagedExpandRequest__Output, _google_showcase_v1beta1_PagedExpandResponse__Output>
-  Wait: MethodDefinition<_google_showcase_v1beta1_WaitRequest, _google_longrunning_Operation, _google_showcase_v1beta1_WaitRequest__Output, _google_longrunning_Operation__Output>
+  Block: MethodDefinition<I_google_showcase_v1beta1_BlockRequest, I_google_showcase_v1beta1_BlockResponse, O_google_showcase_v1beta1_BlockRequest, O_google_showcase_v1beta1_BlockResponse>
+  Chat: MethodDefinition<I_google_showcase_v1beta1_EchoRequest, I_google_showcase_v1beta1_EchoResponse, O_google_showcase_v1beta1_EchoRequest, O_google_showcase_v1beta1_EchoResponse>
+  Collect: MethodDefinition<I_google_showcase_v1beta1_EchoRequest, I_google_showcase_v1beta1_EchoResponse, O_google_showcase_v1beta1_EchoRequest, O_google_showcase_v1beta1_EchoResponse>
+  Echo: MethodDefinition<I_google_showcase_v1beta1_EchoRequest, I_google_showcase_v1beta1_EchoResponse, O_google_showcase_v1beta1_EchoRequest, O_google_showcase_v1beta1_EchoResponse>
+  Expand: MethodDefinition<I_google_showcase_v1beta1_ExpandRequest, I_google_showcase_v1beta1_EchoResponse, O_google_showcase_v1beta1_ExpandRequest, O_google_showcase_v1beta1_EchoResponse>
+  PagedExpand: MethodDefinition<I_google_showcase_v1beta1_PagedExpandRequest, I_google_showcase_v1beta1_PagedExpandResponse, O_google_showcase_v1beta1_PagedExpandRequest, O_google_showcase_v1beta1_PagedExpandResponse>
+  Wait: MethodDefinition<I_google_showcase_v1beta1_WaitRequest, I_google_longrunning_Operation, O_google_showcase_v1beta1_WaitRequest, O_google_longrunning_Operation>
 }

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/EchoRequest.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/EchoRequest.ts
@@ -1,6 +1,6 @@
 // Original file: deps/gapic-showcase/schema/google/showcase/v1beta1/echo.proto
 
-import type { Status as _google_rpc_Status, Status__Output as _google_rpc_Status__Output } from '../../../google/rpc/Status';
+import type { IStatus as I_google_rpc_Status, OStatus as O_google_rpc_Status } from '../../../google/rpc/Status';
 import type { Severity as _google_showcase_v1beta1_Severity } from '../../../google/showcase/v1beta1/Severity';
 
 /**
@@ -9,7 +9,7 @@ import type { Severity as _google_showcase_v1beta1_Severity } from '../../../goo
  * If status is set in this message
  * then the status will be returned as an error.
  */
-export interface EchoRequest {
+export interface IEchoRequest {
   /**
    * The content to be echoed by the server.
    */
@@ -17,7 +17,7 @@ export interface EchoRequest {
   /**
    * The error to be thrown by the server.
    */
-  'error'?: (_google_rpc_Status | null);
+  'error'?: (I_google_rpc_Status | null);
   /**
    * The severity to be echoed by the server.
    */
@@ -31,7 +31,7 @@ export interface EchoRequest {
  * If status is set in this message
  * then the status will be returned as an error.
  */
-export interface EchoRequest__Output {
+export interface OEchoRequest {
   /**
    * The content to be echoed by the server.
    */
@@ -39,7 +39,7 @@ export interface EchoRequest__Output {
   /**
    * The error to be thrown by the server.
    */
-  'error'?: (_google_rpc_Status__Output | null);
+  'error'?: (O_google_rpc_Status | null);
   /**
    * The severity to be echoed by the server.
    */

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/EchoResponse.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/EchoResponse.ts
@@ -5,7 +5,7 @@ import type { Severity as _google_showcase_v1beta1_Severity } from '../../../goo
 /**
  * The response message for the Echo methods.
  */
-export interface EchoResponse {
+export interface IEchoResponse {
   /**
    * The content specified in the request.
    */
@@ -19,7 +19,7 @@ export interface EchoResponse {
 /**
  * The response message for the Echo methods.
  */
-export interface EchoResponse__Output {
+export interface OEchoResponse {
   /**
    * The content specified in the request.
    */

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/ExpandRequest.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/ExpandRequest.ts
@@ -1,11 +1,11 @@
 // Original file: deps/gapic-showcase/schema/google/showcase/v1beta1/echo.proto
 
-import type { Status as _google_rpc_Status, Status__Output as _google_rpc_Status__Output } from '../../../google/rpc/Status';
+import type { IStatus as I_google_rpc_Status, OStatus as O_google_rpc_Status } from '../../../google/rpc/Status';
 
 /**
  * The request message for the Expand method.
  */
-export interface ExpandRequest {
+export interface IExpandRequest {
   /**
    * The content that will be split into words and returned on the stream.
    */
@@ -13,13 +13,13 @@ export interface ExpandRequest {
   /**
    * The error that is thrown after all words are sent on the stream.
    */
-  'error'?: (_google_rpc_Status | null);
+  'error'?: (I_google_rpc_Status | null);
 }
 
 /**
  * The request message for the Expand method.
  */
-export interface ExpandRequest__Output {
+export interface OExpandRequest {
   /**
    * The content that will be split into words and returned on the stream.
    */
@@ -27,5 +27,5 @@ export interface ExpandRequest__Output {
   /**
    * The error that is thrown after all words are sent on the stream.
    */
-  'error': (_google_rpc_Status__Output | null);
+  'error': (O_google_rpc_Status | null);
 }

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/PagedExpandRequest.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/PagedExpandRequest.ts
@@ -4,7 +4,7 @@
 /**
  * The request for the PagedExpand method.
  */
-export interface PagedExpandRequest {
+export interface IPagedExpandRequest {
   /**
    * The string to expand.
    */
@@ -22,7 +22,7 @@ export interface PagedExpandRequest {
 /**
  * The request for the PagedExpand method.
  */
-export interface PagedExpandRequest__Output {
+export interface OPagedExpandRequest {
   /**
    * The string to expand.
    */

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/PagedExpandResponse.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/PagedExpandResponse.ts
@@ -1,15 +1,15 @@
 // Original file: deps/gapic-showcase/schema/google/showcase/v1beta1/echo.proto
 
-import type { EchoResponse as _google_showcase_v1beta1_EchoResponse, EchoResponse__Output as _google_showcase_v1beta1_EchoResponse__Output } from '../../../google/showcase/v1beta1/EchoResponse';
+import type { IEchoResponse as I_google_showcase_v1beta1_EchoResponse, OEchoResponse as O_google_showcase_v1beta1_EchoResponse } from '../../../google/showcase/v1beta1/EchoResponse';
 
 /**
  * The response for the PagedExpand method.
  */
-export interface PagedExpandResponse {
+export interface IPagedExpandResponse {
   /**
    * The words that were expanded.
    */
-  'responses'?: (_google_showcase_v1beta1_EchoResponse)[];
+  'responses'?: (I_google_showcase_v1beta1_EchoResponse)[];
   /**
    * The next page token.
    */
@@ -19,11 +19,11 @@ export interface PagedExpandResponse {
 /**
  * The response for the PagedExpand method.
  */
-export interface PagedExpandResponse__Output {
+export interface OPagedExpandResponse {
   /**
    * The words that were expanded.
    */
-  'responses': (_google_showcase_v1beta1_EchoResponse__Output)[];
+  'responses': (O_google_showcase_v1beta1_EchoResponse)[];
   /**
    * The next page token.
    */

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/WaitMetadata.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/WaitMetadata.ts
@@ -1,23 +1,23 @@
 // Original file: deps/gapic-showcase/schema/google/showcase/v1beta1/echo.proto
 
-import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
+import type { ITimestamp as I_google_protobuf_Timestamp, OTimestamp as O_google_protobuf_Timestamp } from '../../../google/protobuf/Timestamp';
 
 /**
  * The metadata for Wait operation.
  */
-export interface WaitMetadata {
+export interface IWaitMetadata {
   /**
    * The time that this operation will complete.
    */
-  'end_time'?: (_google_protobuf_Timestamp | null);
+  'end_time'?: (I_google_protobuf_Timestamp | null);
 }
 
 /**
  * The metadata for Wait operation.
  */
-export interface WaitMetadata__Output {
+export interface OWaitMetadata {
   /**
    * The time that this operation will complete.
    */
-  'end_time': (_google_protobuf_Timestamp__Output | null);
+  'end_time': (O_google_protobuf_Timestamp | null);
 }

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/WaitRequest.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/WaitRequest.ts
@@ -1,31 +1,31 @@
 // Original file: deps/gapic-showcase/schema/google/showcase/v1beta1/echo.proto
 
-import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
-import type { Status as _google_rpc_Status, Status__Output as _google_rpc_Status__Output } from '../../../google/rpc/Status';
-import type { WaitResponse as _google_showcase_v1beta1_WaitResponse, WaitResponse__Output as _google_showcase_v1beta1_WaitResponse__Output } from '../../../google/showcase/v1beta1/WaitResponse';
-import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../google/protobuf/Duration';
+import type { ITimestamp as I_google_protobuf_Timestamp, OTimestamp as O_google_protobuf_Timestamp } from '../../../google/protobuf/Timestamp';
+import type { IStatus as I_google_rpc_Status, OStatus as O_google_rpc_Status } from '../../../google/rpc/Status';
+import type { IWaitResponse as I_google_showcase_v1beta1_WaitResponse, OWaitResponse as O_google_showcase_v1beta1_WaitResponse } from '../../../google/showcase/v1beta1/WaitResponse';
+import type { IDuration as I_google_protobuf_Duration, ODuration as O_google_protobuf_Duration } from '../../../google/protobuf/Duration';
 
 /**
  * The request for Wait method.
  */
-export interface WaitRequest {
+export interface IWaitRequest {
   /**
    * The time that this operation will complete.
    */
-  'end_time'?: (_google_protobuf_Timestamp | null);
+  'end_time'?: (I_google_protobuf_Timestamp | null);
   /**
    * The error that will be returned by the server. If this code is specified
    * to be the OK rpc code, an empty response will be returned.
    */
-  'error'?: (_google_rpc_Status | null);
+  'error'?: (I_google_rpc_Status | null);
   /**
    * The response to be returned on operation completion.
    */
-  'success'?: (_google_showcase_v1beta1_WaitResponse | null);
+  'success'?: (I_google_showcase_v1beta1_WaitResponse | null);
   /**
    * The duration of this operation.
    */
-  'ttl'?: (_google_protobuf_Duration | null);
+  'ttl'?: (I_google_protobuf_Duration | null);
   'end'?: "end_time"|"ttl";
   'response'?: "error"|"success";
 }
@@ -33,24 +33,24 @@ export interface WaitRequest {
 /**
  * The request for Wait method.
  */
-export interface WaitRequest__Output {
+export interface OWaitRequest {
   /**
    * The time that this operation will complete.
    */
-  'end_time'?: (_google_protobuf_Timestamp__Output | null);
+  'end_time'?: (O_google_protobuf_Timestamp | null);
   /**
    * The error that will be returned by the server. If this code is specified
    * to be the OK rpc code, an empty response will be returned.
    */
-  'error'?: (_google_rpc_Status__Output | null);
+  'error'?: (O_google_rpc_Status | null);
   /**
    * The response to be returned on operation completion.
    */
-  'success'?: (_google_showcase_v1beta1_WaitResponse__Output | null);
+  'success'?: (O_google_showcase_v1beta1_WaitResponse | null);
   /**
    * The duration of this operation.
    */
-  'ttl'?: (_google_protobuf_Duration__Output | null);
+  'ttl'?: (O_google_protobuf_Duration | null);
   'end': "end_time"|"ttl";
   'response': "error"|"success";
 }

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/WaitResponse.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/WaitResponse.ts
@@ -4,7 +4,7 @@
 /**
  * The result of the Wait operation.
  */
-export interface WaitResponse {
+export interface IWaitResponse {
   /**
    * This content of the result.
    */
@@ -14,7 +14,7 @@ export interface WaitResponse {
 /**
  * The result of the Wait operation.
  */
-export interface WaitResponse__Output {
+export interface OWaitResponse {
   /**
    * This content of the result.
    */

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -24,7 +24,7 @@
     "fix": "gts fix",
     "pretest": "npm run compile",
     "posttest": "npm run check",
-    "generate-golden": "node ./build/bin/proto-loader-gen-types.js --keepCase --longs=String --enums=String --defaults --oneofs --json --includeComments -I deps/gapic-showcase/schema/ deps/googleapis/ -O ./golden-generated --grpcLib @grpc/grpc-js google/showcase/v1beta1/echo.proto",
+    "generate-golden": "node ./build/bin/proto-loader-gen-types.js --keepCase --longs=String --enums=String --defaults --oneofs --json --includeComments --inputTemplate=I%s --outputTemplate=O%s -I deps/gapic-showcase/schema/ deps/googleapis/ -O ./golden-generated --grpcLib @grpc/grpc-js google/showcase/v1beta1/echo.proto",
     "validate-golden": "rm -rf ./golden-generated-old && mv ./golden-generated/ ./golden-generated-old && npm run generate-golden && diff -rb ./golden-generated ./golden-generated-old"
   },
   "repository": {


### PR DESCRIPTION
- Allow for customizing the naming pattern for both restricted and permissive types

Enums and filenames are left untouched