### PR TITLE
grpc-js-xds: Reduce GCE xDS interop tests to ping_pong and circuit_breaking (@grpc/grpc-js@1.6.x backport)

### DIFF
--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -52,7 +52,7 @@ GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weigh
   GRPC_NODE_VERBOSITY=DEBUG \
   NODE_XDS_INTEROP_VERBOSITY=1 \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case="all,timeout,circuit_breaking,fault_injection,csds" \
+    --test_case="ping_pong,circuit_breaking" \
     --project_id=grpc-testing \
     --source_image=projects/grpc-testing/global/images/xds-test-server-5 \
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \


### PR DESCRIPTION
Backport of #2310 to @grpc/grpc-js@1.6.x.
---
The migration of other tests to the new framework have been completed around Aug 2022: 

- https://github.com/grpc/grpc-node/commits/81083bd22912bd3272d193dcc14077d0c4f50399/packages/grpc-js-xds/scripts/xds_k8s_lb.sh
- https://github.com/grpc/grpc-node/commits/81083bd22912bd3272d193dcc14077d0c4f50399/packages/grpc-js-xds/scripts/xds_k8s_url_map.sh