### PR TITLE
grpc-js: Export `InterceptingListener` and `NextCall` types

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -237,7 +237,7 @@ export const getClientChannel = (client: Client) => {
 
 export { StatusBuilder };
 
-export { Listener } from './call-interface';
+export { Listener, InterceptingListener } from './call-interface';
 
 export {
   Requester,
@@ -248,6 +248,7 @@ export {
   InterceptorProvider,
   InterceptingCall,
   InterceptorConfigurationError,
+  NextCall
 } from './client-interceptors';
 
 export {


### PR DESCRIPTION
The `InterceptingListener` type is already used in the publicly exported type `InterceptingCall`, and the `NextCall` interface is already publicly used in the publicly exported type `Interceptor`.