### PR TITLE
grpc-js-xds: Update Node version in old test script

### DIFF
--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -24,7 +24,7 @@ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.4/install.sh | b
 # Load NVM
 . $NVM_DIR/nvm.sh
 
-nvm install 12
+nvm install 18
 
 set -exu -o pipefail
 [[ -f /VERSION ]] && cat /VERSION


### PR DESCRIPTION
Node 12 is past EOL and it looks like the TypeScript compiler version we use no longer runs on it.