### PR TITLE
grpc-js: Fix compilation error from new @types/node version (1.7.x)

### DIFF
--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -937,8 +937,8 @@ export class Http2ServerCallStream<
   }
 
   getPeer(): string {
-    const socket = this.stream.session.socket;
-    if (socket.remoteAddress) {
+    const socket = this.stream.session?.socket;
+    if (socket?.remoteAddress) {
       if (socket.remotePort) {
         return `${socket.remoteAddress}:${socket.remotePort}`;
       } else {


### PR DESCRIPTION
Fix a compilation error caused by DefinitelyTyped/DefinitelyTyped#66144.