### PR TITLE
proto-loader: Update dependencies to fix compilation error

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "Google Inc.",
   "contributors": [
     {
@@ -58,9 +58,9 @@
     "@types/node": "^10.17.26",
     "@types/yargs": "^16.0.4",
     "clang-format": "^1.2.2",
-    "gts": "^1.1.0",
+    "gts": "^3.1.0",
     "rimraf": "^3.0.2",
-    "typescript": "~3.8.3"
+    "typescript": "~4.7.4"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
This fixes a breakage in the interop test docker image build. It looks like `lodash` had an update that made it incompatible with `typescript` v3, so I upgraded to `typescript` v4, and I also needed to update `gts` for compatibility with the upgraded `typescript` version.