### PR TITLE
grpc-js: Fix pick_first reconnecting without active calls

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.10.10",
+  "version": "1.10.11",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -32,7 +32,7 @@ import {
   PickResultType,
   UnavailablePicker,
 } from './picker';
-import { Endpoint, SubchannelAddress } from './subchannel-address';
+import { Endpoint, SubchannelAddress, subchannelAddressToString } from './subchannel-address';
 import * as logging from './logging';
 import { LogVerbosity } from './constants';
 import {
@@ -348,7 +348,6 @@ export class PickFirstLoadBalancer implements LoadBalancer {
       if (newState !== ConnectivityState.READY) {
         this.removeCurrentPick();
         this.calculateAndReportNewState();
-        this.requestReresolution();
       }
       return;
     }
@@ -483,6 +482,13 @@ export class PickFirstLoadBalancer implements LoadBalancer {
       subchannel: this.channelControlHelper.createSubchannel(address, {}),
       hasReportedTransientFailure: false,
     }));
+    trace('connectToAddressList([' + addressList.map(address => subchannelAddressToString(address)) + '])');
+    for (const { subchannel } of newChildrenList) {
+      if (subchannel.getConnectivityState() === ConnectivityState.READY) {
+        this.pickSubchannel(subchannel);
+        return;
+      }
+    }
     /* Ref each subchannel before resetting the list, to ensure that
      * subchannels shared between the list don't drop to 0 refs during the
      * transition. */
@@ -527,6 +533,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
     const rawAddressList = ([] as SubchannelAddress[]).concat(
       ...endpointList.map(endpoint => endpoint.addresses)
     );
+    trace('updateAddressList([' + rawAddressList.map(address => subchannelAddressToString(address)) + '])');
     if (rawAddressList.length === 0) {
       throw new Error('No addresses in endpoint list passed to pick_first');
     }


### PR DESCRIPTION
This is another attempt at fixing #2718. The previous attempt, #2680, failed because of #2690. I believe I have fixed that this time. With the original change, I reproduced a failure like the one reported: if the server dropped each connection after 1 second, and the client made requests as quickly as possible, after only a couple of minutes the client would entirely stop attempting to reconnect. With the change to handle ready subchannels in `connectToAddressList`, I ran the same test for half an hour without any problem.