### PR TITLE
grpc-js: Connect with https scheme when using TLS

### DIFF
--- a/packages/grpc-js/src/experimental.ts
+++ b/packages/grpc-js/src/experimental.ts
@@ -63,5 +63,5 @@ export {
   FileWatcherCertificateProvider,
   FileWatcherCertificateProviderConfig
 } from './certificate-provider';
-export { createCertificateProviderChannelCredentials, SecureConnector } from './channel-credentials';
+export { createCertificateProviderChannelCredentials, SecureConnector, SecureConnectResult } from './channel-credentials';
 export { SUBCHANNEL_ARGS_EXCLUDE_KEY_PREFIX } from './internal-channel';


### PR DESCRIPTION
This fixes a bug caught by interop tests that caused Google Front End servers to reject requests made by this library over TLS. Our best guess at a proximate cause for this error is that the request has an unexpected `:scheme` header value of `http` instead of `https` because that is the scheme used in the URL passed to `http2.connect`.

In order to consistently use the correct scheme, `SecureConnector#connect` now annotates the result with an additional field indicating whether the connection is secure, and this value determines the scheme.