### PR TITLE
grpc-tools: Update native build docker image

### DIFF
--- a/tools/release/native/Dockerfile
+++ b/tools/release/native/Dockerfile
@@ -1,11 +1,7 @@
-FROM debian:jessie
+FROM debian:stretch
 
-RUN echo "deb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list
-RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf
-RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 RUN apt-get update
-RUN apt-get -t jessie-backports install -y cmake
-RUN apt-get install -y curl build-essential python libc6-dev-i386 lib32stdc++-4.9-dev jq
+RUN apt-get install -y cmake curl build-essential python libc6-dev-i386 lib32stdc++-6-dev jq
 
 RUN mkdir /usr/local/nvm
 ENV NVM_DIR /usr/local/nvm


### PR DESCRIPTION
The build has been failing recently because some of the GPG keys for accessing apt repositories are too old. This upgrade fixes that in local testing.

The test job this is supposed to fix is "grpc-tools Build / Linux grpc-tools Build"