### PR TITLE
grpc-js: Implement trace function in Http2SubchannelConnector

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -485,7 +485,7 @@ export class Http2SubchannelConnector implements SubchannelConnector {
   private isShutdown = false;
   constructor(private channelTarget: GrpcUri) {}
   private trace(text: string) {
-
+    logging.trace(LogVerbosity.DEBUG, TRACER_NAME, this.channelTarget + ' ' + text);
   }
   private createSession(address: SubchannelAddress, credentials: ChannelCredentials, options: ChannelOptions, proxyConnectionResult: ProxyConnectionResult): Promise<Http2Transport> {
     if (this.isShutdown) {


### PR DESCRIPTION
The missing implementation code was pointed out in #2468.