### PR TITLE
grpc-js: Always use RetryingCall, always call onCommitted

### DIFF
--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -705,33 +705,6 @@ export class InternalChannel {
     );
   }
 
-  createInnerCall(
-    callConfig: CallConfig,
-    method: string,
-    host: string,
-    credentials: CallCredentials,
-    deadline: Deadline
-  ): LoadBalancingCall | RetryingCall {
-    // Create a RetryingCall if retries are enabled
-    if (this.options['grpc.enable_retries'] === 0) {
-      return this.createLoadBalancingCall(
-        callConfig,
-        method,
-        host,
-        credentials,
-        deadline
-      );
-    } else {
-      return this.createRetryingCall(
-        callConfig,
-        method,
-        host,
-        credentials,
-        deadline
-      );
-    }
-  }
-
   createResolvingCall(
     method: string,
     deadline: Deadline,

--- a/packages/grpc-js/src/load-balancing-call.ts
+++ b/packages/grpc-js/src/load-balancing-call.ts
@@ -254,7 +254,6 @@ export class LoadBalancingCall implements Call, DeadlineInfoProvider {
                 );
                 return;
               }
-              this.callConfig.onCommitted?.();
               pickResult.onCallStarted?.();
               this.onCallEnded = pickResult.onCallEnded;
               this.trace(

--- a/packages/grpc-js/src/resolving-call.ts
+++ b/packages/grpc-js/src/resolving-call.ts
@@ -245,7 +245,7 @@ export class ResolvingCall implements Call {
     this.filterStack = this.filterStackFactory.createFilter();
     this.filterStack.sendMetadata(Promise.resolve(this.metadata)).then(
       filteredMetadata => {
-        this.child = this.channel.createInnerCall(
+        this.child = this.channel.createRetryingCall(
           config,
           this.method,
           this.host,


### PR DESCRIPTION
The main change here is to modify the implementation of the `grpc.enable_retries` option. Now, when it is set to 0, instead of skipping `RetryingCall` entirely and making `LoadBalancingCall` a direct child of `ResolvingCall`, `RetryingCall` is used in a new mode that does not perform any retries.

The main purpose of this is to create a place to correctly call `CallConfig#onCommitted` consistently, whether or not that option is set. Previously, it would only be called in `LoadBalancingCall` after starting the `SubchannelCall`. This was both too early (if the call was later retried) and it could fail to be called (if the LB pick failed).

One other change this required was performing the functionality of `commitCall` even if the underlying call already completed, which means that buffered messages will now be cleared more consistently, and the `MessageBufferTracker` should track messages cleared this way more consistently.