### PR TITLE
grpc-js: Fix address equality check in pick-first

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.11",
+  "version": "1.8.12",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -420,8 +420,9 @@ export class PickFirstLoadBalancer implements LoadBalancer {
      * address list is different from the existing one */
     if (
       this.subchannels.length === 0 ||
+      this.latestAddressList.length !== addressList.length ||
       !this.latestAddressList.every(
-        (value, index) => subchannelAddressEqual(addressList[index], value)
+        (value, index) => addressList[index] && subchannelAddressEqual(addressList[index], value)
       )
     ) {
       this.latestAddressList = addressList;

--- a/packages/grpc-js/src/subchannel-address.ts
+++ b/packages/grpc-js/src/subchannel-address.ts
@@ -41,9 +41,15 @@ export function isTcpSubchannelAddress(
 }
 
 export function subchannelAddressEqual(
-  address1: SubchannelAddress,
-  address2: SubchannelAddress
+  address1?: SubchannelAddress,
+  address2?: SubchannelAddress
 ): boolean {
+  if (!address1 && !address2) {
+    return true;
+  }
+  if (!address1 || !address2) {
+    return false;
+  }
   if (isTcpSubchannelAddress(address1)) {
     return (
       isTcpSubchannelAddress(address2) &&


### PR DESCRIPTION
This fixes #2379. In the current code, if the pick-first LB policy gets an address list that is shorter than the previous address list, the loop checking for equality can run off the edge of the list and pass an `undefined` value the type checker doesn't account for into `subchannelAddressEqual`. I added three layers of protection to avoid this:

 1. The loop is skipped if the lengths are equal.
 2. `subchannelAddressEqual` is only called if the value is not `undefined`.
 3. `subchannelAddressEqual` can now handle `undefined` values, in case something like this happens elsewhere.