### PR TITLE
grpc-js: Improve formatting of channelz logs for grpcdebug

### DIFF
--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -477,9 +477,7 @@ export class InternalChannel {
     if (this.channelzEnabled) {
       this.channelzTrace.addTrace(
         'CT_INFO',
-        ConnectivityState[this.connectivityState] +
-          ' -> ' +
-          ConnectivityState[newState]
+        'Connectivity state change to ' + ConnectivityState[newState]
       );
     }
     this.connectivityState = newState;

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -277,9 +277,7 @@ export class Subchannel {
     if (this.channelzEnabled) {
       this.channelzTrace.addTrace(
         'CT_INFO',
-        ConnectivityState[this.connectivityState] +
-          ' -> ' +
-          ConnectivityState[newState]
+        'Connectivity state change to ' + ConnectivityState[newState]
       );
     }
     const previousState = this.connectivityState;


### PR DESCRIPTION
The channelz output from `grpcdebug` in https://github.com/grpc/grpc-node/issues/2502#issuecomment-1660777601 shows logs that look like `CONNECTING -\u003e READY`, which is supposed to be `CONNECTING -> READY`. To make that look better, this change uses a format that is more similar to logs shown in examples in the `grpcdebug` documentation. So, that log line would now say `Connectivity state change to READY`.