### PR TITLE
Resolve exception when Error.stackTraceLimit is undefined

### DIFF
--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -110,7 +110,7 @@ export type ClientOptions = Partial<ChannelOptions> & {
 };
 
 function getErrorStackString(error: Error): string {
-  return error.stack!.split('\n').slice(1).join('\n');
+  return error.stack?.split('\n').slice(1).join('\n') || 'no stack trace available';
 }
 
 /**


### PR DESCRIPTION
Some applications may explicitly set `Error.stackTraceLimit = undefined`.

In this case it is not safe to assume `new Error().stack` is available using the `!` operator.

Before this patch, using grpc-js in this situation when an Error occurs or when a trace is needed may result in uncaught exceptions crashing the application.

One thing I considered is that often stack traces are indented by four spaces by the JS engine such as node. My default message for clarity is just `no track trace available` versus using the magic number of spaces. I'm torn on the right solution here, but I personal prefer the clarity of a plain string rather than assuming our environment is one which adds random spaces to make CLI focused output prettier.