### PR TITLE
grpc-js: Return the result from the UDS resolver only once

### DIFF
--- a/packages/grpc-js/src/resolver-uds.ts
+++ b/packages/grpc-js/src/resolver-uds.ts
@@ -21,6 +21,7 @@ import { ChannelOptions } from './channel-options';
 
 class UdsResolver implements Resolver {
   private addresses: SubchannelAddress[] = [];
+  private hasReturnedResult = false;
   constructor(
     target: GrpcUri,
     private listener: ResolverListener,
@@ -35,14 +36,17 @@ class UdsResolver implements Resolver {
     this.addresses = [{ path }];
   }
   updateResolution(): void {
-    process.nextTick(
-      this.listener.onSuccessfulResolution,
-      this.addresses,
-      null,
-      null,
-      null,
-      {}
-    );
+    if (!this.hasReturnedResult) {
+      this.hasReturnedResult = true;
+      process.nextTick(
+        this.listener.onSuccessfulResolution,
+        this.addresses,
+        null,
+        null,
+        null,
+        {}
+      );
+    }
   }
 
   destroy() {


### PR DESCRIPTION
#2609 did not include the UDS resolver. This fixes that.