### PR TITLE
grpc-js: Add security connector, rework connection establishment

### DIFF
--- a/packages/grpc-js/test/test-channel-credentials.ts
+++ b/packages/grpc-js/test/test-channel-credentials.ts
@@ -69,46 +69,7 @@ const pFixtures = Promise.all(
 });
 
 describe('ChannelCredentials Implementation', () => {
-  describe('createInsecure', () => {
-    it('should return a ChannelCredentials object with no associated secure context', () => {
-      const creds = assert2.noThrowAndReturn(() =>
-        ChannelCredentials.createInsecure()
-      );
-      assert.ok(!creds._getConnectionOptions()?.secureContext);
-    });
-  });
-
   describe('createSsl', () => {
-    it('should work when given no arguments', () => {
-      const creds: ChannelCredentials = assert2.noThrowAndReturn(() =>
-        ChannelCredentials.createSsl()
-      );
-      assert.ok(!!creds._getConnectionOptions());
-    });
-
-    it('should work with just a CA override', async () => {
-      const { ca } = await pFixtures;
-      const creds = assert2.noThrowAndReturn(() =>
-        ChannelCredentials.createSsl(ca)
-      );
-      assert.ok(!!creds._getConnectionOptions());
-    });
-
-    it('should work with just a private key and cert chain', async () => {
-      const { key, cert } = await pFixtures;
-      const creds = assert2.noThrowAndReturn(() =>
-        ChannelCredentials.createSsl(null, key, cert)
-      );
-      assert.ok(!!creds._getConnectionOptions());
-    });
-
-    it('should work with three parameters specified', async () => {
-      const { ca, key, cert } = await pFixtures;
-      const creds = assert2.noThrowAndReturn(() =>
-        ChannelCredentials.createSsl(ca, key, cert)
-      );
-      assert.ok(!!creds._getConnectionOptions());
-    });
 
     it('should throw if just one of private key and cert chain are missing', async () => {
       const { ca, key, cert } = await pFixtures;


### PR DESCRIPTION
This modifies the `ChannelCredentials` API so that instead of providing the connection options which are used to establish a TLS connection, it provides a `SecurityConnector`, which is created using information about a specific subchannel, and is responsible for establishing TLS connections on top of TCP connections.

With this change, the steps of establishing an HTTP/2 session are more cleanly divided:

 - The transport establishes the TCP connection, potentially delegating to the proxy connection code.
 - The security connector establishes the TLS connection on top of the TCP connection (or passes it through untouched, in the case of insecure credentials)
 - The transport creates the HTTP/2 session on top of the socket provided by the security connector.