### PR TITLE
grpc-js-xds: Force submodule update and code generation in prepare script

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {
@@ -9,7 +9,7 @@
     "clean": "gts clean",
     "compile": "tsc",
     "fix": "gts fix",
-    "prepare": "npm run compile",
+    "prepare": "git submodule update --init --recursive && npm run generate-types && npm run compile",
     "pretest": "npm run compile",
     "posttest": "npm run check",
     "generate-types": "proto-loader-gen-types --keepCase --longs String --enums String --defaults --oneofs --includeComments --includeDirs deps/envoy-api/ deps/xds/ deps/googleapis/ deps/protoc-gen-validate/ -O src/generated/ --grpcLib @grpc/grpc-js envoy/service/discovery/v3/ads.proto envoy/service/load_stats/v3/lrs.proto envoy/config/listener/v3/listener.proto envoy/config/route/v3/route.proto envoy/config/cluster/v3/cluster.proto envoy/config/endpoint/v3/endpoint.proto envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto udpa/type/v1/typed_struct.proto xds/type/v3/typed_struct.proto envoy/extensions/filters/http/fault/v3/fault.proto envoy/service/status/v3/csds.proto",

--- a/packages/grpc-js-xds/src/generated/cluster.ts
+++ b/packages/grpc-js-xds/src/generated/cluster.ts
@@ -97,15 +97,6 @@ export interface ProtoGrpcType {
         }
       }
     }
-    extensions: {
-      clusters: {
-        aggregate: {
-          v3: {
-            ClusterConfig: MessageTypeDefinition
-          }
-        }
-      }
-    }
     type: {
       matcher: {
         v3: {


### PR DESCRIPTION
I published version 1.9.1 with the wrong submodule commit checked out, resulting in an inconsistent package that can't load. The distrib tests didn't catch this because they were run with the correct submodule commit. The `prepare` script runs before publishing, so this forces the submodule and the code generated from it to be the correct version.