### PR TITLE
grpc-js: Fix transport trace message formatting

### DIFF
--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -584,7 +584,7 @@ export class Http2SubchannelConnector implements SubchannelConnector {
     logging.trace(
       LogVerbosity.DEBUG,
       TRACER_NAME,
-      this.channelTarget + ' ' + text
+      uriToString(this.channelTarget) + ' ' + text
     );
   }
   private createSession(


### PR DESCRIPTION
I noticed in [this SO question](https://stackoverflow.com/q/76690466/159388) that the `transport` trace logs had `[object Object]` instead of the channel target.