### PR TITLE
proto-loader: Avoid generating duplicate method declarations in some cases

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -555,7 +555,7 @@ function generateServiceClientInterface(formatter: TextFormatter, serviceType: P
   formatter.indent();
   for (const methodName of Object.keys(serviceType.methods).sort()) {
     const method = serviceType.methods[methodName];
-    for (const name of [methodName, camelCase(methodName)]) {
+    for (const name of new Set([methodName, camelCase(methodName)])) {
       if (CLIENT_RESERVED_METHOD_NAMES.has(name)) {
         continue;
       }


### PR DESCRIPTION
For client class types, the code generator generates two method declarations for each method: one for the exact original name, and one for the camel case version of the name. Using `Set` avoids duplication if both of those are the same.

This fixes #2686.