### PR TITLE
grpc-js: add await/async on method that return promise

### DIFF
--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -808,10 +808,10 @@ export class Http2ServerCallStream<
 
     let pushedEnd = false;
 
-    const maybePushEnd = () => {
+    const maybePushEnd = async () => {
       if (!pushedEnd && readsDone && !pendingMessageProcessing) {
         pushedEnd = true;
-        this.pushOrBufferMessage(readable, null);
+        await this.pushOrBufferMessage(readable, null);
       }
     };
 
@@ -844,16 +844,16 @@ export class Http2ServerCallStream<
         // Just return early
         if (!decompressedMessage) return;
 
-        this.pushOrBufferMessage(readable, decompressedMessage);
+        await this.pushOrBufferMessage(readable, decompressedMessage);
       }
       pendingMessageProcessing = false;
       this.stream.resume();
-      maybePushEnd();
+      await maybePushEnd();
     });
 
-    this.stream.once('end', () => {
+    this.stream.once('end', async () => {
       readsDone = true;
-      maybePushEnd();
+      await maybePushEnd();
     });
   }
 
@@ -877,16 +877,16 @@ export class Http2ServerCallStream<
     return this.canPush;
   }
 
-  private pushOrBufferMessage(
+  private async pushOrBufferMessage(
     readable:
       | ServerReadableStream<RequestType, ResponseType>
       | ServerDuplexStream<RequestType, ResponseType>,
     messageBytes: Buffer | null
-  ): void {
+  ): Promise<void> {
     if (this.isPushPending) {
       this.bufferedMessages.push(messageBytes);
     } else {
-      this.pushMessage(readable, messageBytes);
+      await this.pushMessage(readable, messageBytes);
     }
   }
 
@@ -939,7 +939,7 @@ export class Http2ServerCallStream<
     this.isPushPending = false;
 
     if (this.bufferedMessages.length > 0) {
-      this.pushMessage(
+      await this.pushMessage(
         readable,
         this.bufferedMessages.shift() as Buffer | null
       );


### PR DESCRIPTION
add await/async on method that return promise to ensure that the order of message (and of the end of stream) are preserved

The goal is to fix the ticket #2375 where the end of stream can arrive before last messages and the message can be lost.