### PR TITLE
fix: add decoding for url encoded user credentials

### DIFF
--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -80,7 +80,7 @@ function getProxyInfo(): ProxyInfo {
   if (proxyUrl.username) {
     if (proxyUrl.password) {
       log(LogVerbosity.INFO, 'userinfo found in proxy URI');
-      userCred = `${proxyUrl.username}:${proxyUrl.password}`;
+      userCred = decodeURIComponent(`${proxyUrl.username}:${proxyUrl.password}`);
     } else {
       userCred = proxyUrl.username;
     }


### PR DESCRIPTION
Added support for URL encoded user credentials.

Previously, if a username/password contained a special character that required encoding, eg `grpc_proxy=http://user%40example.com:password@127.0.0.1:8888`, then the connection would be rejected (40x).