### PR TITLE
grpc-js: Switch Timer type to Timeout

### DIFF
--- a/packages/grpc-js/src/backoff-timeout.ts
+++ b/packages/grpc-js/src/backoff-timeout.ts
@@ -63,7 +63,7 @@ export class BackoffTimeout {
    * to an object representing a timer that has ended, but it can still be
    * interacted with without error.
    */
-  private timerId: NodeJS.Timer;
+  private timerId: NodeJS.Timeout;
   /**
    * Indicates whether the timer is currently running.
    */

--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -166,7 +166,7 @@ export class InternalChannel {
    * the invariant is that callRefTimer is reffed if and only if pickQueue
    * is non-empty.
    */
-  private readonly callRefTimer: NodeJS.Timer;
+  private readonly callRefTimer: NodeJS.Timeout;
   private configSelector: ConfigSelector | null = null;
   /**
    * This is the error from the name resolver if it failed most recently. It
@@ -182,7 +182,7 @@ export class InternalChannel {
     new Set();
 
   private callCount = 0;
-  private idleTimer: NodeJS.Timer | null = null;
+  private idleTimer: NodeJS.Timeout | null = null;
   private readonly idleTimeoutMs: number;
 
   // Channelz info

--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -507,7 +507,7 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
   private childBalancer: ChildLoadBalancerHandler;
   private addressMap: Map<string, MapEntry> = new Map<string, MapEntry>();
   private latestConfig: OutlierDetectionLoadBalancingConfig | null = null;
-  private ejectionTimer: NodeJS.Timer;
+  private ejectionTimer: NodeJS.Timeout;
   private timerStartTime: Date | null = null;
 
   constructor(channelControlHelper: ChannelControlHelper) {

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -96,7 +96,7 @@ class DnsResolver implements Resolver {
   private defaultResolutionError: StatusObject;
   private backoff: BackoffTimeout;
   private continueResolving = false;
-  private nextResolutionTimer: NodeJS.Timer;
+  private nextResolutionTimer: NodeJS.Timeout;
   private isNextResolutionTimerRunning = false;
   private isServiceConfigEnabled = true;
   constructor(

--- a/packages/grpc-js/src/resolving-call.ts
+++ b/packages/grpc-js/src/resolving-call.ts
@@ -53,7 +53,7 @@ export class ResolvingCall implements Call {
   private deadline: Deadline;
   private host: string;
   private statusWatchers: ((status: StatusObject) => void)[] = [];
-  private deadlineTimer: NodeJS.Timer = setTimeout(() => {}, 0);
+  private deadlineTimer: NodeJS.Timeout = setTimeout(() => {}, 0);
   private filterStack: FilterStack | null = null;
 
   constructor(

--- a/packages/grpc-js/src/retrying-call.ts
+++ b/packages/grpc-js/src/retrying-call.ts
@@ -194,7 +194,7 @@ export class RetryingCall implements Call {
    * Number of attempts so far
    */
   private attempts = 0;
-  private hedgingTimer: NodeJS.Timer | null = null;
+  private hedgingTimer: NodeJS.Timeout | null = null;
   private committedCallIndex: number | null = null;
   private initialRetryBackoffSec = 0;
   private nextRetryBackoffSec = 0;

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -408,7 +408,7 @@ export class Http2ServerCallStream<
   ResponseType
 > extends EventEmitter {
   cancelled = false;
-  deadlineTimer: NodeJS.Timer | null = null;
+  deadlineTimer: NodeJS.Timeout | null = null;
   private statusSent = false;
   private deadline: Deadline = Infinity;
   private wantTrailers = false;

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -1079,8 +1079,8 @@ export class Server {
         );
         this.sessionChildrenTracker.refChild(channelzRef);
       }
-      let connectionAgeTimer: NodeJS.Timer | null = null;
-      let connectionAgeGraceTimer: NodeJS.Timer | null = null;
+      let connectionAgeTimer: NodeJS.Timeout | null = null;
+      let connectionAgeGraceTimer: NodeJS.Timeout | null = null;
       let sessionClosedByServer = false;
       if (this.maxConnectionAgeMs !== UNLIMITED_CONNECTION_AGE_MS) {
         // Apply a random jitter within a +/-10% range
@@ -1115,7 +1115,7 @@ export class Server {
           }
         }, this.maxConnectionAgeMs + jitter).unref?.();
       }
-      const keeapliveTimeTimer: NodeJS.Timer | null = setInterval(() => {
+      const keeapliveTimeTimer: NodeJS.Timeout | null = setInterval(() => {
         const timeoutTImer = setTimeout(() => {
           sessionClosedByServer = true;
           if (this.channelzEnabled) {

--- a/packages/grpc-js/src/subchannel-pool.ts
+++ b/packages/grpc-js/src/subchannel-pool.ts
@@ -45,7 +45,7 @@ export class SubchannelPool {
   /**
    * A timer of a task performing a periodic subchannel cleanup.
    */
-  private cleanupTimer: NodeJS.Timer | null = null;
+  private cleanupTimer: NodeJS.Timeout | null = null;
 
   /**
    * A pool of subchannels use for making connections. Subchannels with the

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -108,7 +108,7 @@ class Http2Transport implements Transport {
   /**
    * Timer reference for timeout that indicates when to send the next ping
    */
-  private keepaliveTimerId: NodeJS.Timer | null = null;
+  private keepaliveTimerId: NodeJS.Timeout | null = null;
   /**
    * Indicates that the keepalive timer ran out while there were no active
    * calls, and a ping should be sent the next time a call starts.
@@ -117,7 +117,7 @@ class Http2Transport implements Transport {
   /**
    * Timer reference tracking when the most recent ping will be considered lost
    */
-  private keepaliveTimeoutId: NodeJS.Timer | null = null;
+  private keepaliveTimeoutId: NodeJS.Timeout | null = null;
   /**
    * Indicates whether keepalive pings should be sent without any active calls
    */


### PR DESCRIPTION
Our build got broken by DefinitelyTyped/DefinitelyTyped#66176. It turns out that `Timer` is an old compatibility type and `Timeout` is the actively used type, so this switch should avoid future breakages.