### PR TITLE
grpc-js: Fix bugs in pick first LB policy and channel subchannel wrapper

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -33,6 +33,7 @@ import {
 } from './picker';
 import {
   SubchannelAddress,
+  subchannelAddressEqual,
   subchannelAddressToString,
 } from './subchannel-address';
 import * as logging from './logging';
@@ -168,7 +169,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
        * connecting to the next one instead of waiting for the connection
        * delay timer. */
       if (
-        subchannel === this.subchannels[this.currentSubchannelIndex] &&
+        subchannel.getRealSubchannel() === this.subchannels[this.currentSubchannelIndex].getRealSubchannel() &&
         newState === ConnectivityState.TRANSIENT_FAILURE
       ) {
         this.startNextSubchannelConnecting();
@@ -420,7 +421,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
     if (
       this.subchannels.length === 0 ||
       !this.latestAddressList.every(
-        (value, index) => addressList[index] === value
+        (value, index) => subchannelAddressEqual(addressList[index], value)
       )
     ) {
       this.latestAddressList = addressList;


### PR DESCRIPTION
This fixes #2368. The change in #2363 caused the pick first LB policy to own `SubchannelWrapper` objects as opposed to `Subchannel` objects for a first time. This triggered a bug that existed since the introduction of subchannel wrappers, where the LB policy would perform an equality test between two subchannel interface objects without handling the case where one is a wrapper. The calls to `getRealSubchannel` fix that. This bug was not previously triggered because the only previous `SubchannelWrapper` implementation was for the outlier detection LB policy, and it makes no sense to use that LB policy with pick first.

In addition, testing this also revealed an older bug that has existed since the introduction of `SubchannelAddress` objects. The LB policy currently performs a naive equality check between two of them, which is always false.

Finally, the `ChannelSubchannelWrapper` class's subchannel connectivity state listener was written as though calls to `addConnectivityStateListener` and `removeConnectivityStateListener` would be intercepted, but they are not, so I removed that code and added code to remove that listener when the wrapper is discarded.