### PR TITLE
Fix host_override param typo:

### DIFF
--- a/packages/grpc-js-xds/src/csds.ts
+++ b/packages/grpc-js-xds/src/csds.ts
@@ -154,7 +154,7 @@ function getCurrentConfig(): ClientConfig {
     node: clientNode,
     generic_xds_configs: genericConfigList
   };
-  trace('Sending curent config ' + JSON.stringify(config, undefined, 2));
+  trace('Sending current config ' + JSON.stringify(config, undefined, 2));
   return config;
 }
 

--- a/test/api/error_test.js
+++ b/test/api/error_test.js
@@ -341,7 +341,7 @@ describe(`${anyGrpc.clientName} client -> ${anyGrpc.serverName} server`, functio
       after(function() {
         server.forceShutdown();
       });
-      describe('Server recieving bad input', function() {
+      describe('Server receiving bad input', function() {
         var misbehavingClient;
         var badArg = Buffer.from([0xFF]);
         before(function() {

--- a/test/interop/interop_client.js
+++ b/test/interop/interop_client.js
@@ -550,7 +550,7 @@ exports.test_cases = test_cases;
  * Execute a single test case.
  * @param {string} address The address of the server to connect to, in the
  *     format 'hostname:port'
- * @param {string} host_overrirde The hostname of the server to use as an SSL
+ * @param {string} host_override The hostname of the server to use as an SSL
  *     override
  * @param {string} test_case The name of the test case to run
  * @param {bool} tls Indicates that a secure channel should be used

--- a/test/performance/benchmark_client.js
+++ b/test/performance/benchmark_client.js
@@ -328,7 +328,7 @@ BenchmarkClient.prototype.startPoisson = function(
 };
 
 /**
- * Return curent statistics for the client. If reset is set, restart
+ * Return current statistics for the client. If reset is set, restart
  * statistic collection.
  * @param {boolean} reset Indicates that statistics should be reset
  * @return {object} Client statistics

--- a/test/performance/benchmark_client_express.js
+++ b/test/performance/benchmark_client_express.js
@@ -243,7 +243,7 @@ BenchmarkClient.prototype.startPoisson = function(
 };
 
 /**
- * Return curent statistics for the client. If reset is set, restart
+ * Return current statistics for the client. If reset is set, restart
  * statistic collection.
  * @param {boolean} reset Indicates that statistics should be reset
  * @return {object} Client statistics

--- a/test/performance/histogram.js
+++ b/test/performance/histogram.js
@@ -95,7 +95,7 @@ Histogram.prototype.mean = function() {
 };
 
 /**
- * Get the variance of all added values. Used to calulate the standard deviation
+ * Get the variance of all added values. Used to calculate the standard deviation
  * @return {number} The variance
  */
 Histogram.prototype.variance = function() {


### PR DESCRIPTION
- Fix `host_override` param typo in /test/interop/interop_client.js
- Fix other typos