### PR TITLE
Revert #2680 "grpc-js: pick_first: Don't automatically reconnect after connection drop"

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -348,6 +348,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
       if (newState !== ConnectivityState.READY) {
         this.removeCurrentPick();
         this.calculateAndReportNewState();
+        this.requestReresolution();
       }
       return;
     }


### PR DESCRIPTION
This change (#2680) was the only one in 1.10.2 that affected the request path, so it is the most likely cause of #2690.