### PR TITLE
grpc-js: Prepare for 1.8.0 release

### DIFF
--- a/PACKAGE-COMPARISON.md
+++ b/PACKAGE-COMPARISON.md
@@ -15,7 +15,7 @@ JWT Access and Service Account Credentials | provided by the [Google Auth Librar
 Interceptors | :heavy_check_mark: | :heavy_check_mark:
 Connection Keepalives | :heavy_check_mark: | :heavy_check_mark:
 HTTP Connect Support | :heavy_check_mark: | :heavy_check_mark:
-Retries | :heavy_check_mark: | :x:
+Retries | :heavy_check_mark: (without hedging) | :heavy_check_mark: (including hedging)
 Stats/tracing/monitoring | :heavy_check_mark: | :x:
 Load Balancing | :heavy_check_mark: | :heavy_check_mark:
 Initial Metadata Options | :heavy_check_mark: | only `waitForReady`

--- a/packages/grpc-js-xds/README.md
+++ b/packages/grpc-js-xds/README.md
@@ -29,3 +29,4 @@ const client = new MyServiceClient('xds:///example.com:123');
  - [xDS Client-Side Fault Injection](https://github.com/grpc/proposal/blob/master/A33-Fault-Injection.md)
  - [Client Status Discovery Service](https://github.com/grpc/proposal/blob/master/A40-csds-support.md)
  - [Outlier Detection](https://github.com/grpc/proposal/blob/master/A50-xds-outlier-detection.md)
+ - [xDS Retry Support](https://github.com/grpc/proposal/blob/master/A44-xds-retry.md)

--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {
@@ -47,7 +47,7 @@
     "re2-wasm": "^1.0.1"
   },
   "peerDependencies": {
-    "@grpc/grpc-js": "~1.7.0"
+    "@grpc/grpc-js": "~1.8.0"
   },
   "engines": {
     "node": ">=10.10.0"

--- a/packages/grpc-js-xds/src/environment.ts
+++ b/packages/grpc-js-xds/src/environment.ts
@@ -17,4 +17,4 @@
 
 export const EXPERIMENTAL_FAULT_INJECTION = (process.env.GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION ?? 'true') === 'true';
 export const EXPERIMENTAL_OUTLIER_DETECTION = (process.env.GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION ?? 'true') === 'true';
-export const EXPERIMENTAL_RETRY = process.env.GRPC_XDS_EXPERIMENTAL_ENABLE_RETRY === 'true';
+export const EXPERIMENTAL_RETRY = (process.env.GRPC_XDS_EXPERIMENTAL_ENABLE_RETRY ?? 'true') === 'true';

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
De-experimentalize xDS retry support, and update versions and documentation. My condition for publishing this release is stable xDS retry support, so I will merge this PR once we reach that point.