### PR TITLE
Update server-call.ts

### DIFF
--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -558,7 +558,7 @@ export class Http2ServerCallStream<
     return metadata;
   }
 
-  receiveUnaryMessage(encoding: string): Promise<RequestType | void> {
+  receiveUnaryMessage(encoding: string): Promise<RequestType> {
     return new Promise((resolve, reject) => {
       const { stream } = this;
 


### PR DESCRIPTION
I am having a TS2345 trying to bootstrap a nestjs application.

transpile/runtime time error:
```
╰─± npm run start 

> app@0.0.1 start
> nest start app --watch


 Info  Webpack is building your sources...

webpack 5.73.0 compiled successfully in 3246 ms
Type-checking in progress...

{"level":"LOG","message":"Starting Nest application... NestFactory","app":"JsonLogger","scope":"static-logger","timestamp":"2023-09-29T14:43:47.849Z"}

...

ERROR in ./node_modules/@grpc/grpc-js/src/server.ts:1182:7
TS2345: Argument of type 'void | Awaited<RequestType>' is not assignable to parameter of type 'RequestType'.
  'RequestType' could be instantiated with an arbitrary type which could be unrelated to 'void | Awaited<RequestType>'.
    1180 |       call,
    1181 |       metadata,
  > 1182 |       request
         |       ^^^^^^^
    1183 |     );
    1184 |
    1185 |     handler.func(

ERROR in ./node_modules/@grpc/grpc-js/src/server.ts:1249:7
TS2345: Argument of type 'void | Awaited<RequestType>' is not assignable to parameter of type 'RequestType'.
  'RequestType' could be instantiated with an arbitrary type which could be unrelated to 'void | Awaited<RequestType>'.
    1247 |       metadata,
    1248 |       handler.serialize,
  > 1249 |       request
         |       ^^^^^^^
    1250 |     );
    1251 |
    1252 |     handler.func(stream);

Found 2 errors in 9748 ms.
```

package.json has:
- dependency: "@grpc/grpc-js": "^1.9.4",
- devDependency: "@types/node": "^20.7.1"


After the fix on local
```
╰─± npm run start 

> app@0.0.1 start
> nest start app --watch


 Info  Webpack is building your sources...

webpack 5.73.0 compiled successfully in 3246 ms
Type-checking in progress...

{"level":"LOG","message":"Starting Nest application... NestFactory","app":"JsonLogger","scope":"static-logger","timestamp":"2023-09-29T14:43:47.849Z"}

...

No errors found.
```

Not sure neither why was it return void if whenever that function is called the request got be null checked. If this is completely wrong just lmk so we can figure out another solution. Thanks.