### PR TITLE
grpc-js: Trace before call to LB policy picker

### DIFF
--- a/packages/grpc-js/src/load-balancing-call.ts
+++ b/packages/grpc-js/src/load-balancing-call.ts
@@ -102,6 +102,7 @@ export class LoadBalancingCall implements Call {
     if (!this.metadata) {
       throw new Error('doPick called before start');
     }
+    this.trace('Pick called')
     const pickResult = this.channel.doPick(this.metadata, this.callConfig.pickInformation);
     const subchannelString = pickResult.subchannel ? 
       '(' + pickResult.subchannel.getChannelzRef().id + ') ' + pickResult.subchannel.getAddress() : 


### PR DESCRIPTION
With a trace log before and after the pick call, this should conclusively determine whether the picker ever hangs.