### PR TITLE
Declare generated GrpcType inheritance

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -760,12 +760,12 @@ function generateRootFile(formatter: TextFormatter, root: Protobuf.Root, options
   generateServiceImports(formatter, root, options);
   formatter.writeLine('');
 
-  formatter.writeLine('type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {');
+  formatter.writeLine('type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = grpc.ServiceClientConstructor & {');
   formatter.writeLine('  new(...args: ConstructorParameters<Constructor>): Subtype;');
   formatter.writeLine('};');
   formatter.writeLine('');
 
-  formatter.writeLine('export interface ProtoGrpcType {');
+  formatter.writeLine('export interface ProtoGrpcType extends grpc.GrpcObject {');
   formatter.indent();
   for (const nested of root.nestedArray) {
     generateSingleLoadedDefinitionType(formatter, nested, options);


### PR DESCRIPTION
Generated interface ProtoGrpcType is in fact an extension of grpc.GrpcObject, but this inheritance wasn't declared until now.

This forced users to cast `grpc.loadPackageDefinition(...): grpc.GrpcObject` first to `as unknown` and only then to `as {GeneratedGrpcType}`.

With this fix users will be able to cast to `as {GeneratedGrpcType}` directly.

Fixes #2851