### PR TITLE
proto-loader-gen-types: Support nominal typing with type branding

### DIFF
--- a/packages/proto-loader/README.md
+++ b/packages/proto-loader/README.md
@@ -92,6 +92,8 @@ Options:
                                                         [string] [default: "%s"]
       --outputTemplate   Template for mapping output or "restricted" type names
                                                 [string] [default: "%s__Output"]
+      --branded          Emit property for branded type whose value is fullName
+                         of the Message               [boolean] [default: false]
 ```
 
 ### Example Usage

--- a/packages/proto-loader/README.md
+++ b/packages/proto-loader/README.md
@@ -63,6 +63,12 @@ proto-loader-gen-types.js [options] filenames...
 Options:
       --help             Show help                                     [boolean]
       --version          Show version number                           [boolean]
+      --inputBranded     Output property for branded type for  "permissive"
+                         types with fullName of the Message as its value
+                                                      [boolean] [default: false]
+      --outputBranded    Output property for branded type for  "restricted"
+                         types with fullName of the Message as its value
+                                                      [boolean] [default: false]
       --keepCase         Preserve the case of field names
                                                       [boolean] [default: false]
       --longs            The type that should be used to output 64 bit integer
@@ -92,12 +98,6 @@ Options:
                                                         [string] [default: "%s"]
       --outputTemplate   Template for mapping output or "restricted" type names
                                                 [string] [default: "%s__Output"]
-      --inputBranded     Output property for branded type for  "permissive"
-                         types with fullName of the Message as its value
-                                                                       [boolean]
-      --outputBranded    Output property for branded type for  "restricted"
-                         types with fullName of the Message as its value
-                                                                       [boolean]
 ```
 
 ### Example Usage

--- a/packages/proto-loader/README.md
+++ b/packages/proto-loader/README.md
@@ -63,12 +63,6 @@ proto-loader-gen-types.js [options] filenames...
 Options:
       --help             Show help                                     [boolean]
       --version          Show version number                           [boolean]
-      --inputBranded     Output property for branded type for  "permissive"
-                         types with fullName of the Message as its value
-                                                      [boolean] [default: false]
-      --outputBranded    Output property for branded type for  "restricted"
-                         types with fullName of the Message as its value
-                                                      [boolean] [default: false]
       --keepCase         Preserve the case of field names
                                                       [boolean] [default: false]
       --longs            The type that should be used to output 64 bit integer
@@ -98,6 +92,12 @@ Options:
                                                         [string] [default: "%s"]
       --outputTemplate   Template for mapping output or "restricted" type names
                                                 [string] [default: "%s__Output"]
+      --inputBranded     Output property for branded type for  "permissive"
+                         types with fullName of the Message as its value
+                                                      [boolean] [default: false]
+      --outputBranded    Output property for branded type for  "restricted"
+                         types with fullName of the Message as its value
+                                                      [boolean] [default: false]
 ```
 
 ### Example Usage

--- a/packages/proto-loader/README.md
+++ b/packages/proto-loader/README.md
@@ -92,8 +92,12 @@ Options:
                                                         [string] [default: "%s"]
       --outputTemplate   Template for mapping output or "restricted" type names
                                                 [string] [default: "%s__Output"]
-      --branded          Emit property for branded type whose value is fullName
-                         of the Message               [boolean] [default: false]
+      --inputBranded     Output property for branded type for  "permissive"
+                         types with fullName of the Message as its value
+                                                                       [boolean]
+      --outputBranded    Output property for branded type for  "restricted"
+                         types with fullName of the Message as its value
+                                                                       [boolean]
 ```
 
 ### Example Usage

--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -37,9 +37,6 @@ const useNameFmter = ({outputTemplate, inputTemplate}: GeneratorOptions) => {
   };
 }
 
-const typeBrandHint = `This field is a type brand and is not populated at runtime. Instances of this type should be created using type assertions.
-https://github.com/grpc/grpc-node/pull/2281`;
-
 type GeneratorOptions = Protobuf.IParseOptions & Protobuf.IConversionOptions & {
   includeDirs?: string[];
   grpcLib: string;
@@ -182,6 +179,9 @@ function formatComment(formatter: TextFormatter, comment?: string | null) {
   }
   formatter.writeLine(' */');
 }
+
+const typeBrandHint = `This field is a type brand and is not populated at runtime. Instances of this type should be created using type assertions.
+https://github.com/grpc/grpc-node/pull/2281`;
 
 function formatTypeBrand(formatter: TextFormatter, messageType: Protobuf.Type) {
   formatComment(formatter, typeBrandHint);

--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -48,8 +48,8 @@ type GeneratorOptions = Protobuf.IParseOptions & Protobuf.IConversionOptions & {
   includeComments?: boolean;
   inputTemplate: string;
   outputTemplate: string;
-  inputBranded?: boolean;
-  outputBranded?: boolean;
+  inputBranded: boolean;
+  outputBranded: boolean;
 }
 
 class TextFormatter {
@@ -831,7 +831,7 @@ async function runScript() {
     .string(['includeDirs', 'grpcLib'])
     .normalize(['includeDirs', 'outDir'])
     .array('includeDirs')
-    .boolean(['keepCase', 'defaults', 'arrays', 'objects', 'oneofs', 'json', 'verbose', 'includeComments', 'inputBranded', 'outputBranded'])
+    .boolean(['keepCase', 'defaults', 'arrays', 'objects', 'oneofs', 'json', 'verbose', 'includeComments'])
     .string(['longs', 'enums', 'bytes', 'inputTemplate', 'outputTemplate'])
     .default('keepCase', false)
     .default('defaults', false)
@@ -863,6 +863,14 @@ async function runScript() {
         case 'String': return String;
         default: return undefined;
       }
+    })
+    .option('inputBranded', {
+      boolean: true,
+      default: false,
+    })
+    .option('outputBranded', {
+      boolean: true,
+      default: false,
     })
     .alias({
       includeDirs: 'I',

--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -45,6 +45,7 @@ type GeneratorOptions = Protobuf.IParseOptions & Protobuf.IConversionOptions & {
   includeComments?: boolean;
   inputTemplate: string;
   outputTemplate: string;
+  branded: boolean;
 }
 
 class TextFormatter {
@@ -263,6 +264,9 @@ function generatePermissiveMessageInterface(formatter: TextFormatter, messageTyp
     }
     formatter.writeLine(`'${oneof.name}'?: ${typeString};`);
   }
+  if (options.branded) {
+    formatter.writeLine(`__type: '${messageType.fullName}'`)
+  }
   formatter.unindent();
   formatter.writeLine('}');
 }
@@ -382,6 +386,9 @@ function generateRestrictedMessageInterface(formatter: TextFormatter, messageTyp
       }
       formatter.writeLine(`'${oneof.name}': ${typeString};`);
     }
+  }
+  if (options.branded) {
+    formatter.writeLine(`__type: '${messageType.fullName}'`)
   }
   formatter.unindent();
   formatter.writeLine('}');
@@ -815,7 +822,7 @@ async function runScript() {
     .string(['includeDirs', 'grpcLib'])
     .normalize(['includeDirs', 'outDir'])
     .array('includeDirs')
-    .boolean(['keepCase', 'defaults', 'arrays', 'objects', 'oneofs', 'json', 'verbose', 'includeComments'])
+    .boolean(['keepCase', 'defaults', 'arrays', 'objects', 'oneofs', 'json', 'verbose', 'includeComments', 'branded'])
     .string(['longs', 'enums', 'bytes', 'inputTemplate', 'outputTemplate'])
     .default('keepCase', false)
     .default('defaults', false)
@@ -829,6 +836,7 @@ async function runScript() {
     .default('bytes', 'Buffer')
     .default('inputTemplate', `${templateStr}`)
     .default('outputTemplate', `${templateStr}__Output`)
+    .default('branded', false)
     .coerce('longs', value => {
       switch (value) {
         case 'String': return String;
@@ -868,6 +876,7 @@ async function runScript() {
       grpcLib: 'The gRPC implementation library that these types will be used with',
       inputTemplate: 'Template for mapping input or "permissive" type names',
       outputTemplate: 'Template for mapping output or "restricted" type names',
+      branded: 'Emit property for branded type whose value is fullName of the Message',
     }).demandOption(['outDir', 'grpcLib'])
     .demand(1)
     .usage('$0 [options] filenames...')

--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -824,27 +824,39 @@ async function writeAllFiles(protoFiles: string[], options: GeneratorOptions) {
 }
 
 async function runScript() {
+  const boolDefaultFalseOption = {
+    boolean: true,
+    default: false,
+  };
   const argv = yargs
     .parserConfiguration({
       'parse-positional-numbers': false
     })
-    .string(['includeDirs', 'grpcLib'])
-    .normalize(['includeDirs', 'outDir'])
-    .array('includeDirs')
-    .boolean(['keepCase', 'defaults', 'arrays', 'objects', 'oneofs', 'json', 'verbose', 'includeComments'])
-    .string(['longs', 'enums', 'bytes', 'inputTemplate', 'outputTemplate'])
-    .default('keepCase', false)
-    .default('defaults', false)
-    .default('arrays', false)
-    .default('objects', false)
-    .default('oneofs', false)
-    .default('json', false)
-    .default('includeComments', false)
-    .default('longs', 'Long')
-    .default('enums', 'number')
-    .default('bytes', 'Buffer')
-    .default('inputTemplate', `${templateStr}`)
-    .default('outputTemplate', `${templateStr}__Output`)
+    .option('keepCase', boolDefaultFalseOption)
+    .option('longs', { string: true, default: 'Long' })
+    .option('enums', { string: true, default: 'number' })
+    .option('bytes', { string: true, default: 'Buffer' })
+    .option('defaults', boolDefaultFalseOption)
+    .option('arrays', boolDefaultFalseOption)
+    .option('objects', boolDefaultFalseOption)
+    .option('oneofs', boolDefaultFalseOption)
+    .option('json', boolDefaultFalseOption)
+    .boolean('verbose')
+    .option('includeComments', boolDefaultFalseOption)
+    .option('includeDirs', {
+      normalize: true,
+      array: true,
+      alias: 'I'
+    })
+    .option('outDir', {
+      alias: 'O',
+      normalize: true,
+    })
+    .option('grpcLib', { string: true })
+    .option('inputTemplate', { string: true, default: `${templateStr}` })
+    .option('outputTemplate', { string: true, default: `${templateStr}__Output` })
+    .option('inputBranded', boolDefaultFalseOption)
+    .option('outputBranded', boolDefaultFalseOption)
     .coerce('longs', value => {
       switch (value) {
         case 'String': return String;
@@ -864,17 +876,7 @@ async function runScript() {
         default: return undefined;
       }
     })
-    .option('inputBranded', {
-      boolean: true,
-      default: false,
-    })
-    .option('outputBranded', {
-      boolean: true,
-      default: false,
-    })
     .alias({
-      includeDirs: 'I',
-      outDir: 'O',
       verbose: 'v'
     }).describe({
       keepCase: 'Preserve the case of field names',

--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -48,7 +48,8 @@ type GeneratorOptions = Protobuf.IParseOptions & Protobuf.IConversionOptions & {
   includeComments?: boolean;
   inputTemplate: string;
   outputTemplate: string;
-  outputBranded: boolean;
+  inputBranded?: boolean;
+  outputBranded?: boolean;
 }
 
 class TextFormatter {
@@ -272,9 +273,9 @@ function generatePermissiveMessageInterface(formatter: TextFormatter, messageTyp
     }
     formatter.writeLine(`'${oneof.name}'?: ${typeString};`);
   }
-  // if (options.inputBranded) {
-  //   formatTypeBrand(formatter, messageType);
-  // }
+  if (options.inputBranded) {
+    formatTypeBrand(formatter, messageType);
+  }
   formatter.unindent();
   formatter.writeLine('}');
 }
@@ -830,7 +831,7 @@ async function runScript() {
     .string(['includeDirs', 'grpcLib'])
     .normalize(['includeDirs', 'outDir'])
     .array('includeDirs')
-    .boolean(['keepCase', 'defaults', 'arrays', 'objects', 'oneofs', 'json', 'verbose', 'includeComments', 'outputBranded'])
+    .boolean(['keepCase', 'defaults', 'arrays', 'objects', 'oneofs', 'json', 'verbose', 'includeComments', 'inputBranded', 'outputBranded'])
     .string(['longs', 'enums', 'bytes', 'inputTemplate', 'outputTemplate'])
     .default('keepCase', false)
     .default('defaults', false)
@@ -844,7 +845,6 @@ async function runScript() {
     .default('bytes', 'Buffer')
     .default('inputTemplate', `${templateStr}`)
     .default('outputTemplate', `${templateStr}__Output`)
-    .default('outputBranded', false)
     .coerce('longs', value => {
       switch (value) {
         case 'String': return String;
@@ -884,6 +884,7 @@ async function runScript() {
       grpcLib: 'The gRPC implementation library that these types will be used with',
       inputTemplate: 'Template for mapping input or "permissive" type names',
       outputTemplate: 'Template for mapping output or "restricted" type names',
+      inputBranded: 'Output property for branded type for  "permissive" types with fullName of the Message as its value',
       outputBranded: 'Output property for branded type for  "restricted" types with fullName of the Message as its value',
     }).demandOption(['outDir', 'grpcLib'])
     .demand(1)


### PR DESCRIPTION
# TL;DR;

This PR introduces a boolean option `branded` for `proto-loader-gen-types`.

If the branded option is on, `interface` representing a Message has additional `__type` property, that has the `fullName` of originating `Message` as its value.

```proto
package test;

message FooRequest {
  string name = 1;
}
```

turns into

```ts
interface FooRequest {
  name: string;
  __type: '.test.FooRequest';
}

```
# Details

Since typescript only supports structural typing, if any two types has the exact same structure, they can be used interchangeably.

This makes codes like below totally valid.

```ts
interface FooRequest {
  name: string;
}

interface BarRequest {
  name: string;
}

function requestFoo(param: FooRequest) { ... }
function requestBar(param: BarRequest) { ... }

const fooArg: FooRequest = { name: "this is foo" };
requestBar(fooArg);  // no compile error
```

**Note** : since method signature generated by proto-loader-gen-types is too complicated, I will use much intuitive version(i.e., requestFoo, requestBar) here.

If this behavior is not what you want, typically you can fix this in typescript by using technique called type branding.

https://github.com/microsoft/TypeScript/blob/7b48a182c05ea4dea81bab73ecbbe9e013a79e99/src/compiler/types.ts#L693-L698

```ts
interface FooRequest {
  name: string;
  __type: 'FooRequest';
}

interface BarRequest {
  name: string;
  __type: 'BarRequest';
}

function requestFoo(param: FooRequest) { ... }
function requestBar(param: BarRequest) { ... }

const fooArg: FooRequest = { name: "this is foo" } as FooRequest;
requestBar(fooArg);  // error!
```

# Restricted vs Permissive

It is often cumbersome to use type assertion when you are providing the branded type.

For example, there is no additional effort required for using branded type returned from gRPC method, but creating a branded object requires type assertion.

```ts
interface FooRequest {
  name: string;
  __type: 'FooRequest';
}

interface FooResponse {
  age: number;
  __type: 'FooResponse';
}

function requestFoo(param: FooRequest): FooResponse { ... }

const res = requestFoo({} as FooRequest); // need type assertion to create branded object
const _res: FooResponse = res;  // no need for type assertion
```

I wonder if we need to include restricted interface only, or should we separate options for restricted and permissive interface respectively?

# Motivating materials
- [Nominal typing](https://basarat.gitbook.io/typescript/main-1/nominaltyping#using-interfaces)
- [Nominal typing in TypeScript source code](https://github.com/Microsoft/TypeScript/blob/7b48a182c05ea4dea81bab73ecbbe9e013a79e99/src/compiler/types.ts#L693-L698)
- [Type branding utility for TypeScript](https://github.com/piotrwitek/utility-types#brandt-u)