### PR TITLE
grpc-js: Call custom `checkServerIdentity` when target name override is set

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -694,11 +694,13 @@ export class Http2SubchannelConnector implements SubchannelConnector {
         if (options['grpc.ssl_target_name_override']) {
           const sslTargetNameOverride =
             options['grpc.ssl_target_name_override']!;
+          const originalCheckServerIdentity =
+            connectionOptions.checkServerIdentity ?? checkServerIdentity;
           connectionOptions.checkServerIdentity = (
             host: string,
             cert: PeerCertificate
           ): Error | undefined => {
-            return checkServerIdentity(sslTargetNameOverride, cert);
+            return originalCheckServerIdentity(sslTargetNameOverride, cert);
           };
           connectionOptions.servername = sslTargetNameOverride;
         } else {
@@ -804,11 +806,13 @@ export class Http2SubchannelConnector implements SubchannelConnector {
       // This option is used for testing only.
       if (options['grpc.ssl_target_name_override']) {
         const sslTargetNameOverride = options['grpc.ssl_target_name_override']!;
+        const originalCheckServerIdentity =
+          connectionOptions.checkServerIdentity ?? checkServerIdentity;
         connectionOptions.checkServerIdentity = (
           host: string,
           cert: PeerCertificate
         ): Error | undefined => {
-          return checkServerIdentity(sslTargetNameOverride, cert);
+          return originalCheckServerIdentity(sslTargetNameOverride, cert);
         };
         connectionOptions.servername = sslTargetNameOverride;
       } else {


### PR DESCRIPTION
This fixes #2703.