### PR TITLE
grpc-js-xds: fix LrsCallState statsTimer memory leak

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js-xds",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Plugin for @grpc/grpc-js. Adds the xds:// URL scheme and associated features.",
   "main": "build/src/index.js",
   "scripts": {

--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -682,6 +682,13 @@ class LrsCallState {
     this.sendStats();
   }
 
+  destroy() {
+    if (this.statsTimer) {
+      this.statsTimer = clearInterval(this.statsTimer);
+    }
+    return null;
+  }
+
   private handleStreamStatus(status: StatusObject) {
     this.client.trace(
       'LRS stream ended. code=' + status.code + ' details= ' + status.details
@@ -932,7 +939,7 @@ class XdsSingleServerClient {
   }
 
   handleLrsStreamEnd() {
-    this.lrsCallState = null;
+    this.lrsCallState = this.lrsCallState ? this.lrsCallState.destroy() : null;
     /* The backoff timer would start the stream when it finishes. If it is not
      * running, restart the stream immediately. */
     if (!this.lrsBackoff.isRunning()) {

--- a/packages/grpc-js-xds/src/xds-client.ts
+++ b/packages/grpc-js-xds/src/xds-client.ts
@@ -684,7 +684,8 @@ class LrsCallState {
 
   destroy() {
     if (this.statsTimer) {
-      this.statsTimer = clearInterval(this.statsTimer);
+      clearInterval(this.statsTimer);
+      this.statsTimer = null;
     }
     return null;
   }


### PR DESCRIPTION
Backport #2891 to 1.12.x with a version bump.