### PR TITLE
grpc-js: Use util.promisify instead of fs/promises for Node 12 compatibility

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
This fixes https://github.com/grpc/grpc-node/issues/2834#issuecomment-2401398011