### PR TITLE
grpc-js: Clean up build directory before building when publishing

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -45,10 +45,10 @@
   "scripts": {
     "build": "npm run compile",
     "clean": "rimraf ./build",
-    "compile": "tsc -p .",
+    "compile": "npm run clean; tsc -p .",
     "format": "clang-format -i -style=\"{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}\" src/*.ts test/*.ts",
     "lint": "npm run check",
-    "prepare": "npm run clean; npm run generate-types && npm run compile",
+    "prepare": "npm run generate-types && npm run compile",
     "test": "gulp test",
     "check": "gts check src/**/*.ts",
     "fix": "gts fix src/*.ts",

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -48,7 +48,7 @@
     "compile": "tsc -p .",
     "format": "clang-format -i -style=\"{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}\" src/*.ts test/*.ts",
     "lint": "npm run check",
-    "prepare": "npm run clean && npm run generate-types && npm run compile",
+    "prepare": "npm run clean; npm run generate-types && npm run compile",
     "test": "gulp test",
     "check": "gts check src/**/*.ts",
     "fix": "gts fix src/*.ts",

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",
@@ -48,7 +48,7 @@
     "compile": "tsc -p .",
     "format": "clang-format -i -style=\"{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}\" src/*.ts test/*.ts",
     "lint": "npm run check",
-    "prepare": "npm run generate-types && npm run compile",
+    "prepare": "npm run clean && npm run generate-types && npm run compile",
     "test": "gulp test",
     "check": "gts check src/**/*.ts",
     "fix": "gts fix src/*.ts",


### PR DESCRIPTION
This fixes #2345. Some build output files from previous versions ended up in the published package. That shouldn't generally cause problems, but apparently it can sometimes.