### PR TITLE
grpc-js-xds: Update `@types/node` and update code for compatibility

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -37,7 +37,7 @@
     "@types/gulp": "^4.0.6",
     "@types/gulp-mocha": "0.0.32",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^13.11.1",
+    "@types/node": ">=20.11.20",
     "@types/yargs": "^15.0.5",
     "find-free-ports": "^3.1.1",
     "gts": "^5.0.1",

--- a/packages/grpc-js-xds/src/load-balancer-priority.ts
+++ b/packages/grpc-js-xds/src/load-balancer-priority.ts
@@ -184,8 +184,8 @@ export class PriorityLoadBalancer implements LoadBalancer {
     private connectivityState: ConnectivityState = ConnectivityState.IDLE;
     private picker: Picker;
     private childBalancer: ChildLoadBalancerHandler;
-    private failoverTimer: NodeJS.Timer | null = null;
-    private deactivationTimer: NodeJS.Timer | null = null;
+    private failoverTimer: NodeJS.Timeout | null = null;
+    private deactivationTimer: NodeJS.Timeout | null = null;
     private seenReadyOrIdleSinceTransientFailure = false;
     constructor(private parent: PriorityLoadBalancer, private name: string, ignoreReresolutionRequests: boolean) {
       this.childBalancer = new ChildLoadBalancerHandler(experimental.createChildChannelControlHelper(this.parent.channelControlHelper, {

--- a/packages/grpc-js-xds/src/load-balancer-weighted-target.ts
+++ b/packages/grpc-js-xds/src/load-balancer-weighted-target.ts
@@ -170,7 +170,7 @@ export class WeightedTargetLoadBalancer implements LoadBalancer {
     private connectivityState: ConnectivityState = ConnectivityState.IDLE;
     private picker: Picker;
     private childBalancer: ChildLoadBalancerHandler;
-    private deactivationTimer: NodeJS.Timer | null = null;
+    private deactivationTimer: NodeJS.Timeout | null = null;
     private weight: number = 0;
 
     constructor(private parent: WeightedTargetLoadBalancer, private name: string) {

--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -104,7 +104,7 @@ export class Watcher<UpdateType> implements ResourceWatcherInterface {
 const RESOURCE_TIMEOUT_MS = 15_000;
 
 class ResourceTimer {
-  private timer: NodeJS.Timer | null = null;
+  private timer: NodeJS.Timeout | null = null;
   private resourceSeen = false;
   constructor(private callState: AdsCallState, private type: XdsResourceType, private name: XdsResourceName) {}
 
@@ -673,7 +673,7 @@ class ClusterLoadReportMap {
 }
 
 class LrsCallState {
-  private statsTimer: NodeJS.Timer | null = null;
+  private statsTimer: NodeJS.Timeout | null = null;
   private sentInitialMessage = false;
   constructor(private client: XdsSingleServerClient, private call: LrsCall, private node: Node) {
     call.on('data', (message: LoadStatsResponse__Output) => {

--- a/packages/grpc-js-xds/test/client.ts
+++ b/packages/grpc-js-xds/test/client.ts
@@ -42,7 +42,7 @@ const BOOTSTRAP_CONFIG_KEY = 'grpc.TEST_ONLY_DO_NOT_USE_IN_PROD.xds_bootstrap_co
 
 export class XdsTestClient {
   private client: EchoTestServiceClient;
-  private callInterval: NodeJS.Timer;
+  private callInterval: NodeJS.Timeout;
 
   constructor(target: string, bootstrapInfo: string, creds?: ChannelCredentials | undefined, options?: ChannelOptions) {
     this.client = new loadedProtos.grpc.testing.EchoTestService(target, creds ?? credentials.createInsecure(), {...options, [BOOTSTRAP_CONFIG_KEY]: bootstrapInfo});


### PR DESCRIPTION
The old version of `@types/node` had a declaration of the `Buffer` declaration that is incompatible with new versions of TypeScript, so this update resolves that. The only changes that needed to be addressed with code changes were:

 1. The `NodeJS.Timer` type has been replaced with `NodeJS.Timeout`.
 2. The `localAddress` field in the `Socket` type is no longer guaranteed to be populated.