### PR TITLE
grpc-js: Include library version and PID in all trace logs

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -42,7 +42,6 @@ can be set.
   - `subchannel_internals` - Traces HTTP/2 session state. Includes per-call logs.
   - `channel_stacktrace` - Traces channel construction events with stack traces.
   - `keepalive` - Traces gRPC keepalive pings
-  - `index` - Traces module loading
   - `outlier_detection` - Traces outlier detection events
 
   The following tracers are added by the `@grpc/grpc-js-xds` library:

--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -273,14 +273,7 @@ import * as load_balancer_outlier_detection from './load-balancer-outlier-detect
 import * as channelz from './channelz';
 import { Deadline } from './deadline';
 
-const clientVersion = require('../../package.json').version;
-
 (() => {
-  logging.trace(
-    LogVerbosity.DEBUG,
-    'index',
-    'Loading @grpc/grpc-js version ' + clientVersion
-  );
   resolver_dns.setup();
   resolver_uds.setup();
   resolver_ip.setup();

--- a/packages/grpc-js/src/logging.ts
+++ b/packages/grpc-js/src/logging.ts
@@ -16,6 +16,9 @@
  */
 
 import { LogVerbosity } from './constants';
+import { pid } from 'process';
+
+const clientVersion = require('../../package.json').version;
 
 const DEFAULT_LOGGER: Partial<Console> = {
   error: (message?: any, ...optionalParams: any[]) => {
@@ -109,7 +112,7 @@ export function trace(
   text: string
 ): void {
   if (isTracerEnabled(tracer)) {
-    log(severity, new Date().toISOString() + ' | ' + tracer + ' | ' + text);
+    log(severity, new Date().toISOString() + ' | v' + clientVersion + ' ' + pid + ' | ' + tracer + ' | ' + text);
   }
 }
 


### PR DESCRIPTION
This fixes #2594 by removing the `index` tracer and moving the relevant information (the library version) into the common prefix of all trace log messages. That will also help confirm the version in the frequent case when people provide snippets of trace logs that don't include the first log, or don't have the `index` tracer enabled. I also included the PID because sometimes people provide logs with output from multiple processes interspersed, and this will help separate them.