### PR TITLE
Backport #2701: Resolve exception when Error.stackTraceLimit is undefined

### DIFF
--- a/packages/grpc-js/src/client.ts
+++ b/packages/grpc-js/src/client.ts
@@ -110,7 +110,7 @@ export type ClientOptions = Partial<ChannelOptions> & {
 };
 
 function getErrorStackString(error: Error): string {
-  return error.stack!.split('\n').slice(1).join('\n');
+  return error.stack?.split('\n').slice(1).join('\n') || 'no stack trace available';
 }
 
 /**


### PR DESCRIPTION
Backport #2701 to 1.10.x