### PR TITLE
grpc-js: pick_first: fix happy eyeballs and reresolution in sticky TF mode

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
This fixes two aspects of the pick_first LB policy's behavior while in sticky TF mode:

 1. When it gets an address update, it should do a happy eyeballs pass. Instead it was skipping that for some reason.
 2. When it enters sticky TF mode, it requests address reresolution, but after that, if it stays in sticky TF mode, there is no trigger to request reresolution again, potentially leading to a perpetually stale address list.