### PR TITLE
proto-loader-gen-types Narrow field Long check

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -414,6 +414,8 @@ function generateMessageInterfaces(formatter: TextFormatter, messageType: Protob
   const childTypes = getChildMessagesAndEnums(messageType);
   formatter.writeLine(`// Original file: ${(messageType.filename ?? 'null')?.replace(/\\/g, '/')}`);
   formatter.writeLine('');
+  const isLongField = (field: Protobuf.Field) =>
+    ['int64', 'uint64', 'sint64', 'fixed64', 'sfixed64'].includes(field.type);
   messageType.fieldsArray.sort((fieldA, fieldB) => fieldA.id - fieldB.id);
   for (const field of messageType.fieldsArray) {
     if (field.resolvedType && childTypes.indexOf(field.resolvedType) < 0) {
@@ -424,7 +426,7 @@ function generateMessageInterfaces(formatter: TextFormatter, messageType: Protob
       seenDeps.add(dependency.fullName);
       formatter.writeLine(getImportLine(dependency, messageType, options));
     }
-    if (field.type.indexOf('64') >= 0) {
+    if (isLongField(field)) {
       usesLong = true;
     }
   }
@@ -439,7 +441,7 @@ function generateMessageInterfaces(formatter: TextFormatter, messageType: Protob
           seenDeps.add(dependency.fullName);
           formatter.writeLine(getImportLine(dependency, messageType, options));
         }
-        if (field.type.indexOf('64') >= 0) {
+        if (isLongField(field)) {
           usesLong = true;
         }
       }


### PR DESCRIPTION
- Explicitly list the primitive field types that use Long, instead of searching for `64` in the type name.

Currently the check for when to import `Long` just looks to see if any field type has `64` in the name.
This potentially leads to adding unused imports that causes a typescript error, when using something like `google.protobuf.Int64Value`

```
src/__generated__/Example.ts:6:1 - error TS6133: 'Long' is declared but its value is never read.

6 import type { Long } from '@grpc/proto-loader';
```