### PR TITLE
grpc-js: Delegate to child picker in ResolvingLoadBalancer#updateResolution

### DIFF
--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -264,7 +264,11 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   private updateResolution() {
     this.innerResolver.updateResolution();
     if (this.currentState === ConnectivityState.IDLE) {
-      this.updateState(ConnectivityState.CONNECTING, new QueuePicker(this));
+      /* this.latestChildPicker is initialized as new QueuePicker(this), which
+       * is an appropriate value here if the child LB policy is unset.
+       * Otherwise, we want to delegate to the child here, in case that
+       * triggers something. */
+      this.updateState(ConnectivityState.CONNECTING, this.latestChildPicker);
     }
     this.backoffTimeout.runOnce();
   }


### PR DESCRIPTION
I believe this will fix the failure seen in [this affinity test run](https://fusion2.corp.google.com/invocations/8df8c4b8-7e16-4b8f-9e32-5a120922461e/targets/grpc%2Fnode%2Fmaster%2Fxds_k8s_lb%2Faffinity_test/tests). This change mirrors behavior in `updateState` from #2568.