### PR TITLE
grpc-js: Implement channel idle timeout

### DIFF
--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -63,6 +63,7 @@ Many channel arguments supported in `grpc` are not supported in `@grpc/grpc-js`.
   - `grpc.per_rpc_retry_buffer_size`
   - `grpc.retry_buffer_size`
   - `grpc.service_config_disable_resolution`
+  - `grpc.client_idle_timeout_ms`
   - `grpc-node.max_session_memory`
   - `channelOverride`
   - `channelFactoryOverride`

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -56,6 +56,7 @@ export interface ChannelOptions {
   'grpc.max_connection_age_grace_ms'?: number;
   'grpc-node.max_session_memory'?: number;
   'grpc.service_config_disable_resolution'?: number;
+  'grpc.client_idle_timeout_ms'?: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
@@ -89,6 +90,7 @@ export const recognizedOptions = {
   'grpc.max_connection_age_grace_ms': true,
   'grpc-node.max_session_memory': true,
   'grpc.service_config_disable_resolution': true,
+  'grpc.client_idle_timeout_ms': true
 };
 
 export function channelOptionsEqual(

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -90,7 +90,7 @@ export const recognizedOptions = {
   'grpc.max_connection_age_grace_ms': true,
   'grpc-node.max_session_memory': true,
   'grpc.service_config_disable_resolution': true,
-  'grpc.client_idle_timeout_ms': true
+  'grpc.client_idle_timeout_ms': true,
 };
 
 export function channelOptionsEqual(

--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -20,7 +20,12 @@ import { ChannelOptions } from './channel-options';
 import { ResolvingLoadBalancer } from './resolving-load-balancer';
 import { SubchannelPool, getSubchannelPool } from './subchannel-pool';
 import { ChannelControlHelper } from './load-balancer';
-import { UnavailablePicker, Picker, PickResultType, QueuePicker } from './picker';
+import {
+  UnavailablePicker,
+  Picker,
+  PickResultType,
+  QueuePicker,
+} from './picker';
 import { Metadata } from './metadata';
 import { Status, LogVerbosity, Propagate } from './constants';
 import { FilterStackFactory } from './filter-stack';
@@ -191,9 +196,10 @@ export class InternalChannel {
   private currentResolutionError: StatusObject | null = null;
   private readonly retryBufferTracker: MessageBufferTracker;
   private keepaliveTime: number;
-  private readonly wrappedSubchannels: Set<ChannelSubchannelWrapper> = new Set();
+  private readonly wrappedSubchannels: Set<ChannelSubchannelWrapper> =
+    new Set();
 
-  private callCount: number = 0;
+  private callCount = 0;
   private idleTimer: NodeJS.Timer | null = null;
   private readonly idleTimeoutMs: number;
 
@@ -274,7 +280,10 @@ export class InternalChannel {
         DEFAULT_PER_RPC_RETRY_BUFFER_SIZE_BYTES
     );
     this.keepaliveTime = options['grpc.keepalive_time_ms'] ?? -1;
-    this.idleTimeoutMs = Math.max(options['grpc.client_idle_timeout_ms'] ?? DEFAULT_IDLE_TIMEOUT_MS, MIN_IDLE_TIMEOUT_MS);
+    this.idleTimeoutMs = Math.max(
+      options['grpc.client_idle_timeout_ms'] ?? DEFAULT_IDLE_TIMEOUT_MS,
+      MIN_IDLE_TIMEOUT_MS
+    );
     const channelControlHelper: ChannelControlHelper = {
       createSubchannel: (
         subchannelAddress: SubchannelAddress,
@@ -567,7 +576,11 @@ export class InternalChannel {
   private maybeStartIdleTimer() {
     if (this.callCount === 0) {
       this.idleTimer = setTimeout(() => {
-        this.trace('Idle timer triggered after ' + this.idleTimeoutMs + 'ms of inactivity');
+        this.trace(
+          'Idle timer triggered after ' +
+            this.idleTimeoutMs +
+            'ms of inactivity'
+        );
         this.enterIdle();
       }, this.idleTimeoutMs);
       this.idleTimer.unref?.();

--- a/packages/grpc-js/src/load-balancer-child-handler.ts
+++ b/packages/grpc-js/src/load-balancer-child-handler.ts
@@ -150,6 +150,10 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
     }
   }
   destroy(): void {
+    /* Note: state updates are only propagated from the child balancer if that
+     * object is equal to this.currentChild or this.pendingChild. Since this
+     * function sets both of those to null, no further state updates will
+     * occur after this function returns. */
     if (this.currentChild) {
       this.currentChild.destroy();
       this.currentChild = null;

--- a/packages/grpc-js/src/resolver.ts
+++ b/packages/grpc-js/src/resolver.ts
@@ -82,7 +82,10 @@ export interface Resolver {
   updateResolution(): void;
 
   /**
-   * Destroy the resolver. Should be called when the owning channel shuts down.
+   * Discard all resources owned by the resolver. A later call to
+   * `updateResolution` should reinitialize those resources.  No
+   * `ResolverListener` callbacks should be called after `destroy` is called
+   * until `updateResolution` is called again.
    */
   destroy(): void;
 }

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -94,9 +94,9 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   /**
    * The resolver class constructed for the target address.
    */
-  private innerResolver: Resolver;
+  private readonly innerResolver: Resolver;
 
-  private childLoadBalancer: ChildLoadBalancerHandler;
+  private readonly childLoadBalancer: ChildLoadBalancerHandler;
   private latestChildState: ConnectivityState = ConnectivityState.IDLE;
   private latestChildPicker: Picker = new QueuePicker(this);
   /**
@@ -324,7 +324,13 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   destroy() {
     this.childLoadBalancer.destroy();
     this.innerResolver.destroy();
-    this.updateState(ConnectivityState.SHUTDOWN, new UnavailablePicker());
+    this.backoffTimeout.reset();
+    this.backoffTimeout.stop();
+    this.latestChildState = ConnectivityState.IDLE;
+    this.latestChildPicker = new QueuePicker(this);
+    this.currentState = ConnectivityState.IDLE;
+    this.previousServiceConfig = null;
+    this.continueResolving = false;
   }
 
   getTypeName() {

--- a/packages/grpc-js/test/common.ts
+++ b/packages/grpc-js/test/common.ts
@@ -17,8 +17,11 @@
 
 import * as loader from '@grpc/proto-loader';
 import * as assert2 from './assert2';
+import * as path from 'path';
+import * as grpc from '../src';
 
-import { GrpcObject, loadPackageDefinition } from '../src/make-client';
+import { GrpcObject, ServiceClientConstructor, ServiceClient, loadPackageDefinition } from '../src/make-client';
+import { readFileSync } from 'fs';
 
 const protoLoaderOptions = {
   keepCase: true,
@@ -35,6 +38,91 @@ export function mockFunction(): never {
 export function loadProtoFile(file: string): GrpcObject {
   const packageDefinition = loader.loadSync(file, protoLoaderOptions);
   return loadPackageDefinition(packageDefinition);
+}
+
+const protoFile = path.join(__dirname, 'fixtures', 'echo_service.proto');
+const echoService = loadProtoFile(protoFile)
+  .EchoService as ServiceClientConstructor;
+
+const ca = readFileSync(path.join(__dirname, 'fixtures', 'ca.pem'));
+const key = readFileSync(path.join(__dirname, 'fixtures', 'server1.key'));
+const cert = readFileSync(path.join(__dirname, 'fixtures', 'server1.pem'));
+
+const serviceImpl = {
+  echo: (
+    call: grpc.ServerUnaryCall<any, any>,
+    callback: grpc.sendUnaryData<any>
+  ) => {
+    callback(null, call.request);
+  },
+};
+
+export class TestServer {
+  private server: grpc.Server;
+  public port: number | null = null;
+  constructor(public useTls: boolean, options?: grpc.ChannelOptions) {
+    this.server = new grpc.Server(options);
+    this.server.addService(echoService.service, serviceImpl);
+  }
+  start(): Promise<void> {
+    let credentials: grpc.ServerCredentials;
+    if (this.useTls) {
+      credentials = grpc.ServerCredentials.createSsl(null, [{private_key: key, cert_chain: cert}]);
+    } else {
+      credentials = grpc.ServerCredentials.createInsecure();
+    }
+    return new Promise<void>((resolve, reject) => {
+      this.server.bindAsync('localhost:0', credentials, (error, port) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        this.port = port;
+        this.server.start();
+        resolve();
+      });
+    });
+  }
+
+  shutdown() {
+    this.server.forceShutdown();
+  }
+}
+
+export class TestClient {
+  private client: ServiceClient;
+  constructor(port: number, useTls: boolean, options?: grpc.ChannelOptions) {
+    let credentials: grpc.ChannelCredentials;
+    if (useTls) {
+      credentials = grpc.credentials.createSsl(ca);
+    } else {
+      credentials = grpc.credentials.createInsecure();
+    }
+    this.client = new echoService(`localhost:${port}`, credentials, options);
+  }
+
+  static createFromServer(server: TestServer, options?: grpc.ChannelOptions) {
+    if (server.port === null) {
+      throw new Error('Cannot create client, server not started');
+    }
+    return new TestClient(server.port, server.useTls, options);
+  }
+
+  waitForReady(deadline: grpc.Deadline, callback: (error?: Error) => void) {
+    this.client.waitForReady(deadline, callback);
+  }
+
+  sendRequest(callback: (error: grpc.ServiceError) => void) {
+    this.client.echo({}, callback);
+  }
+
+  getChannelState() {
+    return this.client.getChannel().getConnectivityState(false);
+  }
+
+  close() {
+    this.client.close();
+  }
 }
 
 export { assert2 };

--- a/packages/grpc-js/test/common.ts
+++ b/packages/grpc-js/test/common.ts
@@ -20,7 +20,12 @@ import * as assert2 from './assert2';
 import * as path from 'path';
 import * as grpc from '../src';
 
-import { GrpcObject, ServiceClientConstructor, ServiceClient, loadPackageDefinition } from '../src/make-client';
+import {
+  GrpcObject,
+  ServiceClientConstructor,
+  ServiceClient,
+  loadPackageDefinition,
+} from '../src/make-client';
 import { readFileSync } from 'fs';
 
 const protoLoaderOptions = {
@@ -67,7 +72,9 @@ export class TestServer {
   start(): Promise<void> {
     let credentials: grpc.ServerCredentials;
     if (this.useTls) {
-      credentials = grpc.ServerCredentials.createSsl(null, [{private_key: key, cert_chain: cert}]);
+      credentials = grpc.ServerCredentials.createSsl(null, [
+        { private_key: key, cert_chain: cert },
+      ]);
     } else {
       credentials = grpc.ServerCredentials.createInsecure();
     }

--- a/packages/grpc-js/test/test-idle-timer.ts
+++ b/packages/grpc-js/test/test-idle-timer.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import * as assert from 'assert';
+import * as grpc from '../src';
+import { TestClient, TestServer } from "./common";
+
+describe('Channel idle timer', () => {
+  let server: TestServer;
+  let client: TestClient | null = null;
+  before(() => {
+    server = new TestServer(false);
+    return server.start();
+  });
+  afterEach(() => {
+    if (client) {
+      client.close();
+      client = null;
+    }
+  })
+  after(() => {
+    server.shutdown();
+  });
+  it('Should go idle after the specified time after a request ends', function(done) {
+    this.timeout(5000);
+    client = TestClient.createFromServer(server, {'grpc.client_idle_timeout_ms': 1000});
+    client.sendRequest(error => {
+      assert.ifError(error);
+      assert.strictEqual(client!.getChannelState(), grpc.connectivityState.READY);
+      setTimeout(() => {
+        assert.strictEqual(client!.getChannelState(), grpc.connectivityState.IDLE);
+        done();
+      }, 1100);
+    });
+  });
+  it('Should be able to make a request after going idle', function(done) {
+    this.timeout(5000);
+    client = TestClient.createFromServer(server, {'grpc.client_idle_timeout_ms': 1000});
+    client.sendRequest(error => {
+      assert.ifError(error);
+      assert.strictEqual(client!.getChannelState(), grpc.connectivityState.READY);
+      setTimeout(() => {
+        assert.strictEqual(client!.getChannelState(), grpc.connectivityState.IDLE);
+        client!.sendRequest(error => {
+          assert.ifError(error);
+          done();
+        });
+      }, 1100);
+    });
+  });
+  it('Should go idle after the specified time after waitForReady ends', function(done) {
+    this.timeout(5000);
+    client = TestClient.createFromServer(server, {'grpc.client_idle_timeout_ms': 1000});
+    const deadline = new Date();
+    deadline.setSeconds(deadline.getSeconds() + 3);
+    client.waitForReady(deadline, error => {
+      assert.ifError(error);
+      assert.strictEqual(client!.getChannelState(), grpc.connectivityState.READY);
+      setTimeout(() => {
+        assert.strictEqual(client!.getChannelState(), grpc.connectivityState.IDLE);
+        done();
+      }, 1100);
+    });
+  });
+  it('Should ensure that the timeout is at least 1 second', function(done) {
+    client = TestClient.createFromServer(server, {'grpc.client_idle_timeout_ms': 50});
+    client.sendRequest(error => {
+      assert.ifError(error);
+      assert.strictEqual(client!.getChannelState(), grpc.connectivityState.READY);
+      setTimeout(() => {
+        // Should still be ready after 100ms
+        assert.strictEqual(client!.getChannelState(), grpc.connectivityState.READY);
+        setTimeout(() => {
+          // Should go IDLE after another second
+          assert.strictEqual(client!.getChannelState(), grpc.connectivityState.IDLE);
+          done();
+        }, 1000);
+      }, 100);
+    });
+  })
+});

--- a/packages/grpc-js/test/test-idle-timer.ts
+++ b/packages/grpc-js/test/test-idle-timer.ts
@@ -17,7 +17,7 @@
 
 import * as assert from 'assert';
 import * as grpc from '../src';
-import { TestClient, TestServer } from "./common";
+import { TestClient, TestServer } from './common';
 
 describe('Channel idle timer', () => {
   let server: TestServer;
@@ -31,30 +31,46 @@ describe('Channel idle timer', () => {
       client.close();
       client = null;
     }
-  })
+  });
   after(() => {
     server.shutdown();
   });
-  it('Should go idle after the specified time after a request ends', function(done) {
+  it('Should go idle after the specified time after a request ends', function (done) {
     this.timeout(5000);
-    client = TestClient.createFromServer(server, {'grpc.client_idle_timeout_ms': 1000});
+    client = TestClient.createFromServer(server, {
+      'grpc.client_idle_timeout_ms': 1000,
+    });
     client.sendRequest(error => {
       assert.ifError(error);
-      assert.strictEqual(client!.getChannelState(), grpc.connectivityState.READY);
+      assert.strictEqual(
+        client!.getChannelState(),
+        grpc.connectivityState.READY
+      );
       setTimeout(() => {
-        assert.strictEqual(client!.getChannelState(), grpc.connectivityState.IDLE);
+        assert.strictEqual(
+          client!.getChannelState(),
+          grpc.connectivityState.IDLE
+        );
         done();
       }, 1100);
     });
   });
-  it('Should be able to make a request after going idle', function(done) {
+  it('Should be able to make a request after going idle', function (done) {
     this.timeout(5000);
-    client = TestClient.createFromServer(server, {'grpc.client_idle_timeout_ms': 1000});
+    client = TestClient.createFromServer(server, {
+      'grpc.client_idle_timeout_ms': 1000,
+    });
     client.sendRequest(error => {
       assert.ifError(error);
-      assert.strictEqual(client!.getChannelState(), grpc.connectivityState.READY);
+      assert.strictEqual(
+        client!.getChannelState(),
+        grpc.connectivityState.READY
+      );
       setTimeout(() => {
-        assert.strictEqual(client!.getChannelState(), grpc.connectivityState.IDLE);
+        assert.strictEqual(
+          client!.getChannelState(),
+          grpc.connectivityState.IDLE
+        );
         client!.sendRequest(error => {
           assert.ifError(error);
           done();
@@ -62,34 +78,53 @@ describe('Channel idle timer', () => {
       }, 1100);
     });
   });
-  it('Should go idle after the specified time after waitForReady ends', function(done) {
+  it('Should go idle after the specified time after waitForReady ends', function (done) {
     this.timeout(5000);
-    client = TestClient.createFromServer(server, {'grpc.client_idle_timeout_ms': 1000});
+    client = TestClient.createFromServer(server, {
+      'grpc.client_idle_timeout_ms': 1000,
+    });
     const deadline = new Date();
     deadline.setSeconds(deadline.getSeconds() + 3);
     client.waitForReady(deadline, error => {
       assert.ifError(error);
-      assert.strictEqual(client!.getChannelState(), grpc.connectivityState.READY);
+      assert.strictEqual(
+        client!.getChannelState(),
+        grpc.connectivityState.READY
+      );
       setTimeout(() => {
-        assert.strictEqual(client!.getChannelState(), grpc.connectivityState.IDLE);
+        assert.strictEqual(
+          client!.getChannelState(),
+          grpc.connectivityState.IDLE
+        );
         done();
       }, 1100);
     });
   });
-  it('Should ensure that the timeout is at least 1 second', function(done) {
-    client = TestClient.createFromServer(server, {'grpc.client_idle_timeout_ms': 50});
+  it('Should ensure that the timeout is at least 1 second', function (done) {
+    client = TestClient.createFromServer(server, {
+      'grpc.client_idle_timeout_ms': 50,
+    });
     client.sendRequest(error => {
       assert.ifError(error);
-      assert.strictEqual(client!.getChannelState(), grpc.connectivityState.READY);
+      assert.strictEqual(
+        client!.getChannelState(),
+        grpc.connectivityState.READY
+      );
       setTimeout(() => {
         // Should still be ready after 100ms
-        assert.strictEqual(client!.getChannelState(), grpc.connectivityState.READY);
+        assert.strictEqual(
+          client!.getChannelState(),
+          grpc.connectivityState.READY
+        );
         setTimeout(() => {
           // Should go IDLE after another second
-          assert.strictEqual(client!.getChannelState(), grpc.connectivityState.IDLE);
+          assert.strictEqual(
+            client!.getChannelState(),
+            grpc.connectivityState.IDLE
+          );
           done();
         }, 1000);
       }, 100);
     });
-  })
+  });
 });


### PR DESCRIPTION
Implement channel idle timeout functionality: after a channel has no active calls for a certain amount of time, it will close any active connections and enter the IDLE state. The amount of time is configured by the [`grpc.client_idle_timeout_ms`](https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html#ga51ab062269cd81298f5adb6fd9a45e99) option. The default value is 30 minutes (1,800,000) and the minimum is 1 second (1000).

The changes making some fields `readonly` are primarily to make it easier to track which ones will be constant for the lifetime of the object and which may need to be reset when going to the IDLE state.

I also added some testing helper code to make it easier to add new tests of client or server behavior.

This is related to #2463 in the sense that that change's client management setup assumes that this change is coming.