### PR TITLE
xds interop: Fix buildscripts not continuing on a failed test suite (@grpc/grpc-js@1.8.x backport)

### DIFF
--- a/packages/grpc-js-xds/scripts/xds_k8s_lb.sh
+++ b/packages/grpc-js-xds/scripts/xds_k8s_lb.sh
@@ -167,7 +167,7 @@ main() {
   local failed_tests=0
   test_suites=("baseline_test" "api_listener_test" "change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test" "outlier_detection_test")
   for test in "${test_suites[@]}"; do
-    run_test $test || (( failed_tests++ ))
+    run_test $test || (( ++failed_tests ))
   done
   echo "Failed test suites: ${failed_tests}"
   if (( failed_tests > 0 )); then


### PR DESCRIPTION
Backport of #2323 to @grpc/grpc-js@1.8.x.
---
Apparently there's a difference between bash 3 and bash 4. OSX comes with bash 3 out-of-box, so for whoever wrote this logic it "worked on my machine".

The `((` construct returns a 0 exit code if the value is non-zero. Since the value starts at 0 and we do a post-increment, it will always fail the first time. Changing it to a pre-increment fixes the problem.