### PR TITLE
grpc-js: Pass channel options to LoadBalancer constructors

### DIFF
--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -88,7 +88,7 @@ const RPC_BEHAVIOR_CHILD_CONFIG = parseLoadBalancingConfig({round_robin: {}});
 class RpcBehaviorLoadBalancer implements LoadBalancer {
   private child: ChildLoadBalancerHandler;
   private latestConfig: RpcBehaviorLoadBalancingConfig | null = null;
-  constructor(channelControlHelper: ChannelControlHelper) {
+  constructor(channelControlHelper: ChannelControlHelper, options: grpc.ChannelOptions) {
     const childChannelControlHelper = createChildChannelControlHelper(channelControlHelper, {
       updateState: (connectivityState, picker) => {
         if (connectivityState === grpc.connectivityState.READY && this.latestConfig) {
@@ -97,7 +97,7 @@ class RpcBehaviorLoadBalancer implements LoadBalancer {
         channelControlHelper.updateState(connectivityState, picker);
       }
     });
-    this.child = new ChildLoadBalancerHandler(childChannelControlHelper);
+    this.child = new ChildLoadBalancerHandler(childChannelControlHelper, options);
   }
   updateAddressList(endpointList: Endpoint[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
     if (!(lbConfig instanceof RpcBehaviorLoadBalancingConfig)) {

--- a/packages/grpc-js-xds/src/load-balancer-cds.ts
+++ b/packages/grpc-js-xds/src/load-balancer-cds.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { connectivityState, status, Metadata, logVerbosity, experimental, LoadBalancingConfig } from '@grpc/grpc-js';
+import { connectivityState, status, Metadata, logVerbosity, experimental, LoadBalancingConfig, ChannelOptions } from '@grpc/grpc-js';
 import { getSingletonXdsClient, Watcher, XdsClient } from './xds-client';
 import { Cluster__Output } from './generated/envoy/config/cluster/v3/Cluster';
 import Endpoint = experimental.Endpoint;
@@ -155,8 +155,8 @@ export class CdsLoadBalancer implements LoadBalancer {
 
   private updatedChild = false;
 
-  constructor(private readonly channelControlHelper: ChannelControlHelper) {
-    this.childBalancer = new XdsClusterResolverChildPolicyHandler(channelControlHelper);
+  constructor(private readonly channelControlHelper: ChannelControlHelper, options: ChannelOptions) {
+    this.childBalancer = new XdsClusterResolverChildPolicyHandler(channelControlHelper, options);
   }
 
   private reportError(errorMessage: string) {

--- a/packages/grpc-js-xds/src/load-balancer-priority.ts
+++ b/packages/grpc-js-xds/src/load-balancer-priority.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { connectivityState as ConnectivityState, status as Status, Metadata, logVerbosity as LogVerbosity, experimental, LoadBalancingConfig } from '@grpc/grpc-js';
+import { connectivityState as ConnectivityState, status as Status, Metadata, logVerbosity as LogVerbosity, experimental, LoadBalancingConfig, ChannelOptions } from '@grpc/grpc-js';
 import LoadBalancer = experimental.LoadBalancer;
 import ChannelControlHelper = experimental.ChannelControlHelper;
 import registerLoadBalancerType = experimental.registerLoadBalancerType;
@@ -180,7 +180,7 @@ export class PriorityLoadBalancer implements LoadBalancer {
             this.parent.channelControlHelper.requestReresolution();
           }
         }
-      }));
+      }), parent.options);
       this.picker = new QueuePicker(this.childBalancer);
       this.startFailoverTimer();
     }
@@ -306,7 +306,7 @@ export class PriorityLoadBalancer implements LoadBalancer {
 
   private updatesPaused = false;
 
-  constructor(private channelControlHelper: ChannelControlHelper) {}
+  constructor(private channelControlHelper: ChannelControlHelper, private options: ChannelOptions) {}
 
   private updateState(state: ConnectivityState, picker: Picker) {
     trace(

--- a/packages/grpc-js-xds/src/load-balancer-weighted-target.ts
+++ b/packages/grpc-js-xds/src/load-balancer-weighted-target.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { connectivityState as ConnectivityState, status as Status, Metadata, logVerbosity, experimental, LoadBalancingConfig } from "@grpc/grpc-js";
+import { connectivityState as ConnectivityState, status as Status, Metadata, logVerbosity, experimental, LoadBalancingConfig, ChannelOptions } from "@grpc/grpc-js";
 import { isLocalityEndpoint, LocalityEndpoint } from "./load-balancer-priority";
 import TypedLoadBalancingConfig = experimental.TypedLoadBalancingConfig;
 import LoadBalancer = experimental.LoadBalancer;
@@ -178,7 +178,7 @@ export class WeightedTargetLoadBalancer implements LoadBalancer {
         updateState: (connectivityState: ConnectivityState, picker: Picker) => {
           this.updateState(connectivityState, picker);
         },
-      }));
+      }), parent.options);
 
       this.picker = new QueuePicker(this.childBalancer);
     }
@@ -243,7 +243,7 @@ export class WeightedTargetLoadBalancer implements LoadBalancer {
   private targetList: string[] = [];
   private updatesPaused = false;
 
-  constructor(private channelControlHelper: ChannelControlHelper) {}
+  constructor(private channelControlHelper: ChannelControlHelper, private options: ChannelOptions) {}
 
   private maybeUpdateState() {
     if (!this.updatesPaused) {

--- a/packages/grpc-js-xds/src/load-balancer-xds-cluster-impl.ts
+++ b/packages/grpc-js-xds/src/load-balancer-xds-cluster-impl.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { experimental, logVerbosity, status as Status, Metadata, connectivityState } from "@grpc/grpc-js";
+import { experimental, logVerbosity, status as Status, Metadata, connectivityState, ChannelOptions } from "@grpc/grpc-js";
 import { validateXdsServerConfig, XdsServerConfig } from "./xds-bootstrap";
 import { getSingletonXdsClient, XdsClient, XdsClusterDropStats, XdsClusterLocalityStats } from "./xds-client";
 import { LocalityEndpoint } from "./load-balancer-priority";
@@ -253,7 +253,7 @@ class XdsClusterImplBalancer implements LoadBalancer {
   private clusterDropStats: XdsClusterDropStats | null = null;
   private xdsClient: XdsClient | null = null;
 
-  constructor(private readonly channelControlHelper: ChannelControlHelper) {
+  constructor(private readonly channelControlHelper: ChannelControlHelper, options: ChannelOptions) {
       this.childBalancer = new ChildLoadBalancerHandler(createChildChannelControlHelper(channelControlHelper, {
         createSubchannel: (subchannelAddress, subchannelArgs) => {
           if (!this.xdsClient || !this.latestConfig || !this.lastestEndpointList) {
@@ -290,7 +290,7 @@ class XdsClusterImplBalancer implements LoadBalancer {
             channelControlHelper.updateState(connectivityState, picker);
           }
         }
-      }));
+      }), options);
     }
   updateAddressList(endpointList: Endpoint[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
     if (!(lbConfig instanceof XdsClusterImplLoadBalancingConfig)) {

--- a/packages/grpc-js-xds/src/load-balancer-xds-cluster-manager.ts
+++ b/packages/grpc-js-xds/src/load-balancer-xds-cluster-manager.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { connectivityState as ConnectivityState, status as Status, experimental, logVerbosity, Metadata, status } from "@grpc/grpc-js/";
+import { connectivityState as ConnectivityState, status as Status, experimental, logVerbosity, Metadata, status, ChannelOptions } from "@grpc/grpc-js/";
 
 import TypedLoadBalancingConfig = experimental.TypedLoadBalancingConfig;
 import LoadBalancer = experimental.LoadBalancer;
@@ -131,7 +131,7 @@ class XdsClusterManager implements LoadBalancer {
         updateState: (connectivityState: ConnectivityState, picker: Picker) => {
           this.updateState(connectivityState, picker);
         },
-      }));
+      }), parent.options);
 
       this.picker = new QueuePicker(this.childBalancer);
     }
@@ -167,7 +167,7 @@ class XdsClusterManager implements LoadBalancer {
   // Shutdown is a placeholder value that will never appear in normal operation.
   private currentState: ConnectivityState = ConnectivityState.SHUTDOWN;
   private updatesPaused = false;
-  constructor(private channelControlHelper: ChannelControlHelper) {}
+  constructor(private channelControlHelper: ChannelControlHelper, private options: ChannelOptions) {}
 
   private maybeUpdateState() {
     if (!this.updatesPaused) {

--- a/packages/grpc-js-xds/src/load-balancer-xds-cluster-resolver.ts
+++ b/packages/grpc-js-xds/src/load-balancer-xds-cluster-resolver.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { LoadBalancingConfig, Metadata, connectivityState, experimental, logVerbosity, status } from "@grpc/grpc-js";
+import { ChannelOptions, LoadBalancingConfig, Metadata, connectivityState, experimental, logVerbosity, status } from "@grpc/grpc-js";
 import { registerLoadBalancerType } from "@grpc/grpc-js/build/src/load-balancer";
 import { EXPERIMENTAL_OUTLIER_DETECTION } from "./environment";
 import { Locality__Output } from "./generated/envoy/config/core/v3/Locality";
@@ -232,14 +232,14 @@ export class XdsClusterResolver implements LoadBalancer {
   private xdsClient: XdsClient | null = null;
   private childBalancer: ChildLoadBalancerHandler;
 
-  constructor(private readonly channelControlHelper: ChannelControlHelper) {
+  constructor(private readonly channelControlHelper: ChannelControlHelper, options: ChannelOptions) {
     this.childBalancer = new ChildLoadBalancerHandler(experimental.createChildChannelControlHelper(channelControlHelper, {
       requestReresolution: () => {
         for (const entry of this.discoveryMechanismList) {
           entry.resolver?.updateResolution();
         }
       }
-    }));
+    }), options);
   }
 
   private maybeUpdateChild() {

--- a/packages/grpc-js-xds/src/load-balancer-xds-wrr-locality.ts
+++ b/packages/grpc-js-xds/src/load-balancer-xds-wrr-locality.ts
@@ -17,7 +17,7 @@
 
 // https://github.com/grpc/proposal/blob/master/A52-xds-custom-lb-policies.md
 
-import { LoadBalancingConfig, experimental, logVerbosity } from "@grpc/grpc-js";
+import { ChannelOptions, LoadBalancingConfig, experimental, logVerbosity } from "@grpc/grpc-js";
 import { loadProtosWithOptionsSync } from "@grpc/proto-loader/build/src/util";
 import { WeightedTargetRaw } from "./load-balancer-weighted-target";
 import { isLocalityEndpoint } from "./load-balancer-priority";
@@ -73,8 +73,8 @@ class XdsWrrLocalityLoadBalancingConfig implements TypedLoadBalancingConfig {
 
 class XdsWrrLocalityLoadBalancer implements LoadBalancer {
   private childBalancer: ChildLoadBalancerHandler;
-  constructor(private readonly channelControlHelper: ChannelControlHelper) {
-    this.childBalancer = new ChildLoadBalancerHandler(channelControlHelper);
+  constructor(private readonly channelControlHelper: ChannelControlHelper, options: ChannelOptions) {
+    this.childBalancer = new ChildLoadBalancerHandler(channelControlHelper, options);
   }
   updateAddressList(endpointList: Endpoint[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
     if (!(lbConfig instanceof XdsWrrLocalityLoadBalancingConfig)) {

--- a/packages/grpc-js-xds/test/test-custom-lb-policies.ts
+++ b/packages/grpc-js-xds/test/test-custom-lb-policies.ts
@@ -24,7 +24,7 @@ import { XdsServer } from "./xds-server";
 import * as assert from 'assert';
 import { WrrLocality } from "../src/generated/envoy/extensions/load_balancing_policies/wrr_locality/v3/WrrLocality";
 import { TypedStruct } from "../src/generated/xds/type/v3/TypedStruct";
-import { connectivityState, experimental, logVerbosity } from "@grpc/grpc-js";
+import { ChannelOptions, connectivityState, experimental, logVerbosity } from "@grpc/grpc-js";
 
 import TypedLoadBalancingConfig = experimental.TypedLoadBalancingConfig;
 import LoadBalancer = experimental.LoadBalancer;
@@ -83,7 +83,7 @@ const RPC_BEHAVIOR_CHILD_CONFIG = parseLoadBalancingConfig({round_robin: {}});
 class RpcBehaviorLoadBalancer implements LoadBalancer {
   private child: ChildLoadBalancerHandler;
   private latestConfig: RpcBehaviorLoadBalancingConfig | null = null;
-  constructor(channelControlHelper: ChannelControlHelper) {
+  constructor(channelControlHelper: ChannelControlHelper, options: ChannelOptions) {
     const childChannelControlHelper = createChildChannelControlHelper(channelControlHelper, {
       updateState: (state, picker) => {
         if (state === connectivityState.READY && this.latestConfig) {
@@ -92,7 +92,7 @@ class RpcBehaviorLoadBalancer implements LoadBalancer {
         channelControlHelper.updateState(state, picker);
       }
     });
-    this.child = new ChildLoadBalancerHandler(childChannelControlHelper);
+    this.child = new ChildLoadBalancerHandler(childChannelControlHelper, options);
   }
   updateAddressList(endpointList: Endpoint[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
     if (!(lbConfig instanceof RpcBehaviorLoadBalancingConfig)) {

--- a/packages/grpc-js/src/load-balancer-child-handler.ts
+++ b/packages/grpc-js/src/load-balancer-child-handler.ts
@@ -84,7 +84,10 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
     }
   };
 
-  constructor(private readonly channelControlHelper: ChannelControlHelper) {}
+  constructor(
+    private readonly channelControlHelper: ChannelControlHelper,
+    private readonly options: ChannelOptions
+  ) {}
 
   protected configUpdateRequiresNewPolicyInstance(
     oldConfig: TypedLoadBalancingConfig,
@@ -111,7 +114,7 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
       this.configUpdateRequiresNewPolicyInstance(this.latestConfig, lbConfig)
     ) {
       const newHelper = new this.ChildPolicyHelper(this);
-      const newChild = createLoadBalancer(lbConfig, newHelper)!;
+      const newChild = createLoadBalancer(lbConfig, newHelper, this.options)!;
       newHelper.setChild(newChild);
       if (this.currentChild === null) {
         this.currentChild = newChild;

--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -585,7 +585,10 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
   private ejectionTimer: NodeJS.Timeout;
   private timerStartTime: Date | null = null;
 
-  constructor(channelControlHelper: ChannelControlHelper) {
+  constructor(
+    channelControlHelper: ChannelControlHelper,
+    options: ChannelOptions
+  ) {
     this.childBalancer = new ChildLoadBalancerHandler(
       createChildChannelControlHelper(channelControlHelper, {
         createSubchannel: (
@@ -619,7 +622,8 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
             channelControlHelper.updateState(connectivityState, picker);
           }
         },
-      })
+      }),
+      options
     );
     this.ejectionTimer = setInterval(() => {}, 0);
     clearInterval(this.ejectionTimer);

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -38,6 +38,7 @@ import {
   endpointToString,
 } from './subchannel-address';
 import { LeafLoadBalancer } from './load-balancer-pick-first';
+import { ChannelOptions } from './channel-options';
 
 const TRACER_NAME = 'round_robin';
 
@@ -99,7 +100,10 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
 
   private childChannelControlHelper: ChannelControlHelper;
 
-  constructor(private readonly channelControlHelper: ChannelControlHelper) {
+  constructor(
+    private readonly channelControlHelper: ChannelControlHelper,
+    private readonly options: ChannelOptions
+  ) {
     this.childChannelControlHelper = createChildChannelControlHelper(
       channelControlHelper,
       {
@@ -186,7 +190,12 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
     trace('Connect to endpoint list ' + endpointList.map(endpointToString));
     this.updatesPaused = true;
     this.children = endpointList.map(
-      endpoint => new LeafLoadBalancer(endpoint, this.childChannelControlHelper)
+      endpoint =>
+        new LeafLoadBalancer(
+          endpoint,
+          this.childChannelControlHelper,
+          this.options
+        )
     );
     for (const child of this.children) {
       child.startConnecting();

--- a/packages/grpc-js/src/load-balancer.ts
+++ b/packages/grpc-js/src/load-balancer.ts
@@ -128,7 +128,10 @@ export interface LoadBalancer {
 }
 
 export interface LoadBalancerConstructor {
-  new (channelControlHelper: ChannelControlHelper): LoadBalancer;
+  new (
+    channelControlHelper: ChannelControlHelper,
+    options: ChannelOptions
+  ): LoadBalancer;
 }
 
 export interface TypedLoadBalancingConfig {
@@ -169,12 +172,14 @@ export function registerDefaultLoadBalancerType(typeName: string) {
 
 export function createLoadBalancer(
   config: TypedLoadBalancingConfig,
-  channelControlHelper: ChannelControlHelper
+  channelControlHelper: ChannelControlHelper,
+  options: ChannelOptions
 ): LoadBalancer | null {
   const typeName = config.getLoadBalancerName();
   if (typeName in registeredLoadBalancerTypes) {
     return new registeredLoadBalancerTypes[typeName].LoadBalancer(
-      channelControlHelper
+      channelControlHelper,
+      options
     );
   } else {
     return null;

--- a/packages/grpc-js/test/test-pick-first.ts
+++ b/packages/grpc-js/test/test-pick-first.ts
@@ -116,7 +116,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -135,7 +135,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -157,7 +157,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         {
@@ -191,7 +191,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -207,7 +207,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -229,7 +229,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -254,7 +254,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -293,7 +293,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -320,7 +320,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -351,7 +351,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -389,7 +389,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -424,7 +424,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -452,7 +452,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -487,7 +487,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -522,7 +522,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -569,7 +569,7 @@ describe('pick_first load balancing policy', () => {
       for (let i = 0; i < 10; i++) {
         endpoints.push({ addresses: [{ host: 'localhost', port: i + 1 }] });
       }
-      const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+      const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
       /* Pick from 10 subchannels 5 times, with address randomization enabled,
        * and verify that at least two different subchannels are picked. The
        * probability choosing the same address every time is 1/10,000, which
@@ -625,7 +625,7 @@ describe('pick_first load balancing policy', () => {
       for (let i = 0; i < 10; i++) {
         endpoints.push({ addresses: [{ host: 'localhost', port: i + 1 }] });
       }
-      const pickFirst = new PickFirstLoadBalancer(channelControlHelper);
+      const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
       pickFirst.updateAddressList(endpoints, config);
       process.nextTick(() => {
         pickFirst.updateAddressList(endpoints, config);


### PR DESCRIPTION
The `ring_hash` LB policy will need access to a channel option, and this is the cleanest way to do that. I also tweaked the pick_first changes from #2561 so that the `reportHealthStatus` option is passed in using an internal channel option instead of a special constructor argument.