### PR TITLE
allow to trace with lazy text calculation

### DIFF
--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -427,11 +427,11 @@ export class InternalChannel {
     trace(
       LogVerbosity.DEBUG,
       'channel_stacktrace',
-      '(' +
+     () => ('(' +
         this.channelzRef.id +
         ') ' +
         'Channel constructed \n' +
-        error.stack?.substring(error.stack.indexOf('\n') + 1)
+        error.stack?.substring(error.stack.indexOf('\n') + 1))
     );
     this.lastActivityTimestamp = new Date();
   }

--- a/packages/grpc-js/src/logging.ts
+++ b/packages/grpc-js/src/logging.ts
@@ -109,9 +109,15 @@ const allEnabled = enabledTracers.has('all');
 export function trace(
   severity: LogVerbosity,
   tracer: string,
-  text: string
+  text: string | (() => string)
 ): void {
   if (isTracerEnabled(tracer)) {
+    let textValue = text;
+    
+    if(typeof text === 'function') {
+      textValue = text();
+    }
+    
     log(
       severity,
       new Date().toISOString() +
@@ -122,10 +128,11 @@ export function trace(
         ' | ' +
         tracer +
         ' | ' +
-        text
+        textValue
     );
   }
 }
+
 
 export function isTracerEnabled(tracer: string): boolean {
   return (


### PR DESCRIPTION
In `internal-channel.ts` file there is a trace after channel is constructed.
In this trace, the full stacktrace is added.

The trace is written only when the log level is on `trace`, but the stacktrace is calculated in any case.
We found in our usage, that if you have a big bundle file it can take few seconds to calculate the stacktrace, it can be reasonable in trace mode but not in production.

I suggest to made the text in trace function to allow also a `delegate` that returns a function.
The delegate will be called only when the trace is materialized.

