### PR TITLE
HTTP CONNECT: handle early server packets

### DIFF
--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -233,6 +233,12 @@ export function getProxiedConnection(
             ' through proxy ' +
             proxyAddressString
         );
+        // The HTTP client may have already read a few bytes of the proxied
+        // connection. If that's the case, put them back into the socket.
+        // See https://github.com/grpc/grpc-node/issues/2744.
+        if (head.length > 0) {
+          socket.unshift(head);
+        }
         if ('secureContext' in connectionOptions) {
           /* The proxy is connecting to a TLS server, so upgrade this socket
            * connection to a TLS connection.


### PR DESCRIPTION
When using an HTTP CONNECT proxy, it is possible for the server's first HTTP2 packet to reach the client before the node's HTTP library even starts parsing the HTTP `HTTP/1.1 200 Connected` response.

When that happens, node's HTTP response parser may take these extra bytes (i.e. the server's first HTTP2 packets) out of the socket into its parsing buffer. That means that these extra bytes will not be emitted through the tunneled socket provided on the `connect` event. Instead, these extra bytes are provided through [the `head` parameter of the `connect` event](https://nodejs.org/docs/latest/api/http.html#event-connect_1).

This PR reinjects these extra bytes (if any) into the tunneled socket.

Fixes #2744.