### PR TITLE
[grpc-js] Fix error messages in `serviceConfig` validation

### DIFF
--- a/packages/grpc-js/src/service-config.ts
+++ b/packages/grpc-js/src/service-config.ts
@@ -143,7 +143,7 @@ function validateRetryPolicy(obj: any): RetryPolicy {
     !DURATION_REGEX.test(obj.initialBackoff)
   ) {
     throw new Error(
-      'Invalid method config retry policy: initialBackoff must be a string consisting of a positive integer followed by s'
+      'Invalid method config retry policy: initialBackoff must be a string consisting of a positive integer or decimal followed by s'
     );
   }
   if (
@@ -152,7 +152,7 @@ function validateRetryPolicy(obj: any): RetryPolicy {
     !DURATION_REGEX.test(obj.maxBackoff)
   ) {
     throw new Error(
-      'Invalid method config retry policy: maxBackoff must be a string consisting of a positive integer followed by s'
+      'Invalid method config retry policy: maxBackoff must be a string consisting of a positive integer or decimal followed by s'
     );
   }
   if (
@@ -228,18 +228,18 @@ function validateHedgingPolicy(obj: any): HedgingPolicy {
       if (typeof value === 'number') {
         if (!Object.values(Status).includes(value)) {
           throw new Error(
-            'Invlid method config hedging policy: nonFatalStatusCodes value not in status code range'
+            'Invalid method config hedging policy: nonFatalStatusCodes value not in status code range'
           );
         }
       } else if (typeof value === 'string') {
         if (!Object.values(Status).includes(value.toUpperCase())) {
           throw new Error(
-            'Invlid method config hedging policy: nonFatalStatusCodes value not a status code name'
+            'Invalid method config hedging policy: nonFatalStatusCodes value not a status code name'
           );
         }
       } else {
         throw new Error(
-          'Invlid method config hedging policy: nonFatalStatusCodes value must be a string or number'
+          'Invalid method config hedging policy: nonFatalStatusCodes value must be a string or number'
         );
       }
     }

--- a/packages/grpc-js/test/test-retry-config.ts
+++ b/packages/grpc-js/test/test-retry-config.ts
@@ -101,19 +101,19 @@ const RETRY_TEST_CASES: TestCase[] = [
       retryableStatusCodes: [14],
     },
     error:
-      /retry policy: initialBackoff must be a string consisting of a positive integer followed by s/,
+      /retry policy: initialBackoff must be a string consisting of a positive integer or decimal followed by s/,
   },
   {
     description: 'a non-numeric initialBackoff',
     config: { ...validRetryConfig, initialBackoff: 'abcs' },
     error:
-      /retry policy: initialBackoff must be a string consisting of a positive integer followed by s/,
+      /retry policy: initialBackoff must be a string consisting of a positive integer or decimal followed by s/,
   },
   {
     description: 'an initialBackoff without an s',
     config: { ...validRetryConfig, initialBackoff: '123' },
     error:
-      /retry policy: initialBackoff must be a string consisting of a positive integer followed by s/,
+      /retry policy: initialBackoff must be a string consisting of a positive integer or decimal followed by s/,
   },
   {
     description: 'omitted maxBackoff',
@@ -124,19 +124,19 @@ const RETRY_TEST_CASES: TestCase[] = [
       retryableStatusCodes: [14],
     },
     error:
-      /retry policy: maxBackoff must be a string consisting of a positive integer followed by s/,
+      /retry policy: maxBackoff must be a string consisting of a positive integer or decimal followed by s/,
   },
   {
     description: 'a non-numeric maxBackoff',
     config: { ...validRetryConfig, maxBackoff: 'abcs' },
     error:
-      /retry policy: maxBackoff must be a string consisting of a positive integer followed by s/,
+      /retry policy: maxBackoff must be a string consisting of a positive integer or decimal followed by s/,
   },
   {
     description: 'an maxBackoff without an s',
     config: { ...validRetryConfig, maxBackoff: '123' },
     error:
-      /retry policy: maxBackoff must be a string consisting of a positive integer followed by s/,
+      /retry policy: maxBackoff must be a string consisting of a positive integer or decimal followed by s/,
   },
   {
     description: 'omitted backoffMultiplier',


### PR DESCRIPTION
This PR corrects five error messages in grpc-js's `serviceConfig` validation:
- 3 typos corrected from `Invld` to `Invalid`
- 2 corrected to say that strings containing decimals are valid in `initialBackoff` and `maxBackoff` values of `retryConfig`.

Validation for `initialBackoff` and `maxBackoff` in `retryConfig` use the following regex which allows decimals:
```
/**
 * Recognizes a number with up to 9 digits after the decimal point, followed by
 * an "s", representing a number of seconds.
 */
const DURATION_REGEX = /^\d+(\.\d{1,9})?s$/;
```

However, the error messages for `initialBackoff` and `maxBackoff` in `validateRetryPolicy` state that the values "must be a string consisting of a positive integer followed by s".

I discovered this when correcting a copied Go serviceConfig containing decimals that did not start with a 0:
```
    ...
    "InitialBackoff": ".002s",
    "MaxBackoff": ".01s",
```
becomes
```
    ...
    "initialBackoff": "0.002s",
    "maxBackoff": "0.01s",
```