### PR TITLE
grpc-js: Optimizing buffer allocation for server server and bidi streams

### DIFF
--- a/packages/grpc-js/src/server-interceptors.ts
+++ b/packages/grpc-js/src/server-interceptors.ts
@@ -856,14 +856,9 @@ export class BaseServerInterceptingCall
         frame.payload.length
     );
 
-    this.stream.write(
-      frame.infoBytes,
-      this.createFrameWriteErrorCallback(callback)
-    );
-    this.stream.write(
-      frame.payload,
-      this.createFrameWriteErrorCallback(callback)
-    );
+    const cb = this.createFrameWriteErrorCallback(callback);
+    this.stream.write(frame.infoBytes, cb);
+    this.stream.write(frame.payload, cb);
   }
   sendStatus(status: PartialStatusObject): void {
     if (this.checkCancelled()) {


### PR DESCRIPTION
Logical continuation of PR #2652 

Reduced allocated memory while making gRPC grame from **2N+5** bytes to **N+5** bytes (where N is length of serialized message)

P.S. Sorry for big diff, [this file](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/server-interceptors.ts)  does not meet the [prettier conditions](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/prettier.config.js) in `master` branch