### PR TITLE
proto-loader: Update to yargs@17.x

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -835,7 +835,7 @@ async function runScript() {
     boolean: true,
     default: false,
   };
-  const argv = yargs
+  const argv = await yargs
     .parserConfiguration({
       'parse-positional-numbers': false
     })

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "author": "Google Inc.",
   "contributors": [
     {
@@ -49,14 +49,14 @@
     "lodash.camelcase": "^4.3.0",
     "long": "^4.0.0",
     "protobufjs": "^7.0.0",
-    "yargs": "^16.2.0"
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@types/lodash.camelcase": "^4.3.4",
     "@types/mkdirp": "^1.0.1",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.26",
-    "@types/yargs": "^16.0.4",
+    "@types/yargs": "^17.0.24",
     "clang-format": "^1.2.2",
     "gts": "^3.1.0",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
This fixes #2435. Yargs version 16 has a dependency that is vulnerable to [CVE-2021-3807](https://github.com/advisories/GHSA-93q8-gq69-wqmw). Yargs 17 has the updated dependency.