### PR TITLE
PSM Interop: Increase old driver QPS to 75 (v1.8.x)

### DIFF
--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -60,7 +60,7 @@ GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weigh
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \
-    --qps=50 \
+    --qps=75 \
     ${XDS_V3_OPT-} \
     --client_cmd="$(which node) --enable-source-maps --prof --logfile=${KOKORO_ARTIFACTS_DIR}/github/grpc/reports/prof.log grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client \
       --server=xds:///{server_uri} \


### PR DESCRIPTION
Update for b/232859415. 50 QPS is too low because part of the test expects it to reach 1000 pending requests, and with a 20 second timeout, it will barely reach that and will never trigger circuit breaking.