### PR TITLE
grpc-js-xds: Use Debian and Node 18 in interop Dockerfile (1.7.x)

### DIFF
--- a/packages/grpc-js-xds/interop/Dockerfile
+++ b/packages/grpc-js-xds/interop/Dockerfile
@@ -16,7 +16,7 @@
 # following command from grpc-node directory:
 # docker build -t <TAG> -f packages/grpc-js-xds/interop/Dockerfile .
 
-FROM node:16-alpine as build
+FROM node:18-slim as build
 
 # Make a grpc-node directory and copy the repo into it.
 WORKDIR /node/src/grpc-node
@@ -27,7 +27,7 @@ RUN npm install
 WORKDIR /node/src/grpc-node/packages/grpc-js-xds
 RUN npm install
 
-FROM node:16-alpine
+FROM node:18-slim
 WORKDIR /node/src/grpc-node
 COPY --from=build /node/src/grpc-node/packages/grpc-js ./packages/grpc-js/
 COPY --from=build /node/src/grpc-node/packages/grpc-js-xds ./packages/grpc-js-xds/


### PR DESCRIPTION
#2405 backported to 1.7.x