### PR TITLE
grpc-js: Fix `commitCallWithMostMessages` trying to commit completed attempts

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/retrying-call.ts
+++ b/packages/grpc-js/src/retrying-call.ts
@@ -273,15 +273,24 @@ export class RetryingCall implements Call {
   }
 
   private commitCallWithMostMessages() {
+    if (this.state === 'COMMITTED') {
+      return;
+    }
     let mostMessages = -1;
     let callWithMostMessages = -1;
     for (const [index, childCall] of this.underlyingCalls.entries()) {
-      if (childCall.nextMessageToSend > mostMessages) {
+      if (childCall.state === 'ACTIVE' && childCall.nextMessageToSend > mostMessages) {
         mostMessages = childCall.nextMessageToSend;
         callWithMostMessages = index;
       }
     }
-    this.commitCall(callWithMostMessages);
+    if (callWithMostMessages === -1) {
+      /* There are no active calls, disable retries to force the next call that
+       * is started to be committed. */
+      this.state = 'TRANSPARENT_ONLY';
+    } else {
+      this.commitCall(callWithMostMessages);
+    }
   }
 
   private isStatusCodeInList(list: (Status | string)[], code: Status) {
@@ -601,7 +610,11 @@ export class RetryingCall implements Call {
       }
     } else {
       this.commitCallWithMostMessages();
-      const call = this.underlyingCalls[this.committedCallIndex!];
+      // commitCallWithMostMessages can fail if we are between ping attempts
+      if (this.committedCallIndex === null) {
+        return;
+      }
+      const call = this.underlyingCalls[this.committedCallIndex];
       bufferEntry.callback = context.callback; 
       if (call.state === 'ACTIVE' && call.nextMessageToSend === messageIndex) {
         call.call.sendMessageWithContext({


### PR DESCRIPTION
This fixes #2347. The call site of `commitCallWithMostMessages` assumes that some call has been committed after the function returns. This can fail for two reasons:

 1. All existing underlying calls are completed.
 2. A completed call has more messages sent than all active calls

This change removes the second possibility entirely, and adds checks to handle the first case properly.