### PR TITLE
proto-loader: Allow the `grpcLib` option to be omitted in the type generator

### DIFF
--- a/packages/proto-loader/README.md
+++ b/packages/proto-loader/README.md
@@ -87,7 +87,8 @@ Options:
   -I, --includeDirs      Directories to search for included files        [array]
   -O, --outDir           Directory in which to output files  [string] [required]
       --grpcLib          The gRPC implementation library that these types will
-                         be used with                        [string] [required]
+                         be used with. If not provided, some types will not be
+                         generated                                      [string]
       --inputTemplate    Template for mapping input or "permissive" type names
                                                         [string] [default: "%s"]
       --outputTemplate   Template for mapping output or "restricted" type names

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "author": "Google Inc.",
   "contributors": [
     {


### PR DESCRIPTION
Currently, `grpcLib` is required, and the types generated use it. With this change, the option can be omitted, and as a result the root file, client, and service implementation types are not generated, and the `ServiceDefinition` types do not reference the `grpc` library. Message and Enum types are still generated without any changes.

This change is mainly needed to implement [gRFC L106: Node Health Check Library 2.0](https://github.com/grpc/proposal/blob/master/L106-node-heath-check-library.md) to enable that library to implement a service without reference to a specific grpc implementation library.