### PR TITLE
Provide the method_name for the CallCredentials callback generateMetadata

### DIFF
--- a/packages/grpc-js/src/call-credentials.ts
+++ b/packages/grpc-js/src/call-credentials.ts
@@ -18,6 +18,7 @@
 import { Metadata } from './metadata';
 
 export interface CallMetadataOptions {
+  method_name: string;
   service_url: string;
 }
 

--- a/packages/grpc-js/src/load-balancing-call.ts
+++ b/packages/grpc-js/src/load-balancing-call.ts
@@ -162,7 +162,7 @@ export class LoadBalancingCall implements Call, DeadlineInfoProvider {
     switch (pickResult.pickResultType) {
       case PickResultType.COMPLETE:
         this.credentials
-          .generateMetadata({ service_url: this.serviceUrl })
+          .generateMetadata({ method_name: this.methodName, service_url: this.serviceUrl })
           .then(
             credsMetadata => {
               /* If this call was cancelled (e.g. by the deadline) before

--- a/packages/grpc-js/test/test-call-credentials.ts
+++ b/packages/grpc-js/test/test-call-credentials.ts
@@ -87,6 +87,7 @@ describe('CallCredentials', () => {
         generateFromServiceURL
       );
       const metadata: Metadata = await callCredentials.generateMetadata({
+        method_name: 'bar',
         service_url: 'foo',
       });
 
@@ -98,7 +99,7 @@ describe('CallCredentials', () => {
         CallCredentials.createFromMetadataGenerator(generateWithError);
       let metadata: Metadata | null = null;
       try {
-        metadata = await callCredentials.generateMetadata({ service_url: '' });
+        metadata = await callCredentials.generateMetadata({ method_name: '', service_url: '' });
       } catch (err) {
         assert.ok(err instanceof Error);
       }
@@ -139,6 +140,7 @@ describe('CallCredentials', () => {
         testCases.map(async testCase => {
           const { credentials, expected } = testCase;
           const metadata: Metadata = await credentials.generateMetadata({
+            method_name: '',
             service_url: '',
           });
 


### PR DESCRIPTION
The method name is required to create valid SIGv4 authenticated requests for [Amazon VPC Lattice](https://docs.aws.amazon.com/vpc-lattice/latest/ug/sigv4-authenticated-requests.html).

This is available in multiple implementations (c++, Golang, PHP).
See also 

- https://grpc.io/docs/guides/auth/#extending-grpc-to-support-other-authentication-mechanisms
- https://docs.aws.amazon.com/vpc-lattice/latest/ug/sigv4-authenticated-requests.html#sigv4-authenticated-requests-golang