### PR TITLE
PSM Interop: Don't fail target if sub-target already failed (@grpc/grpc-js@1.6.x backport)

### DIFF
--- a/packages/grpc-js-xds/scripts/xds_k8s_lb.sh
+++ b/packages/grpc-js-xds/scripts/xds_k8s_lb.sh
@@ -170,9 +170,6 @@ main() {
     run_test $test || (( ++failed_tests ))
   done
   echo "Failed test suites: ${failed_tests}"
-  if (( failed_tests > 0 )); then
-    exit 1
-  fi
 }
 
 main "$@"


### PR DESCRIPTION
Backport of #2457 to @grpc/grpc-js@1.6.x.
---
We configured TestGrid to file bug separately for each failed sub-target, if we still fail the main target, TestGrid will fail duplicate bugs.
The same change in core: https://github.com/grpc/grpc/pull/33222