### PR TITLE
grpc-js-xds: Preserve resource type version and nonce when unsubscribing (1.12.x)

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {

--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -457,9 +457,6 @@ class AdsCallState {
     if (authorityMap.size === 0) {
       typeState.subscribedResources.delete(name.authority);
     }
-    if (typeState.subscribedResources.size === 0) {
-      this.typeStates.delete(type);
-    }
     this.updateNames(type);
   }
 


### PR DESCRIPTION
Backport #2879 to 1.12.x