### PR TITLE
Replace invalid link in grpc-tools README

### DIFF
--- a/packages/grpc-tools/README.md
+++ b/packages/grpc-tools/README.md
@@ -9,7 +9,7 @@ libraries.
 This library exports the `grpc_tools_node_protoc` executable, which accepts all
 of the same arguments as `protoc` itself. For use with Node, you most likely
 want to use CommonJS-style imports. An example of generating code this way can
-be found in [this guide](https://developers.google.com/protocol-buffers/docs/reference/javascript-generated#commonjs-imports).
+be found in [this guide](https://github.com/protocolbuffers/protobuf-javascript/blob/main/docs/index.md).
 The `grpc_tools_node_protoc` automatically includes the Node gRPC plugin, so
 it also accepts the `--grpc_out=[option:]path` argument. The option can be
 one of the following:


### PR DESCRIPTION
The provided link leads to a 404 since Google pulled the documentation page for the JS library and left the poor developers without any documentation.

The original page can be accessed via [Wayback Machine](http://web.archive.org/web/20220422095626/https://developers.google.com/protocol-buffers/docs/reference/javascript-generated).

The replacement link provides the same original content.