### PR TITLE
grpc-js-xds: Add more detailed xDS dependency manager logging

### DIFF
--- a/packages/grpc-js-xds/test/test-core.ts
+++ b/packages/grpc-js-xds/test/test-core.ts
@@ -164,6 +164,38 @@ describe('core xDS functionality', () => {
     xdsServer.setEdsResource(cluster2.getEndpointConfig());
     await cluster2.waitForAllBackendsToReceiveTraffic();
     client.stopCalls();
-
+  });
+  it('should handle switching to a different cluster', async () => {
+    const [backend1, backend2] = await createBackends(2);
+    const serverRoute1 = new FakeServerRoute(backend1.getPort(), 'serverRoute');
+    const serverRoute2 = new FakeServerRoute(backend2.getPort(), 'serverRoute2');
+    xdsServer.setRdsResource(serverRoute1.getRouteConfiguration());
+    xdsServer.setLdsResource(serverRoute1.getListener());
+    xdsServer.setRdsResource(serverRoute2.getRouteConfiguration());
+    xdsServer.setLdsResource(serverRoute2.getListener());
+    xdsServer.addResponseListener((typeUrl, responseState) => {
+      if (responseState.state === 'NACKED') {
+        client?.stopCalls();
+        assert.fail(`Client NACKED ${typeUrl} resource with message ${responseState.errorMessage}`);
+      }
+    });
+    const cluster1 = new FakeEdsCluster('cluster1', 'endpoint1', [{backends: [backend1], locality:{region: 'region1'}}]);
+    const routeGroup1 = new FakeRouteGroup('listener1', 'route1', [{cluster: cluster1}]);
+    await routeGroup1.startAllBackends(xdsServer);
+    xdsServer.setEdsResource(cluster1.getEndpointConfig());
+    xdsServer.setCdsResource(cluster1.getClusterConfig());
+    xdsServer.setRdsResource(routeGroup1.getRouteConfiguration());
+    xdsServer.setLdsResource(routeGroup1.getListener());
+    client = XdsTestClient.createFromServer('listener1', xdsServer);
+    client.startCalls(100);
+    await cluster1.waitForAllBackendsToReceiveTraffic();
+    const cluster2 = new FakeEdsCluster('cluster2', 'endpoint2', [{backends: [backend2], locality:{region: 'region2'}}]);
+    const routeGroup2 = new FakeRouteGroup('listener1', 'route1', [{cluster: cluster2}]);
+    await cluster2.startAllBackends(xdsServer);
+    xdsServer.setEdsResource(cluster2.getEndpointConfig());
+    xdsServer.setCdsResource(cluster2.getClusterConfig());
+    xdsServer.setRdsResource(routeGroup2.getRouteConfiguration());
+    await cluster2.waitForAllBackendsToReceiveTraffic();
+    client.stopCalls();
   })
 });


### PR DESCRIPTION
It looks like the problem fixed in #2879 may have been shadowing a logic error in the xDS dependency manager that is causing the change_backend_service interop test to fail, but with the current logging it's hard to tell what the problem is. This change adds two kinds of detailed trace logging to try to understand that problem:

 - Log each resource watch start and end, with a reason
 - Log whenever `maybeSendUpdate` does not send an update, with a reason

I also added a test to try to replicate the change_backend_service test locally, but it didn't reproduce the failure.