### PR TITLE
grpc-js: Add support for grpc.service_config_disable_resolution

### DIFF
--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -62,6 +62,7 @@ Many channel arguments supported in `grpc` are not supported in `@grpc/grpc-js`.
   - `grpc.enable_retries`
   - `grpc.per_rpc_retry_buffer_size`
   - `grpc.retry_buffer_size`
+  - `grpc.service_config_disable_resolution`
   - `grpc-node.max_session_memory`
   - `channelOverride`
   - `channelFactoryOverride`

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -55,6 +55,7 @@ export interface ChannelOptions {
   'grpc.max_connection_age_ms'?: number;
   'grpc.max_connection_age_grace_ms'?: number;
   'grpc-node.max_session_memory'?: number;
+  'grpc.service_config_disable_resolution'?: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
@@ -87,6 +88,7 @@ export const recognizedOptions = {
   'grpc.max_connection_age_ms': true,
   'grpc.max_connection_age_grace_ms': true,
   'grpc-node.max_session_memory': true,
+  'grpc.service_config_disable_resolution': true,
 };
 
 export function channelOptionsEqual(

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -98,6 +98,7 @@ class DnsResolver implements Resolver {
   private continueResolving = false;
   private nextResolutionTimer: NodeJS.Timer;
   private isNextResolutionTimerRunning = false;
+  private isServiceConfigEnabled = true;
   constructor(
     private target: GrpcUri,
     private listener: ResolverListener,
@@ -126,6 +127,10 @@ class DnsResolver implements Resolver {
       }
     }
     this.percentage = Math.random() * 100;
+
+    if (channelOptions['grpc.service_config_disable_resolution'] === 1) {
+      this.isServiceConfigEnabled = false;
+    }
 
     this.defaultResolutionError = {
       code: Status.UNAVAILABLE,
@@ -255,7 +260,7 @@ class DnsResolver implements Resolver {
       );
       /* If there already is a still-pending TXT resolution, we can just use
        * that result when it comes in */
-      if (this.pendingTxtPromise === null) {
+      if (this.isServiceConfigEnabled && this.pendingTxtPromise === null) {
         /* We handle the TXT query promise differently than the others because
          * the name resolution attempt as a whole is a success even if the TXT
          * lookup fails */


### PR DESCRIPTION
Adds support for `grpc.service_config_disable_resolution` to fix #1518 .