### PR TITLE
grpc-js-xds: Fix behavior when channel goes IDLE

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {

--- a/packages/grpc-js-xds/src/resolver-xds.ts
+++ b/packages/grpc-js-xds/src/resolver-xds.ts
@@ -213,7 +213,7 @@ function getPredicateForMatcher(routeMatch: RouteMatch__Output): Matcher {
  * the ServiceConfig definition. The difference is that the protobuf message
  * defines seconds as a long, which is represented as a string in JavaScript,
  * and the one used in the service config defines it as a number.
- * @param duration 
+ * @param duration
  */
 function protoDurationToDuration(duration: Duration__Output): Duration {
   return {
@@ -235,7 +235,7 @@ function getDefaultRetryMaxInterval(baseInterval: string): string {
 /**
  * Encode a text string as a valid path of a URI, as specified in RFC-3986 section 3.3
  * @param uriPath A value representing an unencoded URI path
- * @returns 
+ * @returns
  */
 function encodeURIPath(uriPath: string): string {
   return uriPath.replace(/[^A-Za-z0-9._~!$&^()*+,;=/-]/g, substring => encodeURIComponent(substring));
@@ -447,7 +447,7 @@ class XdsResolver implements Resolver {
           }
         }
       }
-      let retryPolicy: RetryPolicy | undefined = undefined; 
+      let retryPolicy: RetryPolicy | undefined = undefined;
       if (EXPERIMENTAL_RETRY) {
         const retryConfig = route.route!.retry_policy ?? virtualHost.retry_policy;
         if (retryConfig) {
@@ -458,10 +458,10 @@ class XdsResolver implements Resolver {
             }
           }
           if (retryableStatusCodes.length > 0) {
-            const baseInterval = retryConfig.retry_back_off?.base_interval ? 
-              protoDurationToSecondsString(retryConfig.retry_back_off.base_interval) : 
+            const baseInterval = retryConfig.retry_back_off?.base_interval ?
+              protoDurationToSecondsString(retryConfig.retry_back_off.base_interval) :
               DEFAULT_RETRY_BASE_INTERVAL;
-            const maxInterval = retryConfig.retry_back_off?.max_interval ? 
+            const maxInterval = retryConfig.retry_back_off?.max_interval ?
               protoDurationToSecondsString(retryConfig.retry_back_off.max_interval) :
               getDefaultRetryMaxInterval(baseInterval);
             retryPolicy = {
@@ -664,9 +664,11 @@ class XdsResolver implements Resolver {
   destroy() {
     if (this.listenerResourceName) {
       ListenerResourceType.cancelWatch(this.xdsClient, this.listenerResourceName, this.ldsWatcher);
+      this.isLdsWatcherActive = false;
     }
     if (this.latestRouteConfigName) {
       RouteConfigurationResourceType.cancelWatch(this.xdsClient, this.latestRouteConfigName, this.rdsWatcher);
+      this.latestRouteConfigName = null;
     }
   }
 

--- a/packages/grpc-js-xds/test/client.ts
+++ b/packages/grpc-js-xds/test/client.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { credentials, loadPackageDefinition, ServiceError } from "@grpc/grpc-js";
+import { ChannelOptions, credentials, loadPackageDefinition, ServiceError } from "@grpc/grpc-js";
 import { loadSync } from "@grpc/proto-loader";
 import { ProtoGrpcType } from "./generated/echo";
 import { EchoTestServiceClient } from "./generated/grpc/testing/EchoTestService";
@@ -44,14 +44,14 @@ export class XdsTestClient {
   private client: EchoTestServiceClient;
   private callInterval: NodeJS.Timer;
 
-  constructor(target: string, bootstrapInfo: string) {
-    this.client = new loadedProtos.grpc.testing.EchoTestService(target, credentials.createInsecure(), {[BOOTSTRAP_CONFIG_KEY]: bootstrapInfo});
+  constructor(target: string, bootstrapInfo: string, options?: ChannelOptions) {
+    this.client = new loadedProtos.grpc.testing.EchoTestService(target, credentials.createInsecure(), {...options, [BOOTSTRAP_CONFIG_KEY]: bootstrapInfo});
     this.callInterval = setInterval(() => {}, 0);
     clearInterval(this.callInterval);
   }
 
-  static createFromServer(targetName: string, xdsServer: XdsServer) {
-    return new XdsTestClient(`xds:///${targetName}`, xdsServer.getBootstrapInfoString());
+  static createFromServer(targetName: string, xdsServer: XdsServer, options?: ChannelOptions) {
+    return new XdsTestClient(`xds:///${targetName}`, xdsServer.getBootstrapInfoString(), options);
   }
 
   startCalls(interval: number) {
@@ -97,5 +97,9 @@ export class XdsTestClient {
       });
     }
     sendInner(count, callback);
+  }
+
+  getConnectivityState() {
+    return this.client.getChannel().getConnectivityState(false);
   }
 }


### PR DESCRIPTION
This fixes #2579 (as far as I can tell). The `destroy` method was not resetting the right state, and as a result, it would not start a new watch for the LDS resource, or for the RDS resource once the LDS resource is received.