### PR TITLE
proto-loader: Update dependency on protobufjs

### DIFF
--- a/packages/grpc-health-check/package.json
+++ b/packages/grpc-health-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-health-check",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Google Inc.",
   "description": "Health check client and service for use with gRPC-node",
   "repository": {
@@ -21,7 +21,7 @@
     "generate-test-types": "proto-loader-gen-types --keepCase --longs String --enums String --defaults --oneofs --includeComments --includeDirs proto/ -O test/generated --grpcLib=@grpc/grpc-js health/v1/health.proto"
   },
   "dependencies": {
-    "@grpc/proto-loader": "^0.7.10"
+    "@grpc/proto-loader": "^0.7.13"
   },
   "files": [
     "LICENSE",

--- a/packages/grpc-reflection/package.json
+++ b/packages/grpc-reflection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/reflection",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": {
     "name": "Google Inc."
   },
@@ -31,7 +31,7 @@
     "generate-types": "proto-loader-gen-types --longs String --enums String --bytes Array --defaults --oneofs --includeComments --includeDirs proto/ -O src/generated grpc/reflection/v1/reflection.proto grpc/reflection/v1alpha/reflection.proto"
   },
   "dependencies": {
-    "@grpc/proto-loader": "^0.7.10",
+    "@grpc/proto-loader": "^0.7.13",
     "protobufjs": "^7.2.5"
   },
   "peerDependencies": {

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "author": "Google Inc.",
   "contributors": [
     {
@@ -47,7 +47,7 @@
   "dependencies": {
     "lodash.camelcase": "^4.3.0",
     "long": "^5.0.0",
-    "protobufjs": "^7.2.4",
+    "protobufjs": "^7.2.5",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This sets the minimum version to the one with the fix for [CVE-2023-36665](https://nvd.nist.gov/vuln/detail/CVE-2023-36665).

Also update the dependency on proto-loader in the health check and reflection packages.