### PR TITLE
grpc-js: Restart deadline timer after getting timeout from service config

### DIFF
--- a/packages/grpc-js/src/resolving-call.ts
+++ b/packages/grpc-js/src/resolving-call.ts
@@ -145,6 +145,7 @@ export class ResolvingCall implements Call {
           config.methodConfig.timeout.nanos / 1_000_000
       );
       this.deadline = minDeadline(this.deadline, configDeadline);
+      this.runDeadlineTimer();
     }
 
     this.filterStackFactory.push(config.dynamicFilterFactories);


### PR DESCRIPTION
Just something I forgot to do in the original implementation.