### PR TITLE
grpc-js: Fix call ref timer handling

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -296,7 +296,9 @@ export class InternalChannel {
         this.currentPicker = picker;
         const queueCopy = this.pickQueue.slice();
         this.pickQueue = [];
-        this.callRefTimerUnref();
+        if (queueCopy.length > 0) {
+          this.callRefTimerUnref();
+        }
         for (const call of queueCopy) {
           call.doPick();
         }
@@ -349,11 +351,12 @@ export class InternalChannel {
         process.nextTick(() => {
           const localQueue = this.configSelectionQueue;
           this.configSelectionQueue = [];
-          this.callRefTimerUnref();
+          if (localQueue.length > 0) {
+            this.callRefTimerUnref();
+          }
           for (const call of localQueue) {
             call.getConfig();
           }
-          this.configSelectionQueue = [];
         });
       },
       status => {
@@ -380,7 +383,9 @@ export class InternalChannel {
         }
         const localQueue = this.configSelectionQueue;
         this.configSelectionQueue = [];
-        this.callRefTimerUnref();
+        if (localQueue.length > 0) {
+          this.callRefTimerUnref();
+        }
         for (const call of localQueue) {
           call.reportResolverError(status);
         }


### PR DESCRIPTION
I think this change fixes the bug described in https://github.com/grpc/grpc-node/pull/2586#issuecomment-1835883203.

The purpose of the `callRefTimer` is to hold the process open as long as there are calls that the channel is responsible for tracking because they are queued to either get a config from the resolver, or get a pick from the LB policy. Once a call becomes attached to a connection, that connection takes over tracking it and the responsibility for holding the process open. The general `callRefTimer` workflow goes like this:

 - An update comes in from either the resolver or the LB policy
 - The corresponding queue is emptied
 - The timer is unreffed
 - Each call is prompted to process that update
 - If any call needs to requeue, that will cause the timer to be reffed

Once a resolver update has been received, calls never queue for configs anymore, they get them immediately after being created. And calls only queue for picks once they have a config. So, there is never a case when both queues are in use at the same time. The problem before this change is that if an update comes in from the resolver after the initial resolver update while there are calls in the pick queue, the timer would be unreffed but there would be no calls in the config queue, so nothing would trigger reffing the timer again. The fix is to only unref the timer if there is at least one call in the queue to process. I added the same condition to all call sites for consistency.