### PR TITLE
grpc-tools: Build for older Mac version

### DIFF
--- a/packages/grpc-tools/CMakeLists.txt
+++ b/packages/grpc-tools/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.7" CACHE STRING "Minimum OS X deployment version")
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
 endif(COMMAND cmake_policy)

--- a/packages/grpc-tools/package.json
+++ b/packages/grpc-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-tools",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "author": "Google Inc.",
   "description": "Tools for developing with gRPC on Node.js",
   "homepage": "https://grpc.io/",


### PR DESCRIPTION
It looks like the Mac build environment got upgraded recently and it is building the binary in a way that doesn't work on older environments. This change should make it build the same as how it build on the old environment.

The code in this change comes from [this post](https://stackoverflow.com/a/34208904/159388).