### PR TITLE
grpc-js: Allow garbage collection of IDLE channels

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
This addresses #2893 to the greatest extent reasonable.

This PR includes 3 changes to allow garbage collection of IDLE channels:

 - Modify the subchannel wrapper used by the channel so that it does not register itself until it has a ref, to handle the fact that pick_first may never ref some subchannels.
 - Don't run the `callRefTimer` until a call is started, and stop it when the channel goes IDLE.
 - Move the channelz info into a separate object, so that the reference from channelz only keeps that object alive instead of the whole channel.

A caveat here is that repeatedly creating and discarding channels without closing them will still leak some memory with channelz, because the channel is never unregistered with channelz, so channelz needs to retain the associated data. This does not happen if channelz is disabled for a channel.