### PR TITLE
grpc-js-xds: Add XdsChannelCredentials

### DIFF
--- a/packages/grpc-js-xds/src/index.ts
+++ b/packages/grpc-js-xds/src/index.ts
@@ -31,7 +31,7 @@ import * as typed_struct_lb from './lb-policy-registry/typed-struct';
 import * as pick_first_lb from './lb-policy-registry/pick-first';
 
 export { XdsServer } from './server';
-export { XdsServerCredentials } from './xds-credentials';
+export { XdsChannelCredentials, XdsServerCredentials } from './xds-credentials';
 
 /**
  * Register the "xds:" name scheme with the @grpc/grpc-js library.

--- a/packages/grpc-js-xds/src/resources.ts
+++ b/packages/grpc-js-xds/src/resources.ts
@@ -29,6 +29,7 @@ import { ClusterConfig__Output } from './generated/envoy/extensions/clusters/agg
 import { HttpConnectionManager__Output } from './generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpConnectionManager';
 import { EXPERIMENTAL_FEDERATION } from './environment';
 import { DownstreamTlsContext__Output } from './generated/envoy/extensions/transport_sockets/tls/v3/DownstreamTlsContext';
+import { UpstreamTlsContext__Output } from './generated/envoy/extensions/transport_sockets/tls/v3/UpstreamTlsContext';
 
 export const EDS_TYPE_URL = 'type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment';
 export const CDS_TYPE_URL = 'type.googleapis.com/envoy.config.cluster.v3.Cluster';
@@ -55,10 +56,16 @@ export const DOWNSTREAM_TLS_CONTEXT_TYPE_URL = 'type.googleapis.com/envoy.extens
 
 export type DownstreamTlsContextTypeUrl = 'type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext';
 
+export const UPSTREAM_TLS_CONTEXT_TYPE_URL = 'type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext';
+
+export type UpstreamTlsContextTypeUrl = 'type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext';
+
+export type ResourceTypeUrl = AdsTypeUrl | HttpConnectionManagerTypeUrl | ClusterConfigTypeUrl | DownstreamTlsContextTypeUrl | UpstreamTlsContextTypeUrl;
+
 /**
  * Map type URLs to their corresponding message types
  */
-export type AdsOutputType<T extends AdsTypeUrl | HttpConnectionManagerTypeUrl | ClusterConfigTypeUrl | DownstreamTlsContextTypeUrl> = T extends EdsTypeUrl
+export type AdsOutputType<T extends ResourceTypeUrl> = T extends EdsTypeUrl
   ? ClusterLoadAssignment__Output
   : T extends CdsTypeUrl
   ? Cluster__Output
@@ -70,6 +77,8 @@ export type AdsOutputType<T extends AdsTypeUrl | HttpConnectionManagerTypeUrl | 
   ? HttpConnectionManager__Output
   : T extends ClusterConfigTypeUrl
   ? ClusterConfig__Output
+  : T extends UpstreamTlsContextTypeUrl
+  ? UpstreamTlsContext__Output
   : DownstreamTlsContext__Output;
 
 
@@ -100,7 +109,7 @@ const toObjectOptions = {
   oneofs: true
 }
 
-export function decodeSingleResource<T extends AdsTypeUrl | HttpConnectionManagerTypeUrl | ClusterConfigTypeUrl | DownstreamTlsContextTypeUrl>(targetTypeUrl: T, message: Buffer): AdsOutputType<T> {
+export function decodeSingleResource<T extends ResourceTypeUrl>(targetTypeUrl: T, message: Buffer): AdsOutputType<T> {
   const name = targetTypeUrl.substring(targetTypeUrl.lastIndexOf('/') + 1);
   const type = resourceRoot.lookup(name);
   if (type) {

--- a/packages/grpc-js-xds/src/xds-credentials.ts
+++ b/packages/grpc-js-xds/src/xds-credentials.ts
@@ -15,7 +15,43 @@
  *
  */
 
-import { ServerCredentials } from "@grpc/grpc-js";
+import { CallCredentials, ChannelCredentials, ChannelOptions, ServerCredentials, VerifyOptions, experimental } from "@grpc/grpc-js";
+import { CA_CERT_PROVIDER_KEY, IDENTITY_CERT_PROVIDER_KEY, SAN_MATCHER_KEY, SanMatcher } from "./load-balancer-cds";
+import GrpcUri = experimental.GrpcUri;
+import SecureConnector = experimental.SecureConnector;
+import createCertificateProviderChannelCredentials = experimental.createCertificateProviderChannelCredentials;
+
+export class XdsChannelCredentials extends ChannelCredentials {
+  constructor(private fallbackCredentials: ChannelCredentials) {
+    super();
+  }
+  _isSecure(): boolean {
+    return true;
+  }
+  _equals(other: ChannelCredentials): boolean {
+    return other instanceof XdsChannelCredentials && this.fallbackCredentials === other.fallbackCredentials;
+  }
+  _createSecureConnector(channelTarget: GrpcUri, options: ChannelOptions, callCredentials?: CallCredentials): SecureConnector {
+    if (options[CA_CERT_PROVIDER_KEY]) {
+      const verifyOptions: VerifyOptions = {};
+      if (options[SAN_MATCHER_KEY]) {
+        const matcher = options[SAN_MATCHER_KEY] as SanMatcher;
+        verifyOptions.checkServerIdentity = (hostname, cert) => {
+          if (cert.subjectaltname && matcher.apply(cert.subjectaltname)) {
+            return undefined;
+          } else {
+            return new Error('No matching subject alternative name found in certificate');
+          }
+        }
+      }
+      const certProviderCreds = createCertificateProviderChannelCredentials(options[CA_CERT_PROVIDER_KEY], options[IDENTITY_CERT_PROVIDER_KEY] ?? null, verifyOptions);
+      return certProviderCreds._createSecureConnector(channelTarget, options, callCredentials);
+    } else {
+      return this.fallbackCredentials._createSecureConnector(channelTarget, options, callCredentials);
+    }
+  }
+
+}
 
 export class XdsServerCredentials extends ServerCredentials {
   constructor(private fallbackCredentials: ServerCredentials) {

--- a/packages/grpc-js-xds/src/xds-resource-type/listener-resource-type.ts
+++ b/packages/grpc-js-xds/src/xds-resource-type/listener-resource-type.ts
@@ -198,6 +198,21 @@ function validateFilterChain(context: XdsDecodeContext, filterChain: FilterChain
       trace('require_client_certificate set without validationContext');
       return false;
     }
+    if (validationContext && validationContext.verify_certificate_spki.length > 0) {
+      return false;
+    }
+    if (validationContext && validationContext.verify_certificate_hash.length > 0) {
+      return false;
+    }
+    if (validationContext?.require_signed_certificate_timestamp) {
+      return false;
+    }
+    if (validationContext?.crl) {
+      return false;
+    }
+    if (validationContext?.custom_validator_config) {
+      return false;
+    }
     if (commonTlsContext.tls_params) {
       trace('tls_params set');
       return false;

--- a/packages/grpc-js-xds/test/client.ts
+++ b/packages/grpc-js-xds/test/client.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { ChannelCredentials, ChannelOptions, credentials, loadPackageDefinition, ServiceError } from "@grpc/grpc-js";
+import { ChannelCredentials, ChannelOptions, credentials, loadPackageDefinition, Metadata, ServiceError } from "@grpc/grpc-js";
 import { loadSync } from "@grpc/proto-loader";
 import { ProtoGrpcType } from "./generated/echo";
 import { EchoTestServiceClient } from "./generated/grpc/testing/EchoTestService";
@@ -76,7 +76,7 @@ export class XdsTestClient {
 
   sendOneCall(callback: (error: ServiceError | null) => void) {
     const deadline = new Date();
-    deadline.setMilliseconds(deadline.getMilliseconds() + 500);
+    deadline.setMilliseconds(deadline.getMilliseconds() + 1500);
     this.client.echo({message: 'test'}, {deadline}, (error, value) => {
       callback(error);
     });

--- a/packages/grpc-js-xds/test/test-xds-credentials.ts
+++ b/packages/grpc-js-xds/test/test-xds-credentials.ts
@@ -20,14 +20,20 @@ import { createBackends } from './backend';
 import { FakeEdsCluster, FakeRouteGroup, FakeServerRoute } from './framework';
 import { ControlPlaneServer } from './xds-server';
 import { XdsTestClient } from './client';
-import { XdsServerCredentials } from '../src';
-import { credentials, ServerCredentials } from '@grpc/grpc-js';
+import { XdsChannelCredentials, XdsServerCredentials } from '../src';
+import { credentials, ServerCredentials, experimental } from '@grpc/grpc-js';
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import { Listener } from '../src/generated/envoy/config/listener/v3/Listener';
 import { DownstreamTlsContext } from '../src/generated/envoy/extensions/transport_sockets/tls/v3/DownstreamTlsContext';
 import { AnyExtension } from '@grpc/proto-loader';
 import { DOWNSTREAM_TLS_CONTEXT_TYPE_URL } from '../src/resources';
+import { UpstreamTlsContext } from '../src/generated/envoy/extensions/transport_sockets/tls/v3/UpstreamTlsContext';
+import { StringMatcher } from '../src/generated/envoy/type/matcher/v3/StringMatcher';
+import FileWatcherCertificateProvider = experimental.FileWatcherCertificateProvider;
+import createCertificateProviderChannelCredentials = experimental.createCertificateProviderChannelCredentials;
+
+const caPath = path.join(__dirname, 'fixtures', 'ca.pem');
 
 const ca = readFileSync(path.join(__dirname, 'fixtures', 'ca.pem'));
 const key = readFileSync(path.join(__dirname, 'fixtures', 'server1.key'));
@@ -166,5 +172,198 @@ describe('Server xDS Credentials', () => {
     });
     const error = await client.sendOneCallAsync();
     assert.strictEqual(error, null);
+  });
+});
+describe('Client xDS credentials', () => {
+  let xdsServer: ControlPlaneServer;
+  let client: XdsTestClient;
+  beforeEach(done => {
+    xdsServer = new ControlPlaneServer();
+    xdsServer.startServer(error => {
+      done(error);
+    });
+  });
+  afterEach(() => {
+    client?.close();
+    xdsServer?.shutdownServer();
+  });
+  it('Should use fallback credentials when certificate providers are not configured', async () => {
+    const [backend] = await createBackends(1, true, ServerCredentials.createInsecure());
+    const serverRoute = new FakeServerRoute(backend.getPort(), 'serverRoute');
+    xdsServer.setRdsResource(serverRoute.getRouteConfiguration());
+    xdsServer.setLdsResource(serverRoute.getListener());
+    xdsServer.addResponseListener((typeUrl, responseState) => {
+      if (responseState.state === 'NACKED') {
+        client?.stopCalls();
+        assert.fail(`Client NACKED ${typeUrl} resource with message ${responseState.errorMessage}`);
+      }
+    });
+    const cluster = new FakeEdsCluster('cluster1', 'endpoint1', [{backends: [backend], locality:{region: 'region1'}}]);
+    const routeGroup = new FakeRouteGroup('listener1', 'route1', [{cluster: cluster}]);
+    await routeGroup.startAllBackends(xdsServer);
+    xdsServer.setEdsResource(cluster.getEndpointConfig());
+    xdsServer.setCdsResource(cluster.getClusterConfig());
+    xdsServer.setRdsResource(routeGroup.getRouteConfiguration());
+    xdsServer.setLdsResource(routeGroup.getListener());
+    client = XdsTestClient.createFromServer('listener1', xdsServer, new XdsChannelCredentials(credentials.createInsecure()));
+    const error = await client.sendOneCallAsync();
+    assert.strictEqual(error, null);
+  });
+  it('Should use CA certificates when configured', async () => {
+    const [backend] = await createBackends(1, true, ServerCredentials.createSsl(null, [{private_key: key, cert_chain: cert}]));
+    const serverRoute = new FakeServerRoute(backend.getPort(), 'serverRoute');
+    xdsServer.setRdsResource(serverRoute.getRouteConfiguration());
+    xdsServer.setLdsResource(serverRoute.getListener());
+    xdsServer.addResponseListener((typeUrl, responseState) => {
+      if (responseState.state === 'NACKED') {
+        client?.stopCalls();
+        assert.fail(`Client NACKED ${typeUrl} resource with message ${responseState.errorMessage}`);
+      }
+    });
+    const upstreamTlsContext: UpstreamTlsContext = {
+      common_tls_context: {
+        validation_context: {
+          ca_certificate_provider_instance: {
+            instance_name: 'test_certificates'
+          }
+        }
+      }
+    };
+    const cluster = new FakeEdsCluster('cluster1', 'endpoint1', [{backends: [backend], locality:{region: 'region1'}}], undefined, upstreamTlsContext);
+    const routeGroup = new FakeRouteGroup('listener1', 'route1', [{cluster: cluster}]);
+    await routeGroup.startAllBackends(xdsServer);
+    xdsServer.setEdsResource(cluster.getEndpointConfig());
+    xdsServer.setCdsResource(cluster.getClusterConfig());
+    xdsServer.setRdsResource(routeGroup.getRouteConfiguration());
+    xdsServer.setLdsResource(routeGroup.getListener());
+    client = XdsTestClient.createFromServer('listener1', xdsServer, new XdsChannelCredentials(credentials.createInsecure()));
+    const error = await client.sendOneCallAsync();
+    assert.strictEqual(error, null);
+  });
+  it('Should use identity and CA certificates when configured', async () => {
+    const [backend] = await createBackends(1, true, ServerCredentials.createSsl(ca, [{private_key: key, cert_chain: cert}], true));
+    const serverRoute = new FakeServerRoute(backend.getPort(), 'serverRoute');
+    xdsServer.setRdsResource(serverRoute.getRouteConfiguration());
+    xdsServer.setLdsResource(serverRoute.getListener());
+    xdsServer.addResponseListener((typeUrl, responseState) => {
+      if (responseState.state === 'NACKED') {
+        client?.stopCalls();
+        assert.fail(`Client NACKED ${typeUrl} resource with message ${responseState.errorMessage}`);
+      }
+    });
+    const upstreamTlsContext: UpstreamTlsContext = {
+      common_tls_context: {
+        tls_certificate_provider_instance: {
+          instance_name: 'test_certificates'
+        },
+        validation_context: {
+          ca_certificate_provider_instance: {
+            instance_name: 'test_certificates'
+          }
+        }
+      }
+    };
+    const cluster = new FakeEdsCluster('cluster1', 'endpoint1', [{backends: [backend], locality:{region: 'region1'}}], undefined, upstreamTlsContext);
+    const routeGroup = new FakeRouteGroup('listener1', 'route1', [{cluster: cluster}]);
+    await routeGroup.startAllBackends(xdsServer);
+    xdsServer.setEdsResource(cluster.getEndpointConfig());
+    xdsServer.setCdsResource(cluster.getClusterConfig());
+    xdsServer.setRdsResource(routeGroup.getRouteConfiguration());
+    xdsServer.setLdsResource(routeGroup.getListener());
+    client = XdsTestClient.createFromServer('listener1', xdsServer, new XdsChannelCredentials(credentials.createInsecure()));
+    const error = await client.sendOneCallAsync();
+    assert.strictEqual(error, null);
+  });
+  describe('Subject Alternative Name matching', () => {
+    interface SanTestCase {
+      name: string;
+      matchers: StringMatcher[];
+      expectedSuccess: boolean;
+    }
+    const testCases: SanTestCase[] = [
+      {
+        name: 'empty match',
+        matchers: [],
+        expectedSuccess: true
+      },
+      {
+        name: 'exact DNS match',
+        matchers: [{
+          exact: 'waterzooi.test.google.be',
+          ignore_case: false
+        }],
+        expectedSuccess: true
+      },
+      {
+        name: 'wildcard DNS match',
+        matchers: [{
+          exact: 'foo.test.google.fr',
+          ignore_case: false
+        }],
+        expectedSuccess: true
+      },
+      {
+        name: 'exact IP match',
+        matchers: [{
+          exact: '192.168.1.3',
+          ignore_case: false
+        }],
+        expectedSuccess: true
+      },
+      {
+        name: 'suffix match',
+        matchers: [{
+          suffix: 'test.google.fr',
+          ignore_case: false
+        }],
+        expectedSuccess: true
+      },
+      {
+        name: 'unmatched matcher',
+        matchers: [{
+          exact: 'incorret',
+          ignore_case: false
+        }],
+        expectedSuccess: false
+      },
+    ];
+    for (const {name, matchers, expectedSuccess} of testCases) {
+      it(name, async () => {
+        const [backend] = await createBackends(1, true, ServerCredentials.createSsl(null, [{private_key: key, cert_chain: cert}]));
+        const serverRoute = new FakeServerRoute(backend.getPort(), 'serverRoute');
+        xdsServer.setRdsResource(serverRoute.getRouteConfiguration());
+        xdsServer.setLdsResource(serverRoute.getListener());
+        xdsServer.addResponseListener((typeUrl, responseState) => {
+          if (responseState.state === 'NACKED') {
+            client?.stopCalls();
+            assert.fail(`Client NACKED ${typeUrl} resource with message ${responseState.errorMessage}`);
+          }
+        });
+        const upstreamTlsContext: UpstreamTlsContext = {
+          common_tls_context: {
+            validation_context: {
+              ca_certificate_provider_instance: {
+                instance_name: 'test_certificates'
+              },
+              match_subject_alt_names: matchers
+            }
+          }
+        };
+        const cluster = new FakeEdsCluster('cluster1', 'endpoint1', [{backends: [backend], locality:{region: 'region1'}}], undefined, upstreamTlsContext);
+        const routeGroup = new FakeRouteGroup('listener1', 'route1', [{cluster: cluster}]);
+        await routeGroup.startAllBackends(xdsServer);
+        xdsServer.setEdsResource(cluster.getEndpointConfig());
+        xdsServer.setCdsResource(cluster.getClusterConfig());
+        xdsServer.setRdsResource(routeGroup.getRouteConfiguration());
+        xdsServer.setLdsResource(routeGroup.getListener());
+        client = XdsTestClient.createFromServer('listener1', xdsServer, new XdsChannelCredentials(credentials.createInsecure()));
+        const error = await client.sendOneCallAsync();
+        if (expectedSuccess) {
+          assert.strictEqual(error, null);
+        } else {
+          assert.ok(error);
+        }
+      });
+    }
   });
 });

--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -63,5 +63,5 @@ export {
   FileWatcherCertificateProvider,
   FileWatcherCertificateProviderConfig
 } from './certificate-provider';
-export { createCertificateProviderChannelCredentials } from './channel-credentials';
+export { createCertificateProviderChannelCredentials, SecureConnector } from './channel-credentials';
 export { SUBCHANNEL_ARGS_EXCLUDE_KEY_PREFIX } from './internal-channel';

--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -759,7 +759,6 @@ export class InternalChannel {
       method,
       finalOptions,
       this.filterStackFactory.clone(),
-      this.credentials._getCallCredentials(),
       callNumber
     );
 

--- a/packages/grpc-js/src/load-balancing-call.ts
+++ b/packages/grpc-js/src/load-balancing-call.ts
@@ -161,7 +161,8 @@ export class LoadBalancingCall implements Call, DeadlineInfoProvider {
     );
     switch (pickResult.pickResultType) {
       case PickResultType.COMPLETE:
-        this.credentials
+        const combinedCallCredentials = this.credentials.compose(pickResult.subchannel!.getCallCredentials());
+        combinedCallCredentials
           .generateMetadata({ method_name: this.methodName, service_url: this.serviceUrl })
           .then(
             credsMetadata => {

--- a/packages/grpc-js/src/resolving-call.ts
+++ b/packages/grpc-js/src/resolving-call.ts
@@ -62,12 +62,18 @@ export class ResolvingCall implements Call {
   private configReceivedTime: Date | null = null;
   private childStartTime: Date | null = null;
 
+  /**
+   * Credentials configured for this specific call. Does not include
+   * call credentials associated with the channel credentials used to create
+   * the channel.
+   */
+  private credentials: CallCredentials = CallCredentials.createEmpty();
+
   constructor(
     private readonly channel: InternalChannel,
     private readonly method: string,
     options: CallStreamOptions,
     private readonly filterStackFactory: FilterStackFactory,
-    private credentials: CallCredentials,
     private callNumber: number
   ) {
     this.deadline = options.deadline;
@@ -351,7 +357,7 @@ export class ResolvingCall implements Call {
     }
   }
   setCredentials(credentials: CallCredentials): void {
-    this.credentials = this.credentials.compose(credentials);
+    this.credentials = credentials;
   }
 
   addStatusWatcher(watcher: (status: StatusObject) => void) {

--- a/packages/grpc-js/src/server-credentials.ts
+++ b/packages/grpc-js/src/server-credentials.ts
@@ -338,6 +338,9 @@ class InterceptorServerCredentials extends ServerCredentials {
   override _removeWatcher(watcher: SecureContextWatcher): void {
     this.childCredentials._removeWatcher(watcher);
   }
+  override _getSettings(): SecureServerOptions | null {
+    return this.childCredentials._getSettings();
+  }
 }
 
 export function createServerCredentialsWithInterceptors(credentials: ServerCredentials, interceptors: ServerInterceptor[]): ServerCredentials {

--- a/packages/grpc-js/src/subchannel-interface.ts
+++ b/packages/grpc-js/src/subchannel-interface.ts
@@ -15,6 +15,7 @@
  *
  */
 
+import { CallCredentials } from './call-credentials';
 import type { SubchannelRef } from './channelz';
 import { ConnectivityState } from './connectivity-state';
 import { Subchannel } from './subchannel';
@@ -61,6 +62,11 @@ export interface SubchannelInterface {
    * to avoid implementing getRealSubchannel
    */
   realSubchannelEquals(other: SubchannelInterface): boolean;
+  /**
+   * Get the call credentials associated with the channel credentials for this
+   * subchannel.
+   */
+  getCallCredentials(): CallCredentials;
 }
 
 export abstract class BaseSubchannelWrapper implements SubchannelInterface {
@@ -133,5 +139,8 @@ export abstract class BaseSubchannelWrapper implements SubchannelInterface {
   }
   realSubchannelEquals(other: SubchannelInterface): boolean {
     return this.getRealSubchannel() === other.getRealSubchannel();
+  }
+  getCallCredentials(): CallCredentials {
+    return this.child.getCallCredentials();
   }
 }

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -46,6 +46,7 @@ import {
 import { SubchannelCallInterceptingListener } from './subchannel-call';
 import { SubchannelCall } from './subchannel-call';
 import { CallEventTracker, SubchannelConnector, Transport } from './transport';
+import { CallCredentials } from './call-credentials';
 
 const TRACER_NAME = 'subchannel';
 
@@ -54,7 +55,7 @@ const TRACER_NAME = 'subchannel';
  * to calculate it */
 const KEEPALIVE_MAX_TIME_MS = ~(1 << 31);
 
-export class Subchannel {
+export class Subchannel implements SubchannelInterface {
   /**
    * The subchannel's current connectivity state. Invariant: `session` === `null`
    * if and only if `connectivityState` is IDLE or TRANSIENT_FAILURE.
@@ -514,5 +515,8 @@ export class Subchannel {
     if (newKeepaliveTime > this.keepaliveTime) {
       this.keepaliveTime = newKeepaliveTime;
     }
+  }
+  getCallCredentials(): CallCredentials {
+    return this.secureConnector.getCallCredentials();
   }
 }

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -729,9 +729,17 @@ export class Http2SubchannelConnector implements SubchannelConnector {
     if (this.isShutdown) {
       return Promise.reject();
     }
-    const tcpConnection = await this.tcpConnect(address, options);
-    const secureConnection = await secureConnector.connect(tcpConnection);
-    return this.createSession(secureConnection, address, options);
+    let tcpConnection: net.Socket | null = null;
+    let secureConnection: net.Socket | null  = null;
+    try {
+      tcpConnection = await this.tcpConnect(address, options);
+      secureConnection = await secureConnector.connect(tcpConnection);
+      return this.createSession(secureConnection, address, options);
+    } catch (e) {
+      tcpConnection?.destroy();
+      secureConnection?.destroy();
+      throw e;
+    }
   }
 
   shutdown(): void {

--- a/packages/grpc-js/test/common.ts
+++ b/packages/grpc-js/test/common.ts
@@ -258,6 +258,9 @@ export class MockSubchannel implements SubchannelInterface {
   }
   addHealthStateWatcher(listener: HealthListener): void {}
   removeHealthStateWatcher(listener: HealthListener): void {}
+  getCallCredentials(): grpc.CallCredentials {
+    return grpc.CallCredentials.createEmpty();
+  }
 }
 
 export { assert2 };

--- a/packages/grpc-js/test/test-channel-credentials.ts
+++ b/packages/grpc-js/test/test-channel-credentials.ts
@@ -90,20 +90,6 @@ describe('ChannelCredentials Implementation', () => {
       const composedChannelCreds = channelCreds.compose(callCreds);
       assert.ok(composedChannelCreds instanceof ChannelCredentials);
     });
-
-    it('should be chainable', () => {
-      const callCreds1 = new CallCredentialsMock();
-      const callCreds2 = new CallCredentialsMock();
-      // Associate both call credentials with channelCreds
-      const composedChannelCreds = ChannelCredentials.createSsl()
-        .compose(callCreds1)
-        .compose(callCreds2);
-      // Build a mock object that should be an identical copy
-      const composedCallCreds = callCreds1.compose(callCreds2);
-      const composedChannelCreds2 = ChannelCredentials.createSsl()
-        .compose(composedCallCreds);
-      assert.ok(composedChannelCreds._equals(composedChannelCreds2));
-    });
   });
 });
 


### PR DESCRIPTION
This adds the `XdsChannelCredentials` class, as specified in [gRFC A29](https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md). This also includes some other changes to accommodate that:

 - `CertificateProviderChannelCredentials` have been modified so that if the initial attempt to load certificates is still pending, the secure connector waits for them instead of immediately failing.
 - `CallCredentials` are no longer extracted from `ChannelCredentials` at channel creation time. Instead, they are provided by the secure connector, and by the subchannel that owns it.