### PR TITLE
grpc-js: Bump packages to 1.11.0, and update documentation (actually on 1.11.x this time)

### DIFF
--- a/packages/grpc-js-xds/README.md
+++ b/packages/grpc-js-xds/README.md
@@ -35,3 +35,4 @@ const client = new MyServiceClient('xds:///example.com:123');
  - [xDS Custom Load Balancer Configuration](https://github.com/grpc/proposal/blob/master/A52-xds-custom-lb-policies.md) (Custom load balancer registration not currently supported)
  - [xDS Ring Hash LB Policy](https://github.com/grpc/proposal/blob/master/A42-xds-ring-hash-lb-policy.md)
  - [`pick_first` via xDS](https://github.com/grpc/proposal/blob/master/A62-pick-first.md#pick_first-via-xds-1) (Currently experimental, enabled by environment variable `GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG`)
+ - [xDS-Enabled Servers](https://github.com/grpc/proposal/blob/master/A36-xds-for-servers.md)

--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {
@@ -52,7 +52,7 @@
     "xxhash-wasm": "^1.0.2"
   },
   "peerDependencies": {
-    "@grpc/grpc-js": "~1.10.0"
+    "@grpc/grpc-js": "~1.11.0"
   },
   "engines": {
     "node": ">=10.10.0"

--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -69,6 +69,7 @@ Many channel arguments supported in `grpc` are not supported in `@grpc/grpc-js`.
   - `grpc.client_idle_timeout_ms`
   - `grpc-node.max_session_memory`
   - `grpc-node.tls_enable_trace`
+  - `grpc-node.retry_max_attempts_limit`
   - `channelOverride`
   - `channelFactoryOverride`
 

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.10.11",
+  "version": "1.11.0",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
#2796 but actually on the 1.11.x branch.