### PR TITLE
feat: use Record utility type for generated types

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -236,7 +236,7 @@ function getFieldTypePermissive(field: Protobuf.FieldBase, options: GeneratorOpt
   const valueType = getTypeNamePermissive(field.type, field.resolvedType, field.repeated, field.map, options);
   if (field instanceof Protobuf.MapField) {
     const keyType = field.keyType === 'string' ? 'string' : 'number';
-    return `{[key: ${keyType}]: ${valueType}}`;
+    return `Record<${keyType}, ${valueType}>`;
   } else {
     return valueType;
   }
@@ -344,7 +344,7 @@ function getFieldTypeRestricted(field: Protobuf.FieldBase, options: GeneratorOpt
   const valueType = getTypeNameRestricted(field.type, field.resolvedType, field.repeated, field.map, options);
   if (field instanceof Protobuf.MapField) {
     const keyType = field.keyType === 'string' ? 'string' : 'number';
-    return `{[key: ${keyType}]: ${valueType}}`;
+    return `Record<${keyType}, ${valueType}>`;
   } else {
     return valueType;
   }


### PR DESCRIPTION
`Record` is being introduced into TS since v2.1 (per https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type ) and it just released v5.0 recently, I think it is time for us to embrace the utility type to avoid directly object type writing.