### PR TITLE
grpc-js: Update to newest typescript compiler

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -17,14 +17,14 @@
   "devDependencies": {
     "@types/gulp": "^4.0.6",
     "@types/gulp-mocha": "0.0.32",
-    "@types/lodash": "4.14.186",
+    "@types/lodash": "^4.14.186",
     "@types/mocha": "^5.2.6",
     "@types/ncp": "^2.0.1",
     "@types/pify": "^3.0.2",
     "@types/semver": "^7.3.9",
     "clang-format": "^1.0.55",
     "execa": "^2.0.3",
-    "gts": "^2.0.0",
+    "gts": "^3.1.1",
     "gulp": "^4.0.2",
     "gulp-mocha": "^6.0.0",
     "lodash": "^4.17.4",
@@ -35,7 +35,7 @@
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
     "ts-node": "^8.3.0",
-    "typescript": "^3.7.2"
+    "typescript": "^4.8.4"
   },
   "contributors": [
     {

--- a/packages/grpc-js/src/call-credentials.ts
+++ b/packages/grpc-js/src/call-credentials.ts
@@ -115,6 +115,10 @@ export abstract class CallCredentials {
                 reject(err);
                 return;
               }
+              if (!headers) {
+                reject(new Error('Headers not set by metadata plugin'));
+                return;
+              }
               resolve(headers);
             }
           );

--- a/packages/grpc-js/src/client-interceptors.ts
+++ b/packages/grpc-js/src/client-interceptors.ts
@@ -34,6 +34,7 @@ import { Channel } from './channel';
 import { CallOptions } from './client';
 import { CallCredentials } from './call-credentials';
 import { ClientMethodDefinition } from './make-client';
+import { getErrorMessage } from './error';
 
 /**
  * Error class associated with passing both interceptors and interceptor
@@ -374,7 +375,7 @@ class BaseInterceptingCall implements InterceptingCallInterface {
     } catch (e) {
       this.call.cancelWithStatus(
         Status.INTERNAL,
-        `Request message serialization failure: ${e.message}`
+        `Request message serialization failure: ${getErrorMessage(e)}`
       );
       return;
     }
@@ -401,7 +402,7 @@ class BaseInterceptingCall implements InterceptingCallInterface {
         } catch (e) {
           readError = {
             code: Status.INTERNAL,
-            details: `Response message parsing error: ${e.message}`,
+            details: `Response message parsing error: ${getErrorMessage(e)}`,
             metadata: new Metadata(),
           };
           this.call.cancelWithStatus(readError.code, readError.details);

--- a/packages/grpc-js/src/error.ts
+++ b/packages/grpc-js/src/error.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  } else {
+    return String(error);
+  }
+}
+
+export function getErrorCode(error: unknown): number | null {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as Record<string, unknown>).code === 'number'
+  ) {
+    return (error as Record<string, number>).code;
+  } else {
+    return null;
+  }
+}

--- a/packages/grpc-js/src/metadata.ts
+++ b/packages/grpc-js/src/metadata.ts
@@ -18,6 +18,7 @@
 import * as http2 from 'http2';
 import { log } from './logging';
 import { LogVerbosity } from './constants';
+import { getErrorMessage } from './error';
 const LEGAL_KEY_REGEX = /^[0-9a-z_.-]+$/;
 const LEGAL_NON_BINARY_VALUE_REGEX = /^[ -~]*$/;
 
@@ -294,7 +295,7 @@ export class Metadata {
           }
         }
       } catch (error) {
-        const message = `Failed to add metadata entry ${key}: ${values}. ${error.message}. For more information see https://github.com/grpc/grpc-node/issues/1173`;
+        const message = `Failed to add metadata entry ${key}: ${values}. ${getErrorMessage(error)}. For more information see https://github.com/grpc/grpc-node/issues/1173`;
         log(LogVerbosity.ERROR, message);
       }
     });

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -61,6 +61,7 @@ import {
 import { parseUri } from './uri-parser';
 import { ChannelzCallTracker, ChannelzChildrenTracker, ChannelzTrace, registerChannelzServer, registerChannelzSocket, ServerInfo, ServerRef, SocketInfo, SocketRef, TlsInfo, unregisterChannelzRef } from './channelz';
 import { CipherNameAndProtocol, TLSSocket } from 'tls';
+import { getErrorCode, getErrorMessage } from './error';
 
 const TRACER_NAME = 'server';
 
@@ -865,11 +866,10 @@ export class Server {
             }
           }
 
-          if (err.code === undefined) {
-            err.code = Status.INTERNAL;
-          }
-
-          call.sendError(err);
+          call.sendError({
+            details: getErrorMessage(err),
+            code: getErrorCode(err) ?? Status.INTERNAL
+          });
         }
       }
     );


### PR DESCRIPTION
A recent change to `@types/lodash` broke compatibility with TypeScript 3.9, because that version is outside of the support range. Future changes to types packages will probably cause this again, so the best remedy is to use a newer version of TypeScript. There are two main changes requiring code changes in this library:

 - When creating a Promise, `resolve` can only be called with no parameters if the Promise explicitly has the `void` type parameter.
 - When catching a thrown error, the error now has the `unknown` type, so we need to explicitly check that type.