### PR TITLE
grpc-js: Hold a reference to transport in SubchannelCall

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -65,6 +65,7 @@ export interface TransportDisconnectListener {
 
 export interface Transport {
   getChannelzRef(): SocketRef;
+  getPeerName(): string;
   createCall(metadata: Metadata, host: string, method: string, listener: SubchannelCallInterceptingListener, subchannelCallStatsTracker: Partial<CallEventTracker>): SubchannelCall;
   addDisconnectListener(listener: TransportDisconnectListener): void;
   shutdown(): void;
@@ -448,13 +449,17 @@ class Http2Transport implements Transport {
         }
       }
     }
-    call = new Http2SubchannelCall(http2Stream, eventTracker, listener, this.subchannelAddressString, getNextCallNumber());
+    call = new Http2SubchannelCall(http2Stream, eventTracker, listener, this, getNextCallNumber());
     this.addActiveCall(call);
     return call;
   }
 
   getChannelzRef(): SocketRef {
     return this.channelzRef;
+  }
+
+  getPeerName() {
+    return this.subchannelAddressString;
   }
 
   shutdown() {


### PR DESCRIPTION
https://github.com/grpc/grpc-node/issues/2318#issuecomment-1403124466 reported a regression in that previously fixed issue. I suspect that the problem is that once a subchannel stops using a transport, nothing has a reference to that transport, which makes it eligible to be garbage collected. To avoid this, the subchannel call now holds a reference to the transport, so it stays alive as long as at least one active call is using it.

I also removed the `disconnectListener` because it became unused in the previous refactor.