### PR TITLE
made the call to trace to be called only when tracer is enabled

### DIFF
--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -31,7 +31,7 @@ import {
   getDefaultAuthority,
   mapUriDefaultScheme,
 } from './resolver';
-import { trace } from './logging';
+import { trace, isTracerEnabled } from './logging';
 import { SubchannelAddress } from './subchannel-address';
 import { mapProxyName } from './http_proxy';
 import { GrpcUri, parseUri, uriToString } from './uri-parser';
@@ -424,15 +424,17 @@ export class InternalChannel {
         JSON.stringify(options, undefined, 2)
     );
     const error = new Error();
-    trace(
-      LogVerbosity.DEBUG,
-      'channel_stacktrace',
-      '(' +
-        this.channelzRef.id +
-        ') ' +
-        'Channel constructed \n' +
-        error.stack?.substring(error.stack.indexOf('\n') + 1)
-    );
+    if (isTracerEnabled('channel_stacktrace')){
+      trace(
+        LogVerbosity.DEBUG,
+        'channel_stacktrace',
+        '(' +
+          this.channelzRef.id +
+          ') ' +
+          'Channel constructed \n' +
+          error.stack?.substring(error.stack.indexOf('\n') + 1)
+      );
+    }
     this.lastActivityTimestamp = new Date();
   }
 


### PR DESCRIPTION
In internal-channel.ts file there is a trace after channel is constructed.
In this trace, the full stacktrace is added.

The trace is written only when the log level is on trace, but the stacktrace is calculated in any case.
We found in our usage, that if you have a big bundle file it can take few seconds to calculate the stacktrace, it can be reasonable in trace mode but not in production.

See https://github.com/grpc/grpc-node/pull/2816 for the conversation with @murgatroid99.

<img width="1589" alt="image" src="https://github.com/user-attachments/assets/54d2e117-cebf-4c24-aa5f-41fbb3e32ab2">

