### PR TITLE
Skip the remaining callbacks on connectivity state change

### DIFF
--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -264,6 +264,11 @@ export class Subchannel {
     /* We use a shallow copy of the stateListeners array in case a listener
      * is removed during this iteration */
     for (const listener of [...this.stateListeners]) {
+      if (this.connectivityState !== newState) {
+        logging.log(LogVerbosity.ERROR, 'Subchannel connectivity state was changed before a listener called!');
+        return true;
+      }
+
       listener(this, previousState, newState, this.keepaliveTime);
     }
     return true;


### PR DESCRIPTION
Skip the remaining callbacks in `subchannel.transitionToState()` if connectivity state has been changed before callbacks called.

Connectivity state could be changed by calling `client.close()` inside a callback.
As a result - infinite busy loop in `LoadBalancingCall.doPick()`.

It affected [etcd3 client library](https://github.com/microsoft/etcd3/blob/00bfb8bf3a26e176c48b2f483d70df0605a76006/src/connection-pool.ts#L213]).

