### PR TITLE
grpc-tools: Bump to version 1.11.3

### DIFF
--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-tools",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "author": "Google Inc.",
   "description": "Tools for developing with gRPC on Node.js",
   "homepage": "https://grpc.io/",


### PR DESCRIPTION
To publish the new M1 binaries from #2235.