### PR TITLE
grpc-js-xds: Fix bug that prevented priority name reuse

### DIFF
--- a/packages/grpc-js-xds/interop/Dockerfile
+++ b/packages/grpc-js-xds/interop/Dockerfile
@@ -33,6 +33,6 @@ COPY --from=build /node/src/grpc-node/packages/grpc-js ./packages/grpc-js/
 COPY --from=build /node/src/grpc-node/packages/grpc-js-xds ./packages/grpc-js-xds/
 
 ENV GRPC_VERBOSITY="DEBUG"
-ENV GRPC_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver,fault_injection,http_filter,csds,outlier_detection
+ENV GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager,cds_balancer,xds_cluster_resolver,xds_cluster_impl,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver,fault_injection,http_filter,csds,outlier_detection
 
 ENTRYPOINT [ "node", "/node/src/grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client" ]

--- a/packages/grpc-js-xds/src/load-balancer-xds-cluster-resolver.ts
+++ b/packages/grpc-js-xds/src/load-balancer-xds-cluster-resolver.ts
@@ -331,6 +331,7 @@ export class XdsClusterResolver implements LoadBalancer {
               ...address,
             });
           }
+          newLocalityPriorities.set(localityToName(localityObj.locality), priority);
         }
         const weightedTargetConfig = new WeightedTargetLoadBalancingConfig(childTargets);
         const xdsClusterImplConfig = new XdsClusterImplLoadBalancingConfig(entry.discoveryMechanism.cluster, priorityEntry.dropCategories, [weightedTargetConfig], entry.discoveryMechanism.eds_service_name, entry.discoveryMechanism.lrs_load_reporting_server_name, entry.discoveryMechanism.max_concurrent_requests);


### PR DESCRIPTION
Outlier detection in xDS is broken without this change. Specifically, the `newLocalityPriorities` map tracks which priority each locality is currently in, so that priorities that contain the same locality can use the same name the next time an update is sent. Without this added line, that map will not be populated at all, so priority names will never be reused. This causes the priority policy to always create new LB policy instances for its children, which resets the persistent data the outlier detection LB policy uses to make ejection determinations.

I also updated the tracer list in the interop Dockerfile to include some more recently-added tracers.