### PR TITLE
grpc-js: Make a few improvements to DNS resolving timing

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/backoff-timeout.ts
+++ b/packages/grpc-js/src/backoff-timeout.ts
@@ -78,6 +78,11 @@ export class BackoffTimeout {
    * running is true.
    */
   private startTime: Date = new Date();
+  /**
+   * The approximate time that the currently running timer will end. Only valid
+   * if running is true.
+   */
+  private endTime: Date = new Date();
 
   constructor(private callback: () => void, options?: BackoffOptions) {
     if (options) {
@@ -100,6 +105,8 @@ export class BackoffTimeout {
   }
 
   private runTimer(delay: number) {
+    this.endTime = this.startTime;
+    this.endTime.setMilliseconds(this.endTime.getMilliseconds() + this.nextDelay);
     clearTimeout(this.timerId);
     this.timerId = setTimeout(() => {
       this.callback();
@@ -177,5 +184,13 @@ export class BackoffTimeout {
   unref() {
     this.hasRef = false;
     this.timerId.unref?.();
+  }
+
+  /**
+   * Get the approximate timestamp of when the timer will fire. Only valid if
+   * this.isRunning() is true.
+   */
+  getEndTime() {
+    return this.endTime;
   }
 }

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -353,6 +353,11 @@ class DnsResolver implements Resolver {
      * fires. Otherwise, start resolving immediately. */
     if (this.pendingLookupPromise === null) {
       if (this.isNextResolutionTimerRunning || this.backoff.isRunning()) {
+        if (this.isNextResolutionTimerRunning) {
+          trace('resolution update delayed by "min time between resolutions" rate limit');
+        } else {
+          trace('resolution update delayed by backoff timer until ' + this.backoff.getEndTime().toISOString());
+        }
         this.continueResolving = true;
       } else {
         this.startResolutionWithBackoff();

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -175,6 +175,7 @@ class DnsResolver implements Resolver {
       });
       this.backoff.stop();
       this.backoff.reset();
+      this.stopNextResolutionTimer();
       return;
     }
     if (this.dnsHostname === null) {
@@ -339,9 +340,9 @@ class DnsResolver implements Resolver {
   private startResolutionWithBackoff() {
     if (this.pendingLookupPromise === null) {
       this.continueResolving = false;
-      this.startResolution();
       this.backoff.runOnce();
       this.startNextResolutionTimer();
+      this.startResolution();
     }
   }
 

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -247,6 +247,8 @@ export class ResolvingLoadBalancer implements LoadBalancer {
           configSelector: ConfigSelector | null,
           attributes: { [key: string]: unknown }
         ) => {
+          this.backoffTimeout.stop();
+          this.backoffTimeout.reset();
           let workingServiceConfig: ServiceConfig | null = null;
           /* This first group of conditionals implements the algorithm described
            * in https://github.com/grpc/proposal/blob/master/A21-service-config-error-handling.md

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -222,6 +222,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
          * In that case, the backoff timer callback will call
          * updateResolution */
         if (this.backoffTimeout.isRunning()) {
+          trace('requestReresolution delayed by backoff timer until ' + this.backoffTimeout.getEndTime().toISOString());
           this.continueResolving = true;
         } else {
           this.updateResolution();


### PR DESCRIPTION
This makes a few improvements to issues exposed by the test linked from #2570, specifically related to closing a connection immediately after it is established

 1. In `ResolvingLoadBalancer`, reset the backoff timer when name resolution succeeds.
 2. In `DnsResolver`, start the timers before starting resolution, because the timers can be cancelled immediately after starting resolution, and if they can happen in the wrong order they won't actually be cancelled.
 3. Also in `DnsResolver`, cancel the rate limiting timer when outputting a result for an IP address target. The purpose of the rate limit is to limit DNS query traffic, and an IP address target does not result in a DNS query so the rate limit is unnecessary.

Experimental changes:

 - Added `BackoffTimeout#getEndTime`, to get the approximate time when the timer will fire, if it is running.