### PR TITLE
grpc-tools: Force GNU format for artifact tarballs

### DIFF
--- a/packages/grpc-tools/build_binaries.sh
+++ b/packages/grpc-tools/build_binaries.sh
@@ -46,8 +46,14 @@ artifacts() {
   platform=$1
   arch=$2
   dir=$3
-
-  tar --format=gnu -czf $out_dir/$platform-$arch.tar.gz -C $(dirname $dir) $(basename $dir)
+  case $(uname -s) in
+    Linux)
+      tar -czf $out_dir/$platform-$arch.tar.gz -C $(dirname $dir) $(basename $dir)
+      ;;
+    Darwin)
+      tar --format=gnutar -czf $out_dir/$platform-$arch.tar.gz -C $(dirname $dir) $(basename $dir)
+      ;;
+  esac
 }
 
 case $(uname -s) in

--- a/packages/grpc-tools/build_binaries.sh
+++ b/packages/grpc-tools/build_binaries.sh
@@ -47,7 +47,7 @@ artifacts() {
   arch=$2
   dir=$3
 
-  tar -czf $out_dir/$platform-$arch.tar.gz -C $(dirname $dir) $(basename $dir)
+  tar --format=gnu -czf $out_dir/$platform-$arch.tar.gz -C $(dirname $dir) $(basename $dir)
 }
 
 case $(uname -s) in

--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-tools",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": "Google Inc.",
   "description": "Tools for developing with gRPC on Node.js",
   "homepage": "https://grpc.io/",


### PR DESCRIPTION
This fixes #2287. The current release has a bug where the Mac artifacts are extracted into a directory called `GNUSparseFiles.0`. This comes from extracting a sparse file from a POSIX/PAX format archive ([documentation](https://www.gnu.org/software/tar/manual/html_node/Sparse-Recovery.html)). `file` shows that only the Mac artifacts are in the POSIX format, and the others are in the GNU format. I am assuming that the `tar` implementation in the Mac build environment defaults to the POSIX format, which would mean that we can avoid this problem by forcing the GNU format.