### PR TITLE
grpc-js: Fix a crash when `grpc.keepalive_permit_without_calls` is set

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.19",
+  "version": "1.8.20",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -126,6 +126,14 @@ class Http2Transport implements Transport {
      */
     private remoteName: string | null
   ) {
+    /* Populate subchannelAddressString and channelzRef before doing anything
+     * else, because they are used in the trace methods. */
+    this.subchannelAddressString = subchannelAddressToString(subchannelAddress);
+
+    if (options['grpc.enable_channelz'] === 0) {
+      this.channelzEnabled = false;
+    }
+    this.channelzRef = registerChannelzSocket(this.subchannelAddressString, () => this.getChannelzInfo(), this.channelzEnabled);
     // Build user-agent string.
     this.userAgent = [
       options['grpc.primary_user_agent'],
@@ -147,16 +155,6 @@ class Http2Transport implements Transport {
     } else {
       this.keepaliveWithoutCalls = false;
     }
-    if (this.keepaliveWithoutCalls) {
-      this.maybeStartKeepalivePingTimer();
-    }
-
-    this.subchannelAddressString = subchannelAddressToString(subchannelAddress);
-
-    if (options['grpc.enable_channelz'] === 0) {
-      this.channelzEnabled = false;
-    }
-    this.channelzRef = registerChannelzSocket(this.subchannelAddressString, () => this.getChannelzInfo(), this.channelzEnabled);
 
     session.once('close', () => {
       this.trace('session closed');
@@ -204,6 +202,11 @@ class Http2Transport implements Transport {
             JSON.stringify(settings)
         );
       });
+    }
+    /* Start the keepalive timer last, because this can trigger trace logs,
+     * which should only happen after everything else is set up. */
+    if (this.keepaliveWithoutCalls) {
+      this.maybeStartKeepalivePingTimer();
     }
   }
 


### PR DESCRIPTION
Part of the change in #2513 added a trace line to starting the keepalive timer. That can be called from the constructor if the option `grpc.keepalive_permit_without_calls` is set, and that fails because the object isn't fully constructed. This change just rearranges the constructor so that the parts of the setup that affect trace logs are completed as early as possible, and starting the keepalive timer happens as late as possible.