### PR TITLE
grpc-js: Increase state change deadline in server idle tests

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -1790,19 +1790,22 @@ export class Server {
     // for future refreshes
     if (
       sessionInfo !== undefined &&
-      sessionInfo.activeStreams === 0 &&
-      Date.now() - sessionInfo.lastIdle >= ctx.sessionIdleTimeout
+      sessionInfo.activeStreams === 0
     ) {
-      ctx.trace(
-        'Session idle timeout triggered for ' +
-          socket?.remoteAddress +
-          ':' +
-          socket?.remotePort +
-          ' last idle at ' +
-          sessionInfo.lastIdle
-      );
+      if (Date.now() - sessionInfo.lastIdle >= ctx.sessionIdleTimeout) {
+        ctx.trace(
+          'Session idle timeout triggered for ' +
+            socket?.remoteAddress +
+            ':' +
+            socket?.remotePort +
+            ' last idle at ' +
+            sessionInfo.lastIdle
+        );
 
-      ctx.closeSession(session);
+        ctx.closeSession(session);
+      } else {
+        sessionInfo.timeout.refresh();
+      }
     }
   }
 

--- a/packages/grpc-js/test/test-idle-timer.ts
+++ b/packages/grpc-js/test/test-idle-timer.ts
@@ -199,7 +199,7 @@ describe('Server idle timer', () => {
         grpc.connectivityState.READY
       );
       client?.waitForClientState(
-        Date.now() + 600,
+        Date.now() + 1500,
         grpc.connectivityState.IDLE,
         done
       );
@@ -217,7 +217,7 @@ describe('Server idle timer', () => {
       );
 
       client!.waitForClientState(
-        Date.now() + 600,
+        Date.now() + 1500,
         grpc.connectivityState.IDLE,
         err => {
           if (err) return done(err);
@@ -248,7 +248,7 @@ describe('Server idle timer', () => {
       );
 
       client!.waitForClientState(
-        Date.now() + 600,
+        Date.now() + 1500,
         grpc.connectivityState.IDLE,
         done
       );


### PR DESCRIPTION
I think there are cases where it can take about double the configured idle timeout for a connection to actually go idle. This waits for triple the time for a margin of error.