### PR TITLE
grpc-js-xds: Fix a typo in xds_cluster_impl parsing code

### DIFF
--- a/packages/grpc-js-xds/src/load-balancer-xds-cluster-impl.ts
+++ b/packages/grpc-js-xds/src/load-balancer-xds-cluster-impl.ts
@@ -115,7 +115,7 @@ class XdsClusterImplLoadBalancingConfig implements TypedLoadBalancingConfig {
     if ('eds_service_name' in obj && !(obj.eds_service_name === undefined || typeof obj.eds_service_name === 'string')) {
       throw new Error('xds_cluster_impl config eds_service_name field must be a string if provided');
     }
-    if ('max_concurrent_requests' in obj && (!obj.max_concurrent_requests === undefined || typeof obj.max_concurrent_requests === 'number')) {
+    if ('max_concurrent_requests' in obj && !(obj.max_concurrent_requests === undefined || typeof obj.max_concurrent_requests === 'number')) {
       throw new Error('xds_cluster_impl config max_concurrent_requests must be a number if provided');
     }
     if (!('drop_categories' in obj && Array.isArray(obj.drop_categories))) {

--- a/packages/grpc-js-xds/test/framework.ts
+++ b/packages/grpc-js-xds/test/framework.ts
@@ -84,7 +84,15 @@ export class FakeEdsCluster implements FakeCluster {
       type: 'EDS',
       eds_cluster_config: {eds_config: {ads: {}}, service_name: this.endpointName},
       lb_policy: 'ROUND_ROBIN',
-      lrs_server: {self: {}}
+      lrs_server: {self: {}},
+      circuit_breakers: {
+        thresholds: [
+          {
+            priority: 'DEFAULT',
+            max_requests: {value: 1000}
+          }
+        ]
+      }
     }
   }
 


### PR DESCRIPTION
The circuit breakers configs were not tested before.