### PR TITLE
proto-loader: Update long dependency to match protobufjs

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -45,9 +45,8 @@
     "proto-loader-gen-types": "./build/bin/proto-loader-gen-types.js"
   },
   "dependencies": {
-    "@types/long": "^4.0.1",
     "lodash.camelcase": "^4.3.0",
-    "long": "^4.0.0",
+    "long": "^5.0.0",
     "protobufjs": "^7.2.4",
     "yargs": "^17.7.2"
   },


### PR DESCRIPTION
protobufjs 7.x depends on long ^5.0.0. This PR updates the dependency in proto-loader to match, so that we avoid installing multiple versions of long.