### PR TITLE
grpc-js: Enable outlier detection by default

### DIFF
--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -38,7 +38,7 @@ function trace(text: string): void {
 
 const TYPE_NAME = 'outlier_detection';
 
-const OUTLIER_DETECTION_ENABLED = process.env.GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION === 'true';
+const OUTLIER_DETECTION_ENABLED = process.env.GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION !== 'false';
 
 export interface SuccessRateEjectionConfig {
   readonly stdev_factor: number;


### PR DESCRIPTION
Now that the interop tests are passing.