### PR TITLE
grpc-js: Remove `progress` field in status from retrying call

### DIFF
--- a/packages/grpc-js/src/retrying-call.ts
+++ b/packages/grpc-js/src/retrying-call.ts
@@ -212,7 +212,12 @@ export class RetryingCall implements Call {
       }
     }
     process.nextTick(() => {
-      this.listener?.onReceiveStatus(statusObject);
+      // Explicitly construct status object to remove progress field
+      this.listener?.onReceiveStatus({
+        code: statusObject.code,
+        details: statusObject.details,
+        metadata: statusObject.metadata
+      });
     });
   }
 


### PR DESCRIPTION
`progress` is an implementation detail of the retrying call design. It is meaningful for determining whether to retry an individual attempt, but there is no reason to include it in the final status surfaced to the user.