### PR TITLE
grpc-js-xds: Use authority override to select VirtualHost when provided

### DIFF
--- a/packages/grpc-js-xds/src/resolver-xds.ts
+++ b/packages/grpc-js-xds/src/resolver-xds.ts
@@ -319,9 +319,12 @@ class XdsResolver implements Resolver {
   private handleRouteConfig(routeConfig: RouteConfiguration__Output, isV2: boolean) {
     this.latestRouteConfig = routeConfig;
     this.latestRouteConfigIsV2 = isV2;
-    const virtualHost = findVirtualHostForDomain(routeConfig.virtual_hosts, this.target.path);
+    /* Select the virtual host using the default authority override if it
+     * exists, and the channel target otherwise. */
+    const hostDomain = this.channelOptions['grpc.default_authority'] ?? this.target.path;
+    const virtualHost = findVirtualHostForDomain(routeConfig.virtual_hosts, hostDomain);
     if (virtualHost === null) {
-      this.reportResolutionError('No matching route found');
+      this.reportResolutionError('No matching route found for ' + hostDomain);
       return;
     }
     const virtualHostHttpFilterOverrides = new Map<string, HttpFilterConfig>();


### PR DESCRIPTION
We may also want to do this for per-call authority overrides, but that would require reworking a lot of this class so it is deferred.