### PR TITLE
grpc-js: Improve reporting of HTTP error codes

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
This makes a couple of changes to HTTP status code handling:

 1. When surfacing a gRPC error synthesized from an HTTP status code, the details string now contains the actual status code number.
 2. When a call ends with no trailers received and there was a non-OK HTTP status code, surface that error instead of a more generic error about not receiving trailers. This fixes #2722.

I also added some information to the "RST_STREAM with code 0" error to explain what it means semantically, and I had to refactor `handleTrailers`. That refactor does change the behavior slightly, mainly to prioritize the gRPC status over the HTTP status when provided, which I think is more correct behavior.