### PR TITLE
grpc-js: Unregister socket from channelz when closing transport

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -20,7 +20,7 @@ import { checkServerIdentity, CipherNameAndProtocol, ConnectionOptions, PeerCert
 import { StatusObject } from './call-interface';
 import { ChannelCredentials } from './channel-credentials';
 import { ChannelOptions } from './channel-options';
-import { ChannelzCallTracker, registerChannelzSocket, SocketInfo, SocketRef, TlsInfo } from './channelz';
+import { ChannelzCallTracker, registerChannelzSocket, SocketInfo, SocketRef, TlsInfo, unregisterChannelzRef } from './channelz';
 import { LogVerbosity } from './constants';
 import { getProxiedConnection, ProxyConnectionResult } from './http_proxy';
 import * as logging from './logging';
@@ -471,6 +471,7 @@ class Http2Transport implements Transport {
 
   shutdown() {
     this.session.close();
+    unregisterChannelzRef(this.channelzRef);
   }
 }
 


### PR DESCRIPTION
This fixes #2393. Manual testing shows that without this change, after a channel is closed, the channelz registry reference keeps the transport alive, and that in turn keeps the subchannel alive.