### PR TITLE
grpc-js: Fix typo in previous status message handling fix

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -491,7 +491,7 @@ export class Http2CallStream implements Call {
       try {
         details = decodeURI(metadataMap['grpc-message']);
       } catch (e) {
-        details = metadataMap['grpc-messages'] as string;
+        details = metadataMap['grpc-message'];
       }
       metadata.remove('grpc-message');
       this.trace(


### PR DESCRIPTION
The same as #2213, but making the change on the v1.6.x branch.