### PR TITLE
Update information in README and PACKAGE-COMPARISON docs

### DIFF
--- a/PACKAGE-COMPARISON.md
+++ b/PACKAGE-COMPARISON.md
@@ -1,6 +1,6 @@
 # Feature comparison of `grpc` and `@grpc/grpc-js` packages
 
-Feature | `grpc` | `@grpc/grpc-js`
+Feature | `grpc` (deprecated) | `@grpc/grpc-js`
 --------|--------|----------
 Client | :heavy_check_mark: | :heavy_check_mark:
 Server | :heavy_check_mark: | :heavy_check_mark:
@@ -9,7 +9,7 @@ Streaming RPCs | :heavy_check_mark: | :heavy_check_mark:
 Deadlines | :heavy_check_mark: | :heavy_check_mark:
 Cancellation | :heavy_check_mark: | :heavy_check_mark:
 Automatic Reconnection | :heavy_check_mark: | :heavy_check_mark:
-Per-message Compression | :heavy_check_mark: | only for response messages
+Per-message Compression | :heavy_check_mark: | :heavy_check_mark: (except messages sent by the server)
 Channel State | :heavy_check_mark: | :heavy_check_mark:
 JWT Access and Service Account Credentials | provided by the [Google Auth Library](https://www.npmjs.com/package/google-auth-library) | provided by the [Google Auth Library](https://www.npmjs.com/package/google-auth-library)
 Interceptors | :heavy_check_mark: | :heavy_check_mark:
@@ -17,14 +17,14 @@ Connection Keepalives | :heavy_check_mark: | :heavy_check_mark:
 HTTP Connect Support | :heavy_check_mark: | :heavy_check_mark:
 Retries | :heavy_check_mark: | :x:
 Stats/tracing/monitoring | :heavy_check_mark: | :x:
-Load Balancing | :heavy_check_mark: | Pick first and round robin
+Load Balancing | :heavy_check_mark: | :heavy_check_mark:
 Initial Metadata Options | :heavy_check_mark: | only `waitForReady`
 
 Other Properties | `grpc` | `@grpc/grpc-js`
 -----------------|--------|----------------
 Pure JavaScript Code | :x: | :heavy_check_mark:
-Supported Node Versions | >= 4 | ^8.13.0 or >=10.10.0
-Supported Electron Versions | All | >= 3
+Supported Node Versions | >= 4 and <=14 | ^8.13.0 or >=10.10.0
+Supported Electron Versions | <=11.2 | >= 3
 Supported Platforms | Linux, Windows, MacOS | All
 Supported Architectures | x86, x86-64, ARM7+ | All
 

--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@
 
 For a comparison of the features available in these two libraries, see [this document](https://github.com/grpc/grpc-node/tree/master/PACKAGE-COMPARISON.md)
 
-### C-based Client and Server
-
-Directory: [`packages/grpc-native-core`](https://github.com/grpc/grpc-node/tree/grpc@1.24.x/packages/grpc-native-core) (lives in the `grpc@1.24.x` branch) (see here for installation information)
-
-npm package: [grpc](https://www.npmjs.com/package/grpc).
-
-This is the existing, feature-rich implementation of gRPC using a C++ addon. It works on all LTS versions of Node.js on most platforms that Node.js runs on.
-
-### Pure JavaScript Client
+### Pure JavaScript Client and Server
 
 Directory: [`packages/grpc-js`](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js)
 
 npm package: [@grpc/grpc-js](https://www.npmjs.com/package/@grpc/grpc-js)
 
-This library implements the core functionality of gRPC purely in JavaScript, without a C++ addon. It works on the latest version of Node.js on all platforms that Node.js runs on.
+This library implements the core functionality of gRPC purely in JavaScript, without a C++ addon. It works on the latest versions of Node.js on all platforms that Node.js runs on.
+
+### C-based Client and Server (deprecated)
+
+Directory: [`packages/grpc-native-core`](https://github.com/grpc/grpc-node/tree/grpc@1.24.x/packages/grpc-native-core) (lives in the `grpc@1.24.x` branch) (see here for installation information)
+
+npm package: [grpc](https://www.npmjs.com/package/grpc).
+
+This is the deprecated implementation of gRPC using a C++ addon. It works on versions of Node.js up to 14 on most platforms that Node.js runs on.
 
 ## Other Packages
 


### PR DESCRIPTION
As pointed out in #2283, the information in both of these documents is somewhat out of date, so I updated it. In particular, I marked the old `grpc` package as "deprecated", as has been done in other places. I also switched the order of the two packages in the README, to prioritize the one that is not deprecated.