### PR TITLE
[PSM interop] Don't fail target if sub-target already failed

### DIFF
--- a/packages/grpc-js-xds/scripts/xds_k8s_url_map.sh
+++ b/packages/grpc-js-xds/scripts/xds_k8s_url_map.sh
@@ -156,7 +156,7 @@ main() {
   build_docker_images_if_needed
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
-  run_test url_map
+  run_test url_map || echo "Failed url_map test"
 }
 
 main "$@"


### PR DESCRIPTION
We don't want file multiple bugs if any of the sub-tests of the `url_map` test fails.

The same change in core: https://github.com/grpc/grpc/pull/33520.