### PR TITLE
grpc-health-check: Move `typescript` as a dev dependency

### DIFF
--- a/packages/grpc-health-check/package.json
+++ b/packages/grpc-health-check/package.json
@@ -21,8 +21,7 @@
     "generate-test-types": "proto-loader-gen-types --keepCase --longs String --enums String --defaults --oneofs --includeComments --includeDirs proto/ -O test/generated --grpcLib=@grpc/grpc-js health/v1/health.proto"
   },
   "dependencies": {
-    "@grpc/proto-loader": "^0.7.10",
-    "typescript": "^5.2.2"
+    "@grpc/proto-loader": "^0.7.10"
   },
   "files": [
     "LICENSE",
@@ -35,6 +34,7 @@
   "types": "build/src/health.d.ts",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grpc/grpc-js": "file:../grpc-js"
+    "@grpc/grpc-js": "file:../grpc-js",
+    "typescript": "^5.2.2"
   }
 }


### PR DESCRIPTION
Currently, `typescript` is installed as a dependency in `grpc-health-check` package, but it's only used during build. This pull-request moves it to a dev dependency.