### PR TITLE
grpc-js-xds: De-experimentalize tested features and update feature list

### DIFF
--- a/packages/grpc-js-xds/README.md
+++ b/packages/grpc-js-xds/README.md
@@ -30,5 +30,8 @@ const client = new MyServiceClient('xds:///example.com:123');
  - [Client Status Discovery Service](https://github.com/grpc/proposal/blob/master/A40-csds-support.md)
  - [Outlier Detection](https://github.com/grpc/proposal/blob/master/A50-xds-outlier-detection.md)
  - [xDS Retry Support](https://github.com/grpc/proposal/blob/master/A44-xds-retry.md)
- - [xDS Aggregate and Logical DNS Clusters](https://github.com/grpc/proposal/blob/master/A37-xds-aggregate-and-logical-dns-clusters.md)'
+ - [xDS Aggregate and Logical DNS Clusters](https://github.com/grpc/proposal/blob/master/A37-xds-aggregate-and-logical-dns-clusters.md)
  - [xDS Federation](https://github.com/grpc/proposal/blob/master/A47-xds-federation.md) (Currently experimental, enabled by environment variable `GRPC_EXPERIMENTAL_XDS_FEDERATION`)
+ - [xDS Custom Load Balancer Configuration](https://github.com/grpc/proposal/blob/master/A52-xds-custom-lb-policies.md) (Custom load balancer registration not currently supported)
+ - [xDS Ring Hash LB Policy](https://github.com/grpc/proposal/blob/master/A42-xds-ring-hash-lb-policy.md)
+ - [`pick_first` via xDS](https://github.com/grpc/proposal/blob/master/A62-pick-first.md#pick_first-via-xds-1) (Currently experimental, enabled by environment variable `GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG`)

--- a/packages/grpc-js-xds/gulpfile.ts
+++ b/packages/grpc-js-xds/gulpfile.ts
@@ -62,10 +62,9 @@ const compile = checkTask(() => execNpmCommand('compile'));
 
 const runTests = checkTask(() => {
   process.env.GRPC_EXPERIMENTAL_XDS_FEDERATION = 'true';
-  process.env.GRPC_EXPERIMENTAL_XDS_CUSTOM_LB_CONFIG = 'true';
   process.env.GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG = 'true';
-  if (Number(process.versions.node.split('.')[0]) > 14) {
-    process.env.GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH = 'true';
+  if (Number(process.versions.node.split('.')[0]) <= 14) {
+    process.env.GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH = 'false';
   }
   return gulp.src(`${outDir}/test/**/*.js`)
     .pipe(mocha({reporter: 'mocha-jenkins-reporter',

--- a/packages/grpc-js-xds/src/environment.ts
+++ b/packages/grpc-js-xds/src/environment.ts
@@ -15,10 +15,13 @@
  *
  */
 
+/* Switches to enable or disable experimental features. If the default is
+ * 'true', the feature is enabled by default, if the default is 'false' the
+ * feature is disabled by default. */
 export const EXPERIMENTAL_FAULT_INJECTION = (process.env.GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION ?? 'true') === 'true';
 export const EXPERIMENTAL_OUTLIER_DETECTION = (process.env.GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION ?? 'true') === 'true';
 export const EXPERIMENTAL_RETRY = (process.env.GRPC_XDS_EXPERIMENTAL_ENABLE_RETRY ?? 'true') === 'true';
 export const EXPERIMENTAL_FEDERATION = (process.env.GRPC_EXPERIMENTAL_XDS_FEDERATION ?? 'false') === 'true';
-export const EXPERIMENTAL_CUSTOM_LB_CONFIG = (process.env.GRPC_EXPERIMENTAL_XDS_CUSTOM_LB_CONFIG ?? 'false') === 'true';
-export const EXPERIMENTAL_RING_HASH = (process.env.GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH ?? 'false') === 'true';
+export const EXPERIMENTAL_CUSTOM_LB_CONFIG = (process.env.GRPC_EXPERIMENTAL_XDS_CUSTOM_LB_CONFIG ?? 'true') === 'true';
+export const EXPERIMENTAL_RING_HASH = (process.env.GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH ?? 'true') === 'true';
 export const EXPERIMENTAL_PICK_FIRST = (process.env.GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG ?? 'false') === 'true';


### PR DESCRIPTION
To prepare for the 1.10.0 release.