### PR TITLE
grpc-js: Don't repeat fixed resolver results

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/resolver-dns.ts
+++ b/packages/grpc-js/src/resolver-dns.ts
@@ -99,6 +99,7 @@ class DnsResolver implements Resolver {
   private nextResolutionTimer: NodeJS.Timeout;
   private isNextResolutionTimerRunning = false;
   private isServiceConfigEnabled = true;
+  private returnedIpResult = false;
   constructor(
     private target: GrpcUri,
     private listener: ResolverListener,
@@ -163,16 +164,19 @@ class DnsResolver implements Resolver {
    */
   private startResolution() {
     if (this.ipResult !== null) {
-      trace('Returning IP address for target ' + uriToString(this.target));
-      setImmediate(() => {
-        this.listener.onSuccessfulResolution(
-          this.ipResult!,
-          null,
-          null,
-          null,
-          {}
-        );
-      });
+      if (!this.returnedIpResult) {
+        trace('Returning IP address for target ' + uriToString(this.target));
+        setImmediate(() => {
+          this.listener.onSuccessfulResolution(
+            this.ipResult!,
+            null,
+            null,
+            null,
+            {}
+          );
+        });
+        this.returnedIpResult = true;
+      }
       this.backoff.stop();
       this.backoff.reset();
       this.stopNextResolutionTimer();
@@ -380,6 +384,7 @@ class DnsResolver implements Resolver {
     this.latestLookupResult = null;
     this.latestServiceConfig = null;
     this.latestServiceConfigError = null;
+    this.returnedIpResult = false;
   }
 
   /**

--- a/packages/grpc-js/src/resolver-ip.ts
+++ b/packages/grpc-js/src/resolver-ip.ts
@@ -41,6 +41,7 @@ const DEFAULT_PORT = 443;
 class IpResolver implements Resolver {
   private addresses: SubchannelAddress[] = [];
   private error: StatusObject | null = null;
+  private hasReturnedResult = false;
   constructor(
     target: GrpcUri,
     private listener: ResolverListener,
@@ -87,22 +88,25 @@ class IpResolver implements Resolver {
     trace('Parsed ' + target.scheme + ' address list ' + this.addresses);
   }
   updateResolution(): void {
-    process.nextTick(() => {
-      if (this.error) {
-        this.listener.onError(this.error);
-      } else {
-        this.listener.onSuccessfulResolution(
-          this.addresses,
-          null,
-          null,
-          null,
-          {}
-        );
-      }
-    });
+    if (!this.hasReturnedResult) {
+      this.hasReturnedResult = true;
+      process.nextTick(() => {
+        if (this.error) {
+          this.listener.onError(this.error);
+        } else {
+          this.listener.onSuccessfulResolution(
+            this.addresses,
+            null,
+            null,
+            null,
+            {}
+          );
+        }
+      });
+    }
   }
   destroy(): void {
-    // This resolver owns no resources, so we do nothing here.
+    this.hasReturnedResult = false;
   }
 
   static getDefaultAuthority(target: GrpcUri): string {

--- a/packages/grpc-js/test/test-pick-first.ts
+++ b/packages/grpc-js/test/test-pick-first.ts
@@ -97,7 +97,7 @@ describe('Shuffler', () => {
   });
 });
 
-describe.only('pick_first load balancing policy', () => {
+describe('pick_first load balancing policy', () => {
   const config = new PickFirstLoadBalancingConfig(false);
   let subchannels: MockSubchannel[] = [];
   const baseChannelControlHelper: ChannelControlHelper = {


### PR DESCRIPTION
This should fix https://github.com/grpc/grpc-node/issues/2604#issuecomment-1784525579. PR #2602 changed pick_first behavior so that it would request a resolver update the first time every subchannel reported TRANSIENT_FAILURE after an address list update. With subchannel reuse, a subchannel could already be in TRANSIENT_FAILURE immediately after an address list update, so pick_first would request a resolver update immediately. The rate limit on DNS targets would rate limit that whole process, but the same is not true of IP targets, causing a tight loop that does nothing. IP targets will never return a different address list, so the result is to just not respond to resolver update requests. The flag is reset in the `destroy` function because that is how channel idleness is handled, and an update is expected after that.