### PR TITLE
Fixed generation of grpc services

### DIFF
--- a/packages/grpc-tools/src/node_generator.cc
+++ b/packages/grpc-tools/src/node_generator.cc
@@ -204,7 +204,7 @@ void PrintService(const ServiceDescriptor* service, Printer* out,
   if (!params.generate_package_definition) {
     out->Print(template_vars,
                "exports.$name$Client = "
-               "grpc.makeGenericClientConstructor($name$Service);\n");
+               "grpc.makeGenericClientConstructor($name$Service, '$name$');\n");
   }
   out->PrintRaw(GetNodeComments(service, false).c_str());
 }


### PR DESCRIPTION
This pull request fixes file generation to work with grpc-js. The bug is that the second argument of the makeClientConstructor function is missing, although it is required.

<img width="1229" alt="required_field" src="https://github.com/user-attachments/assets/66baf5e5-fc71-41dc-b94a-8552fd3a2838">

