### PR TITLE
grpc-js: Avoid sending redundant RST_STREAMs from the client

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
Based on the hypothesis that #2625 is caused by RST_STREAM rate limiting (for rapid reset mitigation), this change reduces the chances of that by avoiding sending an RST_STREAM from the client when the server has already half-closed its side of the connection.