### PR TITLE
grpc-js: Restore socket disconnect handling

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -227,6 +227,11 @@ class Http2Transport implements Transport {
       this.handleDisconnect();
     });
 
+    session.socket.once('close', () => {
+      this.trace('connection closed');
+      this.handleDisconnect();
+    });
+
     if (logging.isTracerEnabled(TRACER_NAME)) {
       session.on('remoteSettings', (settings: http2.Settings) => {
         this.trace(


### PR DESCRIPTION
With this change, socket closure causes open streams to report UNAVAILABLE instead of another code when possible. This handling previously existed, but was lost in the refactor that added the transport.