### PR TITLE
grpc-js-xds: Add bootstrap certificate provider config handling

### DIFF
--- a/packages/grpc-js/src/certificate-provider.ts
+++ b/packages/grpc-js/src/certificate-provider.ts
@@ -49,10 +49,6 @@ export interface CertificateProvider {
   removeIdentityCertificateListener(listener: IdentityCertificateUpdateListener): void;
 }
 
-export interface CertificateProviderProvider<Provider> {
-  getInstance(): Provider;
-}
-
 export interface FileWatcherCertificateProviderConfig {
   certificateFile?: string | undefined;
   privateKeyFile?: string | undefined;

--- a/packages/grpc-js/src/duration.ts
+++ b/packages/grpc-js/src/duration.ts
@@ -34,3 +34,15 @@ export function durationToMs(duration: Duration): number {
 export function isDuration(value: any): value is Duration {
   return typeof value.seconds === 'number' && typeof value.nanos === 'number';
 }
+
+const durationRegex = /^(\d+)(?:\.(\d+))?s$/;
+export function parseDuration(value: string): Duration | null {
+  const match = value.match(durationRegex);
+  if (!match) {
+    return null;
+  }
+  return {
+    seconds: Number.parseInt(match[1], 10),
+    nanos: Number.parseInt(match[2].padEnd(9, '0'), 10)
+  };
+}

--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -7,7 +7,7 @@ export {
   createResolver,
 } from './resolver';
 export { GrpcUri, uriToString, splitHostPort, HostPort } from './uri-parser';
-export { Duration, durationToMs } from './duration';
+export { Duration, durationToMs, parseDuration } from './duration';
 export { BackoffTimeout } from './backoff-timeout';
 export {
   LoadBalancer,


### PR DESCRIPTION
As [described in A29](https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md#certificate-provider-plugin-framework), this adds handling for the `certificate_provider` field in the xDS bootstrap file, and a registry of certificate provider plugins configured this way.