### PR TITLE
grpc-js: Stop ejecting when current percent is equal to max

### DIFF
--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -467,7 +467,7 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
     // Step 3
     for (const [address, mapEntry] of this.addressMap.entries()) {
       // Step 3.i
-      if (this.getCurrentEjectionPercent() > this.latestConfig.getMaxEjectionPercent()) {
+      if (this.getCurrentEjectionPercent() >= this.latestConfig.getMaxEjectionPercent()) {
         break;
       }
       // Step 3.ii
@@ -515,7 +515,7 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
     // Step 2
     for (const [address, mapEntry] of this.addressMap.entries()) {
       // Step 2.i
-      if (this.getCurrentEjectionPercent() > this.latestConfig.getMaxEjectionPercent()) {
+      if (this.getCurrentEjectionPercent() >= this.latestConfig.getMaxEjectionPercent()) {
         break;
       }
       // Step 2.ii


### PR DESCRIPTION
This change addresses grpc/proposal#323.