### PR TITLE
grpc-js-xds: Preserve resource type version and nonce when unsubscribing

### DIFF
--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -458,9 +458,6 @@ class AdsCallState {
     if (authorityMap.size === 0) {
       typeState.subscribedResources.delete(name.authority);
     }
-    if (typeState.subscribedResources.size === 0) {
-      this.typeStates.delete(type);
-    }
     this.updateNames(type);
   }
 


### PR DESCRIPTION
This fixes #2875 by never deleting `typeStates` entries in `AdsCallState` once they are created. As a result, the nonce will persist for the duration of the ADS stream. In addition, handling nonces for unknown types is not an issue because a type stays known for the duration of the stream after it is requested once, and we do not guarantee handling of the case where a control plane sends a resource type that was never requested.

The only functional impact that I can see of this change is that it will send a `DiscoveryRequest` with an empty `resource_names` list after unsubscribing from the last resource of a particular type, and I believe that is the correct behavior.

This should not meaningfully impact resource usage, because a type state with no resources is just two strings and an empty map, and there are at most 4 for a given stream, and the lifetime is limited to the lifetime of the stream.