### PR TITLE
grpc-js: round_robin: always have children reconnect immediately

### DIFF
--- a/packages/grpc-js-xds/test/backend.ts
+++ b/packages/grpc-js-xds/test/backend.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { loadPackageDefinition, sendUnaryData, Server, ServerCredentials, ServerUnaryCall, UntypedServiceImplementation } from "@grpc/grpc-js";
+import { loadPackageDefinition, sendUnaryData, Server, ServerCredentials, ServerOptions, ServerUnaryCall, UntypedServiceImplementation } from "@grpc/grpc-js";
 import { loadSync } from "@grpc/proto-loader";
 import { ProtoGrpcType } from "./generated/echo";
 import { EchoRequest__Output } from "./generated/grpc/testing/EchoRequest";
@@ -43,7 +43,7 @@ export class Backend {
   private receivedCallCount = 0;
   private callListeners: (() => void)[] = [];
   private port: number | null = null;
-  constructor() {
+  constructor(private serverOptions?: ServerOptions) {
   }
   Echo(call: ServerUnaryCall<EchoRequest__Output, EchoResponse>, callback: sendUnaryData<EchoResponse>) {
     // call.request.params is currently ignored
@@ -76,13 +76,12 @@ export class Backend {
     if (this.server) {
       throw new Error("Backend already running");
     }
-    this.server = new Server();
+    this.server = new Server(this.serverOptions);
     this.server.addService(loadedProtos.grpc.testing.EchoTestService.service, this as unknown as UntypedServiceImplementation);
     const boundPort = this.port ?? 0;
     this.server.bindAsync(`localhost:${boundPort}`, ServerCredentials.createInsecure(), (error, port) => {
       if (!error) {
         this.port = port;
-        this.server!.start();
       }
       callback(error, port);
     })

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -605,6 +605,10 @@ export class LeafLoadBalancer {
     return this.endpoint;
   }
 
+  exitIdle() {
+    this.pickFirstBalancer.exitIdle();
+  }
+
   destroy() {
     this.pickFirstBalancer.destroy();
   }

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -161,6 +161,15 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
     } else {
       this.updateState(ConnectivityState.IDLE, new QueuePicker(this));
     }
+    /* round_robin should keep all children connected, this is how we do that.
+     * We can't do this more efficiently in the individual child's updateState
+     * callback because that doesn't have a reference to which child the state
+     * change is associated with. */
+    for (const child of this.children) {
+      if (child.getConnectivityState() === ConnectivityState.IDLE) {
+        child.exitIdle();
+      }
+    }
   }
 
   private updateState(newState: ConnectivityState, picker: Picker) {


### PR DESCRIPTION
This fixes #2666. After #2561, round_robin delegates to pick_first for each endpoint. As a result, it runs into essentially the same problem pick_first had that was fixed in #2619: once a child has a READY->IDLE transition, nothing triggers it to start connecting again. round_robin is supposed to have every child connected or connecting at all times, so the fix is to have the child reconnect immediately after it goes to IDLE.

The test is in the xDS package because that is where the problem was detected, because round_robin is used much more in the xDS context.

Note that this won't impact the channel-level idle timeout, because the channel discards the current LB policy when it goes idle.