### PR TITLE
fix(grpc-reflection): [#2671] handle references to root-level message types in default package

### DIFF
--- a/packages/grpc-reflection/proto/sample/sample.proto
+++ b/packages/grpc-reflection/proto/sample/sample.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package sample;
 
 import 'vendor.proto';
+import 'unscoped.proto';
 
 service SampleService {
   rpc Hello (HelloRequest) returns (HelloResponse) {}

--- a/packages/grpc-reflection/proto/sample/unscoped.proto
+++ b/packages/grpc-reflection/proto/sample/unscoped.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+message TopLevelMessage {
+  bool value = 1;
+}
+
+message ProcessRequest {
+  string key = 1;
+  TopLevelMessage message = 2;
+}

--- a/packages/grpc-reflection/src/implementations/common/utils.ts
+++ b/packages/grpc-reflection/src/implementations/common/utils.ts
@@ -3,9 +3,9 @@
  * @example scope('grpc.reflection.v1.Type') == 'grpc.reflection.v1'
  */
 export const scope = (path: string, separator: string = '.') => {
-  if (!path.includes(separator)) {
+  if (!path.includes(separator) || path === separator) {
     return '';
   }
 
-  return path.split(separator).slice(0, -1).join(separator);
+  return path.split(separator).slice(0, -1).join(separator) || separator;
 };

--- a/packages/grpc-reflection/src/implementations/reflection-v1.ts
+++ b/packages/grpc-reflection/src/implementations/reflection-v1.ts
@@ -114,12 +114,12 @@ export class ReflectionV1Implementation {
       let referencedFile: IFileDescriptorProto | null = null;
       if (ref.startsWith('.')) {
         // absolute reference -- just remove the leading '.' and use the ref directly
-        referencedFile = this.symbols[ref.replace(/^\./, '')];
+        referencedFile = this.symbols[ref.slice(1)];
       } else {
         // relative reference -- need to seek upwards up the current package scope until we find it
         let pkg = pkgScope;
         while (pkg && !referencedFile) {
-          referencedFile = this.symbols[`${pkg}.${ref}`];
+          referencedFile = this.symbols[`${pkg.replace(/\.$/, '')}.${ref}`];
           pkg = scope(pkg);
         }
 

--- a/packages/grpc-reflection/test/test-reflection-v1-implementation.ts
+++ b/packages/grpc-reflection/test/test-reflection-v1-implementation.ts
@@ -10,7 +10,10 @@ describe('GrpcReflectionService', () => {
 
   beforeEach(async () => {
     const root = protoLoader.loadSync(path.join(__dirname, '../proto/sample/sample.proto'), {
-      includeDirs: [path.join(__dirname, '../proto/sample/vendor')]
+      includeDirs: [
+        path.join(__dirname, '../proto/sample/'),
+        path.join(__dirname, '../proto/sample/vendor')
+      ]
     });
 
     reflectionService = new ReflectionV1Implementation(root);
@@ -25,7 +28,10 @@ describe('GrpcReflectionService', () => {
 
     it('whitelists services properly', () => {
       const root = protoLoader.loadSync(path.join(__dirname, '../proto/sample/sample.proto'), {
-        includeDirs: [path.join(__dirname, '../proto/sample/vendor')]
+        includeDirs: [
+          path.join(__dirname, '../proto/sample/'),
+          path.join(__dirname, '../proto/sample/vendor')
+        ]
       });
 
       reflectionService = new ReflectionV1Implementation(root, { services: ['sample.SampleService'] });
@@ -124,6 +130,18 @@ describe('GrpcReflectionService', () => {
       assert.deepEqual(
         new Set(names),
         new Set(['sample.proto', 'vendor.proto', 'vendor_dependency.proto']),
+      );
+    });
+
+    it('finds unscoped package types', () => {
+      const descriptors = reflectionService
+        .fileContainingSymbol('.TopLevelMessage')
+        .fileDescriptorProto.map(f => FileDescriptorProto.decode(f) as IFileDescriptorProto);
+
+      const names = descriptors.map((desc) => desc.name);
+      assert.deepEqual(
+        new Set(names),
+        new Set(['root.proto']),
       );
     });
 

--- a/packages/grpc-reflection/test/test-utils.ts
+++ b/packages/grpc-reflection/test/test-utils.ts
@@ -7,8 +7,14 @@ describe('scope', () => {
     assert.strictEqual(scope('grpc.health.v1.HealthCheckResponse.ServiceStatus'), 'grpc.health.v1.HealthCheckResponse');
     assert.strictEqual(scope(scope(scope(scope('grpc.health.v1.HealthCheckResponse.ServiceStatus')))), 'grpc');
   });
+
   it('returns an empty package when at the top', () => {
     assert.strictEqual(scope('Message'), '');
     assert.strictEqual(scope(''), '');
+  });
+
+  it('handles globally scoped references', () => {
+    assert.strictEqual(scope('.Message'), '.');
+    assert.strictEqual(scope(scope('.Message')), '');
   });
 });


### PR DESCRIPTION
Bugfix to handle references to root-level message types in the default (unspecified) package from issue #2671. This was causing warnings about failed lookups to any message type that:
  1. Was in the default package (eg. no `package` directive in the proto file), and
  2. Was at the top-level of the package, not nested in another message

The root cause of this was a bug in the `scope` utility where, when we were seeking up the package scope for where the symbol reference lived, we skipped over the root (`.`) package. Relevant snippet from bug report:
> we end up with `TopLevelMessage` being indexed as `.TopLevelMessage` and the reference to it from `ProcessRequest` being sourced from the scope `.ProcessRequest`. When checking the index the search goes like this in order:
>   1. Check current scope (`.ProcessRequest.TopLevelMessage`) which does not exist
>   2. Check parent scope (`TopLevelMessage`) which does not exist
>   3. Bail out because we're at the root already

This change includes:
  1. A fix to the `scope` utility to prevent it from skipping over the root (`.`) package
  3. A fix to how we reference message types to avoid cases like `.` + `.TopLevelMessage`
  4. A reproduction of the issue from #2671 in `unscoped.proto` as well as a regression test in `test-reflection-v1-implementation.ts`