### PR TITLE
proto-loader: Bump version to 0.7.13

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "author": "Google Inc.",
   "contributors": [
     {


### PR DESCRIPTION
To publish #2711 and #2717.