### PR TITLE
grpc-js: Rearrange some function calls to revert event order changes

### DIFF
--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -200,11 +200,11 @@ export class ServerWritableStreamImpl<RequestType, ResponseType>
   }
 
   _final(callback: Function): void {
+    callback(null);
     this.call.sendStatus({
       ...this.pendingStatus,
       metadata: this.pendingStatus.metadata ?? this.trailingMetadata,
     });
-    callback(null);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -273,11 +273,11 @@ export class ServerDuplexStreamImpl<RequestType, ResponseType>
   }
 
   _final(callback: Function): void {
+    callback(null);
     this.call.sendStatus({
       ...this.pendingStatus,
       metadata: this.pendingStatus.metadata ?? this.trailingMetadata,
     });
-    callback(null);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/grpc-js/src/server-interceptors.ts
+++ b/packages/grpc-js/src/server-interceptors.ts
@@ -842,7 +842,6 @@ export class BaseServerInterceptingCall
     if (this.checkCancelled()) {
       return;
     }
-    this.notifyOnCancel();
 
     trace(
       'Request to method ' +
@@ -869,8 +868,11 @@ export class BaseServerInterceptingCall
           };
 
           this.stream.sendTrailers(trailersToSend);
+          this.notifyOnCancel();
         });
         this.stream.end();
+      } else {
+        this.notifyOnCancel();
       }
     } else {
       if (this.callEventTracker && !this.streamEnded) {
@@ -886,6 +888,7 @@ export class BaseServerInterceptingCall
         ...status.metadata?.toHttp2Headers(),
       };
       this.stream.respond(trailersToSend, { endStream: true });
+      this.notifyOnCancel();
     }
   }
   startRead(): void {


### PR DESCRIPTION
This fixes #2681, according to manual testing. The goal is to ensure that the `cancelled` event is emitted after the `finish` event. First, in `sendStatus`, the `notifyOnCancel` call is moved to after actually sending the status. The most important part of that is moving it into the `wantTrailers` event handler, so that it is only called after the stream is flushed, but it also needs to be in the other branches in that function. In addition, the callback in the `_final` implementations is moved to before the `sendStatus` call to get the right ordering if there is a trailers-only response, which will be sent synchronously.