### PR TITLE
grpc-js: Add more info to deadline exceeded errors

### DIFF
--- a/packages/grpc-js/src/call-interface.ts
+++ b/packages/grpc-js/src/call-interface.ts
@@ -171,3 +171,7 @@ export interface Call {
   getCallNumber(): number;
   setCredentials(credentials: CallCredentials): void;
 }
+
+export interface DeadlineInfoProvider {
+  getDeadlineInfo(): string[];
+}

--- a/packages/grpc-js/src/deadline.ts
+++ b/packages/grpc-js/src/deadline.ts
@@ -93,3 +93,14 @@ export function deadlineToString(deadline: Deadline): string {
     }
   }
 }
+
+/**
+ * Calculate the difference between two dates as a number of seconds and format
+ * it as a string.
+ * @param startDate
+ * @param endDate
+ * @returns
+ */
+export function formatDateDifference(startDate: Date, endDate: Date): string {
+  return ((endDate.getTime() - startDate.getTime()) / 1000).toFixed(3) + 's';
+}

--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -684,7 +684,7 @@ export class InternalChannel {
     host: string,
     credentials: CallCredentials,
     deadline: Deadline
-  ): Call {
+  ): LoadBalancingCall | RetryingCall {
     // Create a RetryingCall if retries are enabled
     if (this.options['grpc.enable_retries'] === 0) {
       return this.createLoadBalancingCall(

--- a/packages/grpc-js/src/load-balancing-call.ts
+++ b/packages/grpc-js/src/load-balancing-call.ts
@@ -121,7 +121,8 @@ export class LoadBalancingCall implements Call, DeadlineInfoProvider {
           status.code +
           ' details="' +
           status.details +
-          '"'
+          '" start time=' +
+          this.startTime.toISOString()
       );
       const finalStatus = { ...status, progress };
       this.listener?.onReceiveStatus(finalStatus);

--- a/packages/grpc-js/src/load-balancing-call.ts
+++ b/packages/grpc-js/src/load-balancing-call.ts
@@ -18,6 +18,7 @@
 import { CallCredentials } from './call-credentials';
 import {
   Call,
+  DeadlineInfoProvider,
   InterceptingListener,
   MessageContext,
   StatusObject,
@@ -25,7 +26,7 @@ import {
 import { SubchannelCall } from './subchannel-call';
 import { ConnectivityState } from './connectivity-state';
 import { LogVerbosity, Status } from './constants';
-import { Deadline, getDeadlineTimeoutString } from './deadline';
+import { Deadline, formatDateDifference, getDeadlineTimeoutString } from './deadline';
 import { InternalChannel } from './internal-channel';
 import { Metadata } from './metadata';
 import { PickResultType } from './picker';
@@ -48,7 +49,7 @@ export interface LoadBalancingCallInterceptingListener
   onReceiveStatus(status: StatusObjectWithProgress): void;
 }
 
-export class LoadBalancingCall implements Call {
+export class LoadBalancingCall implements Call, DeadlineInfoProvider {
   private child: SubchannelCall | null = null;
   private readPending = false;
   private pendingMessage: { context: MessageContext; message: Buffer } | null =
@@ -59,6 +60,8 @@ export class LoadBalancingCall implements Call {
   private metadata: Metadata | null = null;
   private listener: InterceptingListener | null = null;
   private onCallEnded: ((statusCode: Status) => void) | null = null;
+  private startTime: Date;
+  private childStartTime: Date | null = null;
   constructor(
     private readonly channel: InternalChannel,
     private readonly callConfig: CallConfig,
@@ -80,6 +83,26 @@ export class LoadBalancingCall implements Call {
     /* Currently, call credentials are only allowed on HTTPS connections, so we
      * can assume that the scheme is "https" */
     this.serviceUrl = `https://${hostname}/${serviceName}`;
+    this.startTime = new Date();
+  }
+  getDeadlineInfo(): string[] {
+    const deadlineInfo: string[] = [];
+    if (this.childStartTime) {
+      if (this.childStartTime > this.startTime) {
+        if (this.metadata?.getOptions().waitForReady) {
+          deadlineInfo.push('wait_for_ready');
+        }
+        deadlineInfo.push(`LB pick: ${formatDateDifference(this.startTime, this.childStartTime)}`);
+      }
+      deadlineInfo.push(...this.child!.getDeadlineInfo());
+      return deadlineInfo;
+    } else {
+      if (this.metadata?.getOptions().waitForReady) {
+        deadlineInfo.push('wait_for_ready');
+      }
+      deadlineInfo.push('Waiting for LB pick');
+    }
+    return deadlineInfo;
   }
 
   private trace(text: string): void {
@@ -209,6 +232,7 @@ export class LoadBalancingCall implements Call {
                       }
                     },
                   });
+                this.childStartTime = new Date();
               } catch (error) {
                 this.trace(
                   'Failed to start call on picked subchannel ' +

--- a/packages/grpc-js/src/retrying-call.ts
+++ b/packages/grpc-js/src/retrying-call.ts
@@ -261,7 +261,8 @@ export class RetryingCall implements Call, DeadlineInfoProvider {
         statusObject.code +
         ' details="' +
         statusObject.details +
-        '"'
+        '" start time=' +
+        this.startTime.toISOString()
     );
     this.bufferTracker.freeAll(this.callNumber);
     this.writeBufferOffset = this.writeBufferOffset + this.writeBuffer.length;

--- a/packages/grpc-js/src/retrying-call.ts
+++ b/packages/grpc-js/src/retrying-call.ts
@@ -17,12 +17,13 @@
 
 import { CallCredentials } from './call-credentials';
 import { LogVerbosity, Status } from './constants';
-import { Deadline } from './deadline';
+import { Deadline, formatDateDifference } from './deadline';
 import { Metadata } from './metadata';
 import { CallConfig } from './resolver';
 import * as logging from './logging';
 import {
   Call,
+  DeadlineInfoProvider,
   InterceptingListener,
   MessageContext,
   StatusObject,
@@ -121,6 +122,7 @@ interface UnderlyingCall {
   state: UnderlyingCallState;
   call: LoadBalancingCall;
   nextMessageToSend: number;
+  startTime: Date;
 }
 
 /**
@@ -170,7 +172,7 @@ interface WriteBufferEntry {
 
 const PREVIONS_RPC_ATTEMPTS_METADATA_KEY = 'grpc-previous-rpc-attempts';
 
-export class RetryingCall implements Call {
+export class RetryingCall implements Call, DeadlineInfoProvider {
   private state: RetryingCallState;
   private listener: InterceptingListener | null = null;
   private initialMetadata: Metadata | null = null;
@@ -198,6 +200,7 @@ export class RetryingCall implements Call {
   private committedCallIndex: number | null = null;
   private initialRetryBackoffSec = 0;
   private nextRetryBackoffSec = 0;
+  private startTime: Date;
   constructor(
     private readonly channel: InternalChannel,
     private readonly callConfig: CallConfig,
@@ -223,6 +226,22 @@ export class RetryingCall implements Call {
     } else {
       this.state = 'TRANSPARENT_ONLY';
     }
+    this.startTime = new Date();
+  }
+  getDeadlineInfo(): string[] {
+    if (this.underlyingCalls.length === 0) {
+      return [];
+    }
+    const deadlineInfo: string[] = [];
+    const latestCall = this.underlyingCalls[this.underlyingCalls.length - 1];
+    if (this.underlyingCalls.length > 1) {
+      deadlineInfo.push(`previous attempts: ${this.underlyingCalls.length - 1}`);
+    }
+    if (latestCall.startTime > this.startTime) {
+      deadlineInfo.push(`time to current attempt start: ${formatDateDifference(this.startTime, latestCall.startTime)}`);
+    }
+    deadlineInfo.push(...latestCall.call.getDeadlineInfo());
+    return deadlineInfo;
   }
   getCallNumber(): number {
     return this.callNumber;
@@ -628,6 +647,7 @@ export class RetryingCall implements Call {
       state: 'ACTIVE',
       call: child,
       nextMessageToSend: 0,
+      startTime: new Date()
     });
     const previousAttempts = this.attempts - 1;
     const initialMetadata = this.initialMetadata!.clone();

--- a/packages/grpc-js/src/subchannel-address.ts
+++ b/packages/grpc-js/src/subchannel-address.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { isIP } from 'net';
+import { isIP, isIPv6 } from 'net';
 
 export interface TcpSubchannelAddress {
   port: number;
@@ -63,7 +63,11 @@ export function subchannelAddressEqual(
 
 export function subchannelAddressToString(address: SubchannelAddress): string {
   if (isTcpSubchannelAddress(address)) {
-    return address.host + ':' + address.port;
+    if (isIPv6(address.host)) {
+      return '[' + address.host + ']:' + address.port;
+    } else {
+      return address.host + ':' + address.port;
+    }
   } else {
     return address.path;
   }

--- a/packages/grpc-js/src/subchannel-call.ts
+++ b/packages/grpc-js/src/subchannel-call.ts
@@ -70,6 +70,7 @@ export interface SubchannelCall {
   startRead(): void;
   halfClose(): void;
   getCallNumber(): number;
+  getDeadlineInfo(): string[];
 }
 
 export interface StatusObjectWithRstCode extends StatusObject {
@@ -287,6 +288,9 @@ export class Http2SubchannelCall implements SubchannelCall {
       }
       this.callEventTracker.onStreamEnd(false);
     });
+  }
+  getDeadlineInfo(): string[] {
+    return [`remote_addr=${this.getPeer()}`];
   }
 
   public onDisconnect() {


### PR DESCRIPTION
Currently, the details string in a client-side deadline exceeded error is just "Deadline exceeded". This change adds more information to that, to help narrow down the cause of those errors. Specifically, it shows a breakdown of any time taken before the request was actually sent to a specific server, along with the address of the server if it was sent. For example, an error string from a test with all information shown looks like this:

```
Deadline exceeded after 1.001s,name resolution: 0.000s,metadata filters: 0.002s,previous attempts: 0,time to current attempt start: 0.001s,LB pick: 0.006s,remote_addr=[::1]:45251
```

This is just a first pass to get some useful information into the error string, and to add the framework to add or change individual pieces of information there as necessary.

This should largely address #2687.