### PR TITLE
chore: proofread docs

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -64,6 +64,6 @@ can be set.
   - NONE - won't log any
 
 * GRPC_NODE_USE_ALTERNATIVE_RESOLVER
-  Allows changing dns resolve behavior and parse DNS server authority as described in https://github.com/grpc/grpc/blob/master/doc/naming.md
-  - true - use alternative resolver
-  - false - use default resolver (default)
+  Allows changing DNS resolve behavior and parses DNS server authority as described in https://github.com/grpc/grpc/blob/master/doc/naming.md
+  - true - uses alternative resolver
+  - false - uses default resolver (default)


### PR DESCRIPTION
trivial contribution.  DNS had inconsistent capitalization.