### PR TITLE
grpc-js: round_robin: Request resolution on connection drop

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -110,6 +110,13 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
       channelControlHelper,
       {
         updateState: (connectivityState, picker) => {
+          /* Ensure that name resolution is requested again after active
+           * connections are dropped. This is more aggressive than necessary to
+           * accomplish that, so we are counting on resolvers to have
+           * reasonable rate limits. */
+          if (this.currentState === ConnectivityState.READY && connectivityState !== ConnectivityState.READY) {
+            this.channelControlHelper.requestReresolution();
+          }
           this.calculateAndUpdateState();
         },
       }


### PR DESCRIPTION
This should fix #2824. It looks like round_robin was previously relying on pick_first (the leaf balancer) to request name resolution whenever an individual connection would be dropped, but that behavior was a bug that was fixed in #2784. So, round_robin needs to request name resolution itself.