### PR TITLE
grpc-js-xds: Use distroless Node image for interop Dockerfile (1.8.x)

### DIFF
--- a/packages/grpc-js-xds/interop/Dockerfile
+++ b/packages/grpc-js-xds/interop/Dockerfile
@@ -27,7 +27,7 @@ RUN npm install
 WORKDIR /node/src/grpc-node/packages/grpc-js-xds
 RUN npm install
 
-FROM node:18-slim
+FROM gcr.io/distroless/nodejs18-debian11:latest
 WORKDIR /node/src/grpc-node
 COPY --from=build /node/src/grpc-node/packages/grpc-js ./packages/grpc-js/
 COPY --from=build /node/src/grpc-node/packages/grpc-js-xds ./packages/grpc-js-xds/

--- a/packages/grpc-js-xds/interop/Dockerfile
+++ b/packages/grpc-js-xds/interop/Dockerfile
@@ -35,4 +35,4 @@ COPY --from=build /node/src/grpc-node/packages/grpc-js-xds ./packages/grpc-js-xd
 ENV GRPC_VERBOSITY="DEBUG"
 ENV GRPC_TRACE=xds_client,xds_resolver,cds_balancer,eds_balancer,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver,fault_injection,http_filter,csds,outlier_detection
 
-ENTRYPOINT [ "node", "/node/src/grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client" ]
+ENTRYPOINT [ "/nodejs/bin/node", "/node/src/grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client" ]


### PR DESCRIPTION
#2477 for 1.8.x