### PR TITLE
grpc-js-xds: NACK WeightedCluster if total_weight is 0

### DIFF
--- a/packages/grpc-js-xds/src/xds-stream-state/rds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/rds-state.ts
@@ -89,6 +89,9 @@ export class RdsState extends BaseXdsStreamState<RouteConfiguration__Output> imp
           }
         }
         if (route.route!.cluster_specifier === 'weighted_clusters') {
+          if (route.route.weighted_clusters!.total_weight?.value === 0) {
+            return false;
+          }
           let weightSum = 0;
           for (const clusterWeight of route.route.weighted_clusters!.clusters) {
             weightSum += clusterWeight.weight?.value ?? 0;


### PR DESCRIPTION
Another check a few lines later validates that the sum of the individual weights is equal to the total weight, so this also implicitly validates that the sum of the weights is non-zero. The field is a `uint32` so we already assume it is non-negative.