### PR TITLE
grpc-js: Disallow pick_first as child of outlier_detection

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -113,7 +113,7 @@ export class OutlierDetectionLoadBalancingConfig implements LoadBalancingConfig 
     failurePercentageEjection: Partial<FailurePercentageEjectionConfig> | null,
     private readonly childPolicy: LoadBalancingConfig[]
   ) {
-    if (childPolicy[0].getLoadBalancerName() === 'pick_first') {
+    if (childPolicy.length > 0 && childPolicy[0].getLoadBalancerName() === 'pick_first') {
       throw new Error('outlier_detection LB policy cannot have a pick_first child policy');
     }
     this.intervalMs = intervalMs ?? 10_000;

--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -113,6 +113,9 @@ export class OutlierDetectionLoadBalancingConfig implements LoadBalancingConfig 
     failurePercentageEjection: Partial<FailurePercentageEjectionConfig> | null,
     private readonly childPolicy: LoadBalancingConfig[]
   ) {
+    if (childPolicy[0].getLoadBalancerName() === 'pick_first') {
+      throw new Error('outlier_detection LB policy cannot have a pick_first child policy');
+    }
     this.intervalMs = intervalMs ?? 10_000;
     this.baseEjectionTimeMs = baseEjectionTimeMs ?? 30_000;
     this.maxEjectionTimeMs = maxEjectionTimeMs ?? 300_000;
@@ -395,8 +398,8 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
   }
 
   private isCountingEnabled(): boolean {
-    return this.latestConfig !== null && 
-      (this.latestConfig.getSuccessRateEjectionConfig() !== null || 
+    return this.latestConfig !== null &&
+      (this.latestConfig.getSuccessRateEjectionConfig() !== null ||
        this.latestConfig.getFailurePercentageEjectionConfig() !== null);
   }
 
@@ -496,7 +499,7 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
     if (addressesWithTargetVolume < failurePercentageConfig.minimum_hosts) {
       return;
     }
-    
+
     // Step 2
     for (const [address, mapEntry] of this.addressMap.entries()) {
       // Step 2.i

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -137,7 +137,7 @@ class DnsResolver implements Resolver {
       details: `Name resolution failed for target ${uriToString(this.target)}`,
       metadata: new Metadata(),
     };
-    
+
     const backoffOptions: BackoffOptions = {
       initialDelay: channelOptions['grpc.initial_reconnect_backoff_ms'],
       maxDelay: channelOptions['grpc.max_reconnect_backoff_ms'],
@@ -276,7 +276,7 @@ class DnsResolver implements Resolver {
             } catch (err) {
               this.latestServiceConfigError = {
                 code: Status.UNAVAILABLE,
-                details: 'Parsing service config failed',
+                details: `Parsing service config failed with error ${(err as Error).message}`,
                 metadata: new Metadata(),
               };
             }

--- a/packages/grpc-js/test/test-outlier-detection.ts
+++ b/packages/grpc-js/test/test-outlier-detection.ts
@@ -360,6 +360,16 @@ describe('Outlier detection config validation', () => {
       }, /failure_percentage_ejection\.enforcement_percentage parse error: value out of range for percentage/);
     });
   });
+  describe('child_policy', () => {
+    it('Should reject a pick_first child_policy', () => {
+      const loadBalancingConfig = {
+        child_policy: [{pick_first: {}}]
+      };
+      assert.throws(() => {
+        OutlierDetectionLoadBalancingConfig.createFromJson(loadBalancingConfig);
+      }, /outlier_detection LB policy cannot have a pick_first child policy/);
+    });
+  });
 });
 
 describe('Outlier detection', () => {


### PR DESCRIPTION
This makes Node's behavior match the other languages. The only effect outlier detection can have with a pick_first child policy is to cause a reconnection if the request failure percentage exceeds a certain value. We only want to support outlier detection for health checking, not for connection management, so that combination is now disallowed.

If the user triggers this by explicitly passing a service config in channel arguments, constructing the channel will throw the error immediately. If they trigger it by providing the service config in a DNS TXT record, it should cause requests to fail with that error.