### PR TITLE
Fix issue #2631 [@grpc/grpc-reflection] Issue with proto file dependencies only on second or next request

### DIFF
--- a/packages/grpc-reflection/src/implementations/reflection-v1.ts
+++ b/packages/grpc-reflection/src/implementations/reflection-v1.ts
@@ -314,8 +314,8 @@ export class ReflectionV1Implementation {
 
   private getFileDependencies(file: IFileDescriptorProto): IFileDescriptorProto[] {
     const visited: Set<IFileDescriptorProto> = new Set();
-    const toVisit: IFileDescriptorProto[] = this.fileDependencies.get(file) || [];
-
+    const toVisit: IFileDescriptorProto[] = [...(this.fileDependencies.get(file) || [])];
+    
     while (toVisit.length > 0) {
       const current = toVisit.pop();
 


### PR DESCRIPTION
I found issue:

More info about issue #2631 

```typescript
    
    # Correct:
    const toVisit: IFileDescriptorProto[] = [...(this.fileDependencies.get(file) || [])];
    
    # was 
    # const toVisit: IFileDescriptorProto[] = this.fileDependencies.get(file) || [];
    
    while (toVisit.length > 0) {
      # Here loop get item and remove from array but if you 
      # dont spreed fileDendepencies, all depedencies will be removed from original array
      const current = toVisit.pop();

      if (!current || visited.has(current)) {
        continue;
      }

      visited.add(current);
      toVisit.push(...this.fileDependencies.get(current)?.filter((dep) => !visited.has(dep)) || []);
    }

    return Array.from(visited);
  }
```