### PR TITLE
grpc-js-xds: Update gts to be compatible with typescript version

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -38,7 +38,7 @@
     "@types/mocha": "^5.2.6",
     "@types/node": ">=20.11.20",
     "@types/yargs": "^15.0.5",
-    "gts": "^2.0.2",
+    "gts": "^5.0.1",
     "typescript": "^5.1.3",
     "yargs": "^15.4.1"
   },


### PR DESCRIPTION
`gts` has a peer dependency on `typescript` that was incompatible with the dependency we declared.