### PR TITLE
grpc-js: Avoid explicit bind in trailer event handler

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -573,7 +573,9 @@ export class Http2CallStream implements Call {
           }
         }
       });
-      stream.on('trailers', this.handleTrailers.bind(this));
+      stream.on('trailers', (headers: http2.IncomingHttpHeaders) => {
+        this.handleTrailers(headers);
+      });
       stream.on('data', (data: Buffer) => {
         this.trace('receive HTTP/2 data frame of length ' + data.length);
         const messages = this.decoder.write(data);


### PR DESCRIPTION
The reference chain in #2184 shows that the trailer event handler specifically is holding a reference to the `Http2CallStream` object, and that event handler is the only one that uses `bind`, so it seems likely that those are related. With this change, that event handler will be created similarly to the others, so hopefully that will fix the problem.