### PR TITLE
Throw error when keepalive ping fails

### DIFF
--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -426,6 +426,9 @@ class Http2Transport implements Transport {
     try {
       this.session!.ping(
         (err: Error | null, duration: number, payload: Buffer) => {
+          if (err) {
+            throw err;
+          };
           this.keepaliveTrace('Received ping response');
           this.clearKeepaliveTimeout();
           this.maybeStartKeepalivePingTimer();


### PR DESCRIPTION
When working with the keepalive ping, I noticed that the client is always receiving a ping response, even when the server is blocked behind firewall.