### PR TITLE
grpc-js: Propagate connectivity error information to request errors

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/picker.ts
+++ b/packages/grpc-js/src/picker.ts
@@ -97,16 +97,13 @@ export interface Picker {
  */
 export class UnavailablePicker implements Picker {
   private status: StatusObject;
-  constructor(status?: StatusObject) {
-    if (status !== undefined) {
-      this.status = status;
-    } else {
-      this.status = {
-        code: Status.UNAVAILABLE,
-        details: 'No connection established',
-        metadata: new Metadata(),
-      };
-    }
+  constructor(status?: Partial<StatusObject>) {
+    this.status = {
+      code: Status.UNAVAILABLE,
+      details: 'No connection established',
+      metadata: new Metadata(),
+      ...status,
+    };
   }
   pick(pickArgs: PickArgs): TransientFailurePickResult {
     return {

--- a/packages/grpc-js/src/subchannel-interface.ts
+++ b/packages/grpc-js/src/subchannel-interface.ts
@@ -23,7 +23,8 @@ export type ConnectivityStateListener = (
   subchannel: SubchannelInterface,
   previousState: ConnectivityState,
   newState: ConnectivityState,
-  keepaliveTime: number
+  keepaliveTime: number,
+  errorMessage?: string
 ) => void;
 
 /**

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -250,7 +250,8 @@ export class Subchannel {
         error => {
           this.transitionToState(
             [ConnectivityState.CONNECTING],
-            ConnectivityState.TRANSIENT_FAILURE
+            ConnectivityState.TRANSIENT_FAILURE,
+            `${error}`
           );
         }
       );
@@ -265,7 +266,8 @@ export class Subchannel {
    */
   private transitionToState(
     oldStates: ConnectivityState[],
-    newState: ConnectivityState
+    newState: ConnectivityState,
+    errorMessage?: string
   ): boolean {
     if (oldStates.indexOf(this.connectivityState) === -1) {
       return false;
@@ -318,7 +320,7 @@ export class Subchannel {
         throw new Error(`Invalid state: unknown ConnectivityState ${newState}`);
     }
     for (const listener of this.stateListeners) {
-      listener(this, previousState, newState, this.keepaliveTime);
+      listener(this, previousState, newState, this.keepaliveTime, errorMessage);
     }
     return true;
   }

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -741,6 +741,7 @@ export class Http2SubchannelConnector implements SubchannelConnector {
         connectionOptions
       );
       this.session = session;
+      let errorMessage = 'Failed to connect';
       session.unref();
       session.once('connect', () => {
         session.removeAllListeners();
@@ -749,10 +750,14 @@ export class Http2SubchannelConnector implements SubchannelConnector {
       });
       session.once('close', () => {
         this.session = null;
-        reject();
+        // Leave time for error event to happen before rejecting
+        setImmediate(() => {
+          reject(`${errorMessage} (${new Date().toISOString()})`);
+        });
       });
       session.once('error', error => {
-        this.trace('connection failed with error ' + (error as Error).message);
+        errorMessage = (error as Error).message;
+        this.trace('connection failed with error ' + errorMessage);
       });
     });
   }


### PR DESCRIPTION
Specifically, propagate error information from transport code to subchannel connectivity state updates, and from there to pickers returned by pick_first and round_robin. This will help debug connectivity errors, particularly in cases when the request errors do not occur close to the connection attempts in the logs.

The change to the `UnavailablePicker` constructor to accept partial status objects is copied from master.

This change does not cover xDS code.