### PR TITLE
grpc-js-xds: Remove extra 'only' from local testing

### DIFF
--- a/packages/grpc-js-xds/test/test-cluster-type.ts
+++ b/packages/grpc-js-xds/test/test-cluster-type.ts
@@ -24,7 +24,7 @@ import { Backend } from "./backend";
 
 register();
 
-describe.only('Cluster types', () => {
+describe('Cluster types', () => {
   let xdsServer: XdsServer;
   let client: XdsTestClient;
   beforeEach(done => {


### PR DESCRIPTION
The `only` there caused other test groups in other files to be skipped.