### PR TITLE
grpc-js: Handle keepalive ping error

### DIFF
--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -426,6 +426,10 @@ class Http2Transport implements Transport {
     try {
       this.session!.ping(
         (err: Error | null, duration: number, payload: Buffer) => {
+          if (err) {
+            this.keepaliveTrace('Ping failed with error ' + err.message);
+            this.handleDisconnect();
+          }
           this.keepaliveTrace('Received ping response');
           this.clearKeepaliveTimeout();
           this.maybeStartKeepalivePingTimer();


### PR DESCRIPTION
The issue with not handling the error was reported in #2562, but this is the right way to handle the error.