### PR TITLE
fix: track aborted status, do not stringify for tracing

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -97,6 +97,10 @@ export interface StatusObject {
   metadata: Metadata;
 }
 
+export type PartialStatusObject = Pick<StatusObject, 'code' | 'details'> & {
+  metadata: Metadata | null;
+}
+
 export const enum WriteFlags {
   BufferHint = 1,
   NoCompress = 2,

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Channelz.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Channelz.ts
@@ -25,102 +25,102 @@ export interface ChannelzClient extends grpc.Client {
   /**
    * Returns a single Channel, or else a NOT_FOUND code.
    */
-  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetChannelResponse__Output) => void): grpc.ClientUnaryCall;
-  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetChannelResponse__Output) => void): grpc.ClientUnaryCall;
-  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetChannelResponse__Output) => void): grpc.ClientUnaryCall;
-  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetChannelResponse__Output) => void): grpc.ClientUnaryCall;
+  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetChannelResponse__Output>): grpc.ClientUnaryCall;
+  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetChannelResponse__Output>): grpc.ClientUnaryCall;
+  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetChannelResponse__Output>): grpc.ClientUnaryCall;
+  GetChannel(argument: _grpc_channelz_v1_GetChannelRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetChannelResponse__Output>): grpc.ClientUnaryCall;
   
   /**
    * Returns a single Server, or else a NOT_FOUND code.
    */
-  GetServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
-  GetServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
-  GetServer(argument: _grpc_channelz_v1_GetServerRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
-  GetServer(argument: _grpc_channelz_v1_GetServerRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerResponse__Output>): grpc.ClientUnaryCall;
+  GetServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerResponse__Output>): grpc.ClientUnaryCall;
+  GetServer(argument: _grpc_channelz_v1_GetServerRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerResponse__Output>): grpc.ClientUnaryCall;
+  GetServer(argument: _grpc_channelz_v1_GetServerRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerResponse__Output>): grpc.ClientUnaryCall;
   /**
    * Returns a single Server, or else a NOT_FOUND code.
    */
-  getServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
-  getServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
-  getServer(argument: _grpc_channelz_v1_GetServerRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
-  getServer(argument: _grpc_channelz_v1_GetServerRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerResponse__Output) => void): grpc.ClientUnaryCall;
+  getServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerResponse__Output>): grpc.ClientUnaryCall;
+  getServer(argument: _grpc_channelz_v1_GetServerRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerResponse__Output>): grpc.ClientUnaryCall;
+  getServer(argument: _grpc_channelz_v1_GetServerRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerResponse__Output>): grpc.ClientUnaryCall;
+  getServer(argument: _grpc_channelz_v1_GetServerRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerResponse__Output>): grpc.ClientUnaryCall;
   
   /**
    * Gets all server sockets that exist in the process.
    */
-  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
-  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
-  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
-  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerSocketsResponse__Output>): grpc.ClientUnaryCall;
+  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerSocketsResponse__Output>): grpc.ClientUnaryCall;
+  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerSocketsResponse__Output>): grpc.ClientUnaryCall;
+  GetServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerSocketsResponse__Output>): grpc.ClientUnaryCall;
   /**
    * Gets all server sockets that exist in the process.
    */
-  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
-  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
-  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
-  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServerSocketsResponse__Output) => void): grpc.ClientUnaryCall;
+  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerSocketsResponse__Output>): grpc.ClientUnaryCall;
+  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerSocketsResponse__Output>): grpc.ClientUnaryCall;
+  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerSocketsResponse__Output>): grpc.ClientUnaryCall;
+  getServerSockets(argument: _grpc_channelz_v1_GetServerSocketsRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetServerSocketsResponse__Output>): grpc.ClientUnaryCall;
   
   /**
    * Gets all servers that exist in the process.
    */
-  GetServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
-  GetServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
-  GetServers(argument: _grpc_channelz_v1_GetServersRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
-  GetServers(argument: _grpc_channelz_v1_GetServersRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
+  GetServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServersResponse__Output>): grpc.ClientUnaryCall;
+  GetServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetServersResponse__Output>): grpc.ClientUnaryCall;
+  GetServers(argument: _grpc_channelz_v1_GetServersRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServersResponse__Output>): grpc.ClientUnaryCall;
+  GetServers(argument: _grpc_channelz_v1_GetServersRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetServersResponse__Output>): grpc.ClientUnaryCall;
   /**
    * Gets all servers that exist in the process.
    */
-  getServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
-  getServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
-  getServers(argument: _grpc_channelz_v1_GetServersRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
-  getServers(argument: _grpc_channelz_v1_GetServersRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetServersResponse__Output) => void): grpc.ClientUnaryCall;
+  getServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServersResponse__Output>): grpc.ClientUnaryCall;
+  getServers(argument: _grpc_channelz_v1_GetServersRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetServersResponse__Output>): grpc.ClientUnaryCall;
+  getServers(argument: _grpc_channelz_v1_GetServersRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetServersResponse__Output>): grpc.ClientUnaryCall;
+  getServers(argument: _grpc_channelz_v1_GetServersRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetServersResponse__Output>): grpc.ClientUnaryCall;
   
   /**
    * Returns a single Socket or else a NOT_FOUND code.
    */
-  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
-  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
-  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
-  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
+  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetSocketResponse__Output>): grpc.ClientUnaryCall;
+  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetSocketResponse__Output>): grpc.ClientUnaryCall;
+  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetSocketResponse__Output>): grpc.ClientUnaryCall;
+  GetSocket(argument: _grpc_channelz_v1_GetSocketRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetSocketResponse__Output>): grpc.ClientUnaryCall;
   /**
    * Returns a single Socket or else a NOT_FOUND code.
    */
-  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
-  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
-  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
-  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSocketResponse__Output) => void): grpc.ClientUnaryCall;
+  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetSocketResponse__Output>): grpc.ClientUnaryCall;
+  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetSocketResponse__Output>): grpc.ClientUnaryCall;
+  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetSocketResponse__Output>): grpc.ClientUnaryCall;
+  getSocket(argument: _grpc_channelz_v1_GetSocketRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetSocketResponse__Output>): grpc.ClientUnaryCall;
   
   /**
    * Returns a single Subchannel, or else a NOT_FOUND code.
    */
-  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
-  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
-  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
-  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
+  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetSubchannelResponse__Output>): grpc.ClientUnaryCall;
+  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetSubchannelResponse__Output>): grpc.ClientUnaryCall;
+  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetSubchannelResponse__Output>): grpc.ClientUnaryCall;
+  GetSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetSubchannelResponse__Output>): grpc.ClientUnaryCall;
   /**
    * Returns a single Subchannel, or else a NOT_FOUND code.
    */
-  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
-  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
-  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
-  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetSubchannelResponse__Output) => void): grpc.ClientUnaryCall;
+  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetSubchannelResponse__Output>): grpc.ClientUnaryCall;
+  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetSubchannelResponse__Output>): grpc.ClientUnaryCall;
+  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetSubchannelResponse__Output>): grpc.ClientUnaryCall;
+  getSubchannel(argument: _grpc_channelz_v1_GetSubchannelRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetSubchannelResponse__Output>): grpc.ClientUnaryCall;
   
   /**
    * Gets all root channels (i.e. channels the application has directly
    * created). This does not include subchannels nor non-top level channels.
    */
-  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
-  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
-  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
-  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
+  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetTopChannelsResponse__Output>): grpc.ClientUnaryCall;
+  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetTopChannelsResponse__Output>): grpc.ClientUnaryCall;
+  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetTopChannelsResponse__Output>): grpc.ClientUnaryCall;
+  GetTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetTopChannelsResponse__Output>): grpc.ClientUnaryCall;
   /**
    * Gets all root channels (i.e. channels the application has directly
    * created). This does not include subchannels nor non-top level channels.
    */
-  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
-  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
-  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
-  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, callback: (error?: grpc.ServiceError, result?: _grpc_channelz_v1_GetTopChannelsResponse__Output) => void): grpc.ClientUnaryCall;
+  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetTopChannelsResponse__Output>): grpc.ClientUnaryCall;
+  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_channelz_v1_GetTopChannelsResponse__Output>): grpc.ClientUnaryCall;
+  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_channelz_v1_GetTopChannelsResponse__Output>): grpc.ClientUnaryCall;
+  getTopChannels(argument: _grpc_channelz_v1_GetTopChannelsRequest, callback: grpc.requestCallback<_grpc_channelz_v1_GetTopChannelsResponse__Output>): grpc.ClientUnaryCall;
   
 }
 

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -443,9 +443,6 @@ export class Http2ServerCallStream<
           metadata: null,
         });
       }
-
-      // to compensate for a fact that cancelled is not always called
-      this.emit('close');
     });
 
     this.stream.on('drain', () => {
@@ -776,9 +773,6 @@ export class Http2ServerCallStream<
       call.cancelled = true;
       call.emit('cancelled', reason);
     });
-
-    // to compensate for the fact that cancelled is no longer always called
-    this.once('close', () => call.emit('close'))
 
     this.once('callEnd', (status) => call.emit('callEnd', status));
   }

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -19,8 +19,9 @@ import { EventEmitter } from 'events';
 import * as http2 from 'http2';
 import { Duplex, Readable, Writable } from 'stream';
 import * as zlib from 'zlib';
+import { promisify } from 'util';
 
-import { Deadline, StatusObject } from './call-stream';
+import { Deadline, StatusObject, PartialStatusObject } from './call-stream';
 import {
   Status,
   DEFAULT_MAX_SEND_MESSAGE_LENGTH,
@@ -35,6 +36,8 @@ import { ChannelOptions } from './channel-options';
 import * as logging from './logging';
 
 const TRACER_NAME = 'server_call';
+const unzip = promisify(zlib.unzip);
+const inflate = promisify(zlib.inflate);
 
 function trace(text: string): void {
   logging.trace(LogVerbosity.DEBUG, TRACER_NAME, text);
@@ -86,25 +89,22 @@ export type ServerSurfaceCall = {
 export type ServerUnaryCall<RequestType, ResponseType> = ServerSurfaceCall & {
   request: RequestType;
 };
-export type ServerReadableStream<
-  RequestType,
-  ResponseType
-> = ServerSurfaceCall & ObjectReadable<RequestType>;
-export type ServerWritableStream<
-  RequestType,
-  ResponseType
-> = ServerSurfaceCall &
-  ObjectWritable<ResponseType> & {
-    request: RequestType;
-    end: (metadata?: Metadata) => void;
-  };
+export type ServerReadableStream<RequestType, ResponseType> =
+  ServerSurfaceCall & ObjectReadable<RequestType>;
+export type ServerWritableStream<RequestType, ResponseType> =
+  ServerSurfaceCall &
+    ObjectWritable<ResponseType> & {
+      request: RequestType;
+      end: (metadata?: Metadata) => void;
+    };
 export type ServerDuplexStream<RequestType, ResponseType> = ServerSurfaceCall &
   ObjectReadable<RequestType> &
   ObjectWritable<ResponseType> & { end: (metadata?: Metadata) => void };
 
 export class ServerUnaryCallImpl<RequestType, ResponseType>
   extends EventEmitter
-  implements ServerUnaryCall<RequestType, ResponseType> {
+  implements ServerUnaryCall<RequestType, ResponseType>
+{
   cancelled: boolean;
 
   constructor(
@@ -136,7 +136,8 @@ export class ServerUnaryCallImpl<RequestType, ResponseType>
 
 export class ServerReadableStreamImpl<RequestType, ResponseType>
   extends Readable
-  implements ServerReadableStream<RequestType, ResponseType> {
+  implements ServerReadableStream<RequestType, ResponseType>
+{
   cancelled: boolean;
 
   constructor(
@@ -178,7 +179,8 @@ export class ServerReadableStreamImpl<RequestType, ResponseType>
 
 export class ServerWritableStreamImpl<RequestType, ResponseType>
   extends Writable
-  implements ServerWritableStream<RequestType, ResponseType> {
+  implements ServerWritableStream<RequestType, ResponseType>
+{
   cancelled: boolean;
   private trailingMetadata: Metadata;
 
@@ -257,7 +259,8 @@ export class ServerWritableStreamImpl<RequestType, ResponseType>
 
 export class ServerDuplexStreamImpl<RequestType, ResponseType>
   extends Duplex
-  implements ServerDuplexStream<RequestType, ResponseType> {
+  implements ServerDuplexStream<RequestType, ResponseType>
+{
   cancelled: boolean;
   private trailingMetadata: Metadata;
 
@@ -395,7 +398,8 @@ export class Http2ServerCallStream<
   ResponseType
 > extends EventEmitter {
   cancelled = false;
-  deadlineTimer: NodeJS.Timer = setTimeout(() => {}, 0);
+  deadlineTimer: NodeJS.Timer | null = null;
+  private statusSent = false;
   private deadline: Deadline = Infinity;
   private wantTrailers = false;
   private metadataSent = false;
@@ -428,10 +432,20 @@ export class Http2ServerCallStream<
           ' stream closed with rstCode ' +
           this.stream.rstCode
       );
-      this.cancelled = true;
-      this.emit('cancelled', 'cancelled');
-      this.emit('streamEnd', false);
-      this.sendStatus({code: Status.CANCELLED, details: 'Cancelled by client', metadata: new Metadata()});
+
+      if (!this.statusSent) {
+        this.cancelled = true;
+        this.emit('cancelled', 'cancelled');
+        this.emit('streamEnd', false);
+        this.sendStatus({
+          code: Status.CANCELLED,
+          details: 'Cancelled by client',
+          metadata: null,
+        });
+      }
+
+      // to compensate for a fact that cancelled is not always called
+      this.emit('close');
     });
 
     this.stream.on('drain', () => {
@@ -444,9 +458,6 @@ export class Http2ServerCallStream<
     if ('grpc.max_receive_message_length' in options) {
       this.maxReceiveMessageSize = options['grpc.max_receive_message_length']!;
     }
-
-    // Clear noop timer
-    clearTimeout(this.deadlineTimer);
   }
 
   private checkCancelled(): boolean {
@@ -458,52 +469,22 @@ export class Http2ServerCallStream<
     return this.cancelled;
   }
 
-  private getDecompressedMessage(message: Buffer, encoding: string) {
-    switch (encoding) {
-      case 'deflate': {
-        return new Promise<Buffer | undefined>((resolve, reject) => {
-          zlib.inflate(message.slice(5), (err, output) => {
-            if (err) {
-              this.sendError({
-                code: Status.INTERNAL,
-                details: `Received "grpc-encoding" header "${encoding}" but ${encoding} decompression failed`,
-              });
-              resolve();
-            } else {
-              resolve(output);
-            }
-          });
-        });
-      }
-  
-      case 'gzip': {
-        return new Promise<Buffer | undefined>((resolve, reject) => {
-          zlib.unzip(message.slice(5), (err, output) => {
-            if (err) {
-              this.sendError({
-                code: Status.INTERNAL,
-                details: `Received "grpc-encoding" header "${encoding}" but ${encoding} decompression failed`,
-              });
-              resolve();
-            } else {
-              resolve(output);
-            }
-          });
-        });
-      }
-
-      case 'identity': {
-        return Promise.resolve(message.slice(5));
-      }
-  
-      default: {
-        this.sendError({
-          code: Status.UNIMPLEMENTED,
-          details: `Received message compressed with unsupported encoding "${encoding}"`,
-        });
-        return Promise.resolve();
-      }
+  private getDecompressedMessage(
+    message: Buffer,
+    encoding: string
+  ): Buffer | Promise<Buffer> {
+    if (encoding === 'deflate') {
+      return inflate(message.subarray(5));
+    } else if (encoding === 'gzip') {
+      return unzip(message.subarray(5));
+    } else if (encoding === 'identity') {
+      return message.subarray(5);
     }
+
+    return Promise.reject({
+      code: Status.UNIMPLEMENTED,
+      details: `Received message compressed with unsupported encoding "${encoding}"`,
+    });
   }
 
   sendMetadata(customMetadata?: Metadata) {
@@ -518,12 +499,21 @@ export class Http2ServerCallStream<
     this.metadataSent = true;
     const custom = customMetadata ? customMetadata.toHttp2Headers() : null;
     // TODO(cjihrig): Include compression headers.
-    const headers = Object.assign({}, defaultResponseHeaders, custom);
+    const headers = { ...defaultResponseHeaders, ...custom };
     this.stream.respond(headers, defaultResponseOptions);
   }
 
   receiveMetadata(headers: http2.IncomingHttpHeaders) {
     const metadata = Metadata.fromHttp2Headers(headers);
+
+    if (logging.isTracerEnabled(TRACER_NAME)) {
+      trace(
+        'Request to ' +
+          this.handler.path +
+          ' received headers ' +
+          JSON.stringify(metadata.toJSON())
+      );
+    }
 
     // TODO(cjihrig): Receive compression metadata.
 
@@ -556,52 +546,95 @@ export class Http2ServerCallStream<
     return metadata;
   }
 
-  receiveUnaryMessage(encoding: string): Promise<RequestType> {
-    return new Promise((resolve, reject) => {
-      const stream = this.stream;
-      const chunks: Buffer[] = [];
-      let totalLength = 0;
+  receiveUnaryMessage(
+    encoding: string,
+    next: (
+      err: Partial<ServerStatusResponse> | null,
+      request?: RequestType
+    ) => void
+  ): void {
+    const { stream } = this;
 
-      stream.on('data', (data: Buffer) => {
-        chunks.push(data);
-        totalLength += data.byteLength;
-      });
+    let receivedLength = 0;
+    const call = this;
+    const body: Buffer[] = [];
+    const limit = this.maxReceiveMessageSize;
 
-      stream.once('end', async () => {
-        try {
-          const requestBytes = Buffer.concat(chunks, totalLength);
-          if (
-            this.maxReceiveMessageSize !== -1 &&
-            requestBytes.length > this.maxReceiveMessageSize
-          ) {
-            this.sendError({
-              code: Status.RESOURCE_EXHAUSTED,
-              details: `Received message larger than max (${requestBytes.length} vs. ${this.maxReceiveMessageSize})`,
-            });
-            resolve();
-          }
+    stream.on('data', onData);
+    stream.on('end', onEnd);
+    stream.on('error', onEnd);
 
-          this.emit('receiveMessage');
+    function onData(chunk: Buffer) {
+      receivedLength += chunk.byteLength;
 
-          const compressed = requestBytes.readUInt8(0) === 1;
-          const compressedMessageEncoding = compressed ? encoding : 'identity';
-          const decompressedMessage = await this.getDecompressedMessage(requestBytes, compressedMessageEncoding);
+      if (limit !== -1 && receivedLength > limit) {
+        stream.removeListener('data', onData);
+        stream.removeListener('end', onEnd);
+        stream.removeListener('error', onEnd);
+        next({
+          code: Status.RESOURCE_EXHAUSTED,
+          details: `Received message larger than max (${receivedLength} vs. ${limit})`,
+        });
+        return;
+      }
 
-          // Encountered an error with decompression; it'll already have been propogated back
-          // Just return early
-          if (!decompressedMessage) {
-            resolve();
-          }
-          else {
-            resolve(this.deserializeMessage(decompressedMessage));
-          }
-        } catch (err) {
-          err.code = Status.INTERNAL;
-          this.sendError(err);
-          resolve();
-        }
-      });
-    });
+      body.push(chunk);
+    }
+
+    function onEnd(err?: Error) {
+      stream.removeListener('data', onData);
+      stream.removeListener('end', onEnd);
+      stream.removeListener('error', onEnd);
+
+      if (err !== undefined) {
+        next({ code: Status.INTERNAL, details: err.message });
+        return;
+      }
+
+      if (receivedLength === 0) {
+        next({ code: Status.INTERNAL, details: 'received empty unary message' })
+        return;
+      }
+
+      call.emit('receiveMessage');
+
+      const requestBytes = Buffer.concat(body, receivedLength);
+      const compressed = requestBytes.readUInt8(0) === 1;
+      const compressedMessageEncoding = compressed ? encoding : 'identity';
+      const decompressedMessage = call.getDecompressedMessage(
+        requestBytes,
+        compressedMessageEncoding
+      );
+
+      if (Buffer.isBuffer(decompressedMessage)) {
+        call.safeDeserializeMessage(decompressedMessage, next);
+        return;
+      }
+
+      decompressedMessage.then(
+        (decompressed) => call.safeDeserializeMessage(decompressed, next),
+        (err: any) => next(
+          err.code
+            ? err
+            : {
+                code: Status.INTERNAL,
+                details: `Received "grpc-encoding" header "${encoding}" but ${encoding} decompression failed`,
+              }
+        )
+      )
+    }
+  }
+
+  private safeDeserializeMessage(
+    buffer: Buffer,
+    next: (err: Partial<ServerStatusResponse> | null, request?: RequestType) => void
+  ) {
+    try {
+      next(null, this.deserializeMessage(buffer));
+    } catch (err) {
+      err.code = Status.INTERNAL;
+      next(err);
+    }
   }
 
   serializeMessage(value: ResponseType) {
@@ -623,18 +656,19 @@ export class Http2ServerCallStream<
   async sendUnaryMessage(
     err: ServerErrorResponse | ServerStatusResponse | null,
     value?: ResponseType | null,
-    metadata?: Metadata,
+    metadata?: Metadata | null,
     flags?: number
   ) {
     if (this.checkCancelled()) {
       return;
     }
-    if (!metadata) {
-      metadata = new Metadata();
+
+    if (metadata === undefined) {
+      metadata = null;
     }
 
     if (err) {
-      if (!Object.prototype.hasOwnProperty.call(err, 'metadata')) {
+      if (!Object.prototype.hasOwnProperty.call(err, 'metadata') && metadata) {
         err.metadata = metadata;
       }
       this.sendError(err);
@@ -652,7 +686,7 @@ export class Http2ServerCallStream<
     }
   }
 
-  sendStatus(statusObj: StatusObject) {
+  sendStatus(statusObj: PartialStatusObject) {
     this.emit('callEnd', statusObj.code);
     this.emit('streamEnd', statusObj.code === Status.OK);
     if (this.checkCancelled()) {
@@ -668,20 +702,19 @@ export class Http2ServerCallStream<
         statusObj.details
     );
 
-    clearTimeout(this.deadlineTimer);
+    if (this.deadlineTimer) clearTimeout(this.deadlineTimer);
 
     if (!this.wantTrailers) {
       this.wantTrailers = true;
       this.stream.once('wantTrailers', () => {
-        const trailersToSend = Object.assign(
-          {
-            [GRPC_STATUS_HEADER]: statusObj.code,
-            [GRPC_MESSAGE_HEADER]: encodeURI(statusObj.details as string),
-          },
-          statusObj.metadata.toHttp2Headers()
-        );
+        const trailersToSend = {
+          [GRPC_STATUS_HEADER]: statusObj.code,
+          [GRPC_MESSAGE_HEADER]: encodeURI(statusObj.details),
+          ...statusObj.metadata?.toHttp2Headers(),
+        };
 
         this.stream.sendTrailers(trailersToSend);
+        this.statusSent = true;
       });
       this.sendMetadata();
       this.stream.end();
@@ -689,13 +722,13 @@ export class Http2ServerCallStream<
   }
 
   sendError(error: ServerErrorResponse | ServerStatusResponse) {
-    const status: StatusObject = {
+    const status: PartialStatusObject = {
       code: Status.UNKNOWN,
       details: 'message' in error ? error.message : 'Unknown Error',
       metadata:
         'metadata' in error && error.metadata !== undefined
           ? error.metadata
-          : new Metadata(),
+          : null,
     };
 
     if (
@@ -744,6 +777,9 @@ export class Http2ServerCallStream<
       call.emit('cancelled', reason);
     });
 
+    // to compensate for the fact that cancelled is no longer always called
+    this.once('close', () => call.emit('close'))
+
     this.once('callEnd', (status) => call.emit('callEnd', status));
   }
 
@@ -766,7 +802,7 @@ export class Http2ServerCallStream<
         pushedEnd = true;
         this.pushOrBufferMessage(readable, null);
       }
-    }
+    };
 
     this.stream.on('data', async (data: Buffer) => {
       const messages = decoder.write(data);
@@ -788,12 +824,15 @@ export class Http2ServerCallStream<
 
         const compressed = message.readUInt8(0) === 1;
         const compressedMessageEncoding = compressed ? encoding : 'identity';
-        const decompressedMessage = await this.getDecompressedMessage(message, compressedMessageEncoding);
+        const decompressedMessage = await this.getDecompressedMessage(
+          message,
+          compressedMessageEncoding
+        );
 
         // Encountered an error with decompression; it'll already have been propogated back
         // Just return early
         if (!decompressedMessage) return;
-         
+
         this.pushOrBufferMessage(readable, decompressedMessage);
       }
       pendingMessageProcessing = false;


### PR DESCRIPTION
I've been working on improving perf of grpc-js and a few things stood out to me:

1. Each `Http2ServerCallStream` has an empty timer created, which results in overhead, I assume this was done in an effort to have the same backing map, but performance is gained when not cleaning / creating timeouts needlessly
2. Track `aborted` event and in case stream is `aborted` emit `cancelled`, otherwise graceful stream end shouldn't cause what ultimately is exception. This allows for improved performance around cancellation logic
3. Wrap call to tracing as JSON.stringify + toJSON on metadata is an expensive operation and is performed regardless of tracing actually be on

Locally I've had all the tests pass on node 18, fingers crossed they pass everywhere else. I'm still mostly concerned about (2) as I don't yet fully grasp the logic around this call (checked blame and it was like that for 3 years)

Anyhow, hopefully these changes are useful or could be a starting base for further improvements