### PR TITLE
grpc-js: Destroy http2 stream after closing

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -736,6 +736,7 @@ export class Http2CallStream implements Call {
       }
       this.trace('close http2 stream with code ' + code);
       this.http2Stream.close(code);
+      this.http2Stream.destroy();
     }
   }
 


### PR DESCRIPTION
This will probably fix the `ClientHttp2Stream` leak reported in #2184. `close` tries to close an http2 stream, but it waits for incoming data to be read before finalizing that destruction. `destroy` guarantees destruction without waiting for data to be read. We still want to call close to chose the RST_STREAM code to send. By my own reading of that part of the Node source code, even if `destroy` is called before the RST_STREAM is sent, it will ensure that the RST_STREAM is sent, and it will use the code set by the call to `close`.