### PR TITLE
grpc-js: Make filter stack factory clone with a copy of the array

### DIFF
--- a/packages/grpc-js/src/filter-stack.ts
+++ b/packages/grpc-js/src/filter-stack.ts
@@ -89,7 +89,7 @@ export class FilterStackFactory implements FilterFactory<FilterStack> {
   }
 
   clone(): FilterStackFactory {
-    return new FilterStackFactory(this.factories);
+    return new FilterStackFactory([...this.factories]);
   }
 
   createFilter(): FilterStack {


### PR DESCRIPTION
#2271 did not fully fix the problem because the clone still has a reference to the original array.