### PR TITLE
grpc-tools: Build for an older Mac version (attempt 2)

### DIFF
--- a/packages/grpc-tools/CMakeLists.txt
+++ b/packages/grpc-tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
-set(CMAKE_OSX_DEPLOYMENT_TARGET "11.7" CACHE STRING "Minimum OS X deployment version")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.7" CACHE STRING "Minimum OS X deployment version" FORCE)
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
 endif(COMMAND cmake_policy)

--- a/packages/grpc-tools/build_binaries.sh
+++ b/packages/grpc-tools/build_binaries.sh
@@ -70,6 +70,7 @@ case $(uname -s) in
       mkdir $base/build/bin/$arch
       for bin in protoc grpc_node_plugin; do
         lipo -extract x86_64 $base/build/bin/$bin -o $base/build/bin/$arch/$bin
+        otool -l $base/build/bin/$arch/$bin | grep minos
       done
       artifacts darwin $arch $base/build/bin/$arch/
     done


### PR DESCRIPTION
According to [this post](https://stackoverflow.com/a/55294037/159388), adding `FORCE` may help if the option isn't working. The `otool` call should let us check if this worked.