### PR TITLE
chore(grpc-js): remove unused callcredentials parameter from insecure impl

### DIFF
--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -163,8 +163,8 @@ export abstract class ChannelCredentials {
 }
 
 class InsecureChannelCredentialsImpl extends ChannelCredentials {
-  constructor(callCredentials?: CallCredentials) {
-    super(callCredentials);
+  constructor() {
+    super();
   }
 
   compose(callCredentials: CallCredentials): never {


### PR DESCRIPTION
I was looking at this code just to understand the credentials behavior and was having trouble wrapping my head around how insecure credentials could accept call credentials but not allow composing them. Then I realized it is an unused parameter in a private constructor, the public entry point never passes it call credentials. As it's private, I guess it should be OK to remove this to make the code's intent clearer.