### PR TITLE
grpc-js-xds: Support string_match in header matching

### DIFF
--- a/packages/grpc-js-xds/src/matcher.ts
+++ b/packages/grpc-js-xds/src/matcher.ts
@@ -37,14 +37,19 @@ export interface ValueMatcher {
 }
 
 export class ExactValueMatcher implements ValueMatcher {
-  constructor(private targetValue: string) {}
+  constructor(private targetValue: string, private ignoreCase: boolean) {
+  }
 
   apply(value: string) {
-    return value === this.targetValue;
+    if (this.ignoreCase) {
+      return value.toLowerCase() === this.targetValue.toLowerCase();
+    } else {
+      return value === this.targetValue;
+    }
   }
 
   toString() {
-    return 'Exact(' + this.targetValue + ')';
+    return 'Exact(' + this.targetValue + ', ignore_case=' + this.ignoreCase + ')';
   }
 }
 
@@ -94,26 +99,51 @@ export class PresentValueMatcher implements ValueMatcher {
 }
 
 export class PrefixValueMatcher implements ValueMatcher {
-  constructor(private prefix: string) {}
+  constructor(private prefix: string, private ignoreCase: boolean) {
+  }
 
   apply(value: string) {
-    return value.startsWith(this.prefix);
+    if (this.ignoreCase) {
+      return value.toLowerCase().startsWith(this.prefix.toLowerCase());
+    } else {
+      return value.startsWith(this.prefix);
+    }
   }
 
   toString() {
-    return 'Prefix(' + this.prefix + ')';
+    return 'Prefix(' + this.prefix + ', ignore_case=' + this.ignoreCase + ')';
   }
 }
 
 export class SuffixValueMatcher implements ValueMatcher {
-  constructor(private suffix: string) {}
+  constructor(private suffix: string, private ignoreCase: boolean) {}
 
   apply(value: string) {
-    return value.endsWith(this.suffix);
+    if (this.ignoreCase) {
+      return value.toLowerCase().endsWith(this.suffix.toLowerCase());
+    } else {
+      return value.endsWith(this.suffix);
+    }
   }
 
   toString() {
-    return 'Suffix(' + this.suffix + ')';
+    return 'Suffix(' + this.suffix + ', ignore_case=' + this.ignoreCase + ')';
+  }
+}
+
+export class ContainsValueMatcher implements ValueMatcher {
+  constructor(private contains: string, private ignoreCase: boolean) {}
+
+  apply(value: string) {
+    if (this.ignoreCase) {
+      return value.toLowerCase().includes(this.contains.toLowerCase());
+    } else {
+      return value.includes(this.contains);
+    }
+  }
+
+  toString() {
+    return 'Contains(' + this.contains + + ', ignore_case=' + this.ignoreCase + ')';
   }
 }
 

--- a/packages/grpc-js-xds/src/xds-stream-state/rds-state.ts
+++ b/packages/grpc-js-xds/src/xds-stream-state/rds-state.ts
@@ -29,7 +29,8 @@ const SUPPPORTED_HEADER_MATCH_SPECIFIERS = [
   'range_match',
   'present_match',
   'prefix_match',
-  'suffix_match'];
+  'suffix_match',
+  'string_match'];
 const SUPPORTED_CLUSTER_SPECIFIERS = ['cluster', 'weighted_clusters', 'cluster_header'];
 
 const UINT32_MAX = 0xFFFFFFFF;


### PR DESCRIPTION
`string_match` is a type of string matcher that replicates the logic of several existing matchers, with the addition of the `ignore_case` flag. The `ignore_case` flag is intentionally not used for `safe_regex`.