### PR TITLE
feat(grpc-js): allow configurable http2 initial window size

### DIFF
--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -70,6 +70,7 @@ Many channel arguments supported in `grpc` are not supported in `@grpc/grpc-js`.
   - `grpc-node.max_session_memory`
   - `grpc-node.tls_enable_trace`
   - `grpc-node.retry_max_attempts_limit`
+  - `grpc-node.http2_initial_window_size`
   - `channelOverride`
   - `channelFactoryOverride`
 

--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -70,7 +70,7 @@ Many channel arguments supported in `grpc` are not supported in `@grpc/grpc-js`.
   - `grpc-node.max_session_memory`
   - `grpc-node.tls_enable_trace`
   - `grpc-node.retry_max_attempts_limit`
-  - `grpc-node.http2_initial_window_size`
+  - `grpc-node.flow_control_window`
   - `channelOverride`
   - `channelFactoryOverride`
 

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -102,7 +102,7 @@ export const recognizedOptions = {
   'grpc-node.tls_enable_trace': true,
   'grpc.lb.ring_hash.ring_size_cap': true,
   'grpc-node.retry_max_attempts_limit': true,
-  'grpc-node.http2_initial_window_size': true,
+  'grpc-node.flow_control_window': true,
 };
 
 export function channelOptionsEqual(

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -64,7 +64,7 @@ export interface ChannelOptions {
   'grpc-node.tls_enable_trace'?: number;
   'grpc.lb.ring_hash.ring_size_cap'?: number;
   'grpc-node.retry_max_attempts_limit'?: number;
-  'grpc-node.http2_initial_window_size'?: number;
+  'grpc-node.flow_control_window'?: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }

--- a/packages/grpc-js/src/channel-options.ts
+++ b/packages/grpc-js/src/channel-options.ts
@@ -64,6 +64,7 @@ export interface ChannelOptions {
   'grpc-node.tls_enable_trace'?: number;
   'grpc.lb.ring_hash.ring_size_cap'?: number;
   'grpc-node.retry_max_attempts_limit'?: number;
+  'grpc-node.http2_initial_window_size'?: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
@@ -101,6 +102,7 @@ export const recognizedOptions = {
   'grpc-node.tls_enable_trace': true,
   'grpc.lb.ring_hash.ring_size_cap': true,
   'grpc-node.retry_max_attempts_limit': true,
+  'grpc-node.http2_initial_window_size': true,
 };
 
 export function channelOptionsEqual(

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -672,6 +672,11 @@ export class Http2SubchannelConnector implements SubchannelConnector {
       const session = http2.connect(`http://${targetPath}`, {
         createConnection: (authority, option) => {
           return underlyingConnection;
+        },
+        settings: {
+          initialWindowSize:
+            options['grpc-node.http2_initial_window_size'] ||
+            http2.getDefaultSettings().initialWindowSize,
         }
       });
       this.session = session;

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -675,7 +675,7 @@ export class Http2SubchannelConnector implements SubchannelConnector {
         },
         settings: {
           initialWindowSize:
-            options['grpc-node.http2_initial_window_size'] ||
+            options['grpc-node.flow_control_window'] ??
             http2.getDefaultSettings().initialWindowSize,
         }
       });


### PR DESCRIPTION
This PR adds support for setting an `initialWindowSize` in the http2 session. This fixes #2429, as described in the issue the default window size is 64Kb which is OK for typical http2 use cases but isn't so good for usage inside internal networks with larger response sizes.

I have chosen to add a channel option to implement this as it seemed the most sensible way to make this change. Please advise if there is a better way to achieve this.