### PR TITLE
grpc-js: Fix method config name handling in service configs

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/service-config.ts
+++ b/packages/grpc-js/src/service-config.ts
@@ -35,7 +35,7 @@ import {
 } from './load-balancer';
 
 export interface MethodConfigName {
-  service: string;
+  service?: string;
   method?: string;
 }
 
@@ -95,20 +95,36 @@ const DURATION_REGEX = /^\d+(\.\d{1,9})?s$/;
 const CLIENT_LANGUAGE_STRING = 'node';
 
 function validateName(obj: any): MethodConfigName {
-  if (!('service' in obj) || typeof obj.service !== 'string') {
-    throw new Error('Invalid method config name: invalid service');
-  }
-  const result: MethodConfigName = {
-    service: obj.service,
-  };
-  if ('method' in obj) {
-    if (typeof obj.method === 'string') {
-      result.method = obj.method;
-    } else {
-      throw new Error('Invalid method config name: invalid method');
+  // In this context, and unset field and '' are considered the same
+  if ('service' in obj && obj.service !== '') {
+    if (typeof obj.service !== 'string') {
+      throw new Error(
+        `Invalid method config name: invalid service: expected type string, got ${typeof obj.service}`
+      );
     }
+    if ('method' in obj && obj.method !== '') {
+      if (typeof obj.method !== 'string') {
+        throw new Error(
+          `Invalid method config name: invalid method: expected type string, got ${typeof obj.service}`
+        );
+      }
+      return {
+        service: obj.service,
+        method: obj.method,
+      };
+    } else {
+      return {
+        service: obj.service,
+      };
+    }
+  } else {
+    if ('method' in obj && obj.method !== undefined) {
+      throw new Error(
+        `Invalid method config name: method set with empty or unset service`
+      );
+    }
+    return {};
   }
-  return result;
 }
 
 function validateRetryPolicy(obj: any): RetryPolicy {


### PR DESCRIPTION
Issue #2549 made me realize that the code that handles method config names doesn't match the specification in [service_config.proto](https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto), so this fixes that. There are two related changes here:

 1. The service config parser now accepts a method config name with an unset `service` field, and coalesces empty string to unset for both the `service` and `method` fields.
 2. The code for selecting a method config by name now prioritizes the most specifically matching config, instead of the first one in the list that matches at all.