### PR TITLE
grpc-js: Drain incoming http2 data after outputting status

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
This is an attempt to fix the `ClientHttp2Stream` leak described in #2184. The likely cause of the leak is that `stream.close()` is called but it still has incoming data waiting to be read so it is never destroyed. This fixes that by putting the stream into flowing mode and discarding all incoming messages after outputting a status. This should have no user-visible effect because the existing code already does not output any messages after outputting a status.