### PR TITLE
grpc-js: Add channel option to enable TLS tracing

### DIFF
--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -57,6 +57,10 @@ export interface ChannelOptions {
   'grpc-node.max_session_memory'?: number;
   'grpc.service_config_disable_resolution'?: number;
   'grpc.client_idle_timeout_ms'?: number;
+  /**
+   * Set the enableTrace option in TLS clients and servers
+   */
+  'grpc-node.tls_enable_trace'?: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
@@ -91,6 +95,7 @@ export const recognizedOptions = {
   'grpc-node.max_session_memory': true,
   'grpc.service_config_disable_resolution': true,
   'grpc.client_idle_timeout_ms': true,
+  'grpc-node.tls_enable_trace': true,
 };
 
 export function channelOptionsEqual(

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -427,6 +427,8 @@ export class Server {
           serverOptions,
           creds._getSettings()!
         );
+        secureServerOptions.enableTrace =
+          this.options['grpc-node.tls_enable_trace'] === 1;
         http2Server = http2.createSecureServer(secureServerOptions);
         http2Server.on('secureConnection', (socket: TLSSocket) => {
           /* These errors need to be handled by the user of Http2SecureServer,

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -677,6 +677,7 @@ export class Http2SubchannelConnector implements SubchannelConnector {
       connectionOptions = {
         ...connectionOptions,
         ...address,
+        enableTrace: options['grpc-node.tls_enable_trace'] === 1,
       };
 
       /* http2.connect uses the options here:
@@ -759,6 +760,9 @@ export class Http2SubchannelConnector implements SubchannelConnector {
           const hostPort = splitHostPort(targetPath);
           connectionOptions.servername = hostPort?.host ?? targetPath;
         }
+      }
+      if (options['grpc-node.tls_enable_trace']) {
+        connectionOptions.enableTrace = true;
       }
     }
 


### PR DESCRIPTION
This new option `grpc-node.tls_enable_trace` enables the tracing output in Node's built in TLS module. This works on both clients and servers, and it should work when using a proxy on the client.

This option was requested in #2468.