### PR TITLE
Fix build order in root gulpfile to handle cross dependency

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -23,15 +23,15 @@ import * as reflection from './packages/grpc-reflection/gulpfile';
 import * as protobuf from './packages/proto-loader/gulpfile';
 import * as internalTest from './test/gulpfile';
 
-const installAll = gulp.series(jsCore.install, healthCheck.install, protobuf.install, internalTest.install, jsXds.install, reflection.install);
+const installAll = gulp.series(protobuf.install, jsCore.install, healthCheck.install, internalTest.install, jsXds.install, reflection.install);
 
 const lint = gulp.parallel(jsCore.lint);
 
-const build = gulp.series(jsCore.compile, protobuf.compile, jsXds.compile);
+const build = gulp.series(protobuf.compile, jsCore.compile, jsXds.compile);
 
 const setup = gulp.series(installAll);
 
-const setupPureJSInterop = gulp.series(jsCore.install, protobuf.install, internalTest.install);
+const setupPureJSInterop = gulp.series(protobuf.install, jsCore.install, internalTest.install);
 
 const clean = gulp.series(jsCore.clean, protobuf.clean, jsXds.clean);
 

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -59,6 +59,7 @@
     "clang-format": "^1.2.2",
     "gts": "^3.1.0",
     "rimraf": "^3.0.2",
+    "ts-node": "^10.9.2",
     "typescript": "~4.7.4"
   },
   "engines": {


### PR DESCRIPTION
#2700 added a cross dependency between grpc-js and proto-loader, so now proto-loader needs to be built before grpc-js. This change fixes the root gulpfile to respect that order.

I also added the `ts-node` dev dependency in proto-loader because it is needed to run that gulpfile in isolation, for testing.