### PR TITLE
grpc-js: Fix and optimize IDLE timeouts

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -184,6 +184,7 @@ export class InternalChannel {
   private callCount = 0;
   private idleTimer: NodeJS.Timeout | null = null;
   private readonly idleTimeoutMs: number;
+  private lastActivityTimestamp: Date;
 
   // Channelz info
   private readonly channelzEnabled: boolean = true;
@@ -409,6 +410,7 @@ export class InternalChannel {
         'Channel constructed \n' +
         error.stack?.substring(error.stack.indexOf('\n') + 1)
     );
+    this.lastActivityTimestamp = new Date();
   }
 
   private getChannelzInfo(): ChannelInfo {
@@ -556,19 +558,44 @@ export class InternalChannel {
     this.resolvingLoadBalancer.destroy();
     this.updateState(ConnectivityState.IDLE);
     this.currentPicker = new QueuePicker(this.resolvingLoadBalancer);
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
   }
 
-  private maybeStartIdleTimer() {
-    if (this.connectivityState !== ConnectivityState.SHUTDOWN && this.callCount === 0) {
-      this.idleTimer = setTimeout(() => {
+  private startIdleTimeout(timeoutMs: number) {
+    this.idleTimer = setTimeout(() => {
+      if (this.callCount > 0) {
+        /* If there is currently a call, the channel will not go idle for a
+         * period of at least idleTimeoutMs, so check again after that time.
+         */
+        this.startIdleTimeout(this.idleTimeoutMs);
+        return;
+      }
+      const now = new Date();
+      const timeSinceLastActivity = now.valueOf() - this.lastActivityTimestamp.valueOf();
+      if (timeSinceLastActivity >= this.idleTimeoutMs) {
         this.trace(
           'Idle timer triggered after ' +
             this.idleTimeoutMs +
             'ms of inactivity'
         );
         this.enterIdle();
-      }, this.idleTimeoutMs);
-      this.idleTimer.unref?.();
+      } else {
+        /* Whenever the timer fires with the latest activity being too recent,
+         * set the timer again for the time when the time since the last
+         * activity is equal to the timeout. This should result in the timer
+         * firing no more than once every idleTimeoutMs/2 on average. */
+        this.startIdleTimeout(this.idleTimeoutMs - timeSinceLastActivity);
+      }
+    }, timeoutMs);
+    this.idleTimer.unref?.();
+  }
+
+  private maybeStartIdleTimer() {
+    if (this.connectivityState !== ConnectivityState.SHUTDOWN && !this.idleTimer) {
+      this.startIdleTimeout(this.idleTimeoutMs);
     }
   }
 
@@ -577,10 +604,6 @@ export class InternalChannel {
       this.callTracker.addCallStarted();
     }
     this.callCount += 1;
-    if (this.idleTimer) {
-      clearTimeout(this.idleTimer);
-      this.idleTimer = null;
-    }
   }
 
   private onCallEnd(status: StatusObject) {
@@ -592,6 +615,7 @@ export class InternalChannel {
       }
     }
     this.callCount -= 1;
+    this.lastActivityTimestamp = new Date();
     this.maybeStartIdleTimer();
   }
 
@@ -729,6 +753,7 @@ export class InternalChannel {
     const connectivityState = this.connectivityState;
     if (tryToConnect) {
       this.resolvingLoadBalancer.exitIdle();
+      this.lastActivityTimestamp = new Date();
       this.maybeStartIdleTimer();
     }
     return connectivityState;


### PR DESCRIPTION
This fixes #2642: in the current idle timer implementation, if `getConnectivityState(true)` is called multiple times, it can lose track of idle timer handles without cancelling them, resulting in those timers firing inappropriately and setting the connectivity state to IDLE when that should not happen.

This change has two layers of defense against that failure: first, the timer now cannot be started if one is already running, so it should not be possible to lose track of existing running timers. Second, the client now tracks the timestamp of the last activity, and the idle timer will only actually set the state to IDLE if enough time has passed since the last activity.

In addition, this second change is part of an optimization to the idle timeout behavior: previously, the timer would start every time the number of active calls increased from 0, and was cancelled every time the number of active calls decreased to 0. This could cause a lot of timer churn if the user was making many requests in sequence, one at a time. Now instead, the timer is started the first time it is reasonable to do so, and after that it runs for the full timeout and then is started again every time the timer fires, with a variable timeout depending on the time since the last activity. As a result, there is only activity related to the idle timer at most twice per timeout period.