### PR TITLE
Fix missing port in proxy CONNECT when using the default HTTPS port

### DIFF
--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -30,6 +30,7 @@ import {
 import { ChannelOptions } from './channel-options';
 import { GrpcUri, parseUri, splitHostPort, uriToString } from './uri-parser';
 import { URL } from 'url';
+import { DEFAULT_PORT } from './resolver-dns';
 
 const TRACER_NAME = 'proxy';
 
@@ -189,16 +190,19 @@ export function getProxiedConnection(
   if (parsedTarget === null) {
     return Promise.resolve<ProxyConnectionResult>({});
   }
-  const targetHostPost = splitHostPort(parsedTarget.path);
-  if (targetHostPost === null) {
+  const splitHostPost = splitHostPort(parsedTarget.path);
+  if (splitHostPost === null) {
     return Promise.resolve<ProxyConnectionResult>({});
   }
+  const hostPort = `${splitHostPost.host}:${
+    splitHostPost.port ?? DEFAULT_PORT
+  }`;
   const options: http.RequestOptions = {
     method: 'CONNECT',
-    path: targetHostPost.host + ':' + (targetHostPost.port != null ? targetHostPost.port : '443'),
+    path: hostPort,
   };
   const headers: http.OutgoingHttpHeaders = {
-    Host: targetHostPost.host + ':' + (targetHostPost.port != null ? targetHostPost.port : '443'),
+    Host: hostPort,
   };
   // Connect to the subchannel address as a proxy
   if (isTcpSubchannelAddress(address)) {

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -189,12 +189,16 @@ export function getProxiedConnection(
   if (parsedTarget === null) {
     return Promise.resolve<ProxyConnectionResult>({});
   }
+  const targetHostPost = splitHostPort(parsedTarget.path);
+  if (targetHostPost === null) {
+    return Promise.resolve<ProxyConnectionResult>({});
+  }
   const options: http.RequestOptions = {
     method: 'CONNECT',
-    path: parsedTarget.path,
+    path: targetHostPost.host + ':' + (targetHostPost.port != null ? targetHostPost.port : '443'),
   };
   const headers: http.OutgoingHttpHeaders = {
-    Host: parsedTarget.path,
+    Host: targetHostPost.host + ':' + (targetHostPost.port != null ? targetHostPost.port : '443'),
   };
   // Connect to the subchannel address as a proxy
   if (isTcpSubchannelAddress(address)) {

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -43,7 +43,7 @@ function trace(text: string): void {
 /**
  * The default TCP port to connect to if not explicitly specified in the target.
  */
-const DEFAULT_PORT = 443;
+export const DEFAULT_PORT = 443;
 
 const DEFAULT_MIN_TIME_BETWEEN_RESOLUTIONS_MS = 30_000;
 


### PR DESCRIPTION
When the target gRPC URI doesn't contain a port, and as such defaults to the default HTTPS port, the code didn't send the port as part of the `HTTP` `CONNECT` request when a proxy is configured, leading to proxies rejected the request with a 400 Bad Request, as the request line is malformed.

We saw this while using `firebase/firestore` which uses gRPC underneath by default, and connect to "firestore.googleapis.com" without a port by default.

Contributed by courtesy of [swimm.io](https://swimm.io/)