### PR TITLE
Update a 404 doc reference to point to gRPC docs

### DIFF
--- a/packages/grpc-tools/README.md
+++ b/packages/grpc-tools/README.md
@@ -6,13 +6,10 @@ libraries.
 
 ## Usage
 
-This library exports the `grpc_tools_node_protoc` executable, which accepts all
-of the same arguments as `protoc` itself. For use with Node, you most likely
-want to use CommonJS-style imports. An example of generating code this way can
-be found in [this guide](https://developers.google.com/protocol-buffers/docs/reference/javascript-generated#commonjs-imports).
-The `grpc_tools_node_protoc` automatically includes the Node gRPC plugin, so
-it also accepts the `--grpc_out=[option:]path` argument. The option can be
-one of the following:
+This library exports the `grpc_tools_node_protoc` executable, which accepts
+the same arguments as `protoc` itself. The `grpc_tools_node_protoc` automatically
+includes the Node gRPC plugin, so it also accepts the `--grpc_out=[option:]path`
+argument. The option can be one of the following:
 
  - `grpc_js`: Generates code with `require('@grpc/grpc-js')` instead of
    `require('grpc')`
@@ -20,3 +17,6 @@ one of the following:
    gRPC library, and instead generates `PackageDefinition` objects that can
    be passed to the `loadPackageDefinition` function provided by both the
    `grpc` and `@grpc/grpc-js` libraries.
+
+For use in a Node application, examples of pre-compiling a gRPC and protobuf
+integration and integrating dynamically at runtime can be found in [the Node gRPC docs](https://grpc.io/docs/languages/node/).


### PR DESCRIPTION
I found a 404 in the README of the grpc-tools package and updated it to point to the comparable gRPC Node docs.