### PR TITLE
grpc-js: pick_first: Don't automatically reconnect after connection drop

### DIFF
--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -348,7 +348,6 @@ export class PickFirstLoadBalancer implements LoadBalancer {
       if (newState !== ConnectivityState.READY) {
         this.removeCurrentPick();
         this.calculateAndReportNewState();
-        this.requestReresolution();
       }
       return;
     }


### PR DESCRIPTION
From [A62](https://github.com/grpc/proposal/blob/master/A62-pick-first.md):

> If this connection breaks at a later point in time, `pick_first` will not attempt to reconnect until the application requests that it does so, or makes an RPC.

This was a mistake in #2511, but without #2619 and [this change in #2568](https://github.com/grpc/grpc-node/commit/3a43cba3a3a5afb5c0bbfc621922ee023f977e5e#diff-569f9a9708121d140658da08c9840dc00b0dde21c880b320bc251a20cf1fda02), it probably wouldn't work correctly.

This error was pointed out in https://github.com/grpc/grpc-node/pull/2677#issuecomment-1974839742.