### PR TITLE
grpc-tools: Fix x64 arch name in build script

### DIFF
--- a/packages/grpc-tools/build_binaries.sh
+++ b/packages/grpc-tools/build_binaries.sh
@@ -60,7 +60,7 @@ case $(uname -s) in
   Darwin)
     build -DCMAKE_TOOLCHAIN_FILE=linux_64bit.toolchain.cmake -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
-    for arch in "x86_64" "arm64"; do
+    for arch in "x64" "arm64"; do
       mkdir $base/build/bin/$arch
       for bin in protoc grpc_node_plugin; do
         lipo -extract x86_64 $base/build/bin/$bin -o $base/build/bin/$arch/$bin


### PR DESCRIPTION
This is an update to the change made in #2235 to fix #2238. node-pre-gyp refers to the x86-64 architecture as "x64", so we need to use that name whenever we generate output in this script. This doesn't require a new release because I fixed the issue with the last release manually.