### PR TITLE
Fix some issues with the benchmark code

### DIFF
--- a/test/any_grpc.js
+++ b/test/any_grpc.js
@@ -25,7 +25,7 @@ function getImplementation(globalField) {
   const impl = global[globalField];
 
   if (impl === 'js') {
-    return require(`../packages/grpc-${impl}`);
+    return require('../packages/grpc-js');
   } else if (impl === 'native') {
     return require('grpc');
   }

--- a/test/package.json
+++ b/test/package.json
@@ -16,8 +16,10 @@
   "dependencies": {
     "express": "^4.16.3",
     "google-auth-library": "^6.1.0",
-    "grpc": "^1.24.2",
     "lodash": "^4.17.4",
     "poisson-process": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "grpc": "^1.24.2"
   }
 }

--- a/test/performance/benchmark_server.js
+++ b/test/performance/benchmark_server.js
@@ -154,8 +154,9 @@ util.inherits(BenchmarkServer, EventEmitter);
  * Start the benchmark server.
  */
 BenchmarkServer.prototype.start = function() {
-  this.server.bindAsync(this.host + ':' + this.port, this.creds, (err) => {
+  this.server.bindAsync(this.host + ':' + this.port, this.creds, (err, port) => {
     assert.ifError(err);
+    this.port = port;
     this.server.start();
     this.last_wall_time = process.hrtime();
     this.last_usage = process.cpuUsage();

--- a/test/performance/driver.js
+++ b/test/performance/driver.js
@@ -1,0 +1,82 @@
+const grpc = require('../any_grpc').server;
+const protoLoader = require('../../packages/proto-loader');
+const protoPackage = protoLoader.loadSync(
+    'src/proto/grpc/testing/worker_service.proto',
+    {keepCase: true,
+     defaults: true,
+     enums: String,
+     oneofs: true,
+     includeDirs: [__dirname + '/../proto/']});
+const serviceProto = grpc.loadPackageDefinition(protoPackage).grpc.testing;
+
+function main() {
+  const parseArgs = require('minimist');
+  const argv = parseArgs(process.argv, {
+    string: ['client_worker_port', 'server_worker_port']
+  });
+  const clientWorker = new serviceProto.WorkerService(`localhost:${argv.client_worker_port}`, grpc.credentials.createInsecure());
+  const serverWorker = new serviceProto.WorkerService(`localhost:${argv.server_worker_port}`, grpc.credentials.createInsecure());
+  const serverWorkerStream = serverWorker.runServer();
+  const clientWorkerStream = clientWorker.runClient();
+  let firstServerResponseReceived = false;
+  let markCount = 0;
+  serverWorkerStream.on('data', (response) => {
+    console.log('Server stats:', response.stats);
+    if (!firstServerResponseReceived) {
+      firstServerResponseReceived = true;
+      clientWorkerStream.write({
+        setup: {
+          server_targets: [`localhost:${response.port}`],
+          client_channels: 1,
+          outstanding_rpcs_per_channel: 1,
+          histogram_params: {
+            resolution: 0.01,
+            max_possible:60000000000
+          },
+          payload_config: {
+            bytebuf_params: {
+              req_size: 10,
+              resp_size: 10
+            }
+          },
+          load_params: {
+            closed_loop: {}
+          }
+        }
+      });
+      clientWorkerStream.on('status', (status) => {
+        console.log('Received client worker status ' + JSON.stringify(status));
+        serverWorkerStream.end();
+      });
+      const markInterval = setInterval(() => {
+        if (markCount >= 5) {
+          clientWorkerStream.end();
+          clearInterval(markInterval);
+        } else {
+          clientWorkerStream.write({
+            mark: {}
+          });
+          serverWorkerStream.write({
+            mark: {}
+          });
+        }
+        markCount += 1;
+      }, 1000);
+    }
+  });
+  clientWorkerStream.on('data', (response) => {
+    console.log('Client stats:', response.stats);
+  });
+  serverWorkerStream.write({
+    setup: {
+      port: 0
+    }
+  });
+  serverWorkerStream.on('status', (status) => {
+    console.log('Received server worker status ' + JSON.stringify(status));
+  });
+}
+
+if (require.main === module) {
+  main();
+}

--- a/test/performance/worker.js
+++ b/test/performance/worker.js
@@ -39,13 +39,13 @@ function runServer(port, benchmark_impl, callback) {
   server.addService(serviceProto.WorkerService.service,
                     new WorkerServiceImpl(benchmark_impl, server));
   var address = '0.0.0.0:' + port;
-  server.bindAsync(address, server_creds, (err) => {
+  server.bindAsync(address, server_creds, (err, port) => {
     if (err) {
       return callback(err);
     }
 
     server.start();
-    console.log('running QPS worker on %s', address);
+    console.log('running QPS worker on 0.0.0.0:%s', port);
     callback(null, server);
   });
 }


### PR DESCRIPTION
The change in `any_grpc.js` allows code packaging tools such as [`pkg`](https://www.npmjs.com/package/pkg) to correctly process that `require` call.

The old `grpc` library is now an optional dependency, so that installation of other packages can proceed if in environments where that package is not supported, particularly when the runtime is a newer version of Node.

When calling `RunServer` on a worker with a `port` of `0`, the response now reports the actual bound port instead of `0`.

The new `worker.js` is there for manual testing. It expects two workers to be running at the specified ports on `localhost`, and it instructs them to run a simple benchmark.