### PR TITLE
grpc-js-xds: Make legacy interop script use proto-loader correctly

### DIFF
--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -34,6 +34,9 @@ echo "source $NVM_DIR/nvm.sh" > ~/.profile
 echo "source $NVM_DIR/nvm.sh" > ~/.shrc
 export ENV=~/.shrc
 
+cd $base/../proto-loader
+npm install
+
 cd $base/../grpc-js
 npm install
 


### PR DESCRIPTION
#2700 changed grpc-js and grpc-js-xds dev builds to use the local proto-loader installation for faster test turnaround on protobuf TypeScript code generation changes. That PR included changes to the Dockerfile to handle that local usage correctly. This change does the same thing for the legacy test script.