### PR TITLE
grpc-js-xds: Enable the outlier detection interop test

### DIFF
--- a/packages/grpc-js-xds/scripts/xds_k8s_lb.sh
+++ b/packages/grpc-js-xds/scripts/xds_k8s_lb.sh
@@ -159,7 +159,7 @@ main() {
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0
-  test_suites=("baseline_test" "api_listener_test" "change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test")
+  test_suites=("baseline_test" "api_listener_test" "change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test" "outlier_detection")
   for test in "${test_suites[@]}"; do
     run_test $test || (( failed_tests++ ))
   done


### PR DESCRIPTION
This will work once the corresponding feature is enabled in production.