### PR TITLE
fix: export type VerifyOptions

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -27,7 +27,7 @@ import { StatusObject } from './call-interface';
 import { Channel, ChannelImplementation } from './channel';
 import { CompressionAlgorithms } from './compression-algorithms';
 import { ConnectivityState } from './connectivity-state';
-import { ChannelCredentials } from './channel-credentials';
+import { ChannelCredentials, VerifyOptions } from './channel-credentials';
 import {
   CallOptions,
   Client,
@@ -182,6 +182,7 @@ export {
   ServiceDefinition,
   UntypedHandleCall,
   UntypedServiceImplementation,
+  VerifyOptions
 };
 
 /**** Server ****/


### PR DESCRIPTION
<img width="886" alt="image" src="https://github.com/grpc/grpc-node/assets/4998018/33e00380-6b51-4a9b-b68b-60014024ccfd">

<img width="894" alt="image" src="https://github.com/grpc/grpc-node/assets/4998018/017ceb59-0d40-4b78-89e5-0295a7862331">

I think `VerifyOptions` should be export.