### PR TITLE
proto-loader: Bump version to 0.7.9

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.7.9-pre.1",
+  "version": "0.7.9",
   "author": "Google Inc.",
   "contributors": [
     {


### PR DESCRIPTION
We previously updated to a prerelease version in #2526 to test the changes in #2504. The change seems to be OK, so we should be fine to publish this.