### PR TITLE
grpc-js: Test against actively maintained Node versions (@grpc/grpc-js@1.7.x backport)

### DIFF
--- a/run-tests.bat
+++ b/run-tests.bat
@@ -28,8 +28,8 @@ SET JOBS=8
 
 call nvm version
 
-call nvm install 10
-call nvm use 10
+call nvm install 16
+call nvm use 16
 
 git submodule update --init --recursive
 
@@ -40,7 +40,7 @@ call npm install || goto :error
 SET JUNIT_REPORT_STACK=1
 SET FAILED=0
 
-for %%v in (10 12) do (
+for %%v in (14 16) do (
   call nvm install %%v
   call nvm use %%v
   if "%%v"=="4" (

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,7 +28,7 @@ cd $ROOT
 git submodule update --init --recursive
 
 if [ ! -n "$node_versions" ] ; then
-  node_versions="10 12 14 16"
+  node_versions="14 16"
 fi
 
 set +ex


### PR DESCRIPTION
Backport of #2246 to @grpc/grpc-js@1.7.x.
---
Node 10 and 12 are no longer maintained, and Node 18 is now out.