### PR TITLE
grpc-js: Defer evaluating caller stack until an error

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -108,6 +108,10 @@ export type ClientOptions = Partial<ChannelOptions> & {
   callInvocationTransformer?: CallInvocationTransformer;
 };
 
+function getErrorStackString(error: Error): string {
+  return error.stack!.split('\n').slice(1).join('\n');
+}
+
 /**
  * A generic gRPC client. Primarily useful as a base class for all generated
  * clients.
@@ -340,7 +344,7 @@ export class Client {
         receivedStatus = true;
         if (status.code === Status.OK) {
           if (responseMessage === null) {
-            const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
+            const callerStack = getErrorStackString(callerStackError);
             callProperties.callback!(callErrorFromStatus({
               code: Status.INTERNAL,
               details: 'No message received',
@@ -350,7 +354,7 @@ export class Client {
             callProperties.callback!(null, responseMessage);
           }
         } else {
-          const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
+          const callerStack = getErrorStackString(callerStackError);
           callProperties.callback!(callErrorFromStatus(status, callerStack));
         }
         emitter.emit('status', status);
@@ -468,7 +472,7 @@ export class Client {
         receivedStatus = true;
         if (status.code === Status.OK) {
           if (responseMessage === null) {
-            const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
+            const callerStack = getErrorStackString(callerStackError);
             callProperties.callback!(callErrorFromStatus({
               code: Status.INTERNAL,
               details: 'No message received',
@@ -478,7 +482,7 @@ export class Client {
             callProperties.callback!(null, responseMessage);
           }
         } else {
-          const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
+          const callerStack = getErrorStackString(callerStackError);
           callProperties.callback!(callErrorFromStatus(status, callerStack));
         }
         emitter.emit('status', status);
@@ -597,7 +601,7 @@ export class Client {
         receivedStatus = true;
         stream.push(null);
         if (status.code !== Status.OK) {
-          const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
+          const callerStack = getErrorStackString(callerStackError);
           stream.emit('error', callErrorFromStatus(status, callerStack));
         }
         stream.emit('status', status);
@@ -695,7 +699,7 @@ export class Client {
         receivedStatus = true;
         stream.push(null);
         if (status.code !== Status.OK) {
-          const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
+          const callerStack = getErrorStackString(callerStackError);
           stream.emit('error', callErrorFromStatus(status, callerStack));
         }
         stream.emit('status', status);

--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -321,7 +321,7 @@ export class Client {
     }
     let responseMessage: ResponseType | null = null;
     let receivedStatus = false;
-    const callerStack = (new Error().stack!).split('\n').slice(1).join('\n');
+    const callerStackError = new Error();
     call.start(callProperties.metadata, {
       onReceiveMetadata: (metadata) => {
         emitter.emit('metadata', metadata);
@@ -340,6 +340,7 @@ export class Client {
         receivedStatus = true;
         if (status.code === Status.OK) {
           if (responseMessage === null) {
+            const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
             callProperties.callback!(callErrorFromStatus({
               code: Status.INTERNAL,
               details: 'No message received',
@@ -349,6 +350,7 @@ export class Client {
             callProperties.callback!(null, responseMessage);
           }
         } else {
+          const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
           callProperties.callback!(callErrorFromStatus(status, callerStack));
         }
         emitter.emit('status', status);
@@ -447,7 +449,7 @@ export class Client {
     }
     let responseMessage: ResponseType | null = null;
     let receivedStatus = false;
-    const callerStack = (new Error().stack!).split('\n').slice(1).join('\n');
+    const callerStackError = new Error();
     call.start(callProperties.metadata, {
       onReceiveMetadata: (metadata) => {
         emitter.emit('metadata', metadata);
@@ -466,6 +468,7 @@ export class Client {
         receivedStatus = true;
         if (status.code === Status.OK) {
           if (responseMessage === null) {
+            const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
             callProperties.callback!(callErrorFromStatus({
               code: Status.INTERNAL,
               details: 'No message received',
@@ -475,6 +478,7 @@ export class Client {
             callProperties.callback!(null, responseMessage);
           }
         } else {
+          const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
           callProperties.callback!(callErrorFromStatus(status, callerStack));
         }
         emitter.emit('status', status);
@@ -577,7 +581,7 @@ export class Client {
       call.setCredentials(callProperties.callOptions.credentials);
     }
     let receivedStatus = false;
-    const callerStack = (new Error().stack!).split('\n').slice(1).join('\n');
+    const callerStackError = new Error();
     call.start(callProperties.metadata, {
       onReceiveMetadata(metadata: Metadata) {
         stream.emit('metadata', metadata);
@@ -593,6 +597,7 @@ export class Client {
         receivedStatus = true;
         stream.push(null);
         if (status.code !== Status.OK) {
+          const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
           stream.emit('error', callErrorFromStatus(status, callerStack));
         }
         stream.emit('status', status);
@@ -675,7 +680,7 @@ export class Client {
       call.setCredentials(callProperties.callOptions.credentials);
     }
     let receivedStatus = false;
-    const callerStack = (new Error().stack!).split('\n').slice(1).join('\n');
+    const callerStackError = new Error();
     call.start(callProperties.metadata, {
       onReceiveMetadata(metadata: Metadata) {
         stream.emit('metadata', metadata);
@@ -690,6 +695,7 @@ export class Client {
         receivedStatus = true;
         stream.push(null);
         if (status.code !== Status.OK) {
+          const callerStack = callerStackError.stack!.split('\n').slice(1).join('\n');
           stream.emit('error', callErrorFromStatus(status, callerStack));
         }
         stream.emit('status', status);


### PR DESCRIPTION
This is an update to the change I made in #2109 that added caller stack traces to call errors. It turns out that getting the `stack` field of an error is a relatively expensive operation, so we don't do it in the hot path, and instead we wait until an error actually occurs. The goal is to fix the performance issues reported in #2231. #2109 is the only change that looks like it could possibly impact latency between 1.6.7 and 1.6.8.