### PR TITLE
Default to pure JS implementation in tests

### DIFF
--- a/test/any_grpc.js
+++ b/test/any_grpc.js
@@ -22,7 +22,7 @@
 const _ = require('lodash');
 
 function getImplementation(globalField) {
-  const impl = global[globalField];
+  const impl = global[globalField] ?? 'js';
 
   if (impl === 'js') {
     return require('../packages/grpc-js');


### PR DESCRIPTION
As currently written, the `any_grpc.js` file expects the user to use Node's `--require` option with one of the files in `test/fixtures` to determine what gRPC implementations to use on the client and server. This option can be cumbersome to use in some situations. This change makes files usable in those situations with the reduced functionality that the choice of gRPC implementation is not configurable.