### PR TITLE
PSM Interop: do not run circuit_breaking in Legacy xDS v2 suite

### DIFF
--- a/packages/grpc-js-xds/scripts/xds-v3.sh
+++ b/packages/grpc-js-xds/scripts/xds-v3.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-XDS_V3_OPT="--xds_v3_support" $(dirname $0)/xds.sh
+XDS_V3_OPT="--xds_v3_support" TEST_CASES="ping_pong,circuit_breaking" $(dirname $0)/xds.sh

--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -52,7 +52,7 @@ GRPC_NODE_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weigh
   GRPC_NODE_VERBOSITY=DEBUG \
   NODE_XDS_INTEROP_VERBOSITY=1 \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case="ping_pong,circuit_breaking" \
+    --test_case="${TEST_CASES:-ping_pong}" \
     --project_id=grpc-testing \
     --source_image=projects/grpc-testing/global/images/xds-test-server-5 \
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \


### PR DESCRIPTION
Legacy xDS v2 test suite should only be running `ping_pong`.