### PR TITLE
grpc-js-xds: Preserve resource type version and nonce when unsubscribing (1.9.x)

### DIFF
--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -451,9 +451,6 @@ class AdsCallState {
     if (authorityMap.size === 0) {
       typeState.subscribedResources.delete(name.authority);
     }
-    if (typeState.subscribedResources.size === 0) {
-      this.typeStates.delete(type);
-    }
     this.updateNames(type);
   }
 


### PR DESCRIPTION
Backport https://github.com/grpc/grpc-node/pull/2879 to 1.9.x