### PR TITLE
grpc-loader: Expose method options

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -57,6 +57,7 @@
     "@types/node": "^10.17.26",
     "@types/yargs": "^17.0.24",
     "clang-format": "^1.2.2",
+    "google-proto-files": "^3.0.2",
     "gts": "^3.1.0",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -122,18 +122,18 @@ export enum IdempotencyLevel {
 }
 
 export interface NamePart {
-  namePart: string;
-  isExtension: boolean;
+  name_part: string;
+  is_extension: boolean;
 }
 
 export interface UninterpretedOption {
   name?: (NamePart[]|null);
-  identifierValue?: (string|null);
-  positiveIntValue?: (number|Long|string|null);
-  negativeIntValue?: (number|Long|string|null);
-  doubleValue?: (number|null);
-  stringValue?: (Uint8Array|string|null);
-  aggregateValue?: (string|null);
+  identifier_value?: (string|null);
+  positive_int_value?: (number|null);
+  negative_int_value?: (number|null);
+  double_value?: (number|null);
+  string_value?: (string|null);
+  aggregate_value?: (string|null);
 }
 
 export interface CustomHttpPattern {
@@ -150,8 +150,8 @@ export interface HttpRule {
   patch?: (string|null);
   custom?: (CustomHttpPattern|null);
   body?: (string|null);
-  responseBody?: (string|null);
-  additionalBindings?: (HttpRule[]|null);
+  response_body?: (string|null);
+  additional_bindings?: (HttpRule[]|null);
 }
 
 export interface MethodOptions {

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -115,18 +115,18 @@ export interface EnumTypeDefinition extends ProtobufTypeDefinition {
   format: 'Protocol Buffer 3 EnumDescriptorProto';
 }
 
-enum IdempotencyLevel {
+export enum IdempotencyLevel {
   IDEMPOTENCY_UNKNOWN = 0,
   NO_SIDE_EFFECTS = 1,
   IDEMPOTENT = 2
 }
 
-interface NamePart {
+export interface NamePart {
   namePart: string;
   isExtension: boolean;
 }
 
-interface UninterpretedOption {
+export interface UninterpretedOption {
   name?: (NamePart[]|null);
   identifierValue?: (string|null);
   positiveIntValue?: (number|Long|string|null);
@@ -136,12 +136,12 @@ interface UninterpretedOption {
   aggregateValue?: (string|null);
 }
 
-interface CustomHttpPattern {
+export interface CustomHttpPattern {
   kind?: (string|null);
   path?: (string|null);
 }
 
-interface HttpRule {
+export interface HttpRule {
   selector?: (string|null);
   get?: (string|null);
   put?: (string|null);
@@ -154,7 +154,7 @@ interface HttpRule {
   additionalBindings?: (HttpRule[]|null);
 }
 
-interface MethodOptions {
+export interface MethodOptions {
   deprecated?: (boolean|null);
   idempotency_level?: (IdempotencyLevel|keyof typeof IdempotencyLevel|null);
   uninterpreted_option?: (UninterpretedOption[]|null);

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -126,6 +126,8 @@ export interface MethodDefinition<RequestType, ResponseType, OutputRequestType=R
   originalName?: string;
   requestType: MessageTypeDefinition;
   responseType: MessageTypeDefinition;
+  options?: Protobuf.IMethod['options'];
+  parsedOptions?: Protobuf.IMethod['parsedOptions'];
 }
 
 export interface ServiceDefinition {
@@ -242,6 +244,8 @@ function createMethodDefinition(
     originalName: camelCase(method.name),
     requestType: createMessageDefinition(requestType, fileDescriptors),
     responseType: createMessageDefinition(responseType, fileDescriptors),
+    options: method.options,
+    parsedOptions: method.parsedOptions,
   };
 }
 

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -127,39 +127,25 @@ export interface NamePart {
 }
 
 export interface UninterpretedOption {
-  name?: (NamePart[]|null);
-  identifier_value?: (string|null);
-  positive_int_value?: (number|null);
-  negative_int_value?: (number|null);
-  double_value?: (number|null);
-  string_value?: (string|null);
-  aggregate_value?: (string|null);
+  name?: NamePart[];
+  identifier_value?: string;
+  positive_int_value?: number;
+  negative_int_value?: number;
+  double_value?: number;
+  string_value?: string;
+  aggregate_value?: string;
 }
 
 export interface CustomHttpPattern {
-  kind?: (string|null);
-  path?: (string|null);
-}
-
-export interface HttpRule {
-  selector?: (string|null);
-  get?: (string|null);
-  put?: (string|null);
-  post?: (string|null);
-  delete?: (string|null);
-  patch?: (string|null);
-  custom?: (CustomHttpPattern|null);
-  body?: (string|null);
-  response_body?: (string|null);
-  additional_bindings?: (HttpRule[]|null);
+  kind?: string;
+  path?: string;
 }
 
 export interface MethodOptions {
   deprecated?: (boolean|null);
   idempotency_level?: (IdempotencyLevel|keyof typeof IdempotencyLevel|null);
   uninterpreted_option?: (UninterpretedOption[]|null);
-  "(google.api.http)"?: (HttpRule|null);
-  "(google.api.method_signature)"?: (string[]|null);
+  [k: string]: unknown
 }
 
 export interface MethodDefinition<RequestType, ResponseType, OutputRequestType=RequestType, OutputResponseType=ResponseType> {

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -126,8 +126,8 @@ export interface MethodDefinition<RequestType, ResponseType, OutputRequestType=R
   originalName?: string;
   requestType: MessageTypeDefinition;
   responseType: MessageTypeDefinition;
-  options?: Protobuf.IMethod['options'];
-  parsedOptions?: Protobuf.IMethod['parsedOptions'];
+  options?: { [k: string]: any };
+  parsedOptions?: { [k: string]: any };
 }
 
 export interface ServiceDefinition {

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -116,9 +116,9 @@ export interface EnumTypeDefinition extends ProtobufTypeDefinition {
 }
 
 export enum IdempotencyLevel {
-  IDEMPOTENCY_UNKNOWN = 0,
-  NO_SIDE_EFFECTS = 1,
-  IDEMPOTENT = 2
+  IDEMPOTENCY_UNKNOWN = 'IDEMPOTENCY_UNKNOWN',
+  NO_SIDE_EFFECTS = 'NO_SIDE_EFFECTS',
+  IDEMPOTENT = 'IDEMPOTENT'
 }
 
 export interface NamePart {
@@ -136,16 +136,11 @@ export interface UninterpretedOption {
   aggregate_value?: string;
 }
 
-export interface CustomHttpPattern {
-  kind?: string;
-  path?: string;
-}
-
 export interface MethodOptions {
-  deprecated?: (boolean|null);
-  idempotency_level?: (IdempotencyLevel|keyof typeof IdempotencyLevel|null);
-  uninterpreted_option?: (UninterpretedOption[]|null);
-  [k: string]: unknown
+  deprecated?: boolean;
+  idempotency_level?: IdempotencyLevel|keyof typeof IdempotencyLevel;
+  uninterpreted_option?: UninterpretedOption;
+  [k: string]: unknown;
 }
 
 export interface MethodDefinition<RequestType, ResponseType, OutputRequestType=RequestType, OutputResponseType=ResponseType> {

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -138,7 +138,7 @@ export interface UninterpretedOption {
 
 export interface MethodOptions {
   deprecated: boolean;
-  idempotency_level: IdempotencyLevel|keyof typeof IdempotencyLevel;
+  idempotency_level: IdempotencyLevel;
   uninterpreted_option: UninterpretedOption;
   [k: string]: unknown;
 }

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -139,7 +139,7 @@ export interface UninterpretedOption {
 export interface MethodOptions {
   deprecated: boolean;
   idempotency_level: IdempotencyLevel;
-  uninterpreted_option: UninterpretedOption;
+  uninterpreted_option: UninterpretedOption[];
   [k: string]: unknown;
 }
 

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -250,7 +250,18 @@ function createSerializer(cls: Protobuf.Type): Serialize<object> {
 }
 
 function mapMethodOptions(options: Partial<MethodOptions>[] | undefined): MethodOptions {
-  return (options || []).reduce((obj: MethodOptions, item: Partial<MethodOptions>) => ({ ...obj, ...item  }),
+  return (options || []).reduce((obj: MethodOptions, item: Partial<MethodOptions>) => {
+    for (const [key, value] of Object.entries(item)) {
+      switch (key) {
+        case 'uninterpreted_option' :
+          obj.uninterpreted_option.push(item.uninterpreted_option as UninterpretedOption);
+          break;
+        default:
+          obj[key] = value
+      }
+    }
+    return obj
+  },
     {
       deprecated: false,
       idempotency_level: IdempotencyLevel.IDEMPOTENCY_UNKNOWN,

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -249,10 +249,13 @@ function createSerializer(cls: Protobuf.Type): Serialize<object> {
   };
 }
 
-function mapMethodOptions(options: Partial<MethodOptions>[] | undefined): MethodOptions | undefined {
-  return Array.isArray(options) ?
-    options.reduce((obj: MethodOptions, item: Partial<MethodOptions>) => ({ ...obj, ...item  }), {}) :
-    undefined;
+function mapMethodOptions(options: Partial<MethodOptions>[] | undefined): MethodOptions {
+  return (options || []).reduce((obj: MethodOptions, item: Partial<MethodOptions>) => ({ ...obj, ...item  }),
+    {
+      deprecated: false,
+      idempotency_level: IdempotencyLevel.IDEMPOTENCY_UNKNOWN,
+      uninterpreted_option: []
+    });
 }
 
 function createMethodDefinition(

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -137,9 +137,9 @@ export interface UninterpretedOption {
 }
 
 export interface MethodOptions {
-  deprecated?: boolean;
-  idempotency_level?: IdempotencyLevel|keyof typeof IdempotencyLevel;
-  uninterpreted_option?: UninterpretedOption;
+  deprecated: boolean;
+  idempotency_level: IdempotencyLevel|keyof typeof IdempotencyLevel;
+  uninterpreted_option: UninterpretedOption;
   [k: string]: unknown;
 }
 

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -154,7 +154,7 @@ export interface MethodDefinition<RequestType, ResponseType, OutputRequestType=R
   originalName?: string;
   requestType: MessageTypeDefinition;
   responseType: MessageTypeDefinition;
-  options?: MethodOptions;
+  options: MethodOptions;
 }
 
 export interface ServiceDefinition {
@@ -265,8 +265,9 @@ function mapMethodOptions(options: Partial<MethodOptions>[] | undefined): Method
     {
       deprecated: false,
       idempotency_level: IdempotencyLevel.IDEMPOTENCY_UNKNOWN,
-      uninterpreted_option: []
-    });
+      uninterpreted_option: [],
+    }
+  ) as MethodOptions;
 }
 
 function createMethodDefinition(

--- a/packages/proto-loader/test/descriptor_type_test.ts
+++ b/packages/proto-loader/test/descriptor_type_test.ts
@@ -20,6 +20,7 @@ import { rpcFileDescriptorSet } from '../test_protos/rpc.desc';
 import { readFileSync } from 'fs';
 
 import * as proto_loader from '../src/index';
+import { dirname } from "path";
 
 // Relative path from build output directory to test_protos directory
 const TEST_PROTO_DIR = `${__dirname}/../../test_protos/`;
@@ -128,4 +129,20 @@ describe('Descriptor types', () => {
     // This will throw if the file descriptor object cannot be parsed
     proto_loader.loadFileDescriptorSetFromObject(rpcFileDescriptorSet);
   });
+
+  it('Can parse method options into object correctly', () => {
+    const includeDirs = [
+      dirname(require.resolve('google-proto-files/package.json'))
+    ];
+    const packageDefinition = proto_loader.loadSync(`${TEST_PROTO_DIR}/method_options.proto`, { includeDirs });
+    assert('Hello' in packageDefinition);
+    const service = packageDefinition.Hello as proto_loader.ServiceDefinition
+    assert.deepStrictEqual(service.Hello.options, {
+      deprecated: true,
+      idempotency_level: 'IDEMPOTENCY_UNKNOWN',
+      uninterpreted_option: { identifier_value: 'foo' },
+      '(google.api.http)': { post: '/hello' },
+      '(google.api.method_signature)': 'bar'
+    })
+  })
 });

--- a/packages/proto-loader/test/descriptor_type_test.ts
+++ b/packages/proto-loader/test/descriptor_type_test.ts
@@ -140,8 +140,24 @@ describe('Descriptor types', () => {
     assert.deepStrictEqual(service.Hello.options, {
       deprecated: true,
       idempotency_level: 'IDEMPOTENCY_UNKNOWN',
-      uninterpreted_option: { identifier_value: 'foo' },
-      '(google.api.http)': { post: '/hello' },
+      uninterpreted_option: {
+        name: {
+          name_part: 'foo',
+          is_extension:  false,
+        },
+        identifier_value: 'bar',
+        positive_int_value: 9007199254740991,
+        negative_int_value: -9007199254740991,
+        double_value: 1.2345,
+        string_value: 'foobar',
+        aggregate_value: 'foobar'
+      },
+      '(google.api.http)': {
+        post: "/hello",
+        body: "*",
+        response_body: "*",
+        additional_bindings: {}
+      },
       '(google.api.method_signature)': 'bar'
     })
   })

--- a/packages/proto-loader/test/descriptor_type_test.ts
+++ b/packages/proto-loader/test/descriptor_type_test.ts
@@ -20,7 +20,7 @@ import { rpcFileDescriptorSet } from '../test_protos/rpc.desc';
 import { readFileSync } from 'fs';
 
 import * as proto_loader from '../src/index';
-import { dirname } from "path";
+import { dirname } from 'path';
 
 // Relative path from build output directory to test_protos directory
 const TEST_PROTO_DIR = `${__dirname}/../../test_protos/`;

--- a/packages/proto-loader/test/descriptor_type_test.ts
+++ b/packages/proto-loader/test/descriptor_type_test.ts
@@ -160,5 +160,6 @@ describe('Descriptor types', () => {
       },
       '(google.api.method_signature)': 'bar'
     })
+    assert(service.HelloWithoutOptions.options === undefined)
   })
 });

--- a/packages/proto-loader/test/descriptor_type_test.ts
+++ b/packages/proto-loader/test/descriptor_type_test.ts
@@ -160,6 +160,10 @@ describe('Descriptor types', () => {
       },
       '(google.api.method_signature)': 'bar'
     })
-    assert(service.HelloWithoutOptions.options === undefined)
+    assert.deepStrictEqual(service.HelloWithoutOptions.options, {
+      deprecated: false,
+      idempotency_level: 'IDEMPOTENCY_UNKNOWN',
+      uninterpreted_option: []
+    })
   })
 });

--- a/packages/proto-loader/test/descriptor_type_test.ts
+++ b/packages/proto-loader/test/descriptor_type_test.ts
@@ -139,7 +139,7 @@ describe('Descriptor types', () => {
     const service = packageDefinition.Hello as proto_loader.ServiceDefinition
     assert.deepStrictEqual(service.Hello.options, {
       deprecated: true,
-      idempotency_level: 'IDEMPOTENCY_UNKNOWN',
+      idempotency_level: 'NO_SIDE_EFFECTS',
       uninterpreted_option: {
         name: {
           name_part: 'foo',
@@ -164,6 +164,18 @@ describe('Descriptor types', () => {
       deprecated: false,
       idempotency_level: 'IDEMPOTENCY_UNKNOWN',
       uninterpreted_option: []
+    })
+    assert.deepStrictEqual(service.HelloWithSomeOptions.options, {
+      deprecated: true,
+      idempotency_level: 'IDEMPOTENCY_UNKNOWN',
+      uninterpreted_option: [],
+      '(google.api.http)': {
+        get: "/hello",
+        additional_bindings: {
+          body: '*',
+          get: '/hello-world'
+        }
+      },
     })
   })
 });

--- a/packages/proto-loader/test/descriptor_type_test.ts
+++ b/packages/proto-loader/test/descriptor_type_test.ts
@@ -153,9 +153,9 @@ describe('Descriptor types', () => {
         aggregate_value: 'foobar'
       },
       '(google.api.http)': {
-        post: "/hello",
-        body: "*",
-        response_body: "*",
+        post: '/hello',
+        body: '*',
+        response_body: '*',
         additional_bindings: {}
       },
       '(google.api.method_signature)': 'bar'
@@ -170,7 +170,7 @@ describe('Descriptor types', () => {
       idempotency_level: 'IDEMPOTENCY_UNKNOWN',
       uninterpreted_option: [],
       '(google.api.http)': {
-        get: "/hello",
+        get: '/hello',
         additional_bindings: {
           body: '*',
           get: '/hello-world'

--- a/packages/proto-loader/test/descriptor_type_test.ts
+++ b/packages/proto-loader/test/descriptor_type_test.ts
@@ -140,10 +140,10 @@ describe('Descriptor types', () => {
     assert.deepStrictEqual(service.Hello.options, {
       deprecated: true,
       idempotency_level: 'NO_SIDE_EFFECTS',
-      uninterpreted_option: {
+      uninterpreted_option: [{
         name: {
           name_part: 'foo',
-          is_extension:  false,
+          is_extension: false,
         },
         identifier_value: 'bar',
         positive_int_value: 9007199254740991,
@@ -151,7 +151,7 @@ describe('Descriptor types', () => {
         double_value: 1.2345,
         string_value: 'foobar',
         aggregate_value: 'foobar'
-      },
+      }],
       '(google.api.http)': {
         post: '/hello',
         body: '*',

--- a/packages/proto-loader/test_protos/method_options.proto
+++ b/packages/proto-loader/test_protos/method_options.proto
@@ -34,4 +34,5 @@ service Hello {
     };
     option (google.api.method_signature) = 'bar';
   }
+  rpc HelloWithoutOptions (Empty) returns (Empty) {}
 }

--- a/packages/proto-loader/test_protos/method_options.proto
+++ b/packages/proto-loader/test_protos/method_options.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/httpbody.proto";
+
+message Empty {}
+
+message MethodSignature {
+  repeated string method_signature = 0;
+}
+
+service Hello {
+  rpc Hello (Empty) returns (Empty) {
+    option deprecated = true;
+    option idempotency_level = IDEMPOTENCY_UNKNOWN;
+    option uninterpreted_option = {
+      identifier_value: 'foo'
+    };
+    option (google.api.http) = {
+      post: "/hello"
+    };
+    option (google.api.method_signature) = 'bar';
+  }
+}

--- a/packages/proto-loader/test_protos/method_options.proto
+++ b/packages/proto-loader/test_protos/method_options.proto
@@ -7,7 +7,7 @@ import "google/api/httpbody.proto";
 message Empty {}
 
 message MethodSignature {
-  repeated string method_signature = 0;
+  repeated string method_signature = 1;
 }
 
 service Hello {
@@ -15,10 +15,22 @@ service Hello {
     option deprecated = true;
     option idempotency_level = IDEMPOTENCY_UNKNOWN;
     option uninterpreted_option = {
-      identifier_value: 'foo'
+      name: {
+        name_part: 'foo'
+        is_extension:  false
+      }
+      identifier_value: 'bar'
+      positive_int_value: 9007199254740991
+      negative_int_value: -9007199254740991
+      double_value: 1.2345
+      string_value: 'foobar'
+      aggregate_value: 'foobar'
     };
     option (google.api.http) = {
       post: "/hello"
+      body: "*"
+      response_body: "*"
+      additional_bindings: {}
     };
     option (google.api.method_signature) = 'bar';
   }

--- a/packages/proto-loader/test_protos/method_options.proto
+++ b/packages/proto-loader/test_protos/method_options.proto
@@ -13,7 +13,7 @@ message MethodSignature {
 service Hello {
   rpc Hello (Empty) returns (Empty) {
     option deprecated = true;
-    option idempotency_level = IDEMPOTENCY_UNKNOWN;
+    option idempotency_level = NO_SIDE_EFFECTS;
     option uninterpreted_option = {
       name: {
         name_part: 'foo'
@@ -35,4 +35,14 @@ service Hello {
     option (google.api.method_signature) = 'bar';
   }
   rpc HelloWithoutOptions (Empty) returns (Empty) {}
+  rpc HelloWithSomeOptions (Empty) returns (Empty) {
+    option deprecated = true;
+    option (google.api.http) = {
+      get: "/hello"
+      additional_bindings: {
+        get: "/hello-world"
+        body: "*"
+      }
+    };
+  }
 }


### PR DESCRIPTION
This PR adds support for [MethodOptions](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto#L887-L919) to proto-loader.

It is a continuation of #2230 (originally written by @hiepthai) which tries to address the comments of @murgatroid99.