### PR TITLE
grpc-js: Improve event sequencing when handling connection drops

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -387,17 +387,13 @@ class Http2Transport implements Transport {
    * Handle connection drops, but not GOAWAYs.
    */
   private handleDisconnect() {
-    if (this.disconnectHandled) {
-      return;
-    }
     this.clearKeepaliveTimeout();
     this.reportDisconnectToOwner(false);
-    /* Give calls an event loop cycle to finish naturally before reporting the
-     * disconnnection to them. */
+    for (const call of this.activeCalls) {
+      call.onDisconnect();
+    }
+    // Wait an event loop cycle before destroying the connection
     setImmediate(() => {
-      for (const call of this.activeCalls) {
-        call.onDisconnect();
-      }
       this.session.destroy();
     });
   }


### PR DESCRIPTION
This changes a few things to try to report connection drops with the UNAVAILABLE status more consistently:

 - The transport now passes the connection drop event along to the call even if a GOAWAY has already been handled. This is important in the server-side graceful connection shutdown case, in which the server always first sends a GOAWAY and then drops the connection seconds later.
 - The transport now passes the connection drop event along immediately instead of waiting with a `setImmediate`, to ensure that the call sees the event as quickly as possible.
 - The call now delays handling the event with a `setImmediate` to mimic the old sequencing in most cases, but first flags that a connection drop event was seen. User reports indicate that Node (or nghttp2) probably synthesizes a RST_STREAM with the code CANCEL when a connection drops, so if the connection drop flag is set we treat that code as UNAVAILABLE instead of CANCELLED.