### PR TITLE
reflection: Fix references to symbols with no package

### DIFF
--- a/packages/grpc-reflection/package.json
+++ b/packages/grpc-reflection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/reflection",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "Google Inc."
   },

--- a/packages/grpc-reflection/proto/sample/sample.proto
+++ b/packages/grpc-reflection/proto/sample/sample.proto
@@ -8,6 +8,7 @@ import 'unscoped.proto';
 service SampleService {
   rpc Hello (HelloRequest) returns (HelloResponse) {}
   rpc Hello2 (HelloRequest) returns (CommonMessage) {}
+  rpc Hello3 (ProcessRequest) returns (TopLevelMessage) {}
 }
 
 service IgnoreService {

--- a/packages/grpc-reflection/src/implementations/reflection-v1.ts
+++ b/packages/grpc-reflection/src/implementations/reflection-v1.ts
@@ -113,8 +113,12 @@ export class ReflectionV1Implementation {
 
       let referencedFile: IFileDescriptorProto | null = null;
       if (ref.startsWith('.')) {
-        // absolute reference -- just remove the leading '.' and use the ref directly
-        referencedFile = this.symbols[ref.slice(1)];
+        /* absolute reference -- In files with no package, symbols are
+         * populated in the symbols table with a leading period in the key.
+         * If there is a package, the symbol does not have a leading period in
+         * the key. For simplicity, we check without the period, then with it.
+         */
+        referencedFile = this.symbols[ref.slice(1)] ?? this.symbols[ref];
       } else {
         // relative reference -- need to seek upwards up the current package scope until we find it
         let pkg = pkgScope;
@@ -315,7 +319,7 @@ export class ReflectionV1Implementation {
   private getFileDependencies(file: IFileDescriptorProto): IFileDescriptorProto[] {
     const visited: Set<IFileDescriptorProto> = new Set();
     const toVisit: IFileDescriptorProto[] = [...(this.fileDependencies.get(file) || [])];
-    
+
     while (toVisit.length > 0) {
       const current = toVisit.pop();
 

--- a/packages/grpc-reflection/test/test-reflection-v1-implementation.ts
+++ b/packages/grpc-reflection/test/test-reflection-v1-implementation.ts
@@ -51,7 +51,7 @@ describe('GrpcReflectionService', () => {
       const names = descriptors.map((desc) => desc.name);
       assert.deepEqual(
         new Set(names),
-        new Set(['sample.proto', 'vendor.proto', 'vendor_dependency.proto'])
+        new Set(['root.proto', 'sample.proto', 'vendor.proto', 'vendor_dependency.proto'])
       );
     });
 
@@ -99,7 +99,7 @@ describe('GrpcReflectionService', () => {
       const names = descriptors.map((desc) => desc.name);
       assert.deepEqual(
         new Set(names),
-        new Set(['sample.proto', 'vendor.proto', 'vendor_dependency.proto']),
+        new Set(['root.proto', 'sample.proto', 'vendor.proto', 'vendor_dependency.proto']),
       );
     });
 
@@ -129,7 +129,7 @@ describe('GrpcReflectionService', () => {
       const names = descriptors.map((desc) => desc.name);
       assert.deepEqual(
         new Set(names),
-        new Set(['sample.proto', 'vendor.proto', 'vendor_dependency.proto']),
+        new Set(['root.proto', 'sample.proto', 'vendor.proto', 'vendor_dependency.proto']),
       );
     });
 
@@ -169,7 +169,7 @@ describe('GrpcReflectionService', () => {
       const names = descriptors.map((desc) => desc.name);
       assert.deepEqual(
         new Set(names),
-        new Set(['sample.proto', 'vendor.proto', 'vendor_dependency.proto']),
+        new Set(['root.proto', 'sample.proto', 'vendor.proto', 'vendor_dependency.proto']),
       );
     });
   });


### PR DESCRIPTION
This is a follow up to #2673, and fixes #2671 according to my manual testing. The new comment basically explains this change:

> In files with no package, symbols are populated in the symbols table with a leading period in the key. If there is a package, the symbol does not have a leading period in the key. For simplicity, we check without the period, then with it.

CC @jtimmons