### PR TITLE
grpc-js: Cancel and don't start idle timer on shutdown

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -554,7 +554,7 @@ export class InternalChannel {
   }
 
   private maybeStartIdleTimer() {
-    if (this.callCount === 0) {
+    if (this.connectivityState !== ConnectivityState.SHUTDOWN && this.callCount === 0) {
       this.idleTimer = setTimeout(() => {
         this.trace(
           'Idle timer triggered after ' +
@@ -706,6 +706,9 @@ export class InternalChannel {
     this.resolvingLoadBalancer.destroy();
     this.updateState(ConnectivityState.SHUTDOWN);
     clearInterval(this.callRefTimer);
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+    }
     if (this.channelzEnabled) {
       unregisterChannelzRef(this.channelzRef);
     }


### PR DESCRIPTION
This fixes the memory leak reported in https://github.com/grpc/grpc-node/issues/2448#issuecomment-1782690279, according to my manual testing.