### PR TITLE
grpc-js-xds: Implement EDS dualstack support

### DIFF
--- a/packages/grpc-js-xds/src/environment.ts
+++ b/packages/grpc-js-xds/src/environment.ts
@@ -22,3 +22,4 @@ export const EXPERIMENTAL_FEDERATION = (process.env.GRPC_EXPERIMENTAL_XDS_FEDERA
 export const EXPERIMENTAL_CUSTOM_LB_CONFIG = (process.env.GRPC_EXPERIMENTAL_XDS_CUSTOM_LB_CONFIG ?? 'false') === 'true';
 export const EXPERIMENTAL_RING_HASH = (process.env.GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH ?? 'false') === 'true';
 export const EXPERIMENTAL_PICK_FIRST = (process.env.GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG ?? 'false') === 'true';
+export const EXPERIMENTAL_DUALSTACK_ENDPOINTS = (process.env.GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS ?? 'false') === 'true';

--- a/packages/grpc-js-xds/src/generated/ads.ts
+++ b/packages/grpc-js-xds/src/generated/ads.ts
@@ -49,6 +49,7 @@ export interface ProtoGrpcType {
           TcpKeepalive: MessageTypeDefinition
           TrafficDirection: EnumTypeDefinition
           TransportSocket: MessageTypeDefinition
+          TypedExtensionConfig: MessageTypeDefinition
           WatchedDirectory: MessageTypeDefinition
         }
       }

--- a/packages/grpc-js-xds/src/generated/cluster.ts
+++ b/packages/grpc-js-xds/src/generated/cluster.ts
@@ -110,6 +110,12 @@ export interface ProtoGrpcType {
           StringMatcher: MessageTypeDefinition
         }
       }
+      metadata: {
+        v3: {
+          MetadataKey: MessageTypeDefinition
+          MetadataKind: MessageTypeDefinition
+        }
+      }
       v3: {
         CodecClientType: EnumTypeDefinition
         DoubleRange: MessageTypeDefinition

--- a/packages/grpc-js-xds/src/generated/csds.ts
+++ b/packages/grpc-js-xds/src/generated/csds.ts
@@ -61,6 +61,7 @@ export interface ProtoGrpcType {
           TcpKeepalive: MessageTypeDefinition
           TrafficDirection: EnumTypeDefinition
           TransportSocket: MessageTypeDefinition
+          TypedExtensionConfig: MessageTypeDefinition
           WatchedDirectory: MessageTypeDefinition
         }
       }
@@ -90,6 +91,7 @@ export interface ProtoGrpcType {
           ListMatcher: MessageTypeDefinition
           ListStringMatcher: MessageTypeDefinition
           NodeMatcher: MessageTypeDefinition
+          OrMatcher: MessageTypeDefinition
           RegexMatchAndSubstitute: MessageTypeDefinition
           RegexMatcher: MessageTypeDefinition
           StringMatcher: MessageTypeDefinition

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/Cluster.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/Cluster.ts
@@ -27,6 +27,7 @@ import type { Struct as _google_protobuf_Struct, Struct__Output as _google_proto
 import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from '../../../../envoy/config/core/v3/RuntimeDouble';
 import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from '../../../../envoy/type/v3/Percent';
 import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from '../../../../google/protobuf/UInt64Value';
+import type { MetadataKey as _envoy_type_metadata_v3_MetadataKey, MetadataKey__Output as _envoy_type_metadata_v3_MetadataKey__Output } from '../../../../envoy/type/metadata/v3/MetadataKey';
 import type { HealthStatusSet as _envoy_config_core_v3_HealthStatusSet, HealthStatusSet__Output as _envoy_config_core_v3_HealthStatusSet__Output } from '../../../../envoy/config/core/v3/HealthStatusSet';
 import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from '../../../../google/protobuf/DoubleValue';
 import type { Long } from '@grpc/proto-loader';
@@ -944,6 +945,11 @@ export interface _envoy_config_cluster_v3_Cluster_OriginalDstLbConfig {
    * will take precedence over filter state and header override ports
    */
   'upstream_port_override'?: (_google_protobuf_UInt32Value | null);
+  /**
+   * The dynamic metadata key to override destination address.
+   * First the request metadata is considered, then the connection one.
+   */
+  'metadata_key'?: (_envoy_type_metadata_v3_MetadataKey | null);
 }
 
 /**
@@ -978,6 +984,11 @@ export interface _envoy_config_cluster_v3_Cluster_OriginalDstLbConfig__Output {
    * will take precedence over filter state and header override ports
    */
   'upstream_port_override': (_google_protobuf_UInt32Value__Output | null);
+  /**
+   * The dynamic metadata key to override destination address.
+   * First the request metadata is considered, then the connection one.
+   */
+  'metadata_key': (_envoy_type_metadata_v3_MetadataKey__Output | null);
 }
 
 export interface _envoy_config_cluster_v3_Cluster_PreconnectPolicy {

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/Filter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/Filter.ts
@@ -1,6 +1,7 @@
 // Original file: deps/envoy-api/envoy/config/cluster/v3/filter.proto
 
 import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../../../google/protobuf/Any';
+import type { ExtensionConfigSource as _envoy_config_core_v3_ExtensionConfigSource, ExtensionConfigSource__Output as _envoy_config_core_v3_ExtensionConfigSource__Output } from '../../../../envoy/config/core/v3/ExtensionConfigSource';
 
 export interface Filter {
   /**
@@ -11,9 +12,17 @@ export interface Filter {
    * Filter specific configuration which depends on the filter being
    * instantiated. See the supported filters for further documentation.
    * Note that Envoy's :ref:`downstream network
-   * filters <config_network_filters>` are not valid upstream filters.
+   * filters <config_network_filters>` are not valid upstream network filters.
+   * Only one of typed_config or config_discovery can be used.
    */
   'typed_config'?: (_google_protobuf_Any | null);
+  /**
+   * Configuration source specifier for an extension configuration discovery
+   * service. In case of a failure and without the default configuration, the
+   * listener closes the connections.
+   * Only one of typed_config or config_discovery can be used.
+   */
+  'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource | null);
 }
 
 export interface Filter__Output {
@@ -25,7 +34,15 @@ export interface Filter__Output {
    * Filter specific configuration which depends on the filter being
    * instantiated. See the supported filters for further documentation.
    * Note that Envoy's :ref:`downstream network
-   * filters <config_network_filters>` are not valid upstream filters.
+   * filters <config_network_filters>` are not valid upstream network filters.
+   * Only one of typed_config or config_discovery can be used.
    */
   'typed_config': (_google_protobuf_Any__Output | null);
+  /**
+   * Configuration source specifier for an extension configuration discovery
+   * service. In case of a failure and without the default configuration, the
+   * listener closes the connections.
+   * Only one of typed_config or config_discovery can be used.
+   */
+  'config_discovery': (_envoy_config_core_v3_ExtensionConfigSource__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/OutlierDetection.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/OutlierDetection.ts
@@ -2,11 +2,12 @@
 
 import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from '../../../../google/protobuf/UInt32Value';
 import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../../google/protobuf/Duration';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from '../../../../google/protobuf/BoolValue';
 
 /**
  * See the :ref:`architecture overview <arch_overview_outlier_detection>` for
  * more information on outlier detection.
- * [#next-free-field: 23]
+ * [#next-free-field: 24]
  */
 export interface OutlierDetection {
   /**
@@ -163,12 +164,19 @@ export interface OutlierDetection {
    * Defaults to 0s.
    */
   'max_ejection_time_jitter'?: (_google_protobuf_Duration | null);
+  /**
+   * If active health checking is enabled and a host is ejected by outlier detection, a successful active health check
+   * unejects the host by default and considers it as healthy. Unejection also clears all the outlier detection counters.
+   * To change this default behavior set this config to ``false`` where active health checking will not uneject the host.
+   * Defaults to true.
+   */
+  'successful_active_health_check_uneject_host'?: (_google_protobuf_BoolValue | null);
 }
 
 /**
  * See the :ref:`architecture overview <arch_overview_outlier_detection>` for
  * more information on outlier detection.
- * [#next-free-field: 23]
+ * [#next-free-field: 24]
  */
 export interface OutlierDetection__Output {
   /**
@@ -325,4 +333,11 @@ export interface OutlierDetection__Output {
    * Defaults to 0s.
    */
   'max_ejection_time_jitter': (_google_protobuf_Duration__Output | null);
+  /**
+   * If active health checking is enabled and a host is ejected by outlier detection, a successful active health check
+   * unejects the host by default and considers it as healthy. Unejection also clears all the outlier detection counters.
+   * To change this default behavior set this config to ``false`` where active health checking will not uneject the host.
+   * Defaults to true.
+   */
+  'successful_active_health_check_uneject_host': (_google_protobuf_BoolValue__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/TrackClusterStats.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/TrackClusterStats.ts
@@ -16,6 +16,22 @@ export interface TrackClusterStats {
    * of requests and responses will be published.
    */
   'request_response_sizes'?: (boolean);
+  /**
+   * If true, some stats will be emitted per-endpoint, similar to the stats in admin ``/clusters``
+   * output.
+   * 
+   * This does not currently output correct stats during a hot-restart.
+   * 
+   * This is not currently implemented by all stat sinks.
+   * 
+   * These stats do not honor filtering or tag extraction rules in :ref:`StatsConfig
+   * <envoy_v3_api_msg_config.metrics.v3.StatsConfig>` (but fixed-value tags are supported). Admin
+   * endpoint filtering is supported.
+   * 
+   * This may not be used at the same time as
+   * :ref:`load_stats_config <envoy_v3_api_field_config.bootstrap.v3.ClusterManager.load_stats_config>`.
+   */
+  'per_endpoint_stats'?: (boolean);
 }
 
 export interface TrackClusterStats__Output {
@@ -33,4 +49,20 @@ export interface TrackClusterStats__Output {
    * of requests and responses will be published.
    */
   'request_response_sizes': (boolean);
+  /**
+   * If true, some stats will be emitted per-endpoint, similar to the stats in admin ``/clusters``
+   * output.
+   * 
+   * This does not currently output correct stats during a hot-restart.
+   * 
+   * This is not currently implemented by all stat sinks.
+   * 
+   * These stats do not honor filtering or tag extraction rules in :ref:`StatsConfig
+   * <envoy_v3_api_msg_config.metrics.v3.StatsConfig>` (but fixed-value tags are supported). Admin
+   * endpoint filtering is supported.
+   * 
+   * This may not be used at the same time as
+   * :ref:`load_stats_config <envoy_v3_api_field_config.bootstrap.v3.ClusterManager.load_stats_config>`.
+   */
+  'per_endpoint_stats': (boolean);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/BindConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/BindConfig.ts
@@ -4,9 +4,10 @@ import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddres
 import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from '../../../../google/protobuf/BoolValue';
 import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from '../../../../envoy/config/core/v3/SocketOption';
 import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from '../../../../envoy/config/core/v3/ExtraSourceAddress';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from '../../../../envoy/config/core/v3/TypedExtensionConfig';
 
 /**
- * [#next-free-field: 6]
+ * [#next-free-field: 7]
  */
 export interface BindConfig {
   /**
@@ -34,20 +35,23 @@ export interface BindConfig {
    */
   'additional_source_addresses'?: (_envoy_config_core_v3_SocketAddress)[];
   /**
-   * Extra source addresses appended to the address specified in the `source_address`
-   * field. This enables to specify multiple source addresses. Currently, only one extra
-   * address can be supported, and the extra address should have a different IP version
-   * with the address in the `source_address` field. The address which has the same IP
-   * version with the target host's address IP version will be used as bind address. If more
-   * than one extra address specified, only the first address matched IP version will be
-   * returned. If there is no same IP version address found, the address in the `source_address`
-   * will be returned.
+   * Extra source addresses appended to the address specified in the ``source_address``
+   * field. This enables to specify multiple source addresses.
+   * The source address selection is determined by :ref:`local_address_selector
+   * <envoy_v3_api_field_config.core.v3.BindConfig.local_address_selector>`.
    */
   'extra_source_addresses'?: (_envoy_config_core_v3_ExtraSourceAddress)[];
+  /**
+   * Custom local address selector to override the default (i.e.
+   * :ref:`DefaultLocalAddressSelector
+   * <envoy_v3_api_msg_config.upstream.local_address_selector.v3.DefaultLocalAddressSelector>`).
+   * [#extension-category: envoy.upstream.local_address_selector]
+   */
+  'local_address_selector'?: (_envoy_config_core_v3_TypedExtensionConfig | null);
 }
 
 /**
- * [#next-free-field: 6]
+ * [#next-free-field: 7]
  */
 export interface BindConfig__Output {
   /**
@@ -75,14 +79,17 @@ export interface BindConfig__Output {
    */
   'additional_source_addresses': (_envoy_config_core_v3_SocketAddress__Output)[];
   /**
-   * Extra source addresses appended to the address specified in the `source_address`
-   * field. This enables to specify multiple source addresses. Currently, only one extra
-   * address can be supported, and the extra address should have a different IP version
-   * with the address in the `source_address` field. The address which has the same IP
-   * version with the target host's address IP version will be used as bind address. If more
-   * than one extra address specified, only the first address matched IP version will be
-   * returned. If there is no same IP version address found, the address in the `source_address`
-   * will be returned.
+   * Extra source addresses appended to the address specified in the ``source_address``
+   * field. This enables to specify multiple source addresses.
+   * The source address selection is determined by :ref:`local_address_selector
+   * <envoy_v3_api_field_config.core.v3.BindConfig.local_address_selector>`.
    */
   'extra_source_addresses': (_envoy_config_core_v3_ExtraSourceAddress__Output)[];
+  /**
+   * Custom local address selector to override the default (i.e.
+   * :ref:`DefaultLocalAddressSelector
+   * <envoy_v3_api_msg_config.upstream.local_address_selector.v3.DefaultLocalAddressSelector>`).
+   * [#extension-category: envoy.upstream.local_address_selector]
+   */
+  'local_address_selector': (_envoy_config_core_v3_TypedExtensionConfig__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HeaderValue.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HeaderValue.ts
@@ -15,8 +15,15 @@ export interface HeaderValue {
    * The same :ref:`format specifier <config_access_log_format>` as used for
    * :ref:`HTTP access logging <config_access_log>` applies here, however
    * unknown header values are replaced with the empty string instead of ``-``.
+   * Header value is encoded as string. This does not work for non-utf8 characters.
+   * Only one of ``value`` or ``raw_value`` can be set.
    */
   'value'?: (string);
+  /**
+   * Header value is encoded as bytes which can support non-utf8 characters.
+   * Only one of ``value`` or ``raw_value`` can be set.
+   */
+  'raw_value'?: (Buffer | Uint8Array | string);
 }
 
 /**
@@ -33,6 +40,13 @@ export interface HeaderValue__Output {
    * The same :ref:`format specifier <config_access_log_format>` as used for
    * :ref:`HTTP access logging <config_access_log>` applies here, however
    * unknown header values are replaced with the empty string instead of ``-``.
+   * Header value is encoded as string. This does not work for non-utf8 characters.
+   * Only one of ``value`` or ``raw_value`` can be set.
    */
   'value': (string);
+  /**
+   * Header value is encoded as bytes which can support non-utf8 characters.
+   * Only one of ``value`` or ``raw_value`` can be set.
+   */
+  'raw_value': (Buffer);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HeaderValueOption.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HeaderValueOption.ts
@@ -10,9 +10,12 @@ import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _goo
  */
 export enum _envoy_config_core_v3_HeaderValueOption_HeaderAppendAction {
   /**
-   * This action will append the specified value to the existing values if the header
-   * already exists. If the header doesn't exist then this will add the header with
-   * specified key and value.
+   * If the header already exists, this action will result in:
+   * 
+   * - Comma-concatenated for predefined inline headers.
+   * - Duplicate header added in the ``HeaderMap`` for other headers.
+   * 
+   * If the header doesn't exist then this will add new header with specified key and value.
    */
   APPEND_IF_EXISTS_OR_ADD = 0,
   /**
@@ -26,6 +29,11 @@ export enum _envoy_config_core_v3_HeaderValueOption_HeaderAppendAction {
    * with specified key and value.
    */
   OVERWRITE_IF_EXISTS_OR_ADD = 2,
+  /**
+   * This action will overwrite the specified value by discarding any existing values if
+   * the header already exists. If the header doesn't exist then this will be no-op.
+   */
+  OVERWRITE_IF_EXISTS = 3,
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/JsonFormatOptions.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/JsonFormatOptions.ts
@@ -1,0 +1,22 @@
+// Original file: deps/envoy-api/envoy/config/core/v3/substitution_format_string.proto
+
+
+/**
+ * Optional configuration options to be used with json_format.
+ */
+export interface JsonFormatOptions {
+  /**
+   * The output JSON string properties will be sorted.
+   */
+  'sort_properties'?: (boolean);
+}
+
+/**
+ * Optional configuration options to be used with json_format.
+ */
+export interface JsonFormatOptions__Output {
+  /**
+   * The output JSON string properties will be sorted.
+   */
+  'sort_properties': (boolean);
+}

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/QuicProtocolOptions.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/QuicProtocolOptions.ts
@@ -5,7 +5,7 @@ import type { QuicKeepAliveSettings as _envoy_config_core_v3_QuicKeepAliveSettin
 
 /**
  * QUIC protocol options which apply to both downstream and upstream connections.
- * [#next-free-field: 6]
+ * [#next-free-field: 8]
  */
 export interface QuicProtocolOptions {
   /**
@@ -37,7 +37,7 @@ export interface QuicProtocolOptions {
   'initial_connection_window_size'?: (_google_protobuf_UInt32Value | null);
   /**
    * The number of timeouts that can occur before port migration is triggered for QUIC clients.
-   * This defaults to 1. If set to 0, port migration will not occur on path degrading.
+   * This defaults to 4. If set to 0, port migration will not occur on path degrading.
    * Timeout here refers to QUIC internal path degrading timeout mechanism, such as PTO.
    * This has no effect on server sessions.
    */
@@ -47,11 +47,21 @@ export interface QuicProtocolOptions {
    * If absent, use the default keepalive behavior of which a client connection sends PINGs every 15s, and a server connection doesn't do anything.
    */
   'connection_keepalive'?: (_envoy_config_core_v3_QuicKeepAliveSettings | null);
+  /**
+   * A comma-separated list of strings representing QUIC connection options defined in
+   * `QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h>`_ and to be sent by upstream connections.
+   */
+  'connection_options'?: (string);
+  /**
+   * A comma-separated list of strings representing QUIC client connection options defined in
+   * `QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h>`_ and to be sent by upstream connections.
+   */
+  'client_connection_options'?: (string);
 }
 
 /**
  * QUIC protocol options which apply to both downstream and upstream connections.
- * [#next-free-field: 6]
+ * [#next-free-field: 8]
  */
 export interface QuicProtocolOptions__Output {
   /**
@@ -83,7 +93,7 @@ export interface QuicProtocolOptions__Output {
   'initial_connection_window_size': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The number of timeouts that can occur before port migration is triggered for QUIC clients.
-   * This defaults to 1. If set to 0, port migration will not occur on path degrading.
+   * This defaults to 4. If set to 0, port migration will not occur on path degrading.
    * Timeout here refers to QUIC internal path degrading timeout mechanism, such as PTO.
    * This has no effect on server sessions.
    */
@@ -93,4 +103,14 @@ export interface QuicProtocolOptions__Output {
    * If absent, use the default keepalive behavior of which a client connection sends PINGs every 15s, and a server connection doesn't do anything.
    */
   'connection_keepalive': (_envoy_config_core_v3_QuicKeepAliveSettings__Output | null);
+  /**
+   * A comma-separated list of strings representing QUIC connection options defined in
+   * `QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h>`_ and to be sent by upstream connections.
+   */
+  'connection_options': (string);
+  /**
+   * A comma-separated list of strings representing QUIC client connection options defined in
+   * `QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h>`_ and to be sent by upstream connections.
+   */
+  'client_connection_options': (string);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RateLimitSettings.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RateLimitSettings.ts
@@ -14,7 +14,8 @@ export interface RateLimitSettings {
   'max_tokens'?: (_google_protobuf_UInt32Value | null);
   /**
    * Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
-   * per second will be used.
+   * per second will be used. The minimal fill rate is once per year. Lower
+   * fill rates will be set to once per year.
    */
   'fill_rate'?: (_google_protobuf_DoubleValue | null);
 }
@@ -30,7 +31,8 @@ export interface RateLimitSettings__Output {
   'max_tokens': (_google_protobuf_UInt32Value__Output | null);
   /**
    * Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
-   * per second will be used.
+   * per second will be used. The minimal fill rate is once per year. Lower
+   * fill rates will be set to once per year.
    */
   'fill_rate': (_google_protobuf_DoubleValue__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SubstitutionFormatString.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SubstitutionFormatString.ts
@@ -3,11 +3,12 @@
 import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from '../../../../google/protobuf/Struct';
 import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from '../../../../envoy/config/core/v3/DataSource';
 import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from '../../../../envoy/config/core/v3/TypedExtensionConfig';
+import type { JsonFormatOptions as _envoy_config_core_v3_JsonFormatOptions, JsonFormatOptions__Output as _envoy_config_core_v3_JsonFormatOptions__Output } from '../../../../envoy/config/core/v3/JsonFormatOptions';
 
 /**
  * Configuration to use multiple :ref:`command operators <config_access_log_command_operators>`
  * to generate a new string in either plain text or JSON format.
- * [#next-free-field: 7]
+ * [#next-free-field: 8]
  */
 export interface SubstitutionFormatString {
   /**
@@ -98,13 +99,17 @@ export interface SubstitutionFormatString {
    * [#extension-category: envoy.formatter]
    */
   'formatters'?: (_envoy_config_core_v3_TypedExtensionConfig)[];
+  /**
+   * If json_format is used, the options will be applied to the output JSON string.
+   */
+  'json_format_options'?: (_envoy_config_core_v3_JsonFormatOptions | null);
   'format'?: "text_format"|"json_format"|"text_format_source";
 }
 
 /**
  * Configuration to use multiple :ref:`command operators <config_access_log_command_operators>`
  * to generate a new string in either plain text or JSON format.
- * [#next-free-field: 7]
+ * [#next-free-field: 8]
  */
 export interface SubstitutionFormatString__Output {
   /**
@@ -195,5 +200,9 @@ export interface SubstitutionFormatString__Output {
    * [#extension-category: envoy.formatter]
    */
   'formatters': (_envoy_config_core_v3_TypedExtensionConfig__Output)[];
+  /**
+   * If json_format is used, the options will be applied to the output JSON string.
+   */
+  'json_format_options': (_envoy_config_core_v3_JsonFormatOptions__Output | null);
   'format': "text_format"|"json_format"|"text_format_source";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/ClusterLoadAssignment.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/ClusterLoadAssignment.ts
@@ -6,9 +6,6 @@ import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output a
 import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../../google/protobuf/Duration';
 import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from '../../../../envoy/type/v3/FractionalPercent';
 
-/**
- * [#not-implemented-hide:]
- */
 export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy_DropOverload {
   /**
    * Identifier for the policy specifying the drop.
@@ -20,9 +17,6 @@ export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy_DropOver
   'drop_percentage'?: (_envoy_type_v3_FractionalPercent | null);
 }
 
-/**
- * [#not-implemented-hide:]
- */
 export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy_DropOverload__Output {
   /**
    * Identifier for the policy specifying the drop.
@@ -36,7 +30,7 @@ export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy_DropOver
 
 /**
  * Load balancing policy settings.
- * [#next-free-field: 6]
+ * [#next-free-field: 7]
  */
 export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy {
   /**
@@ -59,7 +53,9 @@ export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy {
    * "throttle"_drop = 60%
    * "lb"_drop = 20%  // 50% of the remaining 'actual' load, which is 40%.
    * actual_outgoing_load = 20% // remaining after applying all categories.
-   * [#not-implemented-hide:]
+   * 
+   * Envoy supports only one element and will NACK if more than one element is present.
+   * Other xDS-capable data planes will not necessarily have this limitation.
    */
   'drop_overloads'?: (_envoy_config_endpoint_v3_ClusterLoadAssignment_Policy_DropOverload)[];
   /**
@@ -86,11 +82,22 @@ export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy {
    * Defaults to 0 which means endpoints never go stale.
    */
   'endpoint_stale_after'?: (_google_protobuf_Duration | null);
+  /**
+   * If true, use the :ref:`load balancing weight
+   * <envoy_v3_api_field_config.endpoint.v3.LbEndpoint.load_balancing_weight>` of healthy and unhealthy
+   * hosts to determine the health of the priority level. If false, use the number of healthy and unhealthy hosts
+   * to determine the health of the priority level, or in other words assume each host has a weight of 1 for
+   * this calculation.
+   * 
+   * Note: this is not currently implemented for
+   * :ref:`locality weighted load balancing <arch_overview_load_balancing_locality_weighted_lb>`.
+   */
+  'weighted_priority_health'?: (boolean);
 }
 
 /**
  * Load balancing policy settings.
- * [#next-free-field: 6]
+ * [#next-free-field: 7]
  */
 export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy__Output {
   /**
@@ -113,7 +120,9 @@ export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy__Output 
    * "throttle"_drop = 60%
    * "lb"_drop = 20%  // 50% of the remaining 'actual' load, which is 40%.
    * actual_outgoing_load = 20% // remaining after applying all categories.
-   * [#not-implemented-hide:]
+   * 
+   * Envoy supports only one element and will NACK if more than one element is present.
+   * Other xDS-capable data planes will not necessarily have this limitation.
    */
   'drop_overloads': (_envoy_config_endpoint_v3_ClusterLoadAssignment_Policy_DropOverload__Output)[];
   /**
@@ -140,6 +149,17 @@ export interface _envoy_config_endpoint_v3_ClusterLoadAssignment_Policy__Output 
    * Defaults to 0 which means endpoints never go stale.
    */
   'endpoint_stale_after': (_google_protobuf_Duration__Output | null);
+  /**
+   * If true, use the :ref:`load balancing weight
+   * <envoy_v3_api_field_config.endpoint.v3.LbEndpoint.load_balancing_weight>` of healthy and unhealthy
+   * hosts to determine the health of the priority level. If false, use the number of healthy and unhealthy hosts
+   * to determine the health of the priority level, or in other words assume each host has a weight of 1 for
+   * this calculation.
+   * 
+   * Note: this is not currently implemented for
+   * :ref:`locality weighted load balancing <arch_overview_load_balancing_locality_weighted_lb>`.
+   */
+  'weighted_priority_health': (boolean);
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/Endpoint.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/Endpoint.ts
@@ -2,6 +2,20 @@
 
 import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from '../../../../envoy/config/core/v3/Address';
 
+export interface _envoy_config_endpoint_v3_Endpoint_AdditionalAddress {
+  /**
+   * Additional address that is associated with the endpoint.
+   */
+  'address'?: (_envoy_config_core_v3_Address | null);
+}
+
+export interface _envoy_config_endpoint_v3_Endpoint_AdditionalAddress__Output {
+  /**
+   * Additional address that is associated with the endpoint.
+   */
+  'address': (_envoy_config_core_v3_Address__Output | null);
+}
+
 /**
  * The optional health check configuration.
  */
@@ -107,6 +121,14 @@ export interface Endpoint {
    * :ref:`auto_host_rewrite <envoy_v3_api_field_config.route.v3.RouteAction.auto_host_rewrite>`.
    */
   'hostname'?: (string);
+  /**
+   * An ordered list of addresses that together with ``address`` comprise the
+   * list of addresses for an endpoint. The address given in the ``address`` is
+   * prepended to this list. It is assumed that the list must already be
+   * sorted by preference order of the addresses. This will only be supported
+   * for STATIC and EDS clusters.
+   */
+  'additional_addresses'?: (_envoy_config_endpoint_v3_Endpoint_AdditionalAddress)[];
 }
 
 /**
@@ -142,4 +164,12 @@ export interface Endpoint__Output {
    * :ref:`auto_host_rewrite <envoy_v3_api_field_config.route.v3.RouteAction.auto_host_rewrite>`.
    */
   'hostname': (string);
+  /**
+   * An ordered list of addresses that together with ``address`` comprise the
+   * list of addresses for an endpoint. The address given in the ``address`` is
+   * prepended to this list. It is assumed that the list must already be
+   * sorted by preference order of the addresses. This will only be supported
+   * for STATIC and EDS clusters.
+   */
+  'additional_addresses': (_envoy_config_endpoint_v3_Endpoint_AdditionalAddress__Output)[];
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/LocalityLbEndpoints.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/LocalityLbEndpoints.ts
@@ -57,9 +57,9 @@ export interface LocalityLbEndpoints {
    * default to the highest priority (0).
    * 
    * Under usual circumstances, Envoy will only select endpoints for the highest
-   * priority (0). In the event all endpoints for a particular priority are
+   * priority (0). In the event that enough endpoints for a particular priority are
    * unavailable/unhealthy, Envoy will fail over to selecting endpoints for the
-   * next highest priority group.
+   * next highest priority group. Read more at :ref:`priority levels <arch_overview_load_balancing_priority_levels>`.
    * 
    * Priorities should range from 0 (highest) to N (lowest) without skipping.
    */
@@ -125,9 +125,9 @@ export interface LocalityLbEndpoints__Output {
    * default to the highest priority (0).
    * 
    * Under usual circumstances, Envoy will only select endpoints for the highest
-   * priority (0). In the event all endpoints for a particular priority are
+   * priority (0). In the event that enough endpoints for a particular priority are
    * unavailable/unhealthy, Envoy will fail over to selecting endpoints for the
-   * next highest priority group.
+   * next highest priority group. Read more at :ref:`priority levels <arch_overview_load_balancing_priority_levels>`.
    * 
    * Priorities should range from 0 (highest) to N (lowest) without skipping.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Filter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Filter.ts
@@ -21,7 +21,6 @@ export interface Filter {
    * Configuration source specifier for an extension configuration discovery
    * service. In case of a failure and without the default configuration, the
    * listener closes the connections.
-   * [#not-implemented-hide:]
    */
   'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource | null);
   'config_type'?: "typed_config"|"config_discovery";
@@ -45,7 +44,6 @@ export interface Filter__Output {
    * Configuration source specifier for an extension configuration discovery
    * service. In case of a failure and without the default configuration, the
    * listener closes the connections.
-   * [#not-implemented-hide:]
    */
   'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource__Output | null);
   'config_type': "typed_config"|"config_discovery";

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Listener.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Listener.ts
@@ -131,7 +131,7 @@ export interface _envoy_config_listener_v3_Listener_InternalListenerConfig__Outp
 }
 
 /**
- * [#next-free-field: 34]
+ * [#next-free-field: 35]
  */
 export interface Listener {
   /**
@@ -190,7 +190,12 @@ export interface Listener {
    * before a connection is created.
    * UDP Listener filters can be specified when the protocol in the listener socket address in
    * :ref:`protocol <envoy_v3_api_field_config.core.v3.SocketAddress.protocol>` is :ref:`UDP
-   * <envoy_v3_api_enum_value_config.core.v3.SocketAddress.Protocol.UDP>`.
+   * <envoy_v3_api_enum_value_config.core.v3.SocketAddress.Protocol.UDP>` and no
+   * :ref:`quic_options <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.quic_options>` is specified in :ref:`udp_listener_config <envoy_v3_api_field_config.listener.v3.Listener.udp_listener_config>`.
+   * QUIC listener filters can be specified when :ref:`quic_options
+   * <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.quic_options>` is
+   * specified in :ref:`udp_listener_config <envoy_v3_api_field_config.listener.v3.Listener.udp_listener_config>`.
+   * They are processed sequentially right before connection creation. And like TCP Listener filters, they can be used to manipulate the connection metadata and socket. But the difference is that they can't be used to pause connection creation.
    */
   'listener_filters'?: (_envoy_config_listener_v3_ListenerFilter)[];
   /**
@@ -240,7 +245,7 @@ export interface Listener {
    * Additional socket options that may not be present in Envoy source code or
    * precompiled binaries. The socket options can be updated for a listener when
    * :ref:`enable_reuse_port <envoy_v3_api_field_config.listener.v3.Listener.enable_reuse_port>`
-   * is `true`. Otherwise, if socket options change during a listener update the update will be rejected
+   * is ``true``. Otherwise, if socket options change during a listener update the update will be rejected
    * to make it clear that the options were not updated.
    */
   'socket_options'?: (_envoy_config_core_v3_SocketOption)[];
@@ -415,13 +420,24 @@ export interface Listener {
    */
   'additional_addresses'?: (_envoy_config_listener_v3_AdditionalAddress)[];
   /**
+   * The maximum number of connections to accept from the kernel per socket
+   * event. Envoy may decide to close these connections after accepting them
+   * from the kernel e.g. due to load shedding, or other policies.
+   * If there are more than max_connections_to_accept_per_socket_event
+   * connections pending accept, connections over this threshold will be
+   * accepted in later event loop iterations.
+   * If no value is provided Envoy will accept all connections pending accept
+   * from the kernel.
+   */
+  'max_connections_to_accept_per_socket_event'?: (_google_protobuf_UInt32Value | null);
+  /**
    * The exclusive listener type and the corresponding config.
    */
   'listener_specifier'?: "internal_listener";
 }
 
 /**
- * [#next-free-field: 34]
+ * [#next-free-field: 35]
  */
 export interface Listener__Output {
   /**
@@ -480,7 +496,12 @@ export interface Listener__Output {
    * before a connection is created.
    * UDP Listener filters can be specified when the protocol in the listener socket address in
    * :ref:`protocol <envoy_v3_api_field_config.core.v3.SocketAddress.protocol>` is :ref:`UDP
-   * <envoy_v3_api_enum_value_config.core.v3.SocketAddress.Protocol.UDP>`.
+   * <envoy_v3_api_enum_value_config.core.v3.SocketAddress.Protocol.UDP>` and no
+   * :ref:`quic_options <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.quic_options>` is specified in :ref:`udp_listener_config <envoy_v3_api_field_config.listener.v3.Listener.udp_listener_config>`.
+   * QUIC listener filters can be specified when :ref:`quic_options
+   * <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.quic_options>` is
+   * specified in :ref:`udp_listener_config <envoy_v3_api_field_config.listener.v3.Listener.udp_listener_config>`.
+   * They are processed sequentially right before connection creation. And like TCP Listener filters, they can be used to manipulate the connection metadata and socket. But the difference is that they can't be used to pause connection creation.
    */
   'listener_filters': (_envoy_config_listener_v3_ListenerFilter__Output)[];
   /**
@@ -530,7 +551,7 @@ export interface Listener__Output {
    * Additional socket options that may not be present in Envoy source code or
    * precompiled binaries. The socket options can be updated for a listener when
    * :ref:`enable_reuse_port <envoy_v3_api_field_config.listener.v3.Listener.enable_reuse_port>`
-   * is `true`. Otherwise, if socket options change during a listener update the update will be rejected
+   * is ``true``. Otherwise, if socket options change during a listener update the update will be rejected
    * to make it clear that the options were not updated.
    */
   'socket_options': (_envoy_config_core_v3_SocketOption__Output)[];
@@ -704,6 +725,17 @@ export interface Listener__Output {
    * all addresses use the same protocol, and multiple internal addresses are not supported.
    */
   'additional_addresses': (_envoy_config_listener_v3_AdditionalAddress__Output)[];
+  /**
+   * The maximum number of connections to accept from the kernel per socket
+   * event. Envoy may decide to close these connections after accepting them
+   * from the kernel e.g. due to load shedding, or other policies.
+   * If there are more than max_connections_to_accept_per_socket_event
+   * connections pending accept, connections over this threshold will be
+   * accepted in later event loop iterations.
+   * If no value is provided Envoy will accept all connections pending accept
+   * from the kernel.
+   */
+  'max_connections_to_accept_per_socket_event': (_google_protobuf_UInt32Value__Output | null);
   /**
    * The exclusive listener type and the corresponding config.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/FilterConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/FilterConfig.ts
@@ -23,6 +23,8 @@ export interface FilterConfig {
   'is_optional'?: (boolean);
   /**
    * If true, the filter is disabled in the route or virtual host and the ``config`` field is ignored.
+   * See :ref:`route based filter chain <arch_overview_http_filters_route_based_filter_chain>`
+   * for more details.
    * 
    * .. note::
    * 
@@ -34,8 +36,6 @@ export interface FilterConfig {
    * created and it is too late to change the chain.
    * 
    * This field only make sense for the downstream HTTP filters for now.
-   * 
-   * [#not-implemented-hide:]
    */
   'disabled'?: (boolean);
 }
@@ -61,6 +61,8 @@ export interface FilterConfig__Output {
   'is_optional': (boolean);
   /**
    * If true, the filter is disabled in the route or virtual host and the ``config`` field is ignored.
+   * See :ref:`route based filter chain <arch_overview_http_filters_route_based_filter_chain>`
+   * for more details.
    * 
    * .. note::
    * 
@@ -72,8 +74,6 @@ export interface FilterConfig__Output {
    * created and it is too late to change the chain.
    * 
    * This field only make sense for the downstream HTTP filters for now.
-   * 
-   * [#not-implemented-hide:]
    */
   'disabled': (boolean);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/InternalRedirectPolicy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/InternalRedirectPolicy.ts
@@ -5,6 +5,7 @@ import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig
 
 /**
  * HTTP Internal Redirect :ref:`architecture overview <arch_overview_internal_redirects>`.
+ * [#next-free-field: 6]
  */
 export interface InternalRedirectPolicy {
   /**
@@ -36,10 +37,17 @@ export interface InternalRedirectPolicy {
    * x-forwarded-proto. The default is false.
    */
   'allow_cross_scheme_redirect'?: (boolean);
+  /**
+   * Specifies a list of headers, by name, to copy from the internal redirect into the subsequent
+   * request. If a header is specified here but not present in the redirect, it will be cleared in
+   * the subsequent request.
+   */
+  'response_headers_to_copy'?: (string)[];
 }
 
 /**
  * HTTP Internal Redirect :ref:`architecture overview <arch_overview_internal_redirects>`.
+ * [#next-free-field: 6]
  */
 export interface InternalRedirectPolicy__Output {
   /**
@@ -71,4 +79,10 @@ export interface InternalRedirectPolicy__Output {
    * x-forwarded-proto. The default is false.
    */
   'allow_cross_scheme_redirect': (boolean);
+  /**
+   * Specifies a list of headers, by name, to copy from the internal redirect into the subsequent
+   * request. If a header is specified here but not present in the redirect, it will be cleared in
+   * the subsequent request.
+   */
+  'response_headers_to_copy': (string)[];
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Route.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Route.ts
@@ -81,15 +81,11 @@ export interface Route {
    */
   'request_headers_to_remove'?: (string)[];
   /**
-   * The per_filter_config field can be used to provide route-specific configurations for filters.
-   * The key should match the :ref:`filter config name
+   * This field can be used to provide route specific per filter config. The key should match the
+   * :ref:`filter config name
    * <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-   * The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-   * be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-   * entry referred by the canonical filter name will be provided to the filters as fallback.
-   * 
-   * Use of this field is filter specific;
-   * see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+   * See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+   * for details.
    * [#comment: An entry's value may be wrapped in a
    * :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
    * message to specify additional options.]
@@ -212,15 +208,11 @@ export interface Route__Output {
    */
   'request_headers_to_remove': (string)[];
   /**
-   * The per_filter_config field can be used to provide route-specific configurations for filters.
-   * The key should match the :ref:`filter config name
+   * This field can be used to provide route specific per filter config. The key should match the
+   * :ref:`filter config name
    * <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-   * The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-   * be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-   * entry referred by the canonical filter name will be provided to the filters as fallback.
-   * 
-   * Use of this field is filter specific;
-   * see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+   * See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+   * for details.
    * [#comment: An entry's value may be wrapped in a
    * :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
    * message to specify additional options.]

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteAction.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteAction.ts
@@ -113,6 +113,10 @@ export interface _envoy_config_route_v3_RouteAction_HashPolicy_Cookie {
    * will be set for the cookie.
    */
   'path'?: (string);
+  /**
+   * Additional attributes for the cookie. They will be used when generating a new cookie.
+   */
+  'attributes'?: (_envoy_config_route_v3_RouteAction_HashPolicy_CookieAttribute)[];
 }
 
 /**
@@ -149,6 +153,38 @@ export interface _envoy_config_route_v3_RouteAction_HashPolicy_Cookie__Output {
    * will be set for the cookie.
    */
   'path': (string);
+  /**
+   * Additional attributes for the cookie. They will be used when generating a new cookie.
+   */
+  'attributes': (_envoy_config_route_v3_RouteAction_HashPolicy_CookieAttribute__Output)[];
+}
+
+/**
+ * CookieAttribute defines an API for adding additional attributes for a HTTP cookie.
+ */
+export interface _envoy_config_route_v3_RouteAction_HashPolicy_CookieAttribute {
+  /**
+   * The name of the cookie attribute.
+   */
+  'name'?: (string);
+  /**
+   * The optional value of the cookie attribute.
+   */
+  'value'?: (string);
+}
+
+/**
+ * CookieAttribute defines an API for adding additional attributes for a HTTP cookie.
+ */
+export interface _envoy_config_route_v3_RouteAction_HashPolicy_CookieAttribute__Output {
+  /**
+   * The name of the cookie attribute.
+   */
+  'name': (string);
+  /**
+   * The optional value of the cookie attribute.
+   */
+  'value': (string);
 }
 
 export interface _envoy_config_route_v3_RouteAction_HashPolicy_FilterState {
@@ -372,7 +408,8 @@ export interface _envoy_config_route_v3_RouteAction_HashPolicy_QueryParameter {
   /**
    * The name of the URL query parameter that will be used to obtain the hash
    * key. If the parameter is not present, no hash will be produced. Query
-   * parameter names are case-sensitive.
+   * parameter names are case-sensitive. If query parameters are repeated, only
+   * the first value will be considered.
    */
   'name'?: (string);
 }
@@ -381,7 +418,8 @@ export interface _envoy_config_route_v3_RouteAction_HashPolicy_QueryParameter__O
   /**
    * The name of the URL query parameter that will be used to obtain the hash
    * key. If the parameter is not present, no hash will be produced. Query
-   * parameter names are case-sensitive.
+   * parameter names are case-sensitive. If query parameters are repeated, only
+   * the first value will be considered.
    */
   'name': (string);
 }
@@ -649,7 +687,9 @@ export interface RouteAction {
    * Indicates that during forwarding, the host header will be swapped with
    * the hostname of the upstream host chosen by the cluster manager. This
    * option is applicable only when the destination cluster for a route is of
-   * type ``strict_dns`` or ``logical_dns``. Setting this to true with other cluster types
+   * type ``strict_dns`` or ``logical_dns``,
+   * or when :ref:`hostname <envoy_v3_api_field_config.endpoint.v3.Endpoint.hostname>`
+   * field is not empty. Setting this to true with other cluster types
    * has no effect. Using this option will append the
    * :ref:`config_http_conn_man_headers_x-forwarded-host` header if
    * :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
@@ -924,7 +964,7 @@ export interface RouteAction {
    * :ref:`host_rewrite_path_regex <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_path_regex>`)
    * causes the original value of the host header, if any, to be appended to the
    * :ref:`config_http_conn_man_headers_x-forwarded-host` HTTP header if it is different to the last value appended.
-   * This can be disabled by setting the runtime guard `envoy_reloadable_features_append_xfh_idempotent` to false.
+   * This can be disabled by setting the runtime guard ``envoy_reloadable_features_append_xfh_idempotent`` to false.
    */
   'append_x_forwarded_host'?: (boolean);
   /**
@@ -1033,7 +1073,9 @@ export interface RouteAction__Output {
    * Indicates that during forwarding, the host header will be swapped with
    * the hostname of the upstream host chosen by the cluster manager. This
    * option is applicable only when the destination cluster for a route is of
-   * type ``strict_dns`` or ``logical_dns``. Setting this to true with other cluster types
+   * type ``strict_dns`` or ``logical_dns``,
+   * or when :ref:`hostname <envoy_v3_api_field_config.endpoint.v3.Endpoint.hostname>`
+   * field is not empty. Setting this to true with other cluster types
    * has no effect. Using this option will append the
    * :ref:`config_http_conn_man_headers_x-forwarded-host` header if
    * :ref:`append_x_forwarded_host <envoy_v3_api_field_config.route.v3.RouteAction.append_x_forwarded_host>`
@@ -1308,7 +1350,7 @@ export interface RouteAction__Output {
    * :ref:`host_rewrite_path_regex <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_path_regex>`)
    * causes the original value of the host header, if any, to be appended to the
    * :ref:`config_http_conn_man_headers_x-forwarded-host` HTTP header if it is different to the last value appended.
-   * This can be disabled by setting the runtime guard `envoy_reloadable_features_append_xfh_idempotent` to false.
+   * This can be disabled by setting the runtime guard ``envoy_reloadable_features_append_xfh_idempotent`` to false.
    */
   'append_x_forwarded_host': (boolean);
   /**

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteConfiguration.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteConfiguration.ts
@@ -8,9 +8,10 @@ import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output a
 import type { ClusterSpecifierPlugin as _envoy_config_route_v3_ClusterSpecifierPlugin, ClusterSpecifierPlugin__Output as _envoy_config_route_v3_ClusterSpecifierPlugin__Output } from '../../../../envoy/config/route/v3/ClusterSpecifierPlugin';
 import type { _envoy_config_route_v3_RouteAction_RequestMirrorPolicy, _envoy_config_route_v3_RouteAction_RequestMirrorPolicy__Output } from '../../../../envoy/config/route/v3/RouteAction';
 import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../../../google/protobuf/Any';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from '../../../../envoy/config/core/v3/Metadata';
 
 /**
- * [#next-free-field: 17]
+ * [#next-free-field: 18]
  */
 export interface RouteConfiguration {
   /**
@@ -85,14 +86,11 @@ export interface RouteConfiguration {
    */
   'vhds'?: (_envoy_config_route_v3_Vhds | null);
   /**
-   * By default, headers that should be added/removed are evaluated from most to least specific:
-   * 
-   * * route level
-   * * virtual host level
-   * * connection manager level
-   * 
-   * To allow setting overrides at the route or virtual host level, this order can be reversed
-   * by setting this option to true. Defaults to false.
+   * Headers mutations at all levels are evaluated, if specified. By default, the order is from most
+   * specific (i.e. route entry level) to least specific (i.e. route configuration level). Later header
+   * mutations may override earlier mutations.
+   * This order can be reversed by setting this field to true. In other words, most specific level mutation
+   * is evaluated last.
    */
   'most_specific_header_mutations_wins'?: (boolean);
   /**
@@ -134,24 +132,28 @@ export interface RouteConfiguration {
    */
   'ignore_path_parameters_in_path_matching'?: (boolean);
   /**
-   * The typed_per_filter_config field can be used to provide RouteConfiguration level per filter config.
-   * The key should match the :ref:`filter config name
+   * This field can be used to provide RouteConfiguration level per filter config. The key should match the
+   * :ref:`filter config name
    * <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-   * The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-   * be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-   * entry referred by the canonical filter name will be provided to the filters as fallback.
-   * 
-   * Use of this field is filter specific;
-   * see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+   * See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+   * for details.
    * [#comment: An entry's value may be wrapped in a
    * :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
    * message to specify additional options.]
    */
   'typed_per_filter_config'?: ({[key: string]: _google_protobuf_Any});
+  /**
+   * The metadata field can be used to provide additional information
+   * about the route configuration. It can be used for configuration, stats, and logging.
+   * The metadata should go under the filter namespace that will need it.
+   * For instance, if the metadata is intended for the Router filter,
+   * the filter name should be specified as ``envoy.filters.http.router``.
+   */
+  'metadata'?: (_envoy_config_core_v3_Metadata | null);
 }
 
 /**
- * [#next-free-field: 17]
+ * [#next-free-field: 18]
  */
 export interface RouteConfiguration__Output {
   /**
@@ -226,14 +228,11 @@ export interface RouteConfiguration__Output {
    */
   'vhds': (_envoy_config_route_v3_Vhds__Output | null);
   /**
-   * By default, headers that should be added/removed are evaluated from most to least specific:
-   * 
-   * * route level
-   * * virtual host level
-   * * connection manager level
-   * 
-   * To allow setting overrides at the route or virtual host level, this order can be reversed
-   * by setting this option to true. Defaults to false.
+   * Headers mutations at all levels are evaluated, if specified. By default, the order is from most
+   * specific (i.e. route entry level) to least specific (i.e. route configuration level). Later header
+   * mutations may override earlier mutations.
+   * This order can be reversed by setting this field to true. In other words, most specific level mutation
+   * is evaluated last.
    */
   'most_specific_header_mutations_wins': (boolean);
   /**
@@ -275,18 +274,22 @@ export interface RouteConfiguration__Output {
    */
   'ignore_path_parameters_in_path_matching': (boolean);
   /**
-   * The typed_per_filter_config field can be used to provide RouteConfiguration level per filter config.
-   * The key should match the :ref:`filter config name
+   * This field can be used to provide RouteConfiguration level per filter config. The key should match the
+   * :ref:`filter config name
    * <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-   * The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-   * be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-   * entry referred by the canonical filter name will be provided to the filters as fallback.
-   * 
-   * Use of this field is filter specific;
-   * see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+   * See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+   * for details.
    * [#comment: An entry's value may be wrapped in a
    * :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
    * message to specify additional options.]
    */
   'typed_per_filter_config': ({[key: string]: _google_protobuf_Any__Output});
+  /**
+   * The metadata field can be used to provide additional information
+   * about the route configuration. It can be used for configuration, stats, and logging.
+   * The metadata should go under the filter namespace that will need it.
+   * For instance, if the metadata is intended for the Router filter,
+   * the filter name should be specified as ``envoy.filters.http.router``.
+   */
+  'metadata': (_envoy_config_core_v3_Metadata__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteMatch.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteMatch.ts
@@ -9,13 +9,13 @@ import type { MetadataMatcher as _envoy_type_matcher_v3_MetadataMatcher, Metadat
 import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from '../../../../envoy/config/core/v3/TypedExtensionConfig';
 
 /**
- * An extensible message for matching CONNECT requests.
+ * An extensible message for matching CONNECT or CONNECT-UDP requests.
  */
 export interface _envoy_config_route_v3_RouteMatch_ConnectMatcher {
 }
 
 /**
- * An extensible message for matching CONNECT requests.
+ * An extensible message for matching CONNECT or CONNECT-UDP requests.
  */
 export interface _envoy_config_route_v3_RouteMatch_ConnectMatcher__Output {
 }
@@ -35,6 +35,16 @@ export interface _envoy_config_route_v3_RouteMatch_TlsContextMatchOptions {
   /**
    * If specified, the route will match against whether or not a certificate is validated.
    * If not specified, certificate validation status (true or false) will not be considered when route matching.
+   * 
+   * .. warning::
+   * 
+   * Client certificate validation is not currently performed upon TLS session resumption. For
+   * a resumed TLS session the route will match only when ``validated`` is false, regardless of
+   * whether the client TLS certificate is valid.
+   * 
+   * The only known workaround for this issue is to disable TLS session resumption entirely, by
+   * setting both :ref:`disable_stateless_session_resumption <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.disable_stateless_session_resumption>`
+   * and :ref:`disable_stateful_session_resumption <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.disable_stateful_session_resumption>` on the DownstreamTlsContext.
    */
   'validated'?: (_google_protobuf_BoolValue | null);
 }
@@ -48,6 +58,16 @@ export interface _envoy_config_route_v3_RouteMatch_TlsContextMatchOptions__Outpu
   /**
    * If specified, the route will match against whether or not a certificate is validated.
    * If not specified, certificate validation status (true or false) will not be considered when route matching.
+   * 
+   * .. warning::
+   * 
+   * Client certificate validation is not currently performed upon TLS session resumption. For
+   * a resumed TLS session the route will match only when ``validated`` is false, regardless of
+   * whether the client TLS certificate is valid.
+   * 
+   * The only known workaround for this issue is to disable TLS session resumption entirely, by
+   * setting both :ref:`disable_stateless_session_resumption <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.disable_stateless_session_resumption>`
+   * and :ref:`disable_stateful_session_resumption <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.disable_stateful_session_resumption>` on the DownstreamTlsContext.
    */
   'validated': (_google_protobuf_BoolValue__Output | null);
 }
@@ -84,7 +104,8 @@ export interface RouteMatch {
    * match. The router will check the query string from the ``path`` header
    * against all the specified query parameters. If the number of specified
    * query parameters is nonzero, they all must match the ``path`` header's
-   * query string for a match to occur.
+   * query string for a match to occur. In the event query parameters are
+   * repeated, only the first value for each key will be considered.
    * 
    * .. note::
    * 
@@ -143,11 +164,10 @@ export interface RouteMatch {
    */
   'tls_context'?: (_envoy_config_route_v3_RouteMatch_TlsContextMatchOptions | null);
   /**
-   * If this is used as the matcher, the matcher will only match CONNECT requests.
-   * Note that this will not match HTTP/2 upgrade-style CONNECT requests
-   * (WebSocket and the like) as they are normalized in Envoy as HTTP/1.1 style
-   * upgrades.
-   * This is the only way to match CONNECT requests for HTTP/1.1. For HTTP/2,
+   * If this is used as the matcher, the matcher will only match CONNECT or CONNECT-UDP requests.
+   * Note that this will not match other Extended CONNECT requests (WebSocket and the like) as
+   * they are normalized in Envoy as HTTP/1.1 style upgrades.
+   * This is the only way to match CONNECT requests for HTTP/1.1. For HTTP/2 and HTTP/3,
    * where Extended CONNECT requests may have a path, the path matchers will work if
    * there is a path present.
    * Note that CONNECT support is currently considered alpha in Envoy.
@@ -212,7 +232,8 @@ export interface RouteMatch__Output {
    * match. The router will check the query string from the ``path`` header
    * against all the specified query parameters. If the number of specified
    * query parameters is nonzero, they all must match the ``path`` header's
-   * query string for a match to occur.
+   * query string for a match to occur. In the event query parameters are
+   * repeated, only the first value for each key will be considered.
    * 
    * .. note::
    * 
@@ -271,11 +292,10 @@ export interface RouteMatch__Output {
    */
   'tls_context': (_envoy_config_route_v3_RouteMatch_TlsContextMatchOptions__Output | null);
   /**
-   * If this is used as the matcher, the matcher will only match CONNECT requests.
-   * Note that this will not match HTTP/2 upgrade-style CONNECT requests
-   * (WebSocket and the like) as they are normalized in Envoy as HTTP/1.1 style
-   * upgrades.
-   * This is the only way to match CONNECT requests for HTTP/1.1. For HTTP/2,
+   * If this is used as the matcher, the matcher will only match CONNECT or CONNECT-UDP requests.
+   * Note that this will not match other Extended CONNECT requests (WebSocket and the like) as
+   * they are normalized in Envoy as HTTP/1.1 style upgrades.
+   * This is the only way to match CONNECT requests for HTTP/1.1. For HTTP/2 and HTTP/3,
    * where Extended CONNECT requests may have a path, the path matchers will work if
    * there is a path present.
    * Note that CONNECT support is currently considered alpha in Envoy.

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/ScopedRouteConfiguration.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/ScopedRouteConfiguration.ts
@@ -77,7 +77,7 @@ export interface _envoy_config_route_v3_ScopedRouteConfiguration_Key__Output {
  * fragments:
  * - header_value_extractor:
  * name: X-Route-Selector
- * element_separator: ,
+ * element_separator: ","
  * element:
  * separator: =
  * key: vip
@@ -167,7 +167,7 @@ export interface ScopedRouteConfiguration {
  * fragments:
  * - header_value_extractor:
  * name: X-Route-Selector
- * element_separator: ,
+ * element_separator: ","
  * element:
  * separator: =
  * key: vip

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/VirtualHost.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/VirtualHost.ts
@@ -11,6 +11,7 @@ import type { HedgePolicy as _envoy_config_route_v3_HedgePolicy, HedgePolicy__Ou
 import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from '../../../../google/protobuf/UInt32Value';
 import type { Matcher as _xds_type_matcher_v3_Matcher, Matcher__Output as _xds_type_matcher_v3_Matcher__Output } from '../../../../xds/type/matcher/v3/Matcher';
 import type { _envoy_config_route_v3_RouteAction_RequestMirrorPolicy, _envoy_config_route_v3_RouteAction_RequestMirrorPolicy__Output } from '../../../../envoy/config/route/v3/RouteAction';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from '../../../../envoy/config/core/v3/Metadata';
 
 // Original file: deps/envoy-api/envoy/config/route/v3/route_components.proto
 
@@ -37,7 +38,7 @@ export enum _envoy_config_route_v3_VirtualHost_TlsRequirementType {
  * host header. This allows a single listener to service multiple top level domain path trees. Once
  * a virtual host is selected based on the domain, the routes are processed in order to see which
  * upstream cluster to route to or whether to perform a redirect.
- * [#next-free-field: 24]
+ * [#next-free-field: 25]
  */
 export interface VirtualHost {
   /**
@@ -141,15 +142,11 @@ export interface VirtualHost {
    */
   'include_request_attempt_count'?: (boolean);
   /**
-   * The per_filter_config field can be used to provide virtual host-specific configurations for filters.
-   * The key should match the :ref:`filter config name
+   * This field can be used to provide virtual host level per filter config. The key should match the
+   * :ref:`filter config name
    * <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-   * The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-   * be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-   * entry referred by the canonical filter name will be provided to the filters as fallback.
-   * 
-   * Use of this field is filter specific;
-   * see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+   * See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+   * for details.
    * [#comment: An entry's value may be wrapped in a
    * :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
    * message to specify additional options.]
@@ -209,6 +206,14 @@ export interface VirtualHost {
    * request header in retries initiated by per try timeouts.
    */
   'include_is_timeout_retry_header'?: (boolean);
+  /**
+   * The metadata field can be used to provide additional information
+   * about the virtual host. It can be used for configuration, stats, and logging.
+   * The metadata should go under the filter namespace that will need it.
+   * For instance, if the metadata is intended for the Router filter,
+   * the filter name should be specified as ``envoy.filters.http.router``.
+   */
+  'metadata'?: (_envoy_config_core_v3_Metadata | null);
 }
 
 /**
@@ -217,7 +222,7 @@ export interface VirtualHost {
  * host header. This allows a single listener to service multiple top level domain path trees. Once
  * a virtual host is selected based on the domain, the routes are processed in order to see which
  * upstream cluster to route to or whether to perform a redirect.
- * [#next-free-field: 24]
+ * [#next-free-field: 25]
  */
 export interface VirtualHost__Output {
   /**
@@ -321,15 +326,11 @@ export interface VirtualHost__Output {
    */
   'include_request_attempt_count': (boolean);
   /**
-   * The per_filter_config field can be used to provide virtual host-specific configurations for filters.
-   * The key should match the :ref:`filter config name
+   * This field can be used to provide virtual host level per filter config. The key should match the
+   * :ref:`filter config name
    * <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-   * The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-   * be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-   * entry referred by the canonical filter name will be provided to the filters as fallback.
-   * 
-   * Use of this field is filter specific;
-   * see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+   * See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+   * for details.
    * [#comment: An entry's value may be wrapped in a
    * :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
    * message to specify additional options.]
@@ -389,4 +390,12 @@ export interface VirtualHost__Output {
    * request header in retries initiated by per try timeouts.
    */
   'include_is_timeout_retry_header': (boolean);
+  /**
+   * The metadata field can be used to provide additional information
+   * about the virtual host. It can be used for configuration, stats, and logging.
+   * The metadata should go under the filter namespace that will need it.
+   * For instance, if the metadata is intended for the Router filter,
+   * the filter name should be specified as ``envoy.filters.http.router``.
+   */
+  'metadata': (_envoy_config_core_v3_Metadata__Output | null);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/WeightedCluster.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/WeightedCluster.ts
@@ -81,16 +81,11 @@ export interface _envoy_config_route_v3_WeightedCluster_ClusterWeight {
    */
   'response_headers_to_remove'?: (string)[];
   /**
-   * The per_filter_config field can be used to provide weighted cluster-specific configurations
-   * for filters.
-   * The key should match the :ref:`filter config name
+   * This field can be used to provide weighted cluster specific per filter config. The key should match the
+   * :ref:`filter config name
    * <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-   * The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-   * be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-   * entry referred by the canonical filter name will be provided to the filters as fallback.
-   * 
-   * Use of this field is filter specific;
-   * see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+   * See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+   * for details.
    * [#comment: An entry's value may be wrapped in a
    * :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
    * message to specify additional options.]
@@ -180,16 +175,11 @@ export interface _envoy_config_route_v3_WeightedCluster_ClusterWeight__Output {
    */
   'response_headers_to_remove': (string)[];
   /**
-   * The per_filter_config field can be used to provide weighted cluster-specific configurations
-   * for filters.
-   * The key should match the :ref:`filter config name
+   * This field can be used to provide weighted cluster specific per filter config. The key should match the
+   * :ref:`filter config name
    * <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-   * The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
-   * be used for the backwards compatibility. If there is no entry referred by the filter config name, the
-   * entry referred by the canonical filter name will be provided to the filters as fallback.
-   * 
-   * Use of this field is filter specific;
-   * see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+   * See :ref:`Http filter route specific config <arch_overview_http_filters_per_filter_config>`
+   * for details.
    * [#comment: An entry's value may be wrapped in a
    * :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
    * message to specify additional options.]

--- a/packages/grpc-js-xds/src/generated/envoy/data/accesslog/v3/AccessLogType.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/data/accesslog/v3/AccessLogType.ts
@@ -12,4 +12,7 @@ export enum AccessLogType {
   UpstreamPeriodic = 8,
   UpstreamEnd = 9,
   DownstreamTunnelSuccessfullyEstablished = 10,
+  UdpTunnelUpstreamConnected = 11,
+  UdpPeriodic = 12,
+  UdpSessionEnd = 13,
 }

--- a/packages/grpc-js-xds/src/generated/envoy/data/accesslog/v3/TLSProperties.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/data/accesslog/v3/TLSProperties.ts
@@ -11,6 +11,10 @@ export interface _envoy_data_accesslog_v3_TLSProperties_CertificateProperties {
    * The subject field of the certificate.
    */
   'subject'?: (string);
+  /**
+   * The issuer field of the certificate.
+   */
+  'issuer'?: (string);
 }
 
 export interface _envoy_data_accesslog_v3_TLSProperties_CertificateProperties__Output {
@@ -22,6 +26,10 @@ export interface _envoy_data_accesslog_v3_TLSProperties_CertificateProperties__O
    * The subject field of the certificate.
    */
   'subject': (string);
+  /**
+   * The issuer field of the certificate.
+   */
+  'issuer': (string);
 }
 
 export interface _envoy_data_accesslog_v3_TLSProperties_CertificateProperties_SubjectAltName {

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpConnectionManager.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpConnectionManager.ts
@@ -90,7 +90,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * on stream close, when the HTTP request is complete. If this field is set, the HCM will flush access
    * logs periodically at the specified interval. This is especially useful in the case of long-lived
    * requests, such as CONNECT and Websockets. Final access logs can be detected via the
-   * `requestComplete()` method of `StreamInfo` in access log filters, or thru the `%DURATION%` substitution
+   * ``requestComplete()`` method of ``StreamInfo`` in access log filters, or through the ``%DURATION%`` substitution
    * string.
    * The interval must be at least 1 millisecond.
    */
@@ -116,7 +116,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * on stream close, when the HTTP request is complete. If this field is set, the HCM will flush access
    * logs periodically at the specified interval. This is especially useful in the case of long-lived
    * requests, such as CONNECT and Websockets. Final access logs can be detected via the
-   * `requestComplete()` method of `StreamInfo` in access log filters, or thru the `%DURATION%` substitution
+   * ``requestComplete()`` method of ``StreamInfo`` in access log filters, or through the ``%DURATION%`` substitution
    * string.
    * The interval must be at least 1 millisecond.
    */
@@ -489,7 +489,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
 }
 
 /**
- * [#next-free-field: 10]
+ * [#next-free-field: 11]
  */
 export interface _envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_Tracing {
   /**
@@ -548,10 +548,32 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * on OpenCensus side.
    */
   'provider'?: (_envoy_config_trace_v3_Tracing_Http | null);
+  /**
+   * Create separate tracing span for each upstream request if true. And if this flag is set to true,
+   * the tracing provider will assume that Envoy will be independent hop in the trace chain and may
+   * set span type to client or server based on this flag.
+   * This will deprecate the
+   * :ref:`start_child_span <envoy_v3_api_field_extensions.filters.http.router.v3.Router.start_child_span>`
+   * in the router.
+   * 
+   * Users should set appropriate value based on their tracing provider and actual scenario:
+   * 
+   * * If Envoy is used as sidecar and users want to make the sidecar and its application as only one
+   * hop in the trace chain, this flag should be set to false. And please also make sure the
+   * :ref:`start_child_span <envoy_v3_api_field_extensions.filters.http.router.v3.Router.start_child_span>`
+   * in the router is not set to true.
+   * * If Envoy is used as gateway or independent proxy, or users want to make the sidecar and its
+   * application as different hops in the trace chain, this flag should be set to true.
+   * * If tracing provider that has explicit requirements on span creation (like SkyWalking),
+   * this flag should be set to true.
+   * 
+   * The default value is false for now for backward compatibility.
+   */
+  'spawn_upstream_span'?: (_google_protobuf_BoolValue | null);
 }
 
 /**
- * [#next-free-field: 10]
+ * [#next-free-field: 11]
  */
 export interface _envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_Tracing__Output {
   /**
@@ -610,6 +632,28 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * on OpenCensus side.
    */
   'provider': (_envoy_config_trace_v3_Tracing_Http__Output | null);
+  /**
+   * Create separate tracing span for each upstream request if true. And if this flag is set to true,
+   * the tracing provider will assume that Envoy will be independent hop in the trace chain and may
+   * set span type to client or server based on this flag.
+   * This will deprecate the
+   * :ref:`start_child_span <envoy_v3_api_field_extensions.filters.http.router.v3.Router.start_child_span>`
+   * in the router.
+   * 
+   * Users should set appropriate value based on their tracing provider and actual scenario:
+   * 
+   * * If Envoy is used as sidecar and users want to make the sidecar and its application as only one
+   * hop in the trace chain, this flag should be set to false. And please also make sure the
+   * :ref:`start_child_span <envoy_v3_api_field_extensions.filters.http.router.v3.Router.start_child_span>`
+   * in the router is not set to true.
+   * * If Envoy is used as gateway or independent proxy, or users want to make the sidecar and its
+   * application as different hops in the trace chain, this flag should be set to true.
+   * * If tracing provider that has explicit requirements on span creation (like SkyWalking),
+   * this flag should be set to true.
+   * 
+   * The default value is false for now for backward compatibility.
+   */
+  'spawn_upstream_span': (_google_protobuf_BoolValue__Output | null);
 }
 
 /**
@@ -1162,8 +1206,8 @@ export interface HttpConnectionManager {
    */
   'typed_header_validation_config'?: (_envoy_config_core_v3_TypedExtensionConfig | null);
   /**
-   * Append the `x-forwarded-port` header with the port value client used to connect to Envoy. It
-   * will be ignored if the `x-forwarded-port` header has been set by any trusted proxy in front of Envoy.
+   * Append the ``x-forwarded-port`` header with the port value client used to connect to Envoy. It
+   * will be ignored if the ``x-forwarded-port`` header has been set by any trusted proxy in front of Envoy.
    */
   'append_x_forwarded_port'?: (boolean);
   /**
@@ -1177,8 +1221,8 @@ export interface HttpConnectionManager {
    */
   'early_header_mutation_extensions'?: (_envoy_config_core_v3_TypedExtensionConfig)[];
   /**
-   * Whether the HCM will add ProxyProtocolFilterState to the Connection lifetime filter state. Defaults to `true`.
-   * This should be set to `false` in cases where Envoy's view of the downstream address may not correspond to the
+   * Whether the HCM will add ProxyProtocolFilterState to the Connection lifetime filter state. Defaults to ``true``.
+   * This should be set to ``false`` in cases where Envoy's view of the downstream address may not correspond to the
    * actual client address, for example, if there's another proxy in front of the Envoy.
    */
   'add_proxy_protocol_connection_state'?: (_google_protobuf_BoolValue | null);
@@ -1686,8 +1730,8 @@ export interface HttpConnectionManager__Output {
    */
   'typed_header_validation_config': (_envoy_config_core_v3_TypedExtensionConfig__Output | null);
   /**
-   * Append the `x-forwarded-port` header with the port value client used to connect to Envoy. It
-   * will be ignored if the `x-forwarded-port` header has been set by any trusted proxy in front of Envoy.
+   * Append the ``x-forwarded-port`` header with the port value client used to connect to Envoy. It
+   * will be ignored if the ``x-forwarded-port`` header has been set by any trusted proxy in front of Envoy.
    */
   'append_x_forwarded_port': (boolean);
   /**
@@ -1701,8 +1745,8 @@ export interface HttpConnectionManager__Output {
    */
   'early_header_mutation_extensions': (_envoy_config_core_v3_TypedExtensionConfig__Output)[];
   /**
-   * Whether the HCM will add ProxyProtocolFilterState to the Connection lifetime filter state. Defaults to `true`.
-   * This should be set to `false` in cases where Envoy's view of the downstream address may not correspond to the
+   * Whether the HCM will add ProxyProtocolFilterState to the Connection lifetime filter state. Defaults to ``true``.
+   * This should be set to ``false`` in cases where Envoy's view of the downstream address may not correspond to the
    * actual client address, for example, if there's another proxy in front of the Envoy.
    */
   'add_proxy_protocol_connection_state': (_google_protobuf_BoolValue__Output | null);

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpFilter.ts
@@ -4,7 +4,7 @@ import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__
 import type { ExtensionConfigSource as _envoy_config_core_v3_ExtensionConfigSource, ExtensionConfigSource__Output as _envoy_config_core_v3_ExtensionConfigSource__Output } from '../../../../../../envoy/config/core/v3/ExtensionConfigSource';
 
 /**
- * [#next-free-field: 7]
+ * [#next-free-field: 8]
  */
 export interface HttpFilter {
   /**
@@ -38,11 +38,20 @@ export interface HttpFilter {
    * Otherwise, clients that do not support this filter must reject the config.
    */
   'is_optional'?: (boolean);
+  /**
+   * If true, the filter is disabled by default and must be explicitly enabled by setting
+   * per filter configuration in the route configuration.
+   * See :ref:`route based filter chain <arch_overview_http_filters_route_based_filter_chain>`
+   * for more details.
+   * 
+   * Terminal filters (e.g. ``envoy.filters.http.router``) cannot be marked as disabled.
+   */
+  'disabled'?: (boolean);
   'config_type'?: "typed_config"|"config_discovery";
 }
 
 /**
- * [#next-free-field: 7]
+ * [#next-free-field: 8]
  */
 export interface HttpFilter__Output {
   /**
@@ -76,5 +85,14 @@ export interface HttpFilter__Output {
    * Otherwise, clients that do not support this filter must reject the config.
    */
   'is_optional': (boolean);
+  /**
+   * If true, the filter is disabled by default and must be explicitly enabled by setting
+   * per filter configuration in the route configuration.
+   * See :ref:`route based filter chain <arch_overview_http_filters_route_based_filter_chain>`
+   * for more details.
+   * 
+   * Terminal filters (e.g. ``envoy.filters.http.router``) cannot be marked as disabled.
+   */
+  'disabled': (boolean);
   'config_type': "typed_config"|"config_discovery";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/load_balancing_policies/ring_hash/v3/RingHash.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/load_balancing_policies/ring_hash/v3/RingHash.ts
@@ -54,10 +54,10 @@ export interface RingHash {
    */
   'maximum_ring_size'?: (_google_protobuf_UInt64Value | null);
   /**
-   * If set to `true`, the cluster will use hostname instead of the resolved
+   * If set to ``true``, the cluster will use hostname instead of the resolved
    * address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
    * 
-   * ..note::
+   * .. note::
    * This is deprecated and please use :ref:`consistent_hashing_lb_config
    * <envoy_v3_api_field_extensions.load_balancing_policies.ring_hash.v3.RingHash.consistent_hashing_lb_config>` instead.
    */
@@ -69,7 +69,7 @@ export interface RingHash {
    * Minimum is 100.
    * 
    * This is implemented based on the method described in the paper https://arxiv.org/abs/1608.01350. For the specified
-   * `hash_balance_factor`, requests to any upstream host are capped at `hash_balance_factor/100` times the average number of requests
+   * ``hash_balance_factor``, requests to any upstream host are capped at ``hash_balance_factor/100`` times the average number of requests
    * across the cluster. When a request arrives for an upstream host that is currently serving at its max capacity, linear probing
    * is used to identify an eligible host. Further, the linear probe is implemented using a random jump in hosts ring/table to identify
    * the eligible host (this technique is as described in the paper https://arxiv.org/abs/1908.08762 - the random jump avoids the
@@ -77,10 +77,10 @@ export interface RingHash {
    * 
    * If weights are specified on the hosts, they are respected.
    * 
-   * This is an O(N) algorithm, unlike other load balancers. Using a lower `hash_balance_factor` results in more hosts
+   * This is an O(N) algorithm, unlike other load balancers. Using a lower ``hash_balance_factor`` results in more hosts
    * being probed, so use a higher value if you require better performance.
    * 
-   * ..note::
+   * .. note::
    * This is deprecated and please use :ref:`consistent_hashing_lb_config
    * <envoy_v3_api_field_extensions.load_balancing_policies.ring_hash.v3.RingHash.consistent_hashing_lb_config>` instead.
    */
@@ -121,10 +121,10 @@ export interface RingHash__Output {
    */
   'maximum_ring_size': (_google_protobuf_UInt64Value__Output | null);
   /**
-   * If set to `true`, the cluster will use hostname instead of the resolved
+   * If set to ``true``, the cluster will use hostname instead of the resolved
    * address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
    * 
-   * ..note::
+   * .. note::
    * This is deprecated and please use :ref:`consistent_hashing_lb_config
    * <envoy_v3_api_field_extensions.load_balancing_policies.ring_hash.v3.RingHash.consistent_hashing_lb_config>` instead.
    */
@@ -136,7 +136,7 @@ export interface RingHash__Output {
    * Minimum is 100.
    * 
    * This is implemented based on the method described in the paper https://arxiv.org/abs/1608.01350. For the specified
-   * `hash_balance_factor`, requests to any upstream host are capped at `hash_balance_factor/100` times the average number of requests
+   * ``hash_balance_factor``, requests to any upstream host are capped at ``hash_balance_factor/100`` times the average number of requests
    * across the cluster. When a request arrives for an upstream host that is currently serving at its max capacity, linear probing
    * is used to identify an eligible host. Further, the linear probe is implemented using a random jump in hosts ring/table to identify
    * the eligible host (this technique is as described in the paper https://arxiv.org/abs/1908.08762 - the random jump avoids the
@@ -144,10 +144,10 @@ export interface RingHash__Output {
    * 
    * If weights are specified on the hosts, they are respected.
    * 
-   * This is an O(N) algorithm, unlike other load balancers. Using a lower `hash_balance_factor` results in more hosts
+   * This is an O(N) algorithm, unlike other load balancers. Using a lower ``hash_balance_factor`` results in more hosts
    * being probed, so use a higher value if you require better performance.
    * 
-   * ..note::
+   * .. note::
    * This is deprecated and please use :ref:`consistent_hashing_lb_config
    * <envoy_v3_api_field_extensions.load_balancing_policies.ring_hash.v3.RingHash.consistent_hashing_lb_config>` instead.
    */

--- a/packages/grpc-js-xds/src/generated/envoy/service/status/v3/ClientConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/status/v3/ClientConfig.ts
@@ -136,6 +136,12 @@ export interface ClientConfig {
    * the type URL (like Cluster if it is CDS)
    */
   'generic_xds_configs'?: (_envoy_service_status_v3_ClientConfig_GenericXdsConfig)[];
+  /**
+   * For xDS clients, the scope in which the data is used.
+   * For example, gRPC indicates the data plane target or that the data is
+   * associated with gRPC server(s).
+   */
+  'client_scope'?: (string);
 }
 
 /**
@@ -156,4 +162,10 @@ export interface ClientConfig__Output {
    * the type URL (like Cluster if it is CDS)
    */
   'generic_xds_configs': (_envoy_service_status_v3_ClientConfig_GenericXdsConfig__Output)[];
+  /**
+   * For xDS clients, the scope in which the data is used.
+   * For example, gRPC indicates the data plane target or that the data is
+   * associated with gRPC server(s).
+   */
+  'client_scope': (string);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/status/v3/ClientStatusRequest.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/status/v3/ClientStatusRequest.ts
@@ -16,6 +16,12 @@ export interface ClientStatusRequest {
    * The node making the csds request.
    */
   'node'?: (_envoy_config_core_v3_Node | null);
+  /**
+   * If true, the server will not include the resource contents in the response
+   * (i.e., the generic_xds_configs.xds_config field will not be populated).
+   * [#not-implemented-hide:]
+   */
+  'exclude_resource_contents'?: (boolean);
 }
 
 /**
@@ -31,4 +37,10 @@ export interface ClientStatusRequest__Output {
    * The node making the csds request.
    */
   'node': (_envoy_config_core_v3_Node__Output | null);
+  /**
+   * If true, the server will not include the resource contents in the response
+   * (i.e., the generic_xds_configs.xds_config field will not be populated).
+   * [#not-implemented-hide:]
+   */
+  'exclude_resource_contents': (boolean);
 }

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/OrMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/OrMatcher.ts
@@ -1,0 +1,17 @@
+// Original file: deps/envoy-api/envoy/type/matcher/v3/value.proto
+
+import type { ValueMatcher as _envoy_type_matcher_v3_ValueMatcher, ValueMatcher__Output as _envoy_type_matcher_v3_ValueMatcher__Output } from '../../../../envoy/type/matcher/v3/ValueMatcher';
+
+/**
+ * Specifies a list of alternatives for the match.
+ */
+export interface OrMatcher {
+  'value_matchers'?: (_envoy_type_matcher_v3_ValueMatcher)[];
+}
+
+/**
+ * Specifies a list of alternatives for the match.
+ */
+export interface OrMatcher__Output {
+  'value_matchers': (_envoy_type_matcher_v3_ValueMatcher__Output)[];
+}

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/ValueMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/ValueMatcher.ts
@@ -3,6 +3,7 @@
 import type { DoubleMatcher as _envoy_type_matcher_v3_DoubleMatcher, DoubleMatcher__Output as _envoy_type_matcher_v3_DoubleMatcher__Output } from '../../../../envoy/type/matcher/v3/DoubleMatcher';
 import type { StringMatcher as _envoy_type_matcher_v3_StringMatcher, StringMatcher__Output as _envoy_type_matcher_v3_StringMatcher__Output } from '../../../../envoy/type/matcher/v3/StringMatcher';
 import type { ListMatcher as _envoy_type_matcher_v3_ListMatcher, ListMatcher__Output as _envoy_type_matcher_v3_ListMatcher__Output } from '../../../../envoy/type/matcher/v3/ListMatcher';
+import type { OrMatcher as _envoy_type_matcher_v3_OrMatcher, OrMatcher__Output as _envoy_type_matcher_v3_OrMatcher__Output } from '../../../../envoy/type/matcher/v3/OrMatcher';
 
 /**
  * NullMatch is an empty message to specify a null value.
@@ -19,7 +20,7 @@ export interface _envoy_type_matcher_v3_ValueMatcher_NullMatch__Output {
 /**
  * Specifies the way to match a ProtobufWkt::Value. Primitive values and ListValue are supported.
  * StructValue is not supported and is always not matched.
- * [#next-free-field: 7]
+ * [#next-free-field: 8]
  */
 export interface ValueMatcher {
   /**
@@ -53,15 +54,19 @@ export interface ValueMatcher {
    */
   'list_match'?: (_envoy_type_matcher_v3_ListMatcher | null);
   /**
+   * If specified, a match occurs if and only if any of the alternatives in the match accept the value.
+   */
+  'or_match'?: (_envoy_type_matcher_v3_OrMatcher | null);
+  /**
    * Specifies how to match a value.
    */
-  'match_pattern'?: "null_match"|"double_match"|"string_match"|"bool_match"|"present_match"|"list_match";
+  'match_pattern'?: "null_match"|"double_match"|"string_match"|"bool_match"|"present_match"|"list_match"|"or_match";
 }
 
 /**
  * Specifies the way to match a ProtobufWkt::Value. Primitive values and ListValue are supported.
  * StructValue is not supported and is always not matched.
- * [#next-free-field: 7]
+ * [#next-free-field: 8]
  */
 export interface ValueMatcher__Output {
   /**
@@ -95,7 +100,11 @@ export interface ValueMatcher__Output {
    */
   'list_match'?: (_envoy_type_matcher_v3_ListMatcher__Output | null);
   /**
+   * If specified, a match occurs if and only if any of the alternatives in the match accept the value.
+   */
+  'or_match'?: (_envoy_type_matcher_v3_OrMatcher__Output | null);
+  /**
    * Specifies how to match a value.
    */
-  'match_pattern': "null_match"|"double_match"|"string_match"|"bool_match"|"present_match"|"list_match";
+  'match_pattern': "null_match"|"double_match"|"string_match"|"bool_match"|"present_match"|"list_match"|"or_match";
 }

--- a/packages/grpc-js-xds/src/generated/fault.ts
+++ b/packages/grpc-js-xds/src/generated/fault.ts
@@ -108,6 +108,7 @@ export interface ProtoGrpcType {
           ListMatcher: MessageTypeDefinition
           ListStringMatcher: MessageTypeDefinition
           MetadataMatcher: MessageTypeDefinition
+          OrMatcher: MessageTypeDefinition
           RegexMatchAndSubstitute: MessageTypeDefinition
           RegexMatcher: MessageTypeDefinition
           StringMatcher: MessageTypeDefinition

--- a/packages/grpc-js-xds/src/generated/http_connection_manager.ts
+++ b/packages/grpc-js-xds/src/generated/http_connection_manager.ts
@@ -60,6 +60,7 @@ export interface ProtoGrpcType {
           Http3ProtocolOptions: MessageTypeDefinition
           HttpProtocolOptions: MessageTypeDefinition
           HttpUri: MessageTypeDefinition
+          JsonFormatOptions: MessageTypeDefinition
           KeepaliveSettings: MessageTypeDefinition
           Locality: MessageTypeDefinition
           Metadata: MessageTypeDefinition
@@ -178,6 +179,7 @@ export interface ProtoGrpcType {
           ListMatcher: MessageTypeDefinition
           ListStringMatcher: MessageTypeDefinition
           MetadataMatcher: MessageTypeDefinition
+          OrMatcher: MessageTypeDefinition
           RegexMatchAndSubstitute: MessageTypeDefinition
           RegexMatcher: MessageTypeDefinition
           StringMatcher: MessageTypeDefinition

--- a/packages/grpc-js-xds/src/generated/listener.ts
+++ b/packages/grpc-js-xds/src/generated/listener.ts
@@ -164,6 +164,7 @@ export interface ProtoGrpcType {
           ListMatcher: MessageTypeDefinition
           ListStringMatcher: MessageTypeDefinition
           MetadataMatcher: MessageTypeDefinition
+          OrMatcher: MessageTypeDefinition
           RegexMatchAndSubstitute: MessageTypeDefinition
           RegexMatcher: MessageTypeDefinition
           StringMatcher: MessageTypeDefinition

--- a/packages/grpc-js-xds/src/generated/lrs.ts
+++ b/packages/grpc-js-xds/src/generated/lrs.ts
@@ -49,6 +49,7 @@ export interface ProtoGrpcType {
           TcpKeepalive: MessageTypeDefinition
           TrafficDirection: EnumTypeDefinition
           TransportSocket: MessageTypeDefinition
+          TypedExtensionConfig: MessageTypeDefinition
           WatchedDirectory: MessageTypeDefinition
         }
       }

--- a/packages/grpc-js-xds/src/generated/ring_hash.ts
+++ b/packages/grpc-js-xds/src/generated/ring_hash.ts
@@ -48,6 +48,7 @@ export interface ProtoGrpcType {
           TcpKeepalive: MessageTypeDefinition
           TrafficDirection: EnumTypeDefinition
           TransportSocket: MessageTypeDefinition
+          TypedExtensionConfig: MessageTypeDefinition
           WatchedDirectory: MessageTypeDefinition
         }
       }

--- a/packages/grpc-js-xds/src/generated/route.ts
+++ b/packages/grpc-js-xds/src/generated/route.ts
@@ -99,6 +99,7 @@ export interface ProtoGrpcType {
           ListMatcher: MessageTypeDefinition
           ListStringMatcher: MessageTypeDefinition
           MetadataMatcher: MessageTypeDefinition
+          OrMatcher: MessageTypeDefinition
           RegexMatchAndSubstitute: MessageTypeDefinition
           RegexMatcher: MessageTypeDefinition
           StringMatcher: MessageTypeDefinition

--- a/packages/grpc-js-xds/src/generated/wrr_locality.ts
+++ b/packages/grpc-js-xds/src/generated/wrr_locality.ts
@@ -119,6 +119,12 @@ export interface ProtoGrpcType {
           StringMatcher: MessageTypeDefinition
         }
       }
+      metadata: {
+        v3: {
+          MetadataKey: MessageTypeDefinition
+          MetadataKind: MessageTypeDefinition
+        }
+      }
       v3: {
         CodecClientType: EnumTypeDefinition
         DoubleRange: MessageTypeDefinition


### PR DESCRIPTION
This implements [the EDS part of gRFC A61](https://github.com/grpc/proposal/blob/master/A61-IPv4-IPv6-dualstack-backends.md#support-multiple-addresses-per-endpoint-in-xds). Node does not have stateful session affinity, so that part does not apply.

The first commit is just updating the Envoy API dependency to the same commit hash that grpc/grpc references, and updating the generated code, in order to pick up the change that added the `additional_addresses` field to the `Endpoint` message. The second commit has the actual substance of the change.