### PR TITLE
grpc-js: Handle the grpc-node.max_session_memory option consistently on the client and server

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -346,6 +346,12 @@ export class Server {
       serverOptions.maxSessionMemory = this.options[
         'grpc-node.max_session_memory'
       ];
+    } else {
+      /* By default, set a very large max session memory limit, to effectively
+       * disable enforcement of the limit. Some testing indicates that Node's
+       * behavior degrades badly when this limit is reached, so we solve that
+       * by disabling the check entirely. */
+      serverOptions.maxSessionMemory = Number.MAX_SAFE_INTEGER;
     }
     if ('grpc.max_concurrent_streams' in this.options) {
       serverOptions.settings = {


### PR DESCRIPTION
#2084 changed the default on the client side. This change makes the server handling consistent with that previous change.

Pointed out in https://github.com/grpc/grpc-node/issues/1158#issuecomment-1278633978.