### PR TITLE
grpc-js: Propagate error messages through LB policy tree

### DIFF
--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -91,11 +91,11 @@ class RpcBehaviorLoadBalancer implements LoadBalancer {
   private latestConfig: RpcBehaviorLoadBalancingConfig | null = null;
   constructor(channelControlHelper: ChannelControlHelper) {
     const childChannelControlHelper = createChildChannelControlHelper(channelControlHelper, {
-      updateState: (connectivityState, picker) => {
+      updateState: (connectivityState, picker, errorMessage) => {
         if (connectivityState === grpc.connectivityState.READY && this.latestConfig) {
           picker = new RpcBehaviorPicker(picker, this.latestConfig.getRpcBehavior());
         }
-        channelControlHelper.updateState(connectivityState, picker);
+        channelControlHelper.updateState(connectivityState, picker, errorMessage);
       }
     });
     this.child = new ChildLoadBalancerHandler(childChannelControlHelper);

--- a/packages/grpc-js-xds/test/test-custom-lb-policies.ts
+++ b/packages/grpc-js-xds/test/test-custom-lb-policies.ts
@@ -86,11 +86,11 @@ class RpcBehaviorLoadBalancer implements LoadBalancer {
   private latestConfig: RpcBehaviorLoadBalancingConfig | null = null;
   constructor(channelControlHelper: ChannelControlHelper) {
     const childChannelControlHelper = createChildChannelControlHelper(channelControlHelper, {
-      updateState: (state, picker) => {
+      updateState: (state, picker, errorMessage) => {
         if (state === connectivityState.READY && this.latestConfig) {
           picker = new RpcBehaviorPicker(picker, this.latestConfig.getRpcBehavior());
         }
-        channelControlHelper.updateState(state, picker);
+        channelControlHelper.updateState(state, picker, errorMessage);
       }
     });
     this.child = new ChildLoadBalancerHandler(childChannelControlHelper);

--- a/packages/grpc-js/src/load-balancer-child-handler.ts
+++ b/packages/grpc-js/src/load-balancer-child-handler.ts
@@ -47,7 +47,7 @@ export class ChildLoadBalancerHandler {
         subchannelArgs
       );
     }
-    updateState(connectivityState: ConnectivityState, picker: Picker): void {
+    updateState(connectivityState: ConnectivityState, picker: Picker, errorMessage: string | null): void {
       if (this.calledByPendingChild()) {
         if (connectivityState === ConnectivityState.CONNECTING) {
           return;
@@ -58,7 +58,7 @@ export class ChildLoadBalancerHandler {
       } else if (!this.calledByCurrentChild()) {
         return;
       }
-      this.parent.channelControlHelper.updateState(connectivityState, picker);
+      this.parent.channelControlHelper.updateState(connectivityState, picker, errorMessage);
     }
     requestReresolution(): void {
       const latestChild = this.parent.pendingChild ?? this.parent.currentChild;

--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -493,14 +493,15 @@ export class OutlierDetectionLoadBalancer implements LoadBalancer {
           mapEntry?.subchannelWrappers.push(subchannelWrapper);
           return subchannelWrapper;
         },
-        updateState: (connectivityState: ConnectivityState, picker: Picker) => {
+        updateState: (connectivityState: ConnectivityState, picker: Picker, errorMessage: string) => {
           if (connectivityState === ConnectivityState.READY) {
             channelControlHelper.updateState(
               connectivityState,
-              new OutlierDetectionPicker(picker, this.isCountingEnabled())
+              new OutlierDetectionPicker(picker, this.isCountingEnabled()),
+              errorMessage
             );
           } else {
-            channelControlHelper.updateState(connectivityState, picker);
+            channelControlHelper.updateState(connectivityState, picker, errorMessage);
           }
         },
       })

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -164,7 +164,7 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
     } else if (
       this.countChildrenWithState(ConnectivityState.TRANSIENT_FAILURE) > 0
     ) {
-      const errorMessage = `No connection established. Last error: ${this.lastError}`;
+      const errorMessage = `round_robin: No connection established. Last error: ${this.lastError}`;
       this.updateState(
         ConnectivityState.TRANSIENT_FAILURE,
         new UnavailablePicker({

--- a/packages/grpc-js/src/load-balancer-round-robin.ts
+++ b/packages/grpc-js/src/load-balancer-round-robin.ts
@@ -108,13 +108,16 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
     this.childChannelControlHelper = createChildChannelControlHelper(
       channelControlHelper,
       {
-        updateState: (connectivityState, picker) => {
+        updateState: (connectivityState, picker, errorMessage) => {
           /* Ensure that name resolution is requested again after active
            * connections are dropped. This is more aggressive than necessary to
            * accomplish that, so we are counting on resolvers to have
            * reasonable rate limits. */
           if (this.currentState === ConnectivityState.READY && connectivityState !== ConnectivityState.READY) {
             this.channelControlHelper.requestReresolution();
+          }
+          if (errorMessage) {
+            this.lastError = errorMessage;
           }
           this.calculateAndUpdateState();
         },
@@ -153,21 +156,24 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
             picker: child.getPicker(),
           })),
           index
-        )
+        ),
+        null
       );
     } else if (this.countChildrenWithState(ConnectivityState.CONNECTING) > 0) {
-      this.updateState(ConnectivityState.CONNECTING, new QueuePicker(this));
+      this.updateState(ConnectivityState.CONNECTING, new QueuePicker(this), null);
     } else if (
       this.countChildrenWithState(ConnectivityState.TRANSIENT_FAILURE) > 0
     ) {
+      const errorMessage = `No connection established. Last error: ${this.lastError}`;
       this.updateState(
         ConnectivityState.TRANSIENT_FAILURE,
         new UnavailablePicker({
-          details: `No connection established. Last error: ${this.lastError}`,
-        })
+          details: errorMessage,
+        }),
+        errorMessage
       );
     } else {
-      this.updateState(ConnectivityState.IDLE, new QueuePicker(this));
+      this.updateState(ConnectivityState.IDLE, new QueuePicker(this), null);
     }
     /* round_robin should keep all children connected, this is how we do that.
      * We can't do this more efficiently in the individual child's updateState
@@ -180,7 +186,7 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
     }
   }
 
-  private updateState(newState: ConnectivityState, picker: Picker) {
+  private updateState(newState: ConnectivityState, picker: Picker, errorMessage: string | null) {
     trace(
       ConnectivityState[this.currentState] +
         ' -> ' +
@@ -192,7 +198,7 @@ export class RoundRobinLoadBalancer implements LoadBalancer {
       this.currentReadyPicker = null;
     }
     this.currentState = newState;
-    this.channelControlHelper.updateState(newState, picker);
+    this.channelControlHelper.updateState(newState, picker, errorMessage);
   }
 
   private resetSubchannelList() {

--- a/packages/grpc-js/src/load-balancer.ts
+++ b/packages/grpc-js/src/load-balancer.ts
@@ -46,7 +46,11 @@ export interface ChannelControlHelper {
    * @param connectivityState New connectivity state
    * @param picker New picker
    */
-  updateState(connectivityState: ConnectivityState, picker: Picker): void;
+  updateState(
+    connectivityState: ConnectivityState,
+    picker: Picker,
+    errorMessage: string | null
+  ): void;
   /**
    * Request new data from the resolver.
    */


### PR DESCRIPTION
This modifies the `ChannelControlHelper#updateState` function signature to add an `errorMessage` argument, which can be either a string or null. The expectation is that it should be a string when the status is TRANSIENT_FAILURE, and null otherwise. The purpose of this is to enable LB policies with multiple children to provide some error information from clients when synthesizing an aggregate status to be passed to their parents. In order to avoid including excessive information in the status message, each such LB policy only passes along the last error message it has seen from any child.