### PR TITLE
grpc-js-xds: Use TypeScript 5

### DIFF
--- a/packages/grpc-js-xds/interop/Dockerfile
+++ b/packages/grpc-js-xds/interop/Dockerfile
@@ -31,6 +31,7 @@ RUN npm install
 
 FROM gcr.io/distroless/nodejs18-debian11:latest
 WORKDIR /node/src/grpc-node
+COPY --from=build /node/src/grpc-node/packages/proto-loader ./packages/proto-loader/
 COPY --from=build /node/src/grpc-node/packages/grpc-js ./packages/grpc-js/
 COPY --from=build /node/src/grpc-node/packages/grpc-js-xds ./packages/grpc-js-xds/
 

--- a/packages/grpc-js-xds/interop/Dockerfile
+++ b/packages/grpc-js-xds/interop/Dockerfile
@@ -22,6 +22,8 @@ FROM node:18-slim as build
 WORKDIR /node/src/grpc-node
 COPY . .
 
+WORKDIR /node/src/grpc-node/packages/proto-loader
+RUN npm install
 WORKDIR /node/src/grpc-node/packages/grpc-js
 RUN npm install
 WORKDIR /node/src/grpc-node/packages/grpc-js-xds

--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/grpc/grpc-node#readme",
   "devDependencies": {
     "@grpc/grpc-js": "file:../grpc-js",
+    "@grpc/proto-loader": "file:../proto-loader",
     "@types/gulp": "^4.0.6",
     "@types/gulp-mocha": "0.0.32",
     "@types/mocha": "^5.2.6",

--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^13.11.1",
     "@types/yargs": "^15.0.5",
     "gts": "^5.0.1",
-    "typescript": "^4.9.5",
+    "typescript": "^5.1.3",
     "yargs": "^15.4.1"
   },
   "dependencies": {

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -15,7 +15,7 @@
   "types": "build/src/index.d.ts",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grpc/proto-loader": "../proto-loader",
+    "@grpc/proto-loader": "file:../proto-loader",
     "@types/gulp": "^4.0.6",
     "@types/gulp-mocha": "0.0.32",
     "@types/lodash": "^4.14.186",

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -15,6 +15,7 @@
   "types": "build/src/index.d.ts",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@grpc/proto-loader": "../proto-loader",
     "@types/gulp": "^4.0.6",
     "@types/gulp-mocha": "0.0.32",
     "@types/lodash": "^4.14.186",

--- a/packages/grpc-js/src/generated/channelz.ts
+++ b/packages/grpc-js/src/generated/channelz.ts
@@ -1,7 +1,7 @@
 import type * as grpc from '../index';
 import type { MessageTypeDefinition } from '@grpc/proto-loader';
 
-import type { ChannelzClient as _grpc_channelz_v1_ChannelzClient, ChannelzDefinition as _grpc_channelz_v1_ChannelzDefinition } from './grpc/channelz/v1/Channelz';
+import type { ChannelzClient as _grpc_channelz_v1_ChannelzClient, ChannelzDefinition as _grpc_channelz_v1_ChannelzDefinition } from './grpc/channelz/v1/Channelz.ts';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Address.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Address.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../../google/protobuf/Any';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../../google/protobuf/Any.ts';
 
 /**
  * An address type not included above.

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Channel.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Channel.ts
@@ -1,9 +1,9 @@
 // Original file: proto/channelz.proto
 
-import type { ChannelRef as _grpc_channelz_v1_ChannelRef, ChannelRef__Output as _grpc_channelz_v1_ChannelRef__Output } from '../../../grpc/channelz/v1/ChannelRef';
-import type { ChannelData as _grpc_channelz_v1_ChannelData, ChannelData__Output as _grpc_channelz_v1_ChannelData__Output } from '../../../grpc/channelz/v1/ChannelData';
-import type { SubchannelRef as _grpc_channelz_v1_SubchannelRef, SubchannelRef__Output as _grpc_channelz_v1_SubchannelRef__Output } from '../../../grpc/channelz/v1/SubchannelRef';
-import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef';
+import type { ChannelRef as _grpc_channelz_v1_ChannelRef, ChannelRef__Output as _grpc_channelz_v1_ChannelRef__Output } from '../../../grpc/channelz/v1/ChannelRef.ts';
+import type { ChannelData as _grpc_channelz_v1_ChannelData, ChannelData__Output as _grpc_channelz_v1_ChannelData__Output } from '../../../grpc/channelz/v1/ChannelData.ts';
+import type { SubchannelRef as _grpc_channelz_v1_SubchannelRef, SubchannelRef__Output as _grpc_channelz_v1_SubchannelRef__Output } from '../../../grpc/channelz/v1/SubchannelRef.ts';
+import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef.ts';
 
 /**
  * Channel is a logical grouping of channels, subchannels, and sockets.

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelData.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelData.ts
@@ -1,8 +1,8 @@
 // Original file: proto/channelz.proto
 
-import type { ChannelConnectivityState as _grpc_channelz_v1_ChannelConnectivityState, ChannelConnectivityState__Output as _grpc_channelz_v1_ChannelConnectivityState__Output } from '../../../grpc/channelz/v1/ChannelConnectivityState';
-import type { ChannelTrace as _grpc_channelz_v1_ChannelTrace, ChannelTrace__Output as _grpc_channelz_v1_ChannelTrace__Output } from '../../../grpc/channelz/v1/ChannelTrace';
-import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
+import type { ChannelConnectivityState as _grpc_channelz_v1_ChannelConnectivityState, ChannelConnectivityState__Output as _grpc_channelz_v1_ChannelConnectivityState__Output } from '../../../grpc/channelz/v1/ChannelConnectivityState.ts';
+import type { ChannelTrace as _grpc_channelz_v1_ChannelTrace, ChannelTrace__Output as _grpc_channelz_v1_ChannelTrace__Output } from '../../../grpc/channelz/v1/ChannelTrace.ts';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp.ts';
 import type { Long } from '@grpc/proto-loader';
 
 /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelTrace.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelTrace.ts
@@ -1,7 +1,7 @@
 // Original file: proto/channelz.proto
 
-import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
-import type { ChannelTraceEvent as _grpc_channelz_v1_ChannelTraceEvent, ChannelTraceEvent__Output as _grpc_channelz_v1_ChannelTraceEvent__Output } from '../../../grpc/channelz/v1/ChannelTraceEvent';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp.ts';
+import type { ChannelTraceEvent as _grpc_channelz_v1_ChannelTraceEvent, ChannelTraceEvent__Output as _grpc_channelz_v1_ChannelTraceEvent__Output } from '../../../grpc/channelz/v1/ChannelTraceEvent.ts';
 import type { Long } from '@grpc/proto-loader';
 
 /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelTraceEvent.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ChannelTraceEvent.ts
@@ -1,8 +1,8 @@
 // Original file: proto/channelz.proto
 
-import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
-import type { ChannelRef as _grpc_channelz_v1_ChannelRef, ChannelRef__Output as _grpc_channelz_v1_ChannelRef__Output } from '../../../grpc/channelz/v1/ChannelRef';
-import type { SubchannelRef as _grpc_channelz_v1_SubchannelRef, SubchannelRef__Output as _grpc_channelz_v1_SubchannelRef__Output } from '../../../grpc/channelz/v1/SubchannelRef';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp.ts';
+import type { ChannelRef as _grpc_channelz_v1_ChannelRef, ChannelRef__Output as _grpc_channelz_v1_ChannelRef__Output } from '../../../grpc/channelz/v1/ChannelRef.ts';
+import type { SubchannelRef as _grpc_channelz_v1_SubchannelRef, SubchannelRef__Output as _grpc_channelz_v1_SubchannelRef__Output } from '../../../grpc/channelz/v1/SubchannelRef.ts';
 
 // Original file: proto/channelz.proto
 

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Channelz.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Channelz.ts
@@ -2,20 +2,20 @@
 
 import type * as grpc from '../../../../index'
 import type { MethodDefinition } from '@grpc/proto-loader'
-import type { GetChannelRequest as _grpc_channelz_v1_GetChannelRequest, GetChannelRequest__Output as _grpc_channelz_v1_GetChannelRequest__Output } from '../../../grpc/channelz/v1/GetChannelRequest';
-import type { GetChannelResponse as _grpc_channelz_v1_GetChannelResponse, GetChannelResponse__Output as _grpc_channelz_v1_GetChannelResponse__Output } from '../../../grpc/channelz/v1/GetChannelResponse';
-import type { GetServerRequest as _grpc_channelz_v1_GetServerRequest, GetServerRequest__Output as _grpc_channelz_v1_GetServerRequest__Output } from '../../../grpc/channelz/v1/GetServerRequest';
-import type { GetServerResponse as _grpc_channelz_v1_GetServerResponse, GetServerResponse__Output as _grpc_channelz_v1_GetServerResponse__Output } from '../../../grpc/channelz/v1/GetServerResponse';
-import type { GetServerSocketsRequest as _grpc_channelz_v1_GetServerSocketsRequest, GetServerSocketsRequest__Output as _grpc_channelz_v1_GetServerSocketsRequest__Output } from '../../../grpc/channelz/v1/GetServerSocketsRequest';
-import type { GetServerSocketsResponse as _grpc_channelz_v1_GetServerSocketsResponse, GetServerSocketsResponse__Output as _grpc_channelz_v1_GetServerSocketsResponse__Output } from '../../../grpc/channelz/v1/GetServerSocketsResponse';
-import type { GetServersRequest as _grpc_channelz_v1_GetServersRequest, GetServersRequest__Output as _grpc_channelz_v1_GetServersRequest__Output } from '../../../grpc/channelz/v1/GetServersRequest';
-import type { GetServersResponse as _grpc_channelz_v1_GetServersResponse, GetServersResponse__Output as _grpc_channelz_v1_GetServersResponse__Output } from '../../../grpc/channelz/v1/GetServersResponse';
-import type { GetSocketRequest as _grpc_channelz_v1_GetSocketRequest, GetSocketRequest__Output as _grpc_channelz_v1_GetSocketRequest__Output } from '../../../grpc/channelz/v1/GetSocketRequest';
-import type { GetSocketResponse as _grpc_channelz_v1_GetSocketResponse, GetSocketResponse__Output as _grpc_channelz_v1_GetSocketResponse__Output } from '../../../grpc/channelz/v1/GetSocketResponse';
-import type { GetSubchannelRequest as _grpc_channelz_v1_GetSubchannelRequest, GetSubchannelRequest__Output as _grpc_channelz_v1_GetSubchannelRequest__Output } from '../../../grpc/channelz/v1/GetSubchannelRequest';
-import type { GetSubchannelResponse as _grpc_channelz_v1_GetSubchannelResponse, GetSubchannelResponse__Output as _grpc_channelz_v1_GetSubchannelResponse__Output } from '../../../grpc/channelz/v1/GetSubchannelResponse';
-import type { GetTopChannelsRequest as _grpc_channelz_v1_GetTopChannelsRequest, GetTopChannelsRequest__Output as _grpc_channelz_v1_GetTopChannelsRequest__Output } from '../../../grpc/channelz/v1/GetTopChannelsRequest';
-import type { GetTopChannelsResponse as _grpc_channelz_v1_GetTopChannelsResponse, GetTopChannelsResponse__Output as _grpc_channelz_v1_GetTopChannelsResponse__Output } from '../../../grpc/channelz/v1/GetTopChannelsResponse';
+import type { GetChannelRequest as _grpc_channelz_v1_GetChannelRequest, GetChannelRequest__Output as _grpc_channelz_v1_GetChannelRequest__Output } from '../../../grpc/channelz/v1/GetChannelRequest.ts';
+import type { GetChannelResponse as _grpc_channelz_v1_GetChannelResponse, GetChannelResponse__Output as _grpc_channelz_v1_GetChannelResponse__Output } from '../../../grpc/channelz/v1/GetChannelResponse.ts';
+import type { GetServerRequest as _grpc_channelz_v1_GetServerRequest, GetServerRequest__Output as _grpc_channelz_v1_GetServerRequest__Output } from '../../../grpc/channelz/v1/GetServerRequest.ts';
+import type { GetServerResponse as _grpc_channelz_v1_GetServerResponse, GetServerResponse__Output as _grpc_channelz_v1_GetServerResponse__Output } from '../../../grpc/channelz/v1/GetServerResponse.ts';
+import type { GetServerSocketsRequest as _grpc_channelz_v1_GetServerSocketsRequest, GetServerSocketsRequest__Output as _grpc_channelz_v1_GetServerSocketsRequest__Output } from '../../../grpc/channelz/v1/GetServerSocketsRequest.ts';
+import type { GetServerSocketsResponse as _grpc_channelz_v1_GetServerSocketsResponse, GetServerSocketsResponse__Output as _grpc_channelz_v1_GetServerSocketsResponse__Output } from '../../../grpc/channelz/v1/GetServerSocketsResponse.ts';
+import type { GetServersRequest as _grpc_channelz_v1_GetServersRequest, GetServersRequest__Output as _grpc_channelz_v1_GetServersRequest__Output } from '../../../grpc/channelz/v1/GetServersRequest.ts';
+import type { GetServersResponse as _grpc_channelz_v1_GetServersResponse, GetServersResponse__Output as _grpc_channelz_v1_GetServersResponse__Output } from '../../../grpc/channelz/v1/GetServersResponse.ts';
+import type { GetSocketRequest as _grpc_channelz_v1_GetSocketRequest, GetSocketRequest__Output as _grpc_channelz_v1_GetSocketRequest__Output } from '../../../grpc/channelz/v1/GetSocketRequest.ts';
+import type { GetSocketResponse as _grpc_channelz_v1_GetSocketResponse, GetSocketResponse__Output as _grpc_channelz_v1_GetSocketResponse__Output } from '../../../grpc/channelz/v1/GetSocketResponse.ts';
+import type { GetSubchannelRequest as _grpc_channelz_v1_GetSubchannelRequest, GetSubchannelRequest__Output as _grpc_channelz_v1_GetSubchannelRequest__Output } from '../../../grpc/channelz/v1/GetSubchannelRequest.ts';
+import type { GetSubchannelResponse as _grpc_channelz_v1_GetSubchannelResponse, GetSubchannelResponse__Output as _grpc_channelz_v1_GetSubchannelResponse__Output } from '../../../grpc/channelz/v1/GetSubchannelResponse.ts';
+import type { GetTopChannelsRequest as _grpc_channelz_v1_GetTopChannelsRequest, GetTopChannelsRequest__Output as _grpc_channelz_v1_GetTopChannelsRequest__Output } from '../../../grpc/channelz/v1/GetTopChannelsRequest.ts';
+import type { GetTopChannelsResponse as _grpc_channelz_v1_GetTopChannelsResponse, GetTopChannelsResponse__Output as _grpc_channelz_v1_GetTopChannelsResponse__Output } from '../../../grpc/channelz/v1/GetTopChannelsResponse.ts';
 
 /**
  * Channelz is a service exposed by gRPC servers that provides detailed debug

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetChannelResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetChannelResponse.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { Channel as _grpc_channelz_v1_Channel, Channel__Output as _grpc_channelz_v1_Channel__Output } from '../../../grpc/channelz/v1/Channel';
+import type { Channel as _grpc_channelz_v1_Channel, Channel__Output as _grpc_channelz_v1_Channel__Output } from '../../../grpc/channelz/v1/Channel.ts';
 
 export interface GetChannelResponse {
   /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerResponse.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { Server as _grpc_channelz_v1_Server, Server__Output as _grpc_channelz_v1_Server__Output } from '../../../grpc/channelz/v1/Server';
+import type { Server as _grpc_channelz_v1_Server, Server__Output as _grpc_channelz_v1_Server__Output } from '../../../grpc/channelz/v1/Server.ts';
 
 export interface GetServerResponse {
   /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerSocketsResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetServerSocketsResponse.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef';
+import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef.ts';
 
 export interface GetServerSocketsResponse {
   /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetServersResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetServersResponse.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { Server as _grpc_channelz_v1_Server, Server__Output as _grpc_channelz_v1_Server__Output } from '../../../grpc/channelz/v1/Server';
+import type { Server as _grpc_channelz_v1_Server, Server__Output as _grpc_channelz_v1_Server__Output } from '../../../grpc/channelz/v1/Server.ts';
 
 export interface GetServersResponse {
   /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetSocketResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetSocketResponse.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { Socket as _grpc_channelz_v1_Socket, Socket__Output as _grpc_channelz_v1_Socket__Output } from '../../../grpc/channelz/v1/Socket';
+import type { Socket as _grpc_channelz_v1_Socket, Socket__Output as _grpc_channelz_v1_Socket__Output } from '../../../grpc/channelz/v1/Socket.ts';
 
 export interface GetSocketResponse {
   /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetSubchannelResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetSubchannelResponse.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { Subchannel as _grpc_channelz_v1_Subchannel, Subchannel__Output as _grpc_channelz_v1_Subchannel__Output } from '../../../grpc/channelz/v1/Subchannel';
+import type { Subchannel as _grpc_channelz_v1_Subchannel, Subchannel__Output as _grpc_channelz_v1_Subchannel__Output } from '../../../grpc/channelz/v1/Subchannel.ts';
 
 export interface GetSubchannelResponse {
   /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/GetTopChannelsResponse.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/GetTopChannelsResponse.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { Channel as _grpc_channelz_v1_Channel, Channel__Output as _grpc_channelz_v1_Channel__Output } from '../../../grpc/channelz/v1/Channel';
+import type { Channel as _grpc_channelz_v1_Channel, Channel__Output as _grpc_channelz_v1_Channel__Output } from '../../../grpc/channelz/v1/Channel.ts';
 
 export interface GetTopChannelsResponse {
   /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Security.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Security.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../../google/protobuf/Any';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../../google/protobuf/Any.ts';
 
 export interface _grpc_channelz_v1_Security_OtherSecurity {
   /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Server.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Server.ts
@@ -1,8 +1,8 @@
 // Original file: proto/channelz.proto
 
-import type { ServerRef as _grpc_channelz_v1_ServerRef, ServerRef__Output as _grpc_channelz_v1_ServerRef__Output } from '../../../grpc/channelz/v1/ServerRef';
-import type { ServerData as _grpc_channelz_v1_ServerData, ServerData__Output as _grpc_channelz_v1_ServerData__Output } from '../../../grpc/channelz/v1/ServerData';
-import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef';
+import type { ServerRef as _grpc_channelz_v1_ServerRef, ServerRef__Output as _grpc_channelz_v1_ServerRef__Output } from '../../../grpc/channelz/v1/ServerRef.ts';
+import type { ServerData as _grpc_channelz_v1_ServerData, ServerData__Output as _grpc_channelz_v1_ServerData__Output } from '../../../grpc/channelz/v1/ServerData.ts';
+import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef.ts';
 
 /**
  * Server represents a single server.  There may be multiple servers in a single

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/ServerData.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/ServerData.ts
@@ -1,7 +1,7 @@
 // Original file: proto/channelz.proto
 
-import type { ChannelTrace as _grpc_channelz_v1_ChannelTrace, ChannelTrace__Output as _grpc_channelz_v1_ChannelTrace__Output } from '../../../grpc/channelz/v1/ChannelTrace';
-import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
+import type { ChannelTrace as _grpc_channelz_v1_ChannelTrace, ChannelTrace__Output as _grpc_channelz_v1_ChannelTrace__Output } from '../../../grpc/channelz/v1/ChannelTrace.ts';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp.ts';
 import type { Long } from '@grpc/proto-loader';
 
 /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Socket.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Socket.ts
@@ -1,9 +1,9 @@
 // Original file: proto/channelz.proto
 
-import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef';
-import type { SocketData as _grpc_channelz_v1_SocketData, SocketData__Output as _grpc_channelz_v1_SocketData__Output } from '../../../grpc/channelz/v1/SocketData';
-import type { Address as _grpc_channelz_v1_Address, Address__Output as _grpc_channelz_v1_Address__Output } from '../../../grpc/channelz/v1/Address';
-import type { Security as _grpc_channelz_v1_Security, Security__Output as _grpc_channelz_v1_Security__Output } from '../../../grpc/channelz/v1/Security';
+import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef.ts';
+import type { SocketData as _grpc_channelz_v1_SocketData, SocketData__Output as _grpc_channelz_v1_SocketData__Output } from '../../../grpc/channelz/v1/SocketData.ts';
+import type { Address as _grpc_channelz_v1_Address, Address__Output as _grpc_channelz_v1_Address__Output } from '../../../grpc/channelz/v1/Address.ts';
+import type { Security as _grpc_channelz_v1_Security, Security__Output as _grpc_channelz_v1_Security__Output } from '../../../grpc/channelz/v1/Security.ts';
 
 /**
  * Information about an actual connection.  Pronounced "sock-ay".

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/SocketData.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/SocketData.ts
@@ -1,8 +1,8 @@
 // Original file: proto/channelz.proto
 
-import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp';
-import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from '../../../google/protobuf/Int64Value';
-import type { SocketOption as _grpc_channelz_v1_SocketOption, SocketOption__Output as _grpc_channelz_v1_SocketOption__Output } from '../../../grpc/channelz/v1/SocketOption';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../../google/protobuf/Timestamp.ts';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from '../../../google/protobuf/Int64Value.ts';
+import type { SocketOption as _grpc_channelz_v1_SocketOption, SocketOption__Output as _grpc_channelz_v1_SocketOption__Output } from '../../../grpc/channelz/v1/SocketOption.ts';
 import type { Long } from '@grpc/proto-loader';
 
 /**

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOption.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOption.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../../google/protobuf/Any';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from '../../../google/protobuf/Any.ts';
 
 /**
  * SocketOption represents socket options for a socket.  Specifically, these

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOptionLinger.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOptionLinger.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../google/protobuf/Duration';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../google/protobuf/Duration.ts';
 
 /**
  * For use with SocketOption's additional field.  This is primarily used for

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOptionTimeout.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/SocketOptionTimeout.ts
@@ -1,6 +1,6 @@
 // Original file: proto/channelz.proto
 
-import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../google/protobuf/Duration';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../../google/protobuf/Duration.ts';
 
 /**
  * For use with SocketOption's additional field.  This is primarily used for

--- a/packages/grpc-js/src/generated/grpc/channelz/v1/Subchannel.ts
+++ b/packages/grpc-js/src/generated/grpc/channelz/v1/Subchannel.ts
@@ -1,9 +1,9 @@
 // Original file: proto/channelz.proto
 
-import type { SubchannelRef as _grpc_channelz_v1_SubchannelRef, SubchannelRef__Output as _grpc_channelz_v1_SubchannelRef__Output } from '../../../grpc/channelz/v1/SubchannelRef';
-import type { ChannelData as _grpc_channelz_v1_ChannelData, ChannelData__Output as _grpc_channelz_v1_ChannelData__Output } from '../../../grpc/channelz/v1/ChannelData';
-import type { ChannelRef as _grpc_channelz_v1_ChannelRef, ChannelRef__Output as _grpc_channelz_v1_ChannelRef__Output } from '../../../grpc/channelz/v1/ChannelRef';
-import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef';
+import type { SubchannelRef as _grpc_channelz_v1_SubchannelRef, SubchannelRef__Output as _grpc_channelz_v1_SubchannelRef__Output } from '../../../grpc/channelz/v1/SubchannelRef.ts';
+import type { ChannelData as _grpc_channelz_v1_ChannelData, ChannelData__Output as _grpc_channelz_v1_ChannelData__Output } from '../../../grpc/channelz/v1/ChannelData.ts';
+import type { ChannelRef as _grpc_channelz_v1_ChannelRef, ChannelRef__Output as _grpc_channelz_v1_ChannelRef__Output } from '../../../grpc/channelz/v1/ChannelRef.ts';
+import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from '../../../grpc/channelz/v1/SocketRef.ts';
 
 /**
  * Subchannel is a logical grouping of channels, subchannels, and sockets.


### PR DESCRIPTION
The main change here is to upgrade from TypeScript 4 to TypeScript 5 in the `@grpc/grpc-js-xds` package. This fixes an issue where the generated code changes from #2693 would not be accepted by the compiler.

I also modified `grpc-js` so that it uses the local copy of `proto-loader`, to avoid delays in detecting these issues, and I updated the committed copy of the generated code.