### PR TITLE
grpc-js: Add null check in pick_first array access

### DIFF
--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -306,7 +306,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
           this.children[subchannelIndex].subchannel.getAddress()
       );
       process.nextTick(() => {
-        this.children[subchannelIndex].subchannel.startConnecting();
+        this.children[subchannelIndex]?.subchannel.startConnecting();
       });
     }
     this.connectionDelayTimeout = setTimeout(() => {


### PR DESCRIPTION
This addresses a possible cause of #2537. TypeScript doesn't require this check because the type system does not account for array out-of-bounds access.