### PR TITLE
grpc-js: Make pick_first use exitIdle

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.10",
+  "version": "1.9.11",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
This fixes the bug described in https://github.com/grpc/grpc-node/issues/1490#issuecomment-1814642543. #2609 was introduced to prevent a busy loop when pick_first is in TRANSIENT_FAILURE, and the resolver always returns the result immediately. However, making the resolver only return once caused pick_first to never update after going from READY to IDLE when a connection drops. This fixes that by making `exitIdle` use the most recent address list. This will result in some wasted work if the address list is stale, but if `exitIdle` is called there should also be a resolver update pending, so it will be eventually consistent.