### PR TITLE
fix(grpc-js): client crash on custom error code

### DIFF
--- a/packages/grpc-js/src/retrying-call.ts
+++ b/packages/grpc-js/src/retrying-call.ts
@@ -398,7 +398,7 @@ export class RetryingCall implements Call, DeadlineInfoProvider {
     return list.some(
       value =>
         value === code ||
-        value.toString().toLowerCase() === Status[code].toLowerCase()
+        value.toString().toLowerCase() === Status[code]?.toLowerCase()
     );
   }
 

--- a/packages/grpc-js/test/test-retry.ts
+++ b/packages/grpc-js/test/test-retry.ts
@@ -333,6 +333,7 @@ describe('Retries', () => {
         metadata,
         (error: grpc.ServiceError, response: any) => {
           assert(error);
+          assert.strictEqual(error.code, 300);
           assert.strictEqual(error.details, 'Failed on retry 0');
           done();
         }

--- a/packages/grpc-js/test/test-retry.ts
+++ b/packages/grpc-js/test/test-retry.ts
@@ -323,6 +323,21 @@ describe('Retries', () => {
         }
       );
     });
+
+    it('Should not retry on custom error code', done => {
+      const metadata = new grpc.Metadata();
+      metadata.set('succeed-on-retry-attempt', '2');
+      metadata.set('respond-with-status', '300');
+      client.echo(
+        { value: 'test value', value2: 3 },
+        metadata,
+        (error: grpc.ServiceError, response: any) => {
+          assert(error);
+          assert.strictEqual(error.details, 'Failed on retry 0');
+          done();
+        }
+      );
+    });
   });
 
   describe('Client with hedging configured', () => {


### PR DESCRIPTION
In version 1.11.1, grpc client crashes if receives custom error code with error `cannot read properties of undefined reading .toLowerCase()`