### PR TITLE
grpc-js/grpc-js-xds: Bump version to 1.10.0

### DIFF
--- a/packages/grpc-js-xds/README.md
+++ b/packages/grpc-js-xds/README.md
@@ -1,6 +1,6 @@
 # @grpc/grpc-js xDS plugin
 
-This package provides support for the `xds://` URL scheme to the `@grpc/grpc-js` library. The latest version of this package is compatible with `@grpc/grpc-js` version 1.9.x.
+This package provides support for the `xds://` URL scheme to the `@grpc/grpc-js` library. The latest version of this package is compatible with `@grpc/grpc-js` version 1.10.x.
 
 ## Installation
 

--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {
@@ -50,7 +50,7 @@
     "xxhash-wasm": "^1.0.2"
   },
   "peerDependencies": {
-    "@grpc/grpc-js": "~1.9.0"
+    "@grpc/grpc-js": "~1.10.0"
   },
   "engines": {
     "node": ">=10.10.0"

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.9.14",
+  "version": "1.10.0",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
The first 1.10.x release.