### PR TITLE
grpc-js-xds: Don't call git commands in npm scripts

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -9,7 +9,7 @@
     "clean": "gts clean",
     "compile": "tsc",
     "fix": "gts fix",
-    "prepare": "git submodule update --init --recursive && npm run generate-types && npm run compile",
+    "prepare": "npm run generate-types && npm run compile",
     "pretest": "npm run compile",
     "posttest": "npm run check",
     "generate-types": "proto-loader-gen-types --keepCase --longs String --enums String --defaults --oneofs --includeComments --includeDirs deps/envoy-api/ deps/xds/ deps/googleapis/ deps/protoc-gen-validate/ -O src/generated/ --grpcLib @grpc/grpc-js envoy/service/discovery/v3/ads.proto envoy/service/load_stats/v3/lrs.proto envoy/config/listener/v3/listener.proto envoy/config/route/v3/route.proto envoy/config/cluster/v3/cluster.proto envoy/config/endpoint/v3/endpoint.proto envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto udpa/type/v1/typed_struct.proto xds/type/v3/typed_struct.proto envoy/extensions/filters/http/fault/v3/fault.proto envoy/service/status/v3/csds.proto",


### PR DESCRIPTION
I added this in #2582 to try to avoid situations where we publish with the wrong submodule commit checked out, but it turns out that we need to run local `npm install` in contexts where we don't have git, so this doesn't work.