### PR TITLE
grpc-js-xds: Fix a couple of bugs with the config tears change

### DIFF
--- a/packages/grpc-js/src/backoff-timeout.ts
+++ b/packages/grpc-js/src/backoff-timeout.ts
@@ -107,7 +107,7 @@ export class BackoffTimeout {
   private runTimer(delay: number) {
     this.endTime = this.startTime;
     this.endTime.setMilliseconds(
-      this.endTime.getMilliseconds() + this.nextDelay
+      this.endTime.getMilliseconds() + delay
     );
     clearTimeout(this.timerId);
     this.timerId = setTimeout(() => {

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -275,6 +275,13 @@ export class PickFirstLoadBalancer implements LoadBalancer {
           new PickFirstPicker(this.currentPick)
         );
       }
+    } else if (this.latestAddressList?.length === 0) {
+      this.updateState(
+        ConnectivityState.TRANSIENT_FAILURE,
+        new UnavailablePicker({
+          details: `No connection established. Last error: ${this.lastError}`,
+        })
+      );
     } else if (this.children.length === 0) {
       this.updateState(ConnectivityState.IDLE, new QueuePicker(this));
     } else {

--- a/packages/grpc-js/test/test-pick-first.ts
+++ b/packages/grpc-js/test/test-pick-first.ts
@@ -690,6 +690,19 @@ describe('pick_first load balancing policy', () => {
       });
     });
   });
+  it('Should report TRANSIENT_FAILURE with no addresses', done => {
+    const channelControlHelper = createChildChannelControlHelper(
+      baseChannelControlHelper,
+      {
+        updateState: updateStateCallBackForExpectedStateSequence(
+          [ConnectivityState.TRANSIENT_FAILURE],
+          done
+        ),
+      }
+    );
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    pickFirst.updateAddressList([], config);
+  });
   describe('Address list randomization', () => {
     const shuffleConfig = new PickFirstLoadBalancingConfig(true);
     it('Should pick different subchannels after multiple updates', done => {


### PR DESCRIPTION
This change fixes two significant bugs introduced in #2844:

 1. pick_first reported IDLE instead of TRANSIENT_FAILURE when provided a zero-length address list. This caused all calls to queue for LB picks instead of ending with an error, which means that they piled up quickly.
 2. As a consequence of the way in-use clusters were retained, the xDS dependency manager would provide the config again every time a call was committed (or at least most of the time).