### PR TITLE
Cancellation example: corrected information

### DIFF
--- a/examples/cancellation/README.md
+++ b/examples/cancellation/README.md
@@ -2,8 +2,8 @@
 
 This example shows how clients can cancel in-flight RPCs by cancelling the
 call object returned by the method invocation. The client will receive a status
-with code `CANCELLED` and the server handler's call object will emit a
-`'cancelled'` event.
+with code `CANCELLED` and the server handler's call object will emit either a
+`'cancelled'` event or an `'end'` event.
 
 ## Start the server
 

--- a/examples/cancellation/server.js
+++ b/examples/cancellation/server.js
@@ -38,11 +38,13 @@ function bidirectionalStreamingEcho(call) {
     console.log(`echoing message "${message}"`);
     call.write({message: message});
   });
+  // Either 'end' or 'cancelled' will be emitted when the call is cancelled
   call.on('end', () => {
+    console.log('server received end event')
     call.end();
   });
   call.on('cancelled', () => {
-    console.log('received cancelled event');
+    console.log('server received cancelled event');
   });
 }
 


### PR DESCRIPTION
Explicitly state that the server could get either the `cancelled` event or the `end` event, because that is what actually happens.