### PR TITLE
grpc-js: Ensure server interceptors work with builder utility classes

### DIFF
--- a/packages/grpc-js/src/server-interceptors.ts
+++ b/packages/grpc-js/src/server-interceptors.ts
@@ -345,7 +345,12 @@ export class ServerInterceptingCall implements ServerInterceptingCallInterface {
     private nextCall: ServerInterceptingCallInterface,
     responder?: Responder
   ) {
-    this.responder = { ...defaultResponder, ...responder };
+    this.responder = {
+      start: responder?.start ?? defaultResponder.start,
+      sendMetadata: responder?.sendMetadata ?? defaultResponder.sendMetadata,
+      sendMessage: responder?.sendMessage ?? defaultResponder.sendMessage,
+      sendStatus: responder?.sendStatus ?? defaultResponder.sendStatus,
+    };
   }
 
   private processPendingMessage() {
@@ -369,8 +374,17 @@ export class ServerInterceptingCall implements ServerInterceptingCallInterface {
   start(listener: InterceptingServerListener): void {
     this.responder.start(interceptedListener => {
       const fullInterceptedListener: FullServerListener = {
-        ...defaultServerListener,
-        ...interceptedListener,
+        onReceiveMetadata:
+          interceptedListener?.onReceiveMetadata ??
+          defaultServerListener.onReceiveMetadata,
+        onReceiveMessage:
+          interceptedListener?.onReceiveMessage ??
+          defaultServerListener.onReceiveMessage,
+        onReceiveHalfClose:
+          interceptedListener?.onReceiveHalfClose ??
+          defaultServerListener.onReceiveHalfClose,
+        onCancel:
+          interceptedListener?.onCancel ?? defaultServerListener.onCancel,
       };
       const finalInterceptingListener = new InterceptingServerListenerImpl(
         fullInterceptedListener,


### PR DESCRIPTION
The idea with the part of the code modified here is that the user can pass in a partially filled in responder or server listener, and the rest of the object will be filled in with defaults so that the rest of the class can handle it more simply. Unfortunately, the specific strategy of doing that using the spread operator (`...`) works with unpopulated object fields, but not object fields set to `undefined`, which is what `ResponderBuilder` and `ServerListenerBuilder` produce.

The test auth interceptor partially populates both a listener and a resolver, so switching it to use the builders should ensure that it catches this problem on both sides.