### PR TITLE
grpc-js-xds: Log stats periodically in interop tests

### DIFF
--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -310,6 +310,9 @@ function sendConstantQps(client: TestServiceClient, qps: number, failOnFailedRpc
       makeSingleRequest(client, callType, failOnFailedRpcs, callStatsTracker);
     }
   }, 1000/qps);
+  setInterval(() => {
+    console.log(`Accumulated stats: ${JSON.stringify(accumulatedStats, undefined, 2)}`);
+  }, 1000);
 }
 
 const callTypeEnumMap = {


### PR DESCRIPTION
This is an attempt to get more details on the apparent low QPS that seems to be causing recent interop test failures.