### PR TITLE
grpc-js: Handle unset opaqueData in goaway event

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -194,17 +194,18 @@ class Http2Transport implements Transport {
     });
     session.once(
       'goaway',
-      (errorCode: number, lastStreamID: number, opaqueData: Buffer) => {
+      (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => {
         let tooManyPings = false;
         /* See the last paragraph of
          * https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md#basic-keepalive */
         if (
           errorCode === http2.constants.NGHTTP2_ENHANCE_YOUR_CALM &&
+          opaqueData &&
           opaqueData.equals(tooManyPingsData)
         ) {
           tooManyPings = true;
         }
-        this.trace('connection closed by GOAWAY with code ' + errorCode);
+        this.trace('connection closed by GOAWAY with code ' + errorCode + ' and data ' + opaqueData?.toString());
         this.reportDisconnectToOwner(tooManyPings);
       }
     );


### PR DESCRIPTION
This fixes #2605.