### PR TITLE
fix(docs): list undocumented tracers

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -29,6 +29,7 @@ can be set.
   - `channel` - Traces channel events
   - `connectivity_state` - Traces channel connectivity state changes
   - `dns_resolver` - Traces DNS resolution
+  - `ip_resolver` - Traces IPv4/v6 resolution
   - `pick_first` - Traces the pick first load balancing policy
   - `proxy` - Traces proxy operations
   - `resolving_load_balancer` - Traces the resolving load balancer
@@ -40,6 +41,9 @@ can be set.
   - `subchannel_flowctrl` - Traces HTTP/2 flow control. Includes per-call logs.
   - `subchannel_internals` - Traces HTTP/2 session state. Includes per-call logs.
   - `channel_stacktrace` - Traces channel construction events with stack traces.
+  - `keepalive` - Traces gRPC keepalive pings
+  - `index` - Traces module loading
+  - `outlier_detection` - Traces outlier detection events
 
   The following tracers are added by the `@grpc/grpc-js-xds` library:
   - `cds_balancer` - Traces the CDS load balancing policy


### PR DESCRIPTION
I found some tracers are not documented.

Tracers are defined in follows.
- ip_resolver: https://github.com/grpc/grpc-node/blob/1037b23ba62b4d1205f3dd57f50e553b804d7a04/packages/grpc-js/src/resolver-ip.ts#L27
- keepalive: https://github.com/grpc/grpc-node/blob/31d28b5f147e1392bab22e042aa0282c16a18567/packages/grpc-js/src/subchannel.ts#L325
- index: https://github.com/grpc/grpc-node/blob/8d7d3f3d23e3690b732fb4f8ab3e7666ac72be41/packages/grpc-js/src/index.ts#L282
- outlier_detection: https://github.com/grpc/grpc-node/blob/c323369929e321a3de3465caeb97c74a527c7156/packages/grpc-js/src/load-balancer-outlier-detection.ts#L33
