### PR TITLE
grpc-js: Fix pick-first-load-balancer pick subchannel lost state listener (1.9.x)

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -315,7 +315,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
   }
 
   private pickSubchannel(subchannel: SubchannelInterface) {
-    if (subchannel === this.currentPick) {
+    if (this.currentPick && subchannel.realSubchannelEquals(this.currentPick)) {
       return;
     }
     trace('Pick subchannel with address ' + subchannel.getAddress());


### PR DESCRIPTION
Backport of #2559 to 1.9.x