### PR TITLE
grpc-js: Return LB policy configs from resolvers in JSON form

### DIFF
--- a/packages/grpc-js-xds/src/duration.ts
+++ b/packages/grpc-js-xds/src/duration.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { experimental } from '@grpc/grpc-js';
+import { Duration__Output } from './generated/google/protobuf/Duration';
+import Duration = experimental.Duration;
+
+/**
+ * Convert a Duration protobuf message object to a Duration object as used in
+ * the ServiceConfig definition. The difference is that the protobuf message
+ * defines seconds as a long, which is represented as a string in JavaScript,
+ * and the one used in the service config defines it as a number.
+ * @param duration
+ */
+export function protoDurationToDuration(duration: Duration__Output): Duration {
+  return {
+    seconds: Number.parseInt(duration.seconds),
+    nanos: duration.nanos
+  };
+}

--- a/packages/grpc-js-xds/src/resolver-xds.ts
+++ b/packages/grpc-js-xds/src/resolver-xds.ts
@@ -19,23 +19,19 @@ import * as protoLoader from '@grpc/proto-loader';
 import { RE2 } from 're2-wasm';
 
 import { getSingletonXdsClient, Watcher, XdsClient } from './xds-client';
-import { StatusObject, status, logVerbosity, Metadata, experimental, ChannelOptions } from '@grpc/grpc-js';
+import { StatusObject, status, logVerbosity, Metadata, experimental, ChannelOptions, ServiceConfig, LoadBalancingConfig, RetryPolicy } from '@grpc/grpc-js';
 import Resolver = experimental.Resolver;
 import GrpcUri = experimental.GrpcUri;
 import ResolverListener = experimental.ResolverListener;
 import uriToString = experimental.uriToString;
-import ServiceConfig = experimental.ServiceConfig;
 import registerResolver = experimental.registerResolver;
 import { Listener__Output } from './generated/envoy/config/listener/v3/Listener';
 import { RouteConfiguration__Output } from './generated/envoy/config/route/v3/RouteConfiguration';
 import { HttpConnectionManager__Output } from './generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpConnectionManager';
-import { CdsLoadBalancingConfig } from './load-balancer-cds';
 import { VirtualHost__Output } from './generated/envoy/config/route/v3/VirtualHost';
 import { RouteMatch__Output } from './generated/envoy/config/route/v3/RouteMatch';
 import { HeaderMatcher__Output } from './generated/envoy/config/route/v3/HeaderMatcher';
 import ConfigSelector = experimental.ConfigSelector;
-import LoadBalancingConfig = experimental.LoadBalancingConfig;
-import { XdsClusterManagerLoadBalancingConfig } from './load-balancer-xds-cluster-manager';
 import { ContainsValueMatcher, ExactValueMatcher, FullMatcher, HeaderMatcher, Matcher, PathExactValueMatcher, PathPrefixValueMatcher, PathSafeRegexValueMatcher, PrefixValueMatcher, PresentValueMatcher, RangeValueMatcher, RejectValueMatcher, SafeRegexValueMatcher, SuffixValueMatcher, ValueMatcher } from './matcher';
 import { envoyFractionToFraction, Fraction } from "./fraction";
 import { RouteAction, SingleClusterRouteAction, WeightedCluster, WeightedClusterRouteAction } from './route-action';
@@ -46,10 +42,10 @@ import { createHttpFilter, HttpFilterConfig, parseOverrideFilterConfig, parseTop
 import { EXPERIMENTAL_FAULT_INJECTION, EXPERIMENTAL_FEDERATION, EXPERIMENTAL_RETRY } from './environment';
 import Filter = experimental.Filter;
 import FilterFactory = experimental.FilterFactory;
-import RetryPolicy = experimental.RetryPolicy;
 import { BootstrapInfo, loadBootstrapInfo, validateBootstrapConfig } from './xds-bootstrap';
 import { ListenerResourceType } from './xds-resource-type/listener-resource-type';
 import { RouteConfigurationResourceType } from './xds-resource-type/route-config-resource-type';
+import { protoDurationToDuration } from './duration';
 
 const TRACER_NAME = 'xds_resolver';
 
@@ -208,20 +204,6 @@ function getPredicateForMatcher(routeMatch: RouteMatch__Output): Matcher {
   return new FullMatcher(pathMatcher, headerMatchers, runtimeFraction);
 }
 
-/**
- * Convert a Duration protobuf message object to a Duration object as used in
- * the ServiceConfig definition. The difference is that the protobuf message
- * defines seconds as a long, which is represented as a string in JavaScript,
- * and the one used in the service config defines it as a number.
- * @param duration 
- */
-function protoDurationToDuration(duration: Duration__Output): Duration {
-  return {
-    seconds: Number.parseInt(duration.seconds),
-    nanos: duration.nanos
-  }
-}
-
 function protoDurationToSecondsString(duration: Duration__Output): string {
   return `${duration.seconds + duration.nanos / 1_000_000_000}s`;
 }
@@ -235,7 +217,7 @@ function getDefaultRetryMaxInterval(baseInterval: string): string {
 /**
  * Encode a text string as a valid path of a URI, as specified in RFC-3986 section 3.3
  * @param uriPath A value representing an unencoded URI path
- * @returns 
+ * @returns
  */
 function encodeURIPath(uriPath: string): string {
   return uriPath.replace(/[^A-Za-z0-9._~!$&^()*+,;=/-]/g, substring => encodeURIComponent(substring));
@@ -447,7 +429,7 @@ class XdsResolver implements Resolver {
           }
         }
       }
-      let retryPolicy: RetryPolicy | undefined = undefined; 
+      let retryPolicy: RetryPolicy | undefined = undefined;
       if (EXPERIMENTAL_RETRY) {
         const retryConfig = route.route!.retry_policy ?? virtualHost.retry_policy;
         if (retryConfig) {
@@ -458,10 +440,10 @@ class XdsResolver implements Resolver {
             }
           }
           if (retryableStatusCodes.length > 0) {
-            const baseInterval = retryConfig.retry_back_off?.base_interval ? 
-              protoDurationToSecondsString(retryConfig.retry_back_off.base_interval) : 
+            const baseInterval = retryConfig.retry_back_off?.base_interval ?
+              protoDurationToSecondsString(retryConfig.retry_back_off.base_interval) :
               DEFAULT_RETRY_BASE_INTERVAL;
-            const maxInterval = retryConfig.retry_back_off?.max_interval ? 
+            const maxInterval = retryConfig.retry_back_off?.max_interval ?
               protoDurationToSecondsString(retryConfig.retry_back_off.max_interval) :
               getDefaultRetryMaxInterval(baseInterval);
             retryPolicy = {
@@ -602,11 +584,11 @@ class XdsResolver implements Resolver {
       trace(matcher.toString());
       trace('=> ' + action.toString());
     }
-    const clusterConfigMap = new Map<string, {child_policy: LoadBalancingConfig[]}>();
+    const clusterConfigMap: {[key: string]: {child_policy: LoadBalancingConfig[]}} = {};
     for (const clusterName of this.clusterRefcounts.keys()) {
-      clusterConfigMap.set(clusterName, {child_policy: [new CdsLoadBalancingConfig(clusterName)]});
+      clusterConfigMap[clusterName] = {child_policy: [{cds: {cluster: clusterName}}]};
     }
-    const lbPolicyConfig = new XdsClusterManagerLoadBalancingConfig(clusterConfigMap);
+    const lbPolicyConfig = {xds_cluster_manager: {children: clusterConfigMap}};
     const serviceConfig: ServiceConfig = {
       methodConfig: [],
       loadBalancingConfig: [lbPolicyConfig]
@@ -634,7 +616,7 @@ class XdsResolver implements Resolver {
         this.isLdsWatcherActive = true;
 
       } catch (e) {
-        this.reportResolutionError(e.message);
+        this.reportResolutionError((e as Error).message);
       }
     }
   }
@@ -647,7 +629,7 @@ class XdsResolver implements Resolver {
         try {
           this.bootstrapInfo = loadBootstrapInfo();
         } catch (e) {
-          this.reportResolutionError(e.message);
+          this.reportResolutionError((e as Error).message);
         }
         this.startResolution();
       }

--- a/packages/grpc-js-xds/src/route-action.ts
+++ b/packages/grpc-js-xds/src/route-action.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import { experimental } from '@grpc/grpc-js';
+import { MethodConfig, experimental } from '@grpc/grpc-js';
 import Duration = experimental.Duration;
 import Filter = experimental.Filter;
 import FilterFactory = experimental.FilterFactory;
-import MethodConfig = experimental.MethodConfig;
 
 export interface ClusterResult {
   name: string;

--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -8,16 +8,15 @@ export {
 } from './resolver';
 export { GrpcUri, uriToString } from './uri-parser';
 export { Duration, durationToMs } from './duration';
-export { ServiceConfig, MethodConfig, RetryPolicy } from './service-config';
 export { BackoffTimeout } from './backoff-timeout';
 export {
   LoadBalancer,
-  LoadBalancingConfig,
+  TypedLoadBalancingConfig,
   ChannelControlHelper,
   createChildChannelControlHelper,
   registerLoadBalancerType,
-  getFirstUsableConfig,
-  validateLoadBalancingConfig,
+  selectLbConfigFromList,
+  parseLoadBalancingConfig
 } from './load-balancer';
 export {
   SubchannelAddress,
@@ -42,7 +41,7 @@ export {
   ConnectivityStateListener,
 } from './subchannel-interface';
 export {
-  OutlierDetectionLoadBalancingConfig,
+  OutlierDetectionRawConfig,
   SuccessRateEjectionConfig,
   FailurePercentageEjectionConfig,
 } from './load-balancer-outlier-detection';

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -261,6 +261,8 @@ export { getChannelzServiceDefinition, getChannelzHandlers } from './channelz';
 
 export { addAdminServicesToServer } from './admin';
 
+export { ServiceConfig, LoadBalancingConfig, MethodConfig, RetryPolicy } from './service-config';
+
 import * as experimental from './experimental';
 export { experimental };
 

--- a/packages/grpc-js/src/load-balancer-child-handler.ts
+++ b/packages/grpc-js/src/load-balancer-child-handler.ts
@@ -18,7 +18,7 @@
 import {
   LoadBalancer,
   ChannelControlHelper,
-  LoadBalancingConfig,
+  TypedLoadBalancingConfig,
   createLoadBalancer,
 } from './load-balancer';
 import { SubchannelAddress } from './subchannel-address';
@@ -33,7 +33,7 @@ const TYPE_NAME = 'child_load_balancer_helper';
 export class ChildLoadBalancerHandler implements LoadBalancer {
   private currentChild: LoadBalancer | null = null;
   private pendingChild: LoadBalancer | null = null;
-  private latestConfig: LoadBalancingConfig | null = null;
+  private latestConfig: TypedLoadBalancingConfig | null = null;
 
   private ChildPolicyHelper = class {
     private child: LoadBalancer | null = null;
@@ -87,8 +87,8 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
   constructor(private readonly channelControlHelper: ChannelControlHelper) {}
 
   protected configUpdateRequiresNewPolicyInstance(
-    oldConfig: LoadBalancingConfig,
-    newConfig: LoadBalancingConfig
+    oldConfig: TypedLoadBalancingConfig,
+    newConfig: TypedLoadBalancingConfig
   ): boolean {
     return oldConfig.getLoadBalancerName() !== newConfig.getLoadBalancerName();
   }
@@ -101,7 +101,7 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
    */
   updateAddressList(
     addressList: SubchannelAddress[],
-    lbConfig: LoadBalancingConfig,
+    lbConfig: TypedLoadBalancingConfig,
     attributes: { [key: string]: unknown }
   ): void {
     let childToUpdate: LoadBalancer;

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -18,7 +18,7 @@
 import {
   LoadBalancer,
   ChannelControlHelper,
-  LoadBalancingConfig,
+  TypedLoadBalancingConfig,
   registerDefaultLoadBalancerType,
   registerLoadBalancerType,
 } from './load-balancer';
@@ -53,7 +53,7 @@ const TYPE_NAME = 'pick_first';
  */
 const CONNECTION_DELAY_INTERVAL_MS = 250;
 
-export class PickFirstLoadBalancingConfig implements LoadBalancingConfig {
+export class PickFirstLoadBalancingConfig implements TypedLoadBalancingConfig {
   constructor(private readonly shuffleAddressList: boolean) {}
 
   getLoadBalancerName(): string {
@@ -374,7 +374,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
 
   updateAddressList(
     addressList: SubchannelAddress[],
-    lbConfig: LoadBalancingConfig
+    lbConfig: TypedLoadBalancingConfig
   ): void {
     if (!(lbConfig instanceof PickFirstLoadBalancingConfig)) {
       return;

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -18,7 +18,7 @@
 import {
   LoadBalancer,
   ChannelControlHelper,
-  LoadBalancingConfig,
+  TypedLoadBalancingConfig,
   registerLoadBalancerType,
 } from './load-balancer';
 import { ConnectivityState } from './connectivity-state';
@@ -49,7 +49,7 @@ function trace(text: string): void {
 
 const TYPE_NAME = 'round_robin';
 
-class RoundRobinLoadBalancingConfig implements LoadBalancingConfig {
+class RoundRobinLoadBalancingConfig implements TypedLoadBalancingConfig {
   getLoadBalancerName(): string {
     return TYPE_NAME;
   }
@@ -192,7 +192,7 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
 
   updateAddressList(
     addressList: SubchannelAddress[],
-    lbConfig: LoadBalancingConfig
+    lbConfig: TypedLoadBalancingConfig
   ): void {
     this.resetSubchannelList();
     trace(

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -18,8 +18,8 @@
 import {
   ChannelControlHelper,
   LoadBalancer,
-  LoadBalancingConfig,
-  getFirstUsableConfig,
+  TypedLoadBalancingConfig,
+  selectLbConfigFromList,
 } from './load-balancer';
 import { ServiceConfig, validateServiceConfig } from './service-config';
 import { ConnectivityState } from './connectivity-state';
@@ -211,7 +211,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
           }
           const workingConfigList =
             workingServiceConfig?.loadBalancingConfig ?? [];
-          const loadBalancingConfig = getFirstUsableConfig(
+          const loadBalancingConfig = selectLbConfigFromList(
             workingConfigList,
             true
           );
@@ -308,7 +308,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
 
   updateAddressList(
     addressList: SubchannelAddress[],
-    lbConfig: LoadBalancingConfig | null
+    lbConfig: TypedLoadBalancingConfig | null
   ): never {
     throw new Error('updateAddressList not supported on ResolvingLoadBalancer');
   }

--- a/packages/grpc-js/src/service-config.ts
+++ b/packages/grpc-js/src/service-config.ts
@@ -29,10 +29,6 @@
 import * as os from 'os';
 import { Status } from './constants';
 import { Duration } from './duration';
-import {
-  LoadBalancingConfig,
-  validateLoadBalancingConfig,
-} from './load-balancer';
 
 export interface MethodConfigName {
   service: string;
@@ -66,6 +62,10 @@ export interface MethodConfig {
 export interface RetryThrottling {
   maxTokens: number;
   tokenRatio: number;
+}
+
+export interface LoadBalancingConfig {
+  [key: string]: object;
 }
 
 export interface ServiceConfig {
@@ -338,6 +338,22 @@ export function validateRetryThrottling(obj: any): RetryThrottling {
   };
 }
 
+function validateLoadBalancingConfig(obj: any): LoadBalancingConfig {
+  if (!(typeof obj === 'object' && obj !== null)) {
+    throw new Error(`Invalid loadBalancingConfig: unexpected type ${typeof obj}`);
+  }
+  const keys = Object.keys(obj);
+  if (keys.length > 1) {
+    throw new Error(`Invalid loadBalancingConfig: unexpected multiple keys ${keys}`);
+  }
+  if (keys.length === 0) {
+    throw new Error('Invalid loadBalancingConfig: load balancing policy name required');
+  }
+  return {
+    [keys[0]]: obj[keys[0]]
+  };
+}
+
 export function validateServiceConfig(obj: any): ServiceConfig {
   const result: ServiceConfig = {
     loadBalancingConfig: [],
@@ -353,6 +369,7 @@ export function validateServiceConfig(obj: any): ServiceConfig {
   if ('loadBalancingConfig' in obj) {
     if (Array.isArray(obj.loadBalancingConfig)) {
       for (const config of obj.loadBalancingConfig) {
+
         result.loadBalancingConfig.push(validateLoadBalancingConfig(config));
       }
     } else {

--- a/packages/grpc-js/test/test-deadline.ts
+++ b/packages/grpc-js/test/test-deadline.ts
@@ -18,12 +18,10 @@
 import * as assert from 'assert';
 
 import * as grpc from '../src';
-import { experimental } from '../src';
 import { ServiceClient, ServiceClientConstructor } from '../src/make-client';
 import { loadProtoFile } from './common';
-import ServiceConfig = experimental.ServiceConfig;
 
-const TIMEOUT_SERVICE_CONFIG: ServiceConfig = {
+const TIMEOUT_SERVICE_CONFIG: grpc.ServiceConfig = {
   loadBalancingConfig: [],
   methodConfig: [
     {


### PR DESCRIPTION
More generally, the principle here is that LB policy configs should be created and passed around as plain objects until they need to be passed to an LB policy, at which time they are parsed into a typed object.

In addition, an LB policy config for a non-leaf/petiole policy has a list of possible configs for each child policy, and the first usable config in the list is used. Prior to this change, that selection took place at child policy creation time. Now, it takes place at LB policy config parse time, recursively.

The purpose of this PR is to make it easier to implement [custom LB policies](https://github.com/grpc/proposal/blob/master/A52-xds-custom-lb-policies.md). Specifically, that spec requires generating arbitrary LB policy configs from `Struct` messages.

API changes:

 - The interface `ServiceConfig` and interfaces for its members `MethodConfig`, `LoadBalancingConfig`, and `RetryPolicy` have been moved out of the `experimental` namespace, into the stable public API.
 - The `LoadBalancingConfig` type now refers to simple raw objects instead of class instances.
 - `experimental.getFirstUsableConfig`, `experimental.validateLoadBalancingConfig`, and `experimental.OutlierDetectionLoadBalancingConfig` have been removed.
 - `experimental.selectLbConfigFromList`, `experimental.parseLoadBalancingConfig`, and `experimental.OutlierDetectionRawConfig` have been added.