### PR TITLE
grpc-js: Bump to 1.12.0

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {
@@ -52,7 +52,7 @@
     "xxhash-wasm": "^1.0.2"
   },
   "peerDependencies": {
-    "@grpc/grpc-js": "~1.11.0"
+    "@grpc/grpc-js": "~1.12.0"
   },
   "engines": {
     "node": ">=10.10.0"

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
This release just has a few minor changes, but #2832 is part of a launch.