### PR TITLE
grpc-js: Unref backoff timer in subchannel

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -120,6 +120,7 @@ export class Subchannel {
     this.backoffTimeout = new BackoffTimeout(() => {
       this.handleBackoffTimer();
     }, backoffOptions);
+    this.backoffTimeout.unref();
     this.subchannelAddressString = subchannelAddressToString(subchannelAddress);
 
     this.keepaliveTime = options['grpc.keepalive_time_ms'] ?? -1;


### PR DESCRIPTION
This was making the tests taking a long time to exit after finishing. Our general principle is that grpc should keep the process open if and only if there is a pending request or other surface API event (e.g. channel state change). If a call is not assigned to a connection, the channel has a timer that keeps the process open, and if the call is assigned to a connection, the corresponding transport keeps the connection open. Either way, the subchannel is never responsible for that, so it should unref any timers or other handles that it owns.