### PR TITLE
grpc-js: Make pick_first the universal leaf policy, plus related changes

### DIFF
--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -34,7 +34,7 @@ import TypedLoadBalancingConfig = grpc.experimental.TypedLoadBalancingConfig;
 import LoadBalancer = grpc.experimental.LoadBalancer;
 import ChannelControlHelper = grpc.experimental.ChannelControlHelper;
 import ChildLoadBalancerHandler = grpc.experimental.ChildLoadBalancerHandler;
-import SubchannelAddress = grpc.experimental.SubchannelAddress;
+import Endpoint = grpc.experimental.Endpoint;
 import Picker = grpc.experimental.Picker;
 import PickArgs = grpc.experimental.PickArgs;
 import PickResult = grpc.experimental.PickResult;
@@ -99,12 +99,12 @@ class RpcBehaviorLoadBalancer implements LoadBalancer {
     });
     this.child = new ChildLoadBalancerHandler(childChannelControlHelper);
   }
-  updateAddressList(addressList: SubchannelAddress[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
+  updateAddressList(endpointList: Endpoint[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
     if (!(lbConfig instanceof RpcBehaviorLoadBalancingConfig)) {
       return;
     }
     this.latestConfig = lbConfig;
-    this.child.updateAddressList(addressList, RPC_BEHAVIOR_CHILD_CONFIG, attributes);
+    this.child.updateAddressList(endpointList, RPC_BEHAVIOR_CHILD_CONFIG, attributes);
   }
   exitIdle(): void {
     this.child.exitIdle();

--- a/packages/grpc-js-xds/src/load-balancer-cds.ts
+++ b/packages/grpc-js-xds/src/load-balancer-cds.ts
@@ -18,23 +18,16 @@
 import { connectivityState, status, Metadata, logVerbosity, experimental, LoadBalancingConfig } from '@grpc/grpc-js';
 import { getSingletonXdsClient, Watcher, XdsClient } from './xds-client';
 import { Cluster__Output } from './generated/envoy/config/cluster/v3/Cluster';
-import SubchannelAddress = experimental.SubchannelAddress;
+import Endpoint = experimental.Endpoint;
 import UnavailablePicker = experimental.UnavailablePicker;
 import ChildLoadBalancerHandler = experimental.ChildLoadBalancerHandler;
 import LoadBalancer = experimental.LoadBalancer;
 import ChannelControlHelper = experimental.ChannelControlHelper;
 import registerLoadBalancerType = experimental.registerLoadBalancerType;
 import TypedLoadBalancingConfig = experimental.TypedLoadBalancingConfig;
-import SuccessRateEjectionConfig = experimental.SuccessRateEjectionConfig;
-import FailurePercentageEjectionConfig = experimental.FailurePercentageEjectionConfig;
 import QueuePicker = experimental.QueuePicker;
-import OutlierDetectionRawConfig = experimental.OutlierDetectionRawConfig;
 import parseLoadBalancingConfig = experimental.parseLoadBalancingConfig;
-import { OutlierDetection__Output } from './generated/envoy/config/cluster/v3/OutlierDetection';
-import { Duration__Output } from './generated/google/protobuf/Duration';
-import { EXPERIMENTAL_OUTLIER_DETECTION } from './environment';
 import { DiscoveryMechanism, XdsClusterResolverChildPolicyHandler } from './load-balancer-xds-cluster-resolver';
-import { CLUSTER_CONFIG_TYPE_URL, decodeSingleResource } from './resources';
 import { CdsUpdate, ClusterResourceType } from './xds-resource-type/cluster-resource-type';
 
 const TRACER_NAME = 'cds_balancer';
@@ -258,7 +251,7 @@ export class CdsLoadBalancer implements LoadBalancer {
   }
 
   updateAddressList(
-    addressList: SubchannelAddress[],
+    endpointList: Endpoint[],
     lbConfig: TypedLoadBalancingConfig,
     attributes: { [key: string]: unknown }
   ): void {

--- a/packages/grpc-js-xds/src/load-balancer-xds-cluster-manager.ts
+++ b/packages/grpc-js-xds/src/load-balancer-xds-cluster-manager.ts
@@ -25,7 +25,7 @@ import PickArgs = experimental.PickArgs;
 import PickResultType = experimental.PickResultType;
 import UnavailablePicker = experimental.UnavailablePicker;
 import QueuePicker = experimental.QueuePicker;
-import SubchannelAddress = experimental.SubchannelAddress;
+import Endpoint = experimental.Endpoint;
 import ChildLoadBalancerHandler = experimental.ChildLoadBalancerHandler;
 import ChannelControlHelper = experimental.ChannelControlHelper;
 import selectLbConfigFromList = experimental.selectLbConfigFromList;
@@ -111,7 +111,7 @@ class XdsClusterManagerPicker implements Picker {
 }
 
 interface XdsClusterManagerChild {
-  updateAddressList(addressList: SubchannelAddress[], childConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void;
+  updateAddressList(endpointList: Endpoint[], childConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void;
   exitIdle(): void;
   resetBackoff(): void;
   destroy(): void;
@@ -142,8 +142,8 @@ class XdsClusterManager implements LoadBalancer {
       this.picker = picker;
       this.parent.maybeUpdateState();
     }
-    updateAddressList(addressList: SubchannelAddress[], childConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
-      this.childBalancer.updateAddressList(addressList, childConfig, attributes);
+    updateAddressList(endpointList: Endpoint[], childConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
+      this.childBalancer.updateAddressList(endpointList, childConfig, attributes);
     }
     exitIdle(): void {
       this.childBalancer.exitIdle();
@@ -235,7 +235,7 @@ class XdsClusterManager implements LoadBalancer {
     this.channelControlHelper.updateState(connectivityState, picker);
   }
 
-  updateAddressList(addressList: SubchannelAddress[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
+  updateAddressList(endpointList: Endpoint[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
     if (!(lbConfig instanceof XdsClusterManagerLoadBalancingConfig)) {
       // Reject a config of the wrong type
       trace('Discarding address list update with unrecognized config ' + JSON.stringify(lbConfig.toJsonObject(), undefined, 2));
@@ -259,7 +259,7 @@ class XdsClusterManager implements LoadBalancer {
     for (const [name, childConfig] of configChildren.entries()) {
       if (!this.children.has(name)) {
         const newChild = new this.XdsClusterManagerChildImpl(this, name);
-        newChild.updateAddressList(addressList, childConfig, attributes);
+        newChild.updateAddressList(endpointList, childConfig, attributes);
         this.children.set(name, newChild);
       }
     }

--- a/packages/grpc-js-xds/test/test-custom-lb-policies.ts
+++ b/packages/grpc-js-xds/test/test-custom-lb-policies.ts
@@ -30,7 +30,7 @@ import TypedLoadBalancingConfig = experimental.TypedLoadBalancingConfig;
 import LoadBalancer = experimental.LoadBalancer;
 import ChannelControlHelper = experimental.ChannelControlHelper;
 import ChildLoadBalancerHandler = experimental.ChildLoadBalancerHandler;
-import SubchannelAddress = experimental.SubchannelAddress;
+import Endpoint = experimental.Endpoint;
 import Picker = experimental.Picker;
 import PickArgs = experimental.PickArgs;
 import PickResult = experimental.PickResult;
@@ -94,12 +94,12 @@ class RpcBehaviorLoadBalancer implements LoadBalancer {
     });
     this.child = new ChildLoadBalancerHandler(childChannelControlHelper);
   }
-  updateAddressList(addressList: SubchannelAddress[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
+  updateAddressList(endpointList: Endpoint[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
     if (!(lbConfig instanceof RpcBehaviorLoadBalancingConfig)) {
       return;
     }
     this.latestConfig = lbConfig;
-    this.child.updateAddressList(addressList, RPC_BEHAVIOR_CHILD_CONFIG, attributes);
+    this.child.updateAddressList(endpointList, RPC_BEHAVIOR_CHILD_CONFIG, attributes);
   }
   exitIdle(): void {
     this.child.exitIdle();

--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -17,11 +17,15 @@ export {
   registerLoadBalancerType,
   selectLbConfigFromList,
   parseLoadBalancingConfig,
-  isLoadBalancerNameRegistered
+  isLoadBalancerNameRegistered,
 } from './load-balancer';
+export { LeafLoadBalancer } from './load-balancer-pick-first';
 export {
   SubchannelAddress,
   subchannelAddressToString,
+  Endpoint,
+  endpointToString,
+  endpointHasAddress,
 } from './subchannel-address';
 export { ChildLoadBalancerHandler } from './load-balancer-child-handler';
 export {

--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -44,6 +44,7 @@ export {
   SubchannelInterface,
   BaseSubchannelWrapper,
   ConnectivityStateListener,
+  HealthListener,
 } from './subchannel-interface';
 export {
   OutlierDetectionRawConfig,

--- a/packages/grpc-js/src/load-balancer-child-handler.ts
+++ b/packages/grpc-js/src/load-balancer-child-handler.ts
@@ -21,7 +21,7 @@ import {
   TypedLoadBalancingConfig,
   createLoadBalancer,
 } from './load-balancer';
-import { SubchannelAddress } from './subchannel-address';
+import { Endpoint, SubchannelAddress } from './subchannel-address';
 import { ChannelOptions } from './channel-options';
 import { ConnectivityState } from './connectivity-state';
 import { Picker } from './picker';
@@ -95,12 +95,12 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
 
   /**
    * Prerequisites: lbConfig !== null and lbConfig.name is registered
-   * @param addressList
+   * @param endpointList
    * @param lbConfig
    * @param attributes
    */
   updateAddressList(
-    addressList: SubchannelAddress[],
+    endpointList: Endpoint[],
     lbConfig: TypedLoadBalancingConfig,
     attributes: { [key: string]: unknown }
   ): void {
@@ -131,7 +131,7 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
       }
     }
     this.latestConfig = lbConfig;
-    childToUpdate.updateAddressList(addressList, lbConfig, attributes);
+    childToUpdate.updateAddressList(endpointList, lbConfig, attributes);
   }
   exitIdle(): void {
     if (this.currentChild) {

--- a/packages/grpc-js/src/load-balancer.ts
+++ b/packages/grpc-js/src/load-balancer.ts
@@ -16,7 +16,7 @@
  */
 
 import { ChannelOptions } from './channel-options';
-import { SubchannelAddress } from './subchannel-address';
+import { Endpoint, SubchannelAddress } from './subchannel-address';
 import { ConnectivityState } from './connectivity-state';
 import { Picker } from './picker';
 import { ChannelRef, SubchannelRef } from './channelz';
@@ -95,12 +95,12 @@ export interface LoadBalancer {
    * The load balancer will start establishing connections with the new list,
    * but will continue using any existing connections until the new connections
    * are established
-   * @param addressList The new list of addresses to connect to
+   * @param endpointList The new list of addresses to connect to
    * @param lbConfig The load balancing config object from the service config,
    *     if one was provided
    */
   updateAddressList(
-    addressList: SubchannelAddress[],
+    endpointList: Endpoint[],
     lbConfig: TypedLoadBalancingConfig,
     attributes: { [key: string]: unknown }
   ): void;
@@ -185,7 +185,9 @@ export function isLoadBalancerNameRegistered(typeName: string): boolean {
   return typeName in registeredLoadBalancerTypes;
 }
 
-export function parseLoadBalancingConfig(rawConfig: LoadBalancingConfig): TypedLoadBalancingConfig {
+export function parseLoadBalancingConfig(
+  rawConfig: LoadBalancingConfig
+): TypedLoadBalancingConfig {
   const keys = Object.keys(rawConfig);
   if (keys.length !== 1) {
     throw new Error(
@@ -210,7 +212,9 @@ export function getDefaultConfig() {
   if (!defaultLoadBalancerType) {
     throw new Error('No default load balancer type registered');
   }
-  return new registeredLoadBalancerTypes[defaultLoadBalancerType]!.LoadBalancingConfig();
+  return new registeredLoadBalancerTypes[
+    defaultLoadBalancerType
+  ]!.LoadBalancingConfig();
 }
 
 export function selectLbConfigFromList(
@@ -221,7 +225,11 @@ export function selectLbConfigFromList(
     try {
       return parseLoadBalancingConfig(config);
     } catch (e) {
-      log(LogVerbosity.DEBUG, 'Config parsing failed with error', (e as Error).message);
+      log(
+        LogVerbosity.DEBUG,
+        'Config parsing failed with error',
+        (e as Error).message
+      );
       continue;
     }
   }

--- a/packages/grpc-js/src/picker.ts
+++ b/packages/grpc-js/src/picker.ts
@@ -97,16 +97,13 @@ export interface Picker {
  */
 export class UnavailablePicker implements Picker {
   private status: StatusObject;
-  constructor(status?: StatusObject) {
-    if (status !== undefined) {
-      this.status = status;
-    } else {
-      this.status = {
-        code: Status.UNAVAILABLE,
-        details: 'No connection established',
-        metadata: new Metadata(),
-      };
-    }
+  constructor(status?: Partial<StatusObject>) {
+    this.status = {
+      code: Status.UNAVAILABLE,
+      details: 'No connection established',
+      metadata: new Metadata(),
+      ...status,
+    };
   }
   pick(pickArgs: PickArgs): TransientFailurePickResult {
     return {

--- a/packages/grpc-js/src/resolver-ip.ts
+++ b/packages/grpc-js/src/resolver-ip.ts
@@ -20,7 +20,7 @@ import { ChannelOptions } from './channel-options';
 import { LogVerbosity, Status } from './constants';
 import { Metadata } from './metadata';
 import { registerResolver, Resolver, ResolverListener } from './resolver';
-import { SubchannelAddress } from './subchannel-address';
+import { Endpoint, SubchannelAddress } from './subchannel-address';
 import { GrpcUri, splitHostPort, uriToString } from './uri-parser';
 import * as logging from './logging';
 
@@ -39,7 +39,7 @@ const IPV6_SCHEME = 'ipv6';
 const DEFAULT_PORT = 443;
 
 class IpResolver implements Resolver {
-  private addresses: SubchannelAddress[] = [];
+  private endpoints: Endpoint[] = [];
   private error: StatusObject | null = null;
   constructor(
     target: GrpcUri,
@@ -83,8 +83,8 @@ class IpResolver implements Resolver {
         port: hostPort.port ?? DEFAULT_PORT,
       });
     }
-    this.addresses = addresses;
-    trace('Parsed ' + target.scheme + ' address list ' + this.addresses);
+    this.endpoints = addresses.map(address => ({ addresses: [address] }));
+    trace('Parsed ' + target.scheme + ' address list ' + addresses);
   }
   updateResolution(): void {
     process.nextTick(() => {
@@ -92,7 +92,7 @@ class IpResolver implements Resolver {
         this.listener.onError(this.error);
       } else {
         this.listener.onSuccessfulResolution(
-          this.addresses,
+          this.endpoints,
           null,
           null,
           null,

--- a/packages/grpc-js/src/resolver-uds.ts
+++ b/packages/grpc-js/src/resolver-uds.ts
@@ -15,12 +15,12 @@
  */
 
 import { Resolver, ResolverListener, registerResolver } from './resolver';
-import { SubchannelAddress } from './subchannel-address';
+import { Endpoint } from './subchannel-address';
 import { GrpcUri } from './uri-parser';
 import { ChannelOptions } from './channel-options';
 
 class UdsResolver implements Resolver {
-  private addresses: SubchannelAddress[] = [];
+  private endpoints: Endpoint[] = [];
   constructor(
     target: GrpcUri,
     private listener: ResolverListener,
@@ -32,12 +32,12 @@ class UdsResolver implements Resolver {
     } else {
       path = target.path;
     }
-    this.addresses = [{ path }];
+    this.endpoints = [{ addresses: [{ path }] }];
   }
   updateResolution(): void {
     process.nextTick(
       this.listener.onSuccessfulResolution,
-      this.addresses,
+      this.endpoints,
       null,
       null,
       null,

--- a/packages/grpc-js/src/resolver.ts
+++ b/packages/grpc-js/src/resolver.ts
@@ -17,7 +17,7 @@
 
 import { MethodConfig, ServiceConfig } from './service-config';
 import { StatusObject } from './call-interface';
-import { SubchannelAddress } from './subchannel-address';
+import { Endpoint } from './subchannel-address';
 import { GrpcUri, uriToString } from './uri-parser';
 import { ChannelOptions } from './channel-options';
 import { Metadata } from './metadata';
@@ -55,7 +55,7 @@ export interface ResolverListener {
    *     service configuration was invalid
    */
   onSuccessfulResolution(
-    addressList: SubchannelAddress[],
+    addressList: Endpoint[],
     serviceConfig: ServiceConfig | null,
     serviceConfigError: StatusObject | null,
     configSelector: ConfigSelector | null,

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -32,7 +32,7 @@ import { StatusObject } from './call-interface';
 import { Metadata } from './metadata';
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
-import { SubchannelAddress } from './subchannel-address';
+import { Endpoint } from './subchannel-address';
 import { GrpcUri, uriToString } from './uri-parser';
 import { ChildLoadBalancerHandler } from './load-balancer-child-handler';
 import { ChannelOptions } from './channel-options';
@@ -177,7 +177,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
       target,
       {
         onSuccessfulResolution: (
-          addressList: SubchannelAddress[],
+          endpointList: Endpoint[],
           serviceConfig: ServiceConfig | null,
           serviceConfigError: ServiceError | null,
           configSelector: ConfigSelector | null,
@@ -226,7 +226,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
             return;
           }
           this.childLoadBalancer.updateAddressList(
-            addressList,
+            endpointList,
             loadBalancingConfig,
             attributes
           );
@@ -307,7 +307,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   }
 
   updateAddressList(
-    addressList: SubchannelAddress[],
+    endpointList: Endpoint[],
     lbConfig: TypedLoadBalancingConfig | null
   ): never {
     throw new Error('updateAddressList not supported on ResolvingLoadBalancer');

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -631,12 +631,15 @@ export class Server {
 
     const resolverListener: ResolverListener = {
       onSuccessfulResolution: (
-        addressList,
+        endpointList,
         serviceConfig,
         serviceConfigError
       ) => {
         // We only want one resolution result. Discard all future results
         resolverListener.onSuccessfulResolution = () => {};
+        const addressList = ([] as SubchannelAddress[]).concat(
+          ...endpointList.map(endpoint => endpoint.addresses)
+        );
         if (addressList.length === 0) {
           deferredCallback(
             new Error(`No addresses resolved for port ${port}`),

--- a/packages/grpc-js/src/subchannel-address.ts
+++ b/packages/grpc-js/src/subchannel-address.ts
@@ -86,3 +86,39 @@ export function stringToSubchannelAddress(
     };
   }
 }
+
+export interface Endpoint {
+  addresses: SubchannelAddress[];
+}
+
+export function endpointEqual(endpoint1: Endpoint, endpoint2: Endpoint) {
+  if (endpoint1.addresses.length !== endpoint2.addresses.length) {
+    return false;
+  }
+  for (let i = 0; i < endpoint1.addresses.length; i++) {
+    if (
+      !subchannelAddressEqual(endpoint1.addresses[i], endpoint2.addresses[i])
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function endpointToString(endpoint: Endpoint): string {
+  return (
+    '[' + endpoint.addresses.map(subchannelAddressToString).join(', ') + ']'
+  );
+}
+
+export function endpointHasAddress(
+  endpoint: Endpoint,
+  expectedAddress: SubchannelAddress
+): boolean {
+  for (const address of endpoint.addresses) {
+    if (subchannelAddressEqual(address, expectedAddress)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -461,6 +461,18 @@ export class Subchannel {
     return this.channelzRef;
   }
 
+  isHealthy(): boolean {
+    return true;
+  }
+
+  addHealthStateWatcher(listener: (healthy: boolean) => void): void {
+    // Do nothing with the listener
+  }
+
+  removeHealthStateWatcher(listener: (healthy: boolean) => void): void {
+    // Do nothing with the listener
+  }
+
   getRealSubchannel(): this {
     return this;
   }

--- a/packages/grpc-js/test/common.ts
+++ b/packages/grpc-js/test/common.ts
@@ -27,7 +27,10 @@ import {
   loadPackageDefinition,
 } from '../src/make-client';
 import { readFileSync } from 'fs';
-import { SubchannelInterface } from '../src/subchannel-interface';
+import {
+  HealthListener,
+  SubchannelInterface,
+} from '../src/subchannel-interface';
 import { SubchannelRef } from '../src/channelz';
 import { Subchannel } from '../src/subchannel';
 import { ConnectivityState } from '../src/connectivity-state';
@@ -198,6 +201,11 @@ export class MockSubchannel implements SubchannelInterface {
   realSubchannelEquals(other: grpc.experimental.SubchannelInterface): boolean {
     return this === other;
   }
+  isHealthy(): boolean {
+    return true;
+  }
+  addHealthStateWatcher(listener: HealthListener): void {}
+  removeHealthStateWatcher(listener: HealthListener): void {}
 }
 
 export { assert2 };

--- a/packages/grpc-js/test/test-pick-first.ts
+++ b/packages/grpc-js/test/test-pick-first.ts
@@ -29,10 +29,7 @@ import {
 } from '../src/load-balancer-pick-first';
 import { Metadata } from '../src/metadata';
 import { Picker } from '../src/picker';
-import {
-  SubchannelAddress,
-  subchannelAddressToString,
-} from '../src/subchannel-address';
+import { Endpoint, subchannelAddressToString } from '../src/subchannel-address';
 import { MockSubchannel, TestClient, TestServer } from './common';
 
 function updateStateCallBackForExpectedStateSequence(
@@ -120,7 +117,10 @@ describe('pick_first load balancing policy', () => {
       }
     );
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
-    pickFirst.updateAddressList([{ host: 'localhost', port: 1 }], config);
+    pickFirst.updateAddressList(
+      [{ addresses: [{ host: 'localhost', port: 1 }] }],
+      config
+    );
     process.nextTick(() => {
       subchannels[0].transitionToState(ConnectivityState.READY);
     });
@@ -144,7 +144,10 @@ describe('pick_first load balancing policy', () => {
       }
     );
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
-    pickFirst.updateAddressList([{ host: 'localhost', port: 1 }], config);
+    pickFirst.updateAddressList(
+      [{ addresses: [{ host: 'localhost', port: 1 }] }],
+      config
+    );
   });
   it('Should stay CONNECTING if only some subchannels fail to connect', done => {
     const channelControlHelper = createChildChannelControlHelper(
@@ -159,8 +162,8 @@ describe('pick_first load balancing policy', () => {
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
     pickFirst.updateAddressList(
       [
-        { host: 'localhost', port: 1 },
-        { host: 'localhost', port: 2 },
+        { addresses: [{ host: 'localhost', port: 1 }] },
+        { addresses: [{ host: 'localhost', port: 2 }] },
       ],
       config
     );
@@ -181,8 +184,8 @@ describe('pick_first load balancing policy', () => {
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
     pickFirst.updateAddressList(
       [
-        { host: 'localhost', port: 1 },
-        { host: 'localhost', port: 2 },
+        { addresses: [{ host: 'localhost', port: 1 }] },
+        { addresses: [{ host: 'localhost', port: 2 }] },
       ],
       config
     );
@@ -206,8 +209,8 @@ describe('pick_first load balancing policy', () => {
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
     pickFirst.updateAddressList(
       [
-        { host: 'localhost', port: 1 },
-        { host: 'localhost', port: 2 },
+        { addresses: [{ host: 'localhost', port: 1 }] },
+        { addresses: [{ host: 'localhost', port: 2 }] },
       ],
       config
     );
@@ -245,8 +248,8 @@ describe('pick_first load balancing policy', () => {
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
     pickFirst.updateAddressList(
       [
-        { host: 'localhost', port: 1 },
-        { host: 'localhost', port: 2 },
+        { addresses: [{ host: 'localhost', port: 1 }] },
+        { addresses: [{ host: 'localhost', port: 2 }] },
       ],
       config
     );
@@ -272,8 +275,8 @@ describe('pick_first load balancing policy', () => {
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
     pickFirst.updateAddressList(
       [
-        { host: 'localhost', port: 1 },
-        { host: 'localhost', port: 2 },
+        { addresses: [{ host: 'localhost', port: 1 }] },
+        { addresses: [{ host: 'localhost', port: 2 }] },
       ],
       config
     );
@@ -303,8 +306,8 @@ describe('pick_first load balancing policy', () => {
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
     pickFirst.updateAddressList(
       [
-        { host: 'localhost', port: 1 },
-        { host: 'localhost', port: 2 },
+        { addresses: [{ host: 'localhost', port: 1 }] },
+        { addresses: [{ host: 'localhost', port: 2 }] },
       ],
       config
     );
@@ -312,8 +315,8 @@ describe('pick_first load balancing policy', () => {
       currentStartState = ConnectivityState.CONNECTING;
       pickFirst.updateAddressList(
         [
-          { host: 'localhost', port: 3 },
-          { host: 'localhost', port: 4 },
+          { addresses: [{ host: 'localhost', port: 1 }] },
+          { addresses: [{ host: 'localhost', port: 2 }] },
         ],
         config
       );
@@ -341,14 +344,17 @@ describe('pick_first load balancing policy', () => {
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
     pickFirst.updateAddressList(
       [
-        { host: 'localhost', port: 1 },
-        { host: 'localhost', port: 2 },
+        { addresses: [{ host: 'localhost', port: 1 }] },
+        { addresses: [{ host: 'localhost', port: 2 }] },
       ],
       config
     );
     process.nextTick(() => {
       currentStartState = ConnectivityState.READY;
-      pickFirst.updateAddressList([{ host: 'localhost', port: 3 }], config);
+      pickFirst.updateAddressList(
+        [{ addresses: [{ host: 'localhost', port: 3 }] }],
+        config
+      );
     });
   });
   it('Should transition from READY to IDLE if the connected subchannel disconnects', done => {
@@ -371,7 +377,10 @@ describe('pick_first load balancing policy', () => {
       }
     );
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
-    pickFirst.updateAddressList([{ host: 'localhost', port: 1 }], config);
+    pickFirst.updateAddressList(
+      [{ addresses: [{ host: 'localhost', port: 1 }] }],
+      config
+    );
     process.nextTick(() => {
       subchannels[0].transitionToState(ConnectivityState.IDLE);
     });
@@ -396,10 +405,16 @@ describe('pick_first load balancing policy', () => {
       }
     );
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
-    pickFirst.updateAddressList([{ host: 'localhost', port: 1 }], config);
+    pickFirst.updateAddressList(
+      [{ addresses: [{ host: 'localhost', port: 1 }] }],
+      config
+    );
     process.nextTick(() => {
       currentStartState = ConnectivityState.IDLE;
-      pickFirst.updateAddressList([{ host: 'localhost', port: 2 }], config);
+      pickFirst.updateAddressList(
+        [{ addresses: [{ host: 'localhost', port: 2 }] }],
+        config
+      );
       process.nextTick(() => {
         subchannels[0].transitionToState(ConnectivityState.IDLE);
       });
@@ -425,10 +440,16 @@ describe('pick_first load balancing policy', () => {
       }
     );
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
-    pickFirst.updateAddressList([{ host: 'localhost', port: 1 }], config);
+    pickFirst.updateAddressList(
+      [{ addresses: [{ host: 'localhost', port: 1 }] }],
+      config
+    );
     process.nextTick(() => {
       currentStartState = ConnectivityState.TRANSIENT_FAILURE;
-      pickFirst.updateAddressList([{ host: 'localhost', port: 2 }], config);
+      pickFirst.updateAddressList(
+        [{ addresses: [{ host: 'localhost', port: 2 }] }],
+        config
+      );
       process.nextTick(() => {
         subchannels[0].transitionToState(ConnectivityState.IDLE);
       });
@@ -454,9 +475,15 @@ describe('pick_first load balancing policy', () => {
       }
     );
     const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
-    pickFirst.updateAddressList([{ host: 'localhost', port: 1 }], config);
+    pickFirst.updateAddressList(
+      [{ addresses: [{ host: 'localhost', port: 1 }] }],
+      config
+    );
     process.nextTick(() => {
-      pickFirst.updateAddressList([{ host: 'localhost', port: 2 }], config);
+      pickFirst.updateAddressList(
+        [{ addresses: [{ host: 'localhost', port: 2 }] }],
+        config
+      );
       process.nextTick(() => {
         subchannels[0].transitionToState(ConnectivityState.IDLE);
       });
@@ -490,24 +517,24 @@ describe('pick_first load balancing policy', () => {
           },
         }
       );
-      const addresses: SubchannelAddress[] = [];
+      const endpoints: Endpoint[] = [];
       for (let i = 0; i < 10; i++) {
-        addresses.push({ host: 'localhost', port: i + 1 });
+        endpoints.push({ addresses: [{ host: 'localhost', port: i + 1 }] });
       }
       const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
       /* Pick from 10 subchannels 5 times, with address randomization enabled,
        * and verify that at least two different subchannels are picked. The
        * probability choosing the same address every time is 1/10,000, which
        * I am considering an acceptable flake rate */
-      pickFirst.updateAddressList(addresses, shuffleConfig);
+      pickFirst.updateAddressList(endpoints, shuffleConfig);
       process.nextTick(() => {
-        pickFirst.updateAddressList(addresses, shuffleConfig);
+        pickFirst.updateAddressList(endpoints, shuffleConfig);
         process.nextTick(() => {
-          pickFirst.updateAddressList(addresses, shuffleConfig);
+          pickFirst.updateAddressList(endpoints, shuffleConfig);
           process.nextTick(() => {
-            pickFirst.updateAddressList(addresses, shuffleConfig);
+            pickFirst.updateAddressList(endpoints, shuffleConfig);
             process.nextTick(() => {
-              pickFirst.updateAddressList(addresses, shuffleConfig);
+              pickFirst.updateAddressList(endpoints, shuffleConfig);
               process.nextTick(() => {
                 assert(pickedSubchannels.size > 1);
                 done();
@@ -546,20 +573,20 @@ describe('pick_first load balancing policy', () => {
           },
         }
       );
-      const addresses: SubchannelAddress[] = [];
+      const endpoints: Endpoint[] = [];
       for (let i = 0; i < 10; i++) {
-        addresses.push({ host: 'localhost', port: i + 1 });
+        endpoints.push({ addresses: [{ host: 'localhost', port: i + 1 }] });
       }
       const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
-      pickFirst.updateAddressList(addresses, config);
+      pickFirst.updateAddressList(endpoints, config);
       process.nextTick(() => {
-        pickFirst.updateAddressList(addresses, config);
+        pickFirst.updateAddressList(endpoints, config);
         process.nextTick(() => {
-          pickFirst.updateAddressList(addresses, config);
+          pickFirst.updateAddressList(endpoints, config);
           process.nextTick(() => {
-            pickFirst.updateAddressList(addresses, config);
+            pickFirst.updateAddressList(endpoints, config);
             process.nextTick(() => {
-              pickFirst.updateAddressList(addresses, config);
+              pickFirst.updateAddressList(endpoints, config);
               process.nextTick(() => {
                 assert(pickedSubchannels.size === 1);
                 done();

--- a/packages/grpc-js/test/test-pick-first.ts
+++ b/packages/grpc-js/test/test-pick-first.ts
@@ -125,6 +125,54 @@ describe('pick_first load balancing policy', () => {
       subchannels[0].transitionToState(ConnectivityState.READY);
     });
   });
+  it('Should report READY when a subchannel other than the first connects', done => {
+    const channelControlHelper = createChildChannelControlHelper(
+      baseChannelControlHelper,
+      {
+        updateState: updateStateCallBackForExpectedStateSequence(
+          [ConnectivityState.CONNECTING, ConnectivityState.READY],
+          done
+        ),
+      }
+    );
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    pickFirst.updateAddressList(
+      [
+        { addresses: [{ host: 'localhost', port: 1 }] },
+        { addresses: [{ host: 'localhost', port: 2 }] },
+      ],
+      config
+    );
+    process.nextTick(() => {
+      subchannels[1].transitionToState(ConnectivityState.READY);
+    });
+  });
+  it('Should report READY when a subchannel other than the first in the same endpoint connects', done => {
+    const channelControlHelper = createChildChannelControlHelper(
+      baseChannelControlHelper,
+      {
+        updateState: updateStateCallBackForExpectedStateSequence(
+          [ConnectivityState.CONNECTING, ConnectivityState.READY],
+          done
+        ),
+      }
+    );
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    pickFirst.updateAddressList(
+      [
+        {
+          addresses: [
+            { host: 'localhost', port: 1 },
+            { host: 'localhost', port: 2 },
+          ],
+        },
+      ],
+      config
+    );
+    process.nextTick(() => {
+      subchannels[1].transitionToState(ConnectivityState.READY);
+    });
+  });
   it('Should report READY when updated with a subchannel that is already READY', done => {
     const channelControlHelper = createChildChannelControlHelper(
       baseChannelControlHelper,


### PR DESCRIPTION
This includes most of the changes in the in-progress [gRFC A61: IPv4 and IPv6 Dualstack Backend Support](https://github.com/grpc/proposal/pull/356). In particular, this has the following changes:

 - The `updateAddressList` method of a `LoadBalancer` now takes an `Endpoint` list instead of a `SubchannelAddress` list. An `Endpoint` contains a list of `SubchannelAddresses`.
 - Resolver results are an `Endpoint` list instead of a `SubchannelAddress` list.
 - The round_robin LB policy now delegates to pick_first for each endpoint, instead of managing subchannels directly.
 - The outlier_detection LB policy now tracks call results and ejections by endpoint instead of by address.
 - The `SubchannelInterface` now includes additional methods for reporting health state separately from connectivity state, for pick_first to use as a leaf policy. The outlier_detection LB policy now uses this API to report ejections.

All load balancers and resolvers needed to be updated with the new API. The only substantive change in the xDS library was in the `xds_cluster_impl` LB policy: the locality is now attached to the endpoint instead of the individual subchannel address, so the procedure to determine the locality for an address when wrapping it for load reporting is different.

Currently nothing that produces endpoint lists produces any endpoints with more than one address, so the end-to-end functionality that handles that case is not yet tested. In the future, support will be added for multiple addresses per endpoint in EDS, and that behavior will be tested then.

Experimental API changes:

 - Added `Endpoint`, `endpointToString`, `endpointHasAddress`, `LeafLoadBalancer`, and `HealthListener`.
 - `LoadBalancer#updateAddressList` now takes `Endpoint[]` instead of `SubchannelAddress[]` as the first argument.
 - `ResolverListener#onSuccessfulResolution` now takes `Endpoint[]` instead of `SubchannelAddress[]` as the first argument.
 - `SubchannelInterface` has the new methods `isHealthy`, `addHealthStateWatcher`, and `removeHealthStateWatcher`.
 - `SubchannelWrapper` has the new protected method `setHealthy` and has default implementations of the other new methods, to easily manage health status.