### PR TITLE
grpc-js: Switch LB policy when new one is not CONNECTING

### DIFF
--- a/packages/grpc-js/src/load-balancer-child-handler.ts
+++ b/packages/grpc-js/src/load-balancer-child-handler.ts
@@ -48,7 +48,7 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
     }
     updateState(connectivityState: ConnectivityState, picker: Picker): void {
       if (this.calledByPendingChild()) {
-        if (connectivityState !== ConnectivityState.READY) {
+        if (connectivityState === ConnectivityState.CONNECTING) {
           return;
         }
         this.parent.currentChild?.destroy();


### PR DESCRIPTION
Based on conversations with the team, this is a correction to the behavior when handling an LB policy config update that changes the LB policy type. This `ChildLoadBalancerHandler` class handles graceful switchover from the existing LB policy to the new one. The current behavior is to switch when the new one is in the READY state, but instead it will switch whenever the new one is in any state other than CONNECTING.