### PR TITLE
grpc-js: Shutdown transport if a state change occurs while connecting

### DIFF
--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -245,6 +245,10 @@ export class Subchannel {
                 );
               }
             });
+          } else {
+            /* If we can't transition from CONNECTING to READY here, we will
+             * not be using this transport, so release its resources. */
+            transport.shutdown();
           }
         },
         error => {


### PR DESCRIPTION
In this promise resolution handler, we have a transport that has just finished connecting. We only use it if the subchannel is currently in the CONNECTING state. If it is not, we just drop the transport on the floor. However, it is still holding the resources related to an established connection, so we have to release those by calling `transport.shutdown()`.

I discovered this bug while investigating #2641.