### PR TITLE
grpc-js-xds: Downgrade Node version in old test script to 16

### DIFF
--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -24,7 +24,7 @@ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.4/install.sh | b
 # Load NVM
 . $NVM_DIR/nvm.sh
 
-nvm install 18
+nvm install 16
 
 set -exu -o pipefail
 [[ -f /VERSION ]] && cat /VERSION


### PR DESCRIPTION
This is a modification to #2466. It looks like Node 18 is too new, and it doesn't work in the environment that this test job runs in.