### PR TITLE
feat(grpc-tools): add omit_serialize_instanceof generator option

### DIFF
--- a/packages/grpc-tools/README.md
+++ b/packages/grpc-tools/README.md
@@ -20,3 +20,7 @@ one of the following:
    gRPC library, and instead generates `PackageDefinition` objects that can
    be passed to the `loadPackageDefinition` function provided by both the
    `grpc` and `@grpc/grpc-js` libraries.
+ - `omit_serialize_instanceof`: Omit the `instanceof` check for messages in
+   client code. This is useful when the message was renamed or is from a
+   different package, and serialization would fail with
+   `Expected argument of type …`.

--- a/packages/grpc-tools/src/node_generator.h
+++ b/packages/grpc-tools/src/node_generator.h
@@ -28,6 +28,8 @@ struct Parameters {
   bool generate_package_definition;
   // Use pure JavaScript gRPC Client
   bool grpc_js;
+  // Omit instanceof check for messages in serialize methods
+  bool omit_serialize_instanceof;
 };
 
 grpc::string GenerateFile(const grpc::protobuf::FileDescriptor* file,

--- a/packages/grpc-tools/src/node_plugin.cc
+++ b/packages/grpc-tools/src/node_plugin.cc
@@ -39,6 +39,7 @@ class NodeGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     grpc_node_generator::Parameters generator_parameters;
     generator_parameters.generate_package_definition = false;
     generator_parameters.grpc_js = false;
+    generator_parameters.omit_serialize_instanceof = false;
     if (!parameter.empty()) {
       std::vector<grpc::string> parameters_list =
           grpc_generator::tokenize(parameter, ",");
@@ -48,6 +49,8 @@ class NodeGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
           generator_parameters.generate_package_definition = true;
         } else if (*parameter_string == "grpc_js") {
           generator_parameters.grpc_js = true;
+        } else if (*parameter_string == "omit_serialize_instanceof") {
+          generator_parameters.omit_serialize_instanceof = true;
         }
       }
     }


### PR DESCRIPTION
Fixes #2865 

This adds a new flag `omit_serialize_instanceof` which, when set, omits the `instanceof` check from the generated JS code. It defaults to `false`, which retains the current behavior (ie. with the check).