### PR TITLE
Improve Error Handling in Http2Transport for Graceful vs Abrupt Disconnections

### DIFF
--- a/packages/grpc-js/src/subchannel-call.ts
+++ b/packages/grpc-js/src/subchannel-call.ts
@@ -289,10 +289,11 @@ export class Http2SubchannelCall implements SubchannelCall {
     });
   }
 
-  public onDisconnect() {
+  public onDisconnect(status: Status = Status.UNAVAILABLE) {
     this.endCall({
-      code: Status.UNAVAILABLE,
-      details: 'Connection dropped',
+      code: status,
+      details:
+        status === Status.UNAVAILABLE ? 'Connection dropped' : 'Call cancelled',
       metadata: new Metadata(),
     });
   }


### PR DESCRIPTION
This modification builds upon the changes made in #2563 

Changed: Improved error handling in the `Http2Transport` class to differentiate between graceful and abrupt server disconnections. The `handleDisconnect` method has been updated to distinguish between a server's graceful shutdown, signaled by a `GOAWAY` frame, and abrupt terminations like socket errors.  

The status of active calls is now set more appropriately - either to `Cancelled` or `Unavailable`. This addresses an inconsistency in a project, which previously led to confusion due to varying status codes from different server shutdown methods. It makes error handling clearer and more predictable.