### PR TITLE
Revert "grpc-js: Enable LB policies to override subchannel credentials"

### DIFF
--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -88,7 +88,7 @@ const RPC_BEHAVIOR_CHILD_CONFIG = parseLoadBalancingConfig({round_robin: {}});
 class RpcBehaviorLoadBalancer implements LoadBalancer {
   private child: ChildLoadBalancerHandler;
   private latestConfig: RpcBehaviorLoadBalancingConfig | null = null;
-  constructor(channelControlHelper: ChannelControlHelper, credentials: grpc.ChannelCredentials, options: grpc.ChannelOptions) {
+  constructor(channelControlHelper: ChannelControlHelper, options: grpc.ChannelOptions) {
     const childChannelControlHelper = createChildChannelControlHelper(channelControlHelper, {
       updateState: (connectivityState, picker) => {
         if (connectivityState === grpc.connectivityState.READY && this.latestConfig) {
@@ -97,7 +97,7 @@ class RpcBehaviorLoadBalancer implements LoadBalancer {
         channelControlHelper.updateState(connectivityState, picker);
       }
     });
-    this.child = new ChildLoadBalancerHandler(childChannelControlHelper, credentials, options);
+    this.child = new ChildLoadBalancerHandler(childChannelControlHelper, options);
   }
   updateAddressList(endpointList: Endpoint[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
     if (!(lbConfig instanceof RpcBehaviorLoadBalancingConfig)) {

--- a/packages/grpc-js-xds/src/load-balancer-cds.ts
+++ b/packages/grpc-js-xds/src/load-balancer-cds.ts
@@ -15,7 +15,9 @@
  *
  */
 
-import { connectivityState, status, Metadata, logVerbosity, experimental, LoadBalancingConfig, ChannelOptions, ChannelCredentials } from '@grpc/grpc-js';
+import { connectivityState, status, Metadata, logVerbosity, experimental, LoadBalancingConfig, ChannelOptions } from '@grpc/grpc-js';
+import { getSingletonXdsClient, Watcher, XdsClient } from './xds-client';
+import { Cluster__Output } from './generated/envoy/config/cluster/v3/Cluster';
 import Endpoint = experimental.Endpoint;
 import UnavailablePicker = experimental.UnavailablePicker;
 import ChildLoadBalancerHandler = experimental.ChildLoadBalancerHandler;
@@ -97,8 +99,8 @@ export class CdsLoadBalancer implements LoadBalancer {
   private priorityNames: string[] = [];
   private nextPriorityChildNumber = 0;
 
-  constructor(private readonly channelControlHelper: ChannelControlHelper, credentials: ChannelCredentials, options: ChannelOptions) {
-    this.childBalancer = new ChildLoadBalancerHandler(channelControlHelper, credentials, options);
+  constructor(private readonly channelControlHelper: ChannelControlHelper, options: ChannelOptions) {
+    this.childBalancer = new ChildLoadBalancerHandler(channelControlHelper, options);
   }
 
   private getNextPriorityName(cluster: string) {

--- a/packages/grpc-js-xds/src/load-balancer-priority.ts
+++ b/packages/grpc-js-xds/src/load-balancer-priority.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { connectivityState as ConnectivityState, status as Status, Metadata, logVerbosity as LogVerbosity, experimental, LoadBalancingConfig, ChannelOptions, ChannelCredentials } from '@grpc/grpc-js';
+import { connectivityState as ConnectivityState, status as Status, Metadata, logVerbosity as LogVerbosity, experimental, LoadBalancingConfig, ChannelOptions } from '@grpc/grpc-js';
 import LoadBalancer = experimental.LoadBalancer;
 import ChannelControlHelper = experimental.ChannelControlHelper;
 import registerLoadBalancerType = experimental.registerLoadBalancerType;
@@ -197,7 +197,7 @@ export class PriorityLoadBalancer implements LoadBalancer {
             this.parent.channelControlHelper.requestReresolution();
           }
         }
-      }), parent.credentials, parent.options);
+      }), parent.options);
       this.picker = new QueuePicker(this.childBalancer);
       this.startFailoverTimer();
     }
@@ -323,7 +323,7 @@ export class PriorityLoadBalancer implements LoadBalancer {
 
   private updatesPaused = false;
 
-  constructor(private channelControlHelper: ChannelControlHelper, private credentials: ChannelCredentials, private options: ChannelOptions) {}
+  constructor(private channelControlHelper: ChannelControlHelper, private options: ChannelOptions) {}
 
   private updateState(state: ConnectivityState, picker: Picker) {
     trace(

--- a/packages/grpc-js-xds/src/load-balancer-ring-hash.ts
+++ b/packages/grpc-js-xds/src/load-balancer-ring-hash.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { experimental, logVerbosity, connectivityState, status, Metadata, ChannelOptions, LoadBalancingConfig, ChannelCredentials } from '@grpc/grpc-js';
+import { experimental, logVerbosity, connectivityState, status, Metadata, ChannelOptions, LoadBalancingConfig } from '@grpc/grpc-js';
 import { isLocalityEndpoint } from './load-balancer-priority';
 import TypedLoadBalancingConfig = experimental.TypedLoadBalancingConfig;
 import LeafLoadBalancer = experimental.LeafLoadBalancer;
@@ -226,7 +226,7 @@ class RingHashLoadBalancer implements LoadBalancer {
   private currentState: connectivityState = connectivityState.IDLE;
   private ring: RingEntry[] = [];
   private ringHashSizeCap = DEFAULT_RING_SIZE_CAP;
-  constructor(private channelControlHelper: ChannelControlHelper, private credentials: ChannelCredentials, private options: ChannelOptions) {
+  constructor(private channelControlHelper: ChannelControlHelper, private options: ChannelOptions) {
     this.childChannelControlHelper = createChildChannelControlHelper(
       channelControlHelper,
       {
@@ -407,7 +407,7 @@ class RingHashLoadBalancer implements LoadBalancer {
       } else {
         this.leafMap.set(
           endpoint,
-          new LeafLoadBalancer(endpoint, this.childChannelControlHelper, this.credentials, this.options)
+          new LeafLoadBalancer(endpoint, this.childChannelControlHelper, this.options)
         );
       }
       const weight = this.leafWeightMap.get(endpoint);

--- a/packages/grpc-js-xds/src/load-balancer-weighted-target.ts
+++ b/packages/grpc-js-xds/src/load-balancer-weighted-target.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { connectivityState as ConnectivityState, status as Status, Metadata, logVerbosity, experimental, LoadBalancingConfig, ChannelOptions, ChannelCredentials } from "@grpc/grpc-js";
+import { connectivityState as ConnectivityState, status as Status, Metadata, logVerbosity, experimental, LoadBalancingConfig, ChannelOptions } from "@grpc/grpc-js";
 import { isLocalityEndpoint, LocalityEndpoint } from "./load-balancer-priority";
 import TypedLoadBalancingConfig = experimental.TypedLoadBalancingConfig;
 import LoadBalancer = experimental.LoadBalancer;
@@ -178,7 +178,7 @@ export class WeightedTargetLoadBalancer implements LoadBalancer {
         updateState: (connectivityState: ConnectivityState, picker: Picker) => {
           this.updateState(connectivityState, picker);
         },
-      }), parent.credentials, parent.options);
+      }), parent.options);
 
       this.picker = new QueuePicker(this.childBalancer);
     }
@@ -243,7 +243,7 @@ export class WeightedTargetLoadBalancer implements LoadBalancer {
   private targetList: string[] = [];
   private updatesPaused = false;
 
-  constructor(private channelControlHelper: ChannelControlHelper, private credentials: ChannelCredentials, private options: ChannelOptions) {}
+  constructor(private channelControlHelper: ChannelControlHelper, private options: ChannelOptions) {}
 
   private maybeUpdateState() {
     if (!this.updatesPaused) {

--- a/packages/grpc-js-xds/src/load-balancer-xds-cluster-manager.ts
+++ b/packages/grpc-js-xds/src/load-balancer-xds-cluster-manager.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { connectivityState as ConnectivityState, status as Status, experimental, logVerbosity, Metadata, status, ChannelOptions, ChannelCredentials } from "@grpc/grpc-js/";
+import { connectivityState as ConnectivityState, status as Status, experimental, logVerbosity, Metadata, status, ChannelOptions } from "@grpc/grpc-js/";
 
 import TypedLoadBalancingConfig = experimental.TypedLoadBalancingConfig;
 import LoadBalancer = experimental.LoadBalancer;
@@ -131,7 +131,7 @@ class XdsClusterManager implements LoadBalancer {
         updateState: (connectivityState: ConnectivityState, picker: Picker) => {
           this.updateState(connectivityState, picker);
         },
-      }), parent.credentials, parent.options);
+      }), parent.options);
 
       this.picker = new QueuePicker(this.childBalancer);
     }
@@ -167,7 +167,7 @@ class XdsClusterManager implements LoadBalancer {
   // Shutdown is a placeholder value that will never appear in normal operation.
   private currentState: ConnectivityState = ConnectivityState.SHUTDOWN;
   private updatesPaused = false;
-  constructor(private channelControlHelper: ChannelControlHelper, private credentials: ChannelCredentials, private options: ChannelOptions) {}
+  constructor(private channelControlHelper: ChannelControlHelper, private options: ChannelOptions) {}
 
   private maybeUpdateState() {
     if (!this.updatesPaused) {

--- a/packages/grpc-js-xds/src/load-balancer-xds-wrr-locality.ts
+++ b/packages/grpc-js-xds/src/load-balancer-xds-wrr-locality.ts
@@ -17,7 +17,7 @@
 
 // https://github.com/grpc/proposal/blob/master/A52-xds-custom-lb-policies.md
 
-import { ChannelCredentials, ChannelOptions, LoadBalancingConfig, experimental, logVerbosity } from "@grpc/grpc-js";
+import { ChannelOptions, LoadBalancingConfig, experimental, logVerbosity } from "@grpc/grpc-js";
 import { loadProtosWithOptionsSync } from "@grpc/proto-loader/build/src/util";
 import { WeightedTargetRaw } from "./load-balancer-weighted-target";
 import { isLocalityEndpoint } from "./load-balancer-priority";
@@ -73,8 +73,8 @@ class XdsWrrLocalityLoadBalancingConfig implements TypedLoadBalancingConfig {
 
 class XdsWrrLocalityLoadBalancer implements LoadBalancer {
   private childBalancer: ChildLoadBalancerHandler;
-  constructor(private readonly channelControlHelper: ChannelControlHelper, credentials: ChannelCredentials, options: ChannelOptions) {
-    this.childBalancer = new ChildLoadBalancerHandler(channelControlHelper, credentials, options);
+  constructor(private readonly channelControlHelper: ChannelControlHelper, options: ChannelOptions) {
+    this.childBalancer = new ChildLoadBalancerHandler(channelControlHelper, options);
   }
   updateAddressList(endpointList: Endpoint[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
     if (!(lbConfig instanceof XdsWrrLocalityLoadBalancingConfig)) {

--- a/packages/grpc-js-xds/test/test-custom-lb-policies.ts
+++ b/packages/grpc-js-xds/test/test-custom-lb-policies.ts
@@ -24,7 +24,7 @@ import { ControlPlaneServer } from "./xds-server";
 import * as assert from 'assert';
 import { WrrLocality } from "../src/generated/envoy/extensions/load_balancing_policies/wrr_locality/v3/WrrLocality";
 import { TypedStruct } from "../src/generated/xds/type/v3/TypedStruct";
-import { ChannelCredentials, ChannelOptions, connectivityState, experimental, logVerbosity } from "@grpc/grpc-js";
+import { ChannelOptions, connectivityState, experimental, logVerbosity } from "@grpc/grpc-js";
 
 import TypedLoadBalancingConfig = experimental.TypedLoadBalancingConfig;
 import LoadBalancer = experimental.LoadBalancer;
@@ -84,7 +84,7 @@ const RPC_BEHAVIOR_CHILD_CONFIG = parseLoadBalancingConfig({round_robin: {}});
 class RpcBehaviorLoadBalancer implements LoadBalancer {
   private child: ChildLoadBalancerHandler;
   private latestConfig: RpcBehaviorLoadBalancingConfig | null = null;
-  constructor(channelControlHelper: ChannelControlHelper, credentials: ChannelCredentials, options: ChannelOptions) {
+  constructor(channelControlHelper: ChannelControlHelper, options: ChannelOptions) {
     const childChannelControlHelper = createChildChannelControlHelper(channelControlHelper, {
       updateState: (state, picker) => {
         if (state === connectivityState.READY && this.latestConfig) {
@@ -93,7 +93,7 @@ class RpcBehaviorLoadBalancer implements LoadBalancer {
         channelControlHelper.updateState(state, picker);
       }
     });
-    this.child = new ChildLoadBalancerHandler(childChannelControlHelper, credentials, options);
+    this.child = new ChildLoadBalancerHandler(childChannelControlHelper, options);
   }
   updateAddressList(endpointList: Endpoint[], lbConfig: TypedLoadBalancingConfig, attributes: { [key: string]: unknown; }): void {
     if (!(lbConfig instanceof RpcBehaviorLoadBalancingConfig)) {

--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -294,14 +294,13 @@ export class InternalChannel {
     const channelControlHelper: ChannelControlHelper = {
       createSubchannel: (
         subchannelAddress: SubchannelAddress,
-        subchannelArgs: ChannelOptions,
-        credentialsOverride: ChannelCredentials | null
+        subchannelArgs: ChannelOptions
       ) => {
         const subchannel = this.subchannelPool.getOrCreateSubchannel(
           this.target,
           subchannelAddress,
           Object.assign({}, this.options, subchannelArgs),
-          credentialsOverride ?? this.credentials
+          this.credentials
         );
         subchannel.throttleKeepalive(this.keepaliveTime);
         if (this.channelzEnabled) {
@@ -350,7 +349,6 @@ export class InternalChannel {
     this.resolvingLoadBalancer = new ResolvingLoadBalancer(
       this.target,
       channelControlHelper,
-      credentials,
       options,
       (serviceConfig, configSelector) => {
         if (serviceConfig.retryThrottling) {

--- a/packages/grpc-js/src/load-balancer-child-handler.ts
+++ b/packages/grpc-js/src/load-balancer-child-handler.ts
@@ -27,7 +27,6 @@ import { ConnectivityState } from './connectivity-state';
 import { Picker } from './picker';
 import type { ChannelRef, SubchannelRef } from './channelz';
 import { SubchannelInterface } from './subchannel-interface';
-import { ChannelCredentials } from './channel-credentials';
 
 const TYPE_NAME = 'child_load_balancer_helper';
 
@@ -41,13 +40,11 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
     constructor(private parent: ChildLoadBalancerHandler) {}
     createSubchannel(
       subchannelAddress: SubchannelAddress,
-      subchannelArgs: ChannelOptions,
-      credentialsOverride: ChannelCredentials | null
+      subchannelArgs: ChannelOptions
     ): SubchannelInterface {
       return this.parent.channelControlHelper.createSubchannel(
         subchannelAddress,
-        subchannelArgs,
-        credentialsOverride
+        subchannelArgs
       );
     }
     updateState(connectivityState: ConnectivityState, picker: Picker): void {
@@ -89,7 +86,6 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
 
   constructor(
     private readonly channelControlHelper: ChannelControlHelper,
-    private readonly credentials: ChannelCredentials,
     private readonly options: ChannelOptions
   ) {}
 
@@ -118,7 +114,7 @@ export class ChildLoadBalancerHandler implements LoadBalancer {
       this.configUpdateRequiresNewPolicyInstance(this.latestConfig, lbConfig)
     ) {
       const newHelper = new this.ChildPolicyHelper(this);
-      const newChild = createLoadBalancer(lbConfig, newHelper, this.credentials, this.options)!;
+      const newChild = createLoadBalancer(lbConfig, newHelper, this.options)!;
       newHelper.setChild(newChild);
       if (this.currentChild === null) {
         this.currentChild = newChild;

--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -43,7 +43,6 @@ import {
 } from './subchannel-interface';
 import * as logging from './logging';
 import { LoadBalancingConfig } from './service-config';
-import { ChannelCredentials } from './channel-credentials';
 
 const TRACER_NAME = 'outlier_detection';
 
@@ -470,20 +469,17 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
 
   constructor(
     channelControlHelper: ChannelControlHelper,
-    credentials: ChannelCredentials,
     options: ChannelOptions
   ) {
     this.childBalancer = new ChildLoadBalancerHandler(
       createChildChannelControlHelper(channelControlHelper, {
         createSubchannel: (
           subchannelAddress: SubchannelAddress,
-          subchannelArgs: ChannelOptions,
-          credentialsOverride: ChannelCredentials | null
+          subchannelArgs: ChannelOptions
         ) => {
           const originalSubchannel = channelControlHelper.createSubchannel(
             subchannelAddress,
-            subchannelArgs,
-            credentialsOverride
+            subchannelArgs
           );
           const mapEntry =
             this.entryMap.getForSubchannelAddress(subchannelAddress);
@@ -509,7 +505,6 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
           }
         },
       }),
-      credentials,
       options
     );
     this.ejectionTimer = setInterval(() => {}, 0);

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -43,7 +43,6 @@ import {
 import { isTcpSubchannelAddress } from './subchannel-address';
 import { isIPv6 } from 'net';
 import { ChannelOptions } from './channel-options';
-import { ChannelCredentials } from './channel-credentials';
 
 const TRACER_NAME = 'pick_first';
 
@@ -244,7 +243,6 @@ export class PickFirstLoadBalancer implements LoadBalancer {
    */
   constructor(
     private readonly channelControlHelper: ChannelControlHelper,
-    credentials: ChannelCredentials,
     options: ChannelOptions
   ) {
     this.connectionDelayTimeout = setTimeout(() => {}, 0);
@@ -466,7 +464,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
   private connectToAddressList(addressList: SubchannelAddress[]) {
     trace('connectToAddressList([' + addressList.map(address => subchannelAddressToString(address)) + '])');
     const newChildrenList = addressList.map(address => ({
-      subchannel: this.channelControlHelper.createSubchannel(address, {}, null),
+      subchannel: this.channelControlHelper.createSubchannel(address, {}),
       hasReportedTransientFailure: false,
     }));
     for (const { subchannel } of newChildrenList) {
@@ -562,7 +560,6 @@ export class LeafLoadBalancer {
   constructor(
     private endpoint: Endpoint,
     channelControlHelper: ChannelControlHelper,
-    credentials: ChannelCredentials,
     options: ChannelOptions
   ) {
     const childChannelControlHelper = createChildChannelControlHelper(
@@ -577,7 +574,6 @@ export class LeafLoadBalancer {
     );
     this.pickFirstBalancer = new PickFirstLoadBalancer(
       childChannelControlHelper,
-      credentials,
       { ...options, [REPORT_HEALTH_STATUS_OPTION_NAME]: true }
     );
     this.latestPicker = new QueuePicker(this.pickFirstBalancer);

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -39,7 +39,6 @@ import {
 } from './subchannel-address';
 import { LeafLoadBalancer } from './load-balancer-pick-first';
 import { ChannelOptions } from './channel-options';
-import { ChannelCredentials } from './channel-credentials';
 
 const TRACER_NAME = 'round_robin';
 
@@ -105,7 +104,6 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
 
   constructor(
     private readonly channelControlHelper: ChannelControlHelper,
-    private readonly credentials: ChannelCredentials,
     private readonly options: ChannelOptions
   ) {
     this.childChannelControlHelper = createChildChannelControlHelper(
@@ -216,7 +214,6 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
         new LeafLoadBalancer(
           endpoint,
           this.childChannelControlHelper,
-          this.credentials,
           this.options
         )
     );

--- a/packages/grpc-js/src/load-balancer.ts
+++ b/packages/grpc-js/src/load-balancer.ts
@@ -24,7 +24,6 @@ import { SubchannelInterface } from './subchannel-interface';
 import { LoadBalancingConfig } from './service-config';
 import { log } from './logging';
 import { LogVerbosity } from './constants';
-import { ChannelCredentials } from './channel-credentials';
 
 /**
  * A collection of functions associated with a channel that a load balancer
@@ -38,8 +37,7 @@ export interface ChannelControlHelper {
    */
   createSubchannel(
     subchannelAddress: SubchannelAddress,
-    subchannelArgs: ChannelOptions,
-    credentialsOverride: ChannelCredentials | null
+    subchannelArgs: ChannelOptions
   ): SubchannelInterface;
   /**
    * Passes a new subchannel picker up to the channel. This is called if either
@@ -132,7 +130,6 @@ export interface LoadBalancer {
 export interface LoadBalancerConstructor {
   new (
     channelControlHelper: ChannelControlHelper,
-    credentials: ChannelCredentials,
     options: ChannelOptions
   ): LoadBalancer;
 }
@@ -176,14 +173,12 @@ export function registerDefaultLoadBalancerType(typeName: string) {
 export function createLoadBalancer(
   config: TypedLoadBalancingConfig,
   channelControlHelper: ChannelControlHelper,
-  credentials: ChannelCredentials,
   options: ChannelOptions
 ): LoadBalancer | null {
   const typeName = config.getLoadBalancerName();
   if (typeName in registeredLoadBalancerTypes) {
     return new registeredLoadBalancerTypes[typeName].LoadBalancer(
       channelControlHelper,
-      credentials,
       options
     );
   } else {

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -40,7 +40,6 @@ import { Endpoint } from './subchannel-address';
 import { GrpcUri, uriToString } from './uri-parser';
 import { ChildLoadBalancerHandler } from './load-balancer-child-handler';
 import { ChannelOptions } from './channel-options';
-import { ChannelCredentials } from './channel-credentials';
 
 const TRACER_NAME = 'resolving_load_balancer';
 
@@ -199,7 +198,6 @@ export class ResolvingLoadBalancer implements LoadBalancer {
   constructor(
     private readonly target: GrpcUri,
     private readonly channelControlHelper: ChannelControlHelper,
-    credentials: ChannelCredentials,
     channelOptions: ChannelOptions,
     private readonly onSuccessfulResolution: ResolutionCallback,
     private readonly onFailedResolution: ResolutionFailureCallback
@@ -245,7 +243,6 @@ export class ResolvingLoadBalancer implements LoadBalancer {
         removeChannelzChild:
           channelControlHelper.removeChannelzChild.bind(channelControlHelper),
       },
-      credentials,
       channelOptions
     );
     this.innerResolver = createResolver(

--- a/packages/grpc-js/test/test-pick-first.ts
+++ b/packages/grpc-js/test/test-pick-first.ts
@@ -31,7 +31,6 @@ import { Metadata } from '../src/metadata';
 import { Picker } from '../src/picker';
 import { Endpoint, subchannelAddressToString } from '../src/subchannel-address';
 import { MockSubchannel, TestClient, TestServer } from './common';
-import { credentials } from '../src';
 
 function updateStateCallBackForExpectedStateSequence(
   expectedStateSequence: ConnectivityState[],
@@ -98,7 +97,6 @@ describe('Shuffler', () => {
 describe('pick_first load balancing policy', () => {
   const config = new PickFirstLoadBalancingConfig(false);
   let subchannels: MockSubchannel[] = [];
-  const creds = credentials.createInsecure();
   const baseChannelControlHelper: ChannelControlHelper = {
     createSubchannel: (subchannelAddress, subchannelArgs) => {
       const subchannel = new MockSubchannel(
@@ -125,7 +123,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -144,7 +142,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -166,7 +164,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         {
@@ -200,7 +198,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -216,7 +214,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -238,7 +236,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -263,7 +261,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -302,7 +300,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -329,7 +327,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -360,7 +358,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -398,7 +396,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [
         { addresses: [{ host: 'localhost', port: 1 }] },
@@ -433,7 +431,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -461,7 +459,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -496,7 +494,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -531,7 +529,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -577,7 +575,7 @@ describe('pick_first load balancing policy', () => {
         },
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -637,7 +635,7 @@ describe('pick_first load balancing policy', () => {
         },
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -678,7 +676,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList(
       [{ addresses: [{ host: 'localhost', port: 1 }] }],
       config
@@ -700,7 +698,7 @@ describe('pick_first load balancing policy', () => {
         ),
       }
     );
-    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+    const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
     pickFirst.updateAddressList([], config);
   });
   describe('Address list randomization', () => {
@@ -735,7 +733,7 @@ describe('pick_first load balancing policy', () => {
       for (let i = 0; i < 10; i++) {
         endpoints.push({ addresses: [{ host: 'localhost', port: i + 1 }] });
       }
-      const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+      const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
       /* Pick from 10 subchannels 5 times, with address randomization enabled,
        * and verify that at least two different subchannels are picked. The
        * probability choosing the same address every time is 1/10,000, which
@@ -791,7 +789,7 @@ describe('pick_first load balancing policy', () => {
       for (let i = 0; i < 10; i++) {
         endpoints.push({ addresses: [{ host: 'localhost', port: i + 1 }] });
       }
-      const pickFirst = new PickFirstLoadBalancer(channelControlHelper, creds, {});
+      const pickFirst = new PickFirstLoadBalancer(channelControlHelper, {});
       pickFirst.updateAddressList(endpoints, config);
       process.nextTick(() => {
         pickFirst.updateAddressList(endpoints, config);


### PR DESCRIPTION
This reverts PR #2821. After discussions in the team, I decided that it makes more sense to go in a different direction to implement xDS channel credentials.