### PR TITLE
grpc-js: Fix tracking of active calls in transport

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -354,16 +354,20 @@ class Http2Transport implements Transport {
 
   private removeActiveCall(call: Http2SubchannelCall) {
     this.activeCalls.delete(call);
-    if (this.activeCalls.size === 0 && !this.keepaliveWithoutCalls) {
+    if (this.activeCalls.size === 0) {
       this.session.unref();
-      this.stopKeepalivePings();
+      if (!this.keepaliveWithoutCalls) {
+        this.stopKeepalivePings();
+      }
     }
   }
 
   private addActiveCall(call: Http2SubchannelCall) {
-    if (this.activeCalls.size === 0 && !this.keepaliveWithoutCalls) {
+    if (this.activeCalls.size === 0) {
       this.session.ref();
-      this.startKeepalivePings();
+      if (!this.keepaliveWithoutCalls) {
+        this.startKeepalivePings();
+      }
     }
     this.activeCalls.add(call);
   }


### PR DESCRIPTION
Calling `ref` and `unref` on the session determines whether the session keeps the process alive. The handling of this needs to be independent of keepalive settings.

I think this is the actual problem in https://github.com/grpc/grpc-node/issues/2318#issuecomment-1404127354.