### PR TITLE
grpc-js: Reference session in transport when there are active calls

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/subchannel-call.ts
+++ b/packages/grpc-js/src/subchannel-call.ts
@@ -198,6 +198,7 @@ export class Http2SubchannelCall implements SubchannelCall {
        * we can bubble up the error message from that event. */
       process.nextTick(() => {
         this.trace('HTTP/2 stream closed with code ' + http2Stream.rstCode);
+        this.callEventTracker.onStreamEnd(this.finalStatus?.code === Status.OK);
         /* If we have a final status with an OK status code, that means that
          * we have received all of the messages and we have processed the
          * trailers and the call completed successfully, so it doesn't matter
@@ -288,7 +289,6 @@ export class Http2SubchannelCall implements SubchannelCall {
         );
         this.internalError = err;
       }
-      this.callEventTracker.onStreamEnd(false);
     });
   }
 
@@ -403,7 +403,6 @@ export class Http2SubchannelCall implements SubchannelCall {
   }
 
   private handleTrailers(headers: http2.IncomingHttpHeaders) {
-    this.callEventTracker.onStreamEnd(true);
     let headersString = '';
     for (const header of Object.keys(headers)) {
       headersString += '\t\t' + header + ': ' + headers[header] + '\n';

--- a/packages/grpc-js/src/subchannel-call.ts
+++ b/packages/grpc-js/src/subchannel-call.ts
@@ -198,7 +198,6 @@ export class Http2SubchannelCall implements SubchannelCall {
        * we can bubble up the error message from that event. */
       process.nextTick(() => {
         this.trace('HTTP/2 stream closed with code ' + http2Stream.rstCode);
-        this.callEventTracker.onStreamEnd(this.finalStatus?.code === Status.OK);
         /* If we have a final status with an OK status code, that means that
          * we have received all of the messages and we have processed the
          * trailers and the call completed successfully, so it doesn't matter
@@ -289,6 +288,7 @@ export class Http2SubchannelCall implements SubchannelCall {
         );
         this.internalError = err;
       }
+      this.callEventTracker.onStreamEnd(false);
     });
   }
 
@@ -403,6 +403,7 @@ export class Http2SubchannelCall implements SubchannelCall {
   }
 
   private handleTrailers(headers: http2.IncomingHttpHeaders) {
+    this.callEventTracker.onStreamEnd(true);
     let headersString = '';
     for (const header of Object.keys(headers)) {
       headersString += '\t\t' + header + ': ' + headers[header] + '\n';

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -354,12 +354,14 @@ class Http2Transport implements Transport {
   private removeActiveCall(call: Http2SubchannelCall) {
     this.activeCalls.delete(call);
     if (this.activeCalls.size === 0 && !this.keepaliveWithoutCalls) {
+      this.session.unref();
       this.stopKeepalivePings();
     }
   }
 
   private addActiveCall(call: Http2SubchannelCall) {
     if (this.activeCalls.size === 0 && !this.keepaliveWithoutCalls) {
+      this.session.ref();
       this.startKeepalivePings();
     }
     this.activeCalls.add(call);

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -420,6 +420,7 @@ class Http2Transport implements Transport {
         },
         onCallEnd: status => {
           subchannelCallStatsTracker.onCallEnd?.(status);
+          this.removeActiveCall(call);
         },
         onStreamEnd: success => {
           if (success) {
@@ -427,7 +428,6 @@ class Http2Transport implements Transport {
           } else {
             this.streamTracker.addCallFailed();
           }
-          this.removeActiveCall(call);
           subchannelCallStatsTracker.onStreamEnd?.(success);
         }
       }


### PR DESCRIPTION
This matches the previous behavior of the subchannel's call refcount. The session needs to be reffed to keep the Node process alive if it is in use.

This should fix #2318.