### PR TITLE
grpc-js-xds: interop: output CPU profile logs in old framework tests

### DIFF
--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -59,7 +59,7 @@ GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weigh
     --gcp_suffix=$(date '+%s') \
     --verbose \
     ${XDS_V3_OPT-} \
-    --client_cmd="$(which node) --enable-source-maps --prof --logfile=grpc/reports/prof.log grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client \
+    --client_cmd="$(which node) --enable-source-maps --prof --logfile=${KOKORO_ARTIFACTS_DIR}/grpc/reports/prof.log grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client \
       --server=xds:///{server_uri} \
       --stats_port={stats_port} \
       --qps={qps} \

--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -59,7 +59,7 @@ GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weigh
     --gcp_suffix=$(date '+%s') \
     --verbose \
     ${XDS_V3_OPT-} \
-    --client_cmd="$(which node) --enable-source-maps grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client \
+    --client_cmd="$(which node) --enable-source-maps --prof --logfile=grpc/reports/prof.log grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client \
       --server=xds:///{server_uri} \
       --stats_port={stats_port} \
       --qps={qps} \


### PR DESCRIPTION
I am doing this with the old framework because I am unsure how this would work in the new framework when the client is in a docker container. The config file grabs artifacts from `github/grpc/reports/**`, so hopefully this should work.