### PR TITLE
grpc-js: delays maybeOutputStatus in end event handler a bit

### DIFF
--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelConnectivityState.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelConnectivityState.ts
@@ -3,21 +3,37 @@
 
 // Original file: proto/channelz.proto
 
-export enum _grpc_channelz_v1_ChannelConnectivityState_State {
-  UNKNOWN = 0,
-  IDLE = 1,
-  CONNECTING = 2,
-  READY = 3,
-  TRANSIENT_FAILURE = 4,
-  SHUTDOWN = 5,
-}
+export const _grpc_channelz_v1_ChannelConnectivityState_State = {
+  UNKNOWN: 'UNKNOWN',
+  IDLE: 'IDLE',
+  CONNECTING: 'CONNECTING',
+  READY: 'READY',
+  TRANSIENT_FAILURE: 'TRANSIENT_FAILURE',
+  SHUTDOWN: 'SHUTDOWN',
+} as const;
+
+export type _grpc_channelz_v1_ChannelConnectivityState_State =
+  | 'UNKNOWN'
+  | 0
+  | 'IDLE'
+  | 1
+  | 'CONNECTING'
+  | 2
+  | 'READY'
+  | 3
+  | 'TRANSIENT_FAILURE'
+  | 4
+  | 'SHUTDOWN'
+  | 5
+
+export type _grpc_channelz_v1_ChannelConnectivityState_State__Output = typeof _grpc_channelz_v1_ChannelConnectivityState_State[keyof typeof _grpc_channelz_v1_ChannelConnectivityState_State]
 
 /**
  * These come from the specified states in this document:
  * https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
  */
 export interface ChannelConnectivityState {
-  'state'?: (_grpc_channelz_v1_ChannelConnectivityState_State | keyof typeof _grpc_channelz_v1_ChannelConnectivityState_State);
+  'state'?: (_grpc_channelz_v1_ChannelConnectivityState_State);
 }
 
 /**
@@ -25,5 +41,5 @@ export interface ChannelConnectivityState {
  * https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
  */
 export interface ChannelConnectivityState__Output {
-  'state': (keyof typeof _grpc_channelz_v1_ChannelConnectivityState_State);
+  'state': (_grpc_channelz_v1_ChannelConnectivityState_State__Output);
 }

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelTraceEvent.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelTraceEvent.ts
@@ -9,12 +9,30 @@ import type { SubchannelRef as _grpc_channelz_v1_SubchannelRef, SubchannelRef__O
 /**
  * The supported severity levels of trace events.
  */
-export enum _grpc_channelz_v1_ChannelTraceEvent_Severity {
-  CT_UNKNOWN = 0,
-  CT_INFO = 1,
-  CT_WARNING = 2,
-  CT_ERROR = 3,
-}
+export const _grpc_channelz_v1_ChannelTraceEvent_Severity = {
+  CT_UNKNOWN: 'CT_UNKNOWN',
+  CT_INFO: 'CT_INFO',
+  CT_WARNING: 'CT_WARNING',
+  CT_ERROR: 'CT_ERROR',
+} as const;
+
+/**
+ * The supported severity levels of trace events.
+ */
+export type _grpc_channelz_v1_ChannelTraceEvent_Severity =
+  | 'CT_UNKNOWN'
+  | 0
+  | 'CT_INFO'
+  | 1
+  | 'CT_WARNING'
+  | 2
+  | 'CT_ERROR'
+  | 3
+
+/**
+ * The supported severity levels of trace events.
+ */
+export type _grpc_channelz_v1_ChannelTraceEvent_Severity__Output = typeof _grpc_channelz_v1_ChannelTraceEvent_Severity[keyof typeof _grpc_channelz_v1_ChannelTraceEvent_Severity]
 
 /**
  * A trace event is an interesting thing that happened to a channel or
@@ -28,7 +46,7 @@ export interface ChannelTraceEvent {
   /**
    * the severity of the trace event
    */
-  'severity'?: (_grpc_channelz_v1_ChannelTraceEvent_Severity | keyof typeof _grpc_channelz_v1_ChannelTraceEvent_Severity);
+  'severity'?: (_grpc_channelz_v1_ChannelTraceEvent_Severity);
   /**
    * When this event occurred.
    */
@@ -56,7 +74,7 @@ export interface ChannelTraceEvent__Output {
   /**
    * the severity of the trace event
    */
-  'severity': (keyof typeof _grpc_channelz_v1_ChannelTraceEvent_Severity);
+  'severity': (_grpc_channelz_v1_ChannelTraceEvent_Severity__Output);
   /**
    * When this event occurred.
    */

--- a/packages/grpc-js/src/subchannel-call.ts
+++ b/packages/grpc-js/src/subchannel-call.ts
@@ -191,7 +191,9 @@ export class Http2SubchannelCall implements SubchannelCall {
     });
     http2Stream.on('end', () => {
       this.readsClosed = true;
-      this.maybeOutputStatus();
+      process.nextTick(() => {
+        this.maybeOutputStatus();
+      });
     });
     http2Stream.on('close', () => {
       /* Use process.next tick to ensure that this code happens after any


### PR DESCRIPTION
Fix some edge cases that the process.nextTick in `push` function hasn't been processed yet while the end stream event kicks in, which updates `statusOutput` causing the last chunk of data desserted.