### PR TITLE
Fix loading protofiles on Windows when using includeDirs

### DIFF
--- a/packages/proto-loader/src/util.ts
+++ b/packages/proto-loader/src/util.ts
@@ -27,7 +27,7 @@ function addIncludePathResolver(root: Protobuf.Root, includePaths: string[]) {
       return target;
     }
     for (const directory of includePaths) {
-      const fullPath: string = path.join(directory, target);
+      const fullPath: string = path.join(directory, target).replace(/\\/g, '/');
       try {
         fs.accessSync(fullPath, fs.constants.R_OK);
         return fullPath;


### PR DESCRIPTION
In the process of loading protofiles, I noticed that errors appear
Error: duplicate name 'module' in Namespace ...

The protofiles were fixed and I specified the path to them through includeDirs.
On UNIX systems, file uploads worked correctly. There is a problem on Windows

After analyzing, I realized that the error is in path.join. On Windows the path is returned with \ , on UNIX systems it is /

