### PR TITLE
fix: support CIDR blocks in no_proxy env variable

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -11,10 +11,11 @@ can be set.
   checked in order, and the first one that has a value is used.
 
 * no_grpc_proxy, no_proxy
-  A comma separated list of hostnames to connect to without using a proxy even
-  if a proxy is set. These variables are checked in order, and the first one
+  A comma separated list of comma-separated list of hostnames, IP addresses,
+  or CIDR blocks to connect to without using a proxy even
+  if a proxy is set, for example: no_proxy=example.com,192.168.0.1,192.168.0.0/16.
+  These variables are checked in order, and the first one
   that has a value is used.
-  The `no_proxy` environment variable could be a comma-separated list of hostnames, IP addresses, or CIDR blocks (no_proxy=example.com,192.168.0.1,192.168.0.0/16).
 
 * GRPC_SSL_CIPHER_SUITES
   A colon separated list of cipher suites to use with OpenSSL

--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -14,6 +14,7 @@ can be set.
   A comma separated list of hostnames to connect to without using a proxy even
   if a proxy is set. These variables are checked in order, and the first one
   that has a value is used.
+  The `no_proxy` environment variable could be a comma-separated list of hostnames, IP addresses, or CIDR blocks (no_proxy=example.com,192.168.0.1,192.168.0.0/16).
 
 * GRPC_SSL_CIPHER_SUITES
   A colon separated list of cipher suites to use with OpenSSL

--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -11,7 +11,7 @@ can be set.
   checked in order, and the first one that has a value is used.
 
 * no_grpc_proxy, no_proxy
-  A comma separated list of comma-separated list of hostnames, IP addresses,
+  A comma separated list of hostnames, IP addresses,
   or CIDR blocks to connect to without using a proxy even
   if a proxy is set, for example: no_proxy=example.com,192.168.0.1,192.168.0.0/16.
   These variables are checked in order, and the first one

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -162,15 +162,10 @@ function hostMatchesNoProxyList(serverHost: string): boolean {
     const parsedCIDR = parseCIDR(host);
     // host is a CIDR and serverHost is an IP address
     if (isIPv4(serverHost) && parsedCIDR && isIpInCIDR(parsedCIDR, serverHost)) {
-      trace('Not using proxy for target in no_proxy list: ' + serverHost);
       return true;
-    }
-    // host is a single IP or a domain name suffix
-    else {
-      if (serverHost.endsWith(host)) {
-        trace('Not using proxy for target in no_proxy list: ' + serverHost);
-        return true;
-      }
+    } else if (serverHost.endsWith(host)) {
+      // host is a single IP or a domain name suffix
+      return true;
     }
   }
   return false;

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -151,13 +151,10 @@ function isIpInCIDR(cidr: CIDRNotation, serverHost: string) {
   const mask = -1 << (32 - cidr.prefixLength);
   const hostIP = ipToInt(serverHost);
 
-  const networkAddress = ip & mask;
-  const broadcastAddress = networkAddress | ~mask;
-
-  return hostIP >= networkAddress && hostIP <= broadcastAddress;
+  return (hostIP & mask) === (ip & mask);
 }
 
-function checkHostInNoProxyHostList(serverHost: string): boolean {
+function hostMatchesNoProxyList(serverHost: string): boolean {
   for (const host of getNoProxyHostList()) {
     const parsedCIDR = parseCIDR(host);
     // host is a single IP address or a CIDR notation or a domain
@@ -197,7 +194,7 @@ export function mapProxyName(
     return noProxyResult;
   }
   const serverHost = hostPort.host;
-  if (checkHostInNoProxyHostList(serverHost)) {
+  if (hostMatchesNoProxyList(serverHost)) {
     trace('Not using proxy for target in no_proxy list: ' + uriToString(target));
     return noProxyResult;
   }

--- a/packages/grpc-js/src/http_proxy.ts
+++ b/packages/grpc-js/src/http_proxy.ts
@@ -160,17 +160,17 @@ function isIpInCIDR(cidr: CIDRNotation, serverHost: string) {
 function hostMatchesNoProxyList(serverHost: string): boolean {
   for (const host of getNoProxyHostList()) {
     const parsedCIDR = parseCIDR(host);
+    // host is a CIDR and serverHost is an IP address
+    if (isIPv4(serverHost) && parsedCIDR && isIpInCIDR(parsedCIDR, serverHost)) {
+      trace('Not using proxy for target in no_proxy list: ' + serverHost);
+      return true;
+    }
     // host is a single IP or a domain name suffix
-    if (!parsedCIDR) {
-      if (host === serverHost || serverHost.includes(host)) {
+    else {
+      if (serverHost.endsWith(host)) {
         trace('Not using proxy for target in no_proxy list: ' + serverHost);
         return true;
       }
-    }
-    // host is a CIDR or a domain
-    else if (isIpInCIDR(parsedCIDR, serverHost)) {
-      trace('Not using proxy for target in no_proxy list: ' + serverHost);
-      return true;
     }
   }
   return false;


### PR DESCRIPTION
**Issue created https://github.com/grpc/grpc-node/issues/2878**

**Issue:** 

The grpc-js lib doesn't support having CIDR blocks in the **NO_PROXY** variable (like 172.16.0.0/12
192.168.0.0/16). It only checks if the address we target is in the list of IPs in the NO_PROXY. Hence, it supposes that NO_PROXY is a list of single IPs.

For example if the NO_PROXY contains 192.168.0.0/16 and the IP you're trying to reach is 192.168.0.10. This latter is NOT considered in the range of the NO_PROXY because the lib just compares the IP to the elements of the NO_PROXY list.

We also want to support the case where we whitelist domain name suffixes in the NO_PROXY (like example.com, .internal., .local. ).

**What is done in this PR:**

- Parse NO_PROXY list to get the ip and the prefix length of the CIDR
- Check if targeted ip is in the range of the CIDR.
- Check if targeted host contains the domain suffix.