### PR TITLE
grpc-js-xds: Preserve resource type version and nonce when unsubscribing (1.11.x)

### DIFF
--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -455,9 +455,6 @@ class AdsCallState {
     if (authorityMap.size === 0) {
       typeState.subscribedResources.delete(name.authority);
     }
-    if (typeState.subscribedResources.size === 0) {
-      this.typeStates.delete(type);
-    }
     this.updateNames(type);
   }
 


### PR DESCRIPTION
Backport #2879 to 1.11.x