### PR TITLE
grpc-js: Fix check for whether to send a trailers-only response

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/server-interceptors.ts
+++ b/packages/grpc-js/src/server-interceptors.ts
@@ -866,7 +866,7 @@ export class BaseServerInterceptingCall
         status.details
     );
 
-    if (this.stream.headersSent) {
+    if (this.metadataSent) {
       if (!this.wantTrailers) {
         this.wantTrailers = true;
         this.stream.once('wantTrailers', () => {


### PR DESCRIPTION
I think this is the cause of #2707. If headers are queued to send but have not actually been sent because they were blocked by TCP flow control, the server will get to this point and think that it should send a trailers-only response. The new check is more correct anyway: sending a trailers-only response should depend on whether the application has decided to send anything else.