### PR TITLE
Keepalive bugfixes and unify timers strategies between client and server

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -1623,6 +1623,9 @@ export class Server {
         );
       };
 
+      /* eslint-disable-next-line prefer-const */
+      let sendPing: () => void; // hoisted for use in maybeStartKeepalivePingTimer
+
       const maybeStartKeepalivePingTimer = () => {
         if (!canSendPing()) {
           return;
@@ -1637,7 +1640,7 @@ export class Server {
         keepaliveTimeout.unref?.();
       };
 
-      const sendPing = () => {
+      sendPing = () => {
         if (!canSendPing()) {
           return;
         }

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -18,67 +18,43 @@
 import * as http2 from 'http2';
 import * as util from 'util';
 
-import { CipherNameAndProtocol, TLSSocket } from 'tls';
 import { ServiceError } from './call';
-import { PartialStatusObject } from './call-interface';
-import { ChannelOptions } from './channel-options';
-import {
-  ChannelzCallTracker,
-  ChannelzCallTrackerStub,
-  ChannelzChildrenTracker,
-  ChannelzChildrenTrackerStub,
-  ChannelzTrace,
-  ChannelzTraceStub,
-  ServerInfo,
-  ServerRef,
-  SocketInfo,
-  SocketRef,
-  TlsInfo,
-  registerChannelzServer,
-  registerChannelzSocket,
-  unregisterChannelzRef,
-} from './channelz';
-import { LogVerbosity, Status } from './constants';
-import * as logging from './logging';
+import { Status, LogVerbosity } from './constants';
 import { Deserialize, Serialize, ServiceDefinition } from './make-client';
 import { Metadata } from './metadata';
-import {
-  ResolverListener,
-  createResolver,
-  mapUriDefaultScheme,
-} from './resolver';
 import {
   BidiStreamingHandler,
   ClientStreamingHandler,
   HandleCall,
   Handler,
   HandlerType,
+  sendUnaryData,
   ServerDuplexStream,
   ServerDuplexStreamImpl,
-  ServerErrorResponse,
   ServerReadableStream,
-  ServerStatusResponse,
   ServerStreamingHandler,
   ServerUnaryCall,
   ServerWritableStream,
   ServerWritableStreamImpl,
   UnaryHandler,
-  sendUnaryData,
+  ServerErrorResponse,
+  ServerStatusResponse,
   serverErrorToStatus,
 } from './server-call';
 import { ServerCredentials } from './server-credentials';
+import { ChannelOptions } from './channel-options';
 import {
-  ServerInterceptingCallInterface,
-  ServerInterceptor,
-  getServerInterceptingCall,
-} from './server-interceptors';
+  createResolver,
+  ResolverListener,
+  mapUriDefaultScheme,
+} from './resolver';
+import * as logging from './logging';
 import {
   SubchannelAddress,
   isTcpSubchannelAddress,
-  stringToSubchannelAddress,
   subchannelAddressToString,
+  stringToSubchannelAddress,
 } from './subchannel-address';
-import { CallEventTracker } from './transport';
 import {
   GrpcUri,
   combineHostPort,
@@ -86,6 +62,30 @@ import {
   splitHostPort,
   uriToString,
 } from './uri-parser';
+import {
+  ChannelzCallTracker,
+  ChannelzCallTrackerStub,
+  ChannelzChildrenTracker,
+  ChannelzChildrenTrackerStub,
+  ChannelzTrace,
+  ChannelzTraceStub,
+  registerChannelzServer,
+  registerChannelzSocket,
+  ServerInfo,
+  ServerRef,
+  SocketInfo,
+  SocketRef,
+  TlsInfo,
+  unregisterChannelzRef,
+} from './channelz';
+import { CipherNameAndProtocol, TLSSocket } from 'tls';
+import {
+  ServerInterceptingCallInterface,
+  ServerInterceptor,
+  getServerInterceptingCall,
+} from './server-interceptors';
+import { PartialStatusObject } from './call-interface';
+import { CallEventTracker } from './transport';
 
 const UNLIMITED_CONNECTION_AGE_MS = ~(1 << 31);
 const KEEPALIVE_MAX_TIME_MS = ~(1 << 31);

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -1421,8 +1421,6 @@ export class Server {
 
       if (this.keepaliveTimeMs < KEEPALIVE_MAX_TIME_MS) {
         keepaliveInterval = setInterval(() => {
-          // NOTE to self: document in PR that prior implementation would overwrite the prior pending timeout
-          // if the timeout had not occurred before the prior interval had elapsed (bad bug)
           const keepaliveTimeout = setTimeout(() => {
             if (keepaliveInterval) {
               clearInterval(keepaliveInterval);

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -1443,6 +1443,9 @@ export class Server {
         );
       };
 
+      /* eslint-disable-next-line prefer-const */
+      let sendPing: () => void; // hoisted for use in maybeStartKeepalivePingTimer
+
       const maybeStartKeepalivePingTimer = () => {
         if (!canSendPing()) {
           return;
@@ -1457,7 +1460,7 @@ export class Server {
         keepaliveTimeout.unref?.();
       };
 
-      const sendPing = () => {
+      sendPing = () => {
         if (!canSendPing()) {
           return;
         }

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -1495,6 +1495,7 @@ export class Server {
         keepaliveTimeout = setTimeout(() => {
           clearKeepaliveTimeout();
           this.keepaliveTrace('Ping timeout passed without response');
+          this.trace('Connection dropped by keepalive timeout');
           sessionClosedByServer = true;
           session.close();
         }, this.keepaliveTimeoutMs);

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -422,6 +422,7 @@ class Http2Transport implements Transport {
       'Sending ping with timeout ' + this.keepaliveTimeoutMs + 'ms'
     );
     this.keepaliveTimer = setTimeout(() => {
+      this.keepaliveTimer = null;
       this.keepaliveTrace('Ping timeout passed without response');
       this.handleDisconnect();
     }, this.keepaliveTimeoutMs);
@@ -471,6 +472,7 @@ class Http2Transport implements Transport {
         'Starting keepalive timer for ' + this.keepaliveTimeMs + 'ms'
       );
       this.keepaliveTimer = setTimeout(() => {
+        this.keepaliveTimer = null;
         this.maybeSendPing();
       }, this.keepaliveTimeMs);
       this.keepaliveTimer.unref?.();


### PR DESCRIPTION
Improve server-side keepalives, possibly resolve bug where keepalive errors were not being treated as errors.

- Bugfix: Ensure that if session.ping returns false we correctly identify fail the keepalive and connection
- Bugfix: Ensure that if the interval between keepalives being sent occurs faster than the prior keepalive's timeout that we do not overwrite the reference to the prior timeout. Before this change: we could have in theory prevented a valid keepalive timeout from clearing itself because it's object reference was replaced with a newer timeout. This rewrite keeps every timeout as a local (vs a shared state per session). Even if the timeout outlives the lifetime of a session, we still guard against errors by checking that the parent interval is not falsy. I reckon this could result in a short-term memory leak per session which is bounded for a maximum of keepaliveTimeoutMs. On the other hand even with that potential for a short reference hold, this implementation proposed here is more correct I think. One alternative we could do is keep a list of pending timeouts.. which is complex for a rare situation that will self resolve anyhow when keepaliveTimeoutMs is reached. So I'm going with the cheaper, more common case.
- Bug Fix: keepalive intervals were being cleared with an incorrect clearTimeout before. Not sure if this was causing intervals leaks in some nodejs impls or not. (v20.13.1 seems to accept this mismatch without issue)
- Rename variables for clarity, to prevent future bugs like swapping clearInterval vs clearTimeout.
- Trace on GOAWAY frames and ensure we drop the connection
- Implementation is repeated in two places, per warning from https://github.com/grpc/grpc-node/pull/2756#issuecomment-2136031256
- This commit supercedes the prior PR on a master branch which was out of date. https://github.com/grpc/grpc-node/pull/2756

Aims to help resolve https://github.com/grpc/grpc-node/issues/2734