### PR TITLE
benchmark: Delay shutdown in quitWorker

### DIFF
--- a/test/performance/driver.js
+++ b/test/performance/driver.js
@@ -74,6 +74,20 @@ function main() {
   });
   serverWorkerStream.on('status', (status) => {
     console.log('Received server worker status ' + JSON.stringify(status));
+    clientWorker.quitWorker({}, (error, response) => {
+      if (error) {
+        console.log('Received error on clientWorker.quitWorker:', error);
+      } else {
+        console.log('Received response from clientWorker.quitWorker');
+      }
+    });
+    serverWorker.quitWorker({}, (error, response) => {
+      if (error) {
+        console.log('Received error on serverWorker.quitWorker:', error);
+      } else {
+        console.log('Received response from serverWorker.quitWorker');
+      }
+    });
   });
 }
 

--- a/test/performance/worker_service_impl.js
+++ b/test/performance/worker_service_impl.js
@@ -41,7 +41,12 @@ module.exports = function WorkerServiceImpl(benchmark_impl, server) {
 
   this.quitWorker = function quitWorker(call, callback) {
     callback(null, {});
-    server.tryShutdown(function() {});
+    /* Due to https://github.com/nodejs/node/issues/42713, tryShutdown acts
+     * like forceShutdown on some Node versions. So, delay calling tryShutdown
+     * until after done handling this request. */
+    setTimeout(() => {
+      server.tryShutdown(function() {});
+    }, 10);
   };
 
   this.runClient = function runClient(call) {


### PR DESCRIPTION
This error is probably the last thing keeping this benchmark from working with our benchmarking suite.