### PR TITLE
grpc-js-xds: interop: Fix timestamp handling when config changes

### DIFF
--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -345,7 +345,7 @@ function makeSingleRequest(client: TestServiceClient, type: CallType, failOnFail
 
 function sendConstantQps(client: TestServiceClient, qps: number, failOnFailedRpcs: boolean, callStatsTracker: CallStatsTracker) {
   const callStartTimestampsTrackers: {[callType: string]: RecentTimestampList} = {};
-  for (const callType of currentConfig.callTypes) {
+  for (const callType of ['EmptyCall', 'UnaryCall']) {
     callStartTimestampsTrackers[callType] = new RecentTimestampList(qps);
   }
   setInterval(() => {


### PR DESCRIPTION
This is an update to #2263, to handle the case where the set of configured call types changes after the process starts.