### PR TITLE
grpc-js-xds: Reference clusters for ConfigSelector lifetime

### DIFF
--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -377,6 +377,7 @@ export class InternalChannel {
             'Address resolution succeeded'
           );
         }
+        this.configSelector?.unref();
         this.configSelector = configSelector;
         this.currentResolutionError = null;
         /* We process the queue asynchronously to ensure that the corresponding
@@ -568,7 +569,7 @@ export class InternalChannel {
     if (this.configSelector) {
       return {
         type: 'SUCCESS',
-        config: this.configSelector(method, metadata, this.randomChannelId),
+        config: this.configSelector.invoke(method, metadata, this.randomChannelId),
       };
     } else {
       if (this.currentResolutionError) {
@@ -790,6 +791,8 @@ export class InternalChannel {
     }
 
     this.subchannelPool.unrefUnusedSubchannels();
+    this.configSelector?.unref();
+    this.configSelector = null;
   }
 
   getTarget() {

--- a/packages/grpc-js/src/resolver.ts
+++ b/packages/grpc-js/src/resolver.ts
@@ -37,7 +37,8 @@ export interface CallConfig {
  * https://github.com/grpc/proposal/blob/master/A31-xds-timeout-support-and-config-selector.md#new-functionality-in-grpc
  */
 export interface ConfigSelector {
-  (methodName: string, metadata: Metadata, channelId: number): CallConfig;
+  invoke(methodName: string, metadata: Metadata, channelId: number): CallConfig;
+  unref(): void;
 }
 
 /**


### PR DESCRIPTION
First, this modifies the `ConfigSelector` API to make it an object instead of a function. The object has an `invoke` method, which is called the same way the function was previously called, and an additional `unref` function, which signals the end of the lifetime of the `ConfigSelector`. This allows resolvers to track and act on the lifetime of the `ConfigSelector`.

Second, this modifies the xDS resolver so that it keeps a cluster ref for each cluster that a `ConfigSelector` can select, for the lifetime of the `ConfigSelector`, plus an additional ref for each call for which a cluster has been selected, until that call is committed. This ensures that once a `ConfigSelector` is created, every cluster it can select will be subscribed to continuously until no more calls need it.