### PR TITLE
grpc-js/grpc-js-xds: Update to 1.9.0, and update READMEs

### DIFF
--- a/packages/grpc-js-xds/README.md
+++ b/packages/grpc-js-xds/README.md
@@ -1,6 +1,6 @@
 # @grpc/grpc-js xDS plugin
 
-This package provides support for the `xds://` URL scheme to the `@grpc/grpc-js` library. The latest version of this package is compatible with `@grpc/grpc-js` version 1.2.x.
+This package provides support for the `xds://` URL scheme to the `@grpc/grpc-js` library. The latest version of this package is compatible with `@grpc/grpc-js` version 1.9.x.
 
 ## Installation
 
@@ -30,3 +30,5 @@ const client = new MyServiceClient('xds:///example.com:123');
  - [Client Status Discovery Service](https://github.com/grpc/proposal/blob/master/A40-csds-support.md)
  - [Outlier Detection](https://github.com/grpc/proposal/blob/master/A50-xds-outlier-detection.md)
  - [xDS Retry Support](https://github.com/grpc/proposal/blob/master/A44-xds-retry.md)
+ - [xDS Aggregate and Logical DNS Clusters](https://github.com/grpc/proposal/blob/master/A37-xds-aggregate-and-logical-dns-clusters.md)'
+ - [xDS Federation](https://github.com/grpc/proposal/blob/master/A47-xds-federation.md) (Currently experimental, enabled by environment variable `GRPC_EXPERIMENTAL_XDS_FEDERATION`)

--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {
@@ -49,7 +49,7 @@
     "vscode-uri": "^3.0.7"
   },
   "peerDependencies": {
-    "@grpc/grpc-js": "~1.8.0"
+    "@grpc/grpc-js": "~1.9.0"
   },
   "engines": {
     "node": ">=10.10.0"

--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -65,6 +65,7 @@ Many channel arguments supported in `grpc` are not supported in `@grpc/grpc-js`.
   - `grpc.service_config_disable_resolution`
   - `grpc.client_idle_timeout_ms`
   - `grpc-node.max_session_memory`
+  - `grpc-node.tls_enable_trace`
   - `channelOverride`
   - `channelFactoryOverride`
 

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.8.21",
+  "version": "1.9.0",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
It looks like line 3 of grpc-js-xds/README.md wasn't updated for a while, but it's probably not worth going back and changing it.