### PR TITLE
grpc-js: support content-subtype option in http2 transport

### DIFF
--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -62,6 +62,14 @@ export interface ChannelOptions {
    */
   'grpc-node.tls_enable_trace'?: number;
   'grpc.lb.ring_hash.ring_size_cap'?: number;
+  /**
+   * This option will set the "content-subtype" for a request.
+   * For example, a "content-subtype" of "proto" will result in a content-type of
+   * "application/grpc+proto". And this will always be lowercase. See
+   * https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests for
+   * more details.
+   */
+  'grpc-node.http_content_subtype'?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -62,14 +62,6 @@ export interface ChannelOptions {
    */
   'grpc-node.tls_enable_trace'?: number;
   'grpc.lb.ring_hash.ring_size_cap'?: number;
-  /**
-   * This option will set the "content-subtype" for a request.
-   * For example, a "content-subtype" of "proto" will result in a content-type of
-   * "application/grpc+proto". And this will always be lowercase. See
-   * https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests for
-   * more details.
-   */
-  'grpc-node.http_content_subtype'?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }

--- a/packages/grpc-js/src/metadata.ts
+++ b/packages/grpc-js/src/metadata.ts
@@ -81,6 +81,14 @@ export interface MetadataOptions {
   cacheableRequest?: boolean;
   /* Signal that the initial metadata should be corked. Defaults to false. */
   corked?: boolean;
+  /**
+   * This option will set the "content-subtype" for a request.
+   * For example, a "content-subtype" of "proto" will result in a content-type of
+   * "application/grpc+proto". And this will always be lowercase. See
+   * https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests for
+   * more details.
+   */
+  contentSubtype?: string;
 }
 
 /**

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -124,7 +124,6 @@ class Http2Transport implements Transport {
   private keepaliveWithoutCalls = false;
 
   private userAgent: string;
-  private contentSubtype?: string;
 
   private activeCalls: Set<Http2SubchannelCall> = new Set();
 
@@ -174,10 +173,6 @@ class Http2Transport implements Transport {
     ]
       .filter(e => e)
       .join(' '); // remove falsey values first
-
-    if ('grpc.http_content_subtype' in options) {
-      this.contentSubtype = options['grpc-node.http_content_subtype'];
-    }
 
     if ('grpc.keepalive_time_ms' in options) {
       this.keepaliveTimeMs = options['grpc.keepalive_time_ms']!;
@@ -513,8 +508,9 @@ class Http2Transport implements Transport {
     headers[HTTP2_HEADER_TE] = 'trailers';
 
     let contentTypeHeader = 'application/grpc';
-    if (this.contentSubtype) {
-      contentTypeHeader += `+${this.contentSubtype}`;
+    const { contentSubtype } = metadata.getOptions();
+    if (contentSubtype) {
+      contentTypeHeader += `+${contentSubtype}`;
     }
     headers[HTTP2_HEADER_CONTENT_TYPE] = contentTypeHeader;
 


### PR DESCRIPTION
Hi all,

`HTTP2Transport` has set the `Content-Type` Header as `application/grpc` by default, which library users cannot modify.

The gRPC protocol spec allows using of "content-subtype" just like `application/grpc+proto` at
 <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests>.

Some gRPC server implementation such as [cloudwego/kitex](https://github.com/cloudwego/kitex) depends on this header to detect the payload codec(like thrift, JSON, etc.).

So this PR has added ~~a new channel option `grpc-node.http_content_subtype`~~ to let end-users modify the subtype if they need it.

---

Updated(2023-03-15): move option to `MetadataOptions` as simpler `contentSubtype`.