### PR TITLE
grpc-js: pick_first: fix currentPick comparison in resetSubchannelList

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -382,7 +382,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
 
   private resetSubchannelList() {
     for (const child of this.children) {
-      if (child.subchannel !== this.currentPick) {
+      if (!(this.currentPick && child.subchannel.realSubchannelEquals(this.currentPick))) {
         /* The connectivity state listener is the same whether the subchannel
          * is in the list of children or it is the currentPick, so if it is in
          * both, removing it here would cause problems. In particular, that


### PR DESCRIPTION
I believe this is the cause of #2621. This is a very similar problem to the one fixed in #2559. The potential incorrect behavior here is that a subchannel in the subchannel list is the same as the one that has been picked, but it is wrapped with a different object so the check here compares false, resulting in removing the listener erroneously. That would cause pick_first to not react to subsequent changes in the subchannel state, which matches the log shown in #2621. I don't actually know of a code path that could cause this this outcome, but it's best to be consistent in how we check this anyway.