### PR TITLE
grpc-js: Fix reuse of channel filter stack factory

### DIFF
--- a/packages/grpc-js/src/filter-stack.ts
+++ b/packages/grpc-js/src/filter-stack.ts
@@ -88,6 +88,10 @@ export class FilterStackFactory implements FilterFactory<FilterStack> {
     this.factories.unshift(...filterFactories);
   }
 
+  clone(): FilterStackFactory {
+    return new FilterStackFactory(this.factories);
+  }
+
   createFilter(): FilterStack {
     return new FilterStack(
       this.factories.map((factory) => factory.createFilter())

--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -439,7 +439,7 @@ export class InternalChannel {
       parentCall: parentCall,
     };
 
-    const call = new ResolvingCall(this, method, finalOptions, this.filterStackFactory, this.credentials._getCallCredentials(), getNextCallNumber());
+    const call = new ResolvingCall(this, method, finalOptions, this.filterStackFactory.clone(), this.credentials._getCallCredentials(), getNextCallNumber());
 
     if (this.channelzEnabled) {
       this.callTracker.addCallStarted();


### PR DESCRIPTION
CPU performance logs of xDS tests showed that a large amount of time was being spent in `FaultInjectionFilter#sendMetadata` in multiple tests. I believe this is caused by [this section of `ResolvingCall`](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/resolving-call.ts#L176) that extends the `filterStackFactory` with the filters from the config from the resolver. The `filterStackFactory` there is the same one owned by the channel, so each call would add another instance of the filter for future calls. The solution is to provide a copy of the object to each call, so that it does not add to the original.