### PR TITLE
proto-loader: Update dependencies to fix compilation error (1.6.x)

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -58,9 +58,9 @@
     "@types/node": "^10.17.26",
     "@types/yargs": "^16.0.4",
     "clang-format": "^1.2.2",
-    "gts": "^1.1.0",
+    "gts": "^3.1.0",
     "rimraf": "^3.0.2",
-    "typescript": "~3.8.3"
+    "typescript": "~4.7.4"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
This is the same as #2196. That breakage is also impacting the test jobs on the 1.6.x branch.