### PR TITLE
fix: cannot send ping without ref

### DIFF
--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -396,6 +396,7 @@ class Http2Transport implements Transport {
 
   private canSendPing() {
     return (
+      !!this.channelzRef &&
       this.keepaliveTimeMs > 0 &&
       (this.keepaliveWithoutCalls || this.activeCalls.size > 0)
     );


### PR DESCRIPTION
The logger statements rely on `this.channelzRef.id` which is possibly undefined depending on when execution occurs.

In order to avoid possibly undefined `.id`, ensure you can only send ping if `channelzRef` exists

Hey all, encountered a problem like this in usage. Just a suggested change, I'm not planning on following-up on this I'm afraid. We're planning to downgrade dependencies locally.