### PR TITLE
proto-loader: Undo upgrade of 'long' dependency

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": "Google Inc.",
   "contributors": [
     {
@@ -45,8 +45,9 @@
     "proto-loader-gen-types": "./build/bin/proto-loader-gen-types.js"
   },
   "dependencies": {
+    "@types/long": "^4.0.1",
     "lodash.camelcase": "^4.3.0",
-    "long": "^5.0.0",
+    "long": "^4.0.0",
     "protobufjs": "^7.0.0",
     "yargs": "^16.2.0"
   },


### PR DESCRIPTION
This reverts #2192. We thought it wouldn't break Cloud API client libraries, but it did. We'll try this again in the future after they have made some changes.