### PR TITLE
grpc-js-xds: NACK with detailed validation errors

### DIFF
--- a/packages/grpc-js-xds/src/xds-resource-type/cluster-resource-type.ts
+++ b/packages/grpc-js-xds/src/xds-resource-type/cluster-resource-type.ts
@@ -265,27 +265,23 @@ export class ClusterResourceType extends XdsResourceType {
         }
       };
     } else if(EXPERIMENTAL_RING_HASH && message.lb_policy === 'RING_HASH') {
-      if (message.ring_hash_lb_config) {
-        if (message.ring_hash_lb_config.hash_function !== 'XX_HASH') {
-          errors.push(`unsupported ring_hash_lb_config.hash_function: ${message.ring_hash_lb_config.hash_function}`);
-        }
-        const minRingSize = message.ring_hash_lb_config.minimum_ring_size ? Number(message.ring_hash_lb_config.minimum_ring_size.value) : 1024;
-        if (minRingSize > 8_388_608) {
-          errors.push(`ring_hash_lb_config.minimum_ring_size is too large: ${minRingSize}`);
-        }
-        const maxRingSize = message.ring_hash_lb_config.maximum_ring_size ? Number(message.ring_hash_lb_config.maximum_ring_size.value) : 8_388_608;
-        if (maxRingSize > 8_388_608) {
-          errors.push(`ring_hash_lb_config.maximum_ring_size is too large: ${maxRingSize}`);
-        }
-        lbPolicyConfig = {
-          ring_hash: {
-            min_ring_size: minRingSize,
-            max_ring_size: maxRingSize
-          }
-        };
-      } else {
-        errors.push(`lb_policy == RING_HASH but ring_hash_lb_config is unset`);
+      if (message.ring_hash_lb_config && message.ring_hash_lb_config.hash_function !== 'XX_HASH') {
+        errors.push(`unsupported ring_hash_lb_config.hash_function: ${message.ring_hash_lb_config.hash_function}`);
       }
+      const minRingSize = message.ring_hash_lb_config?.minimum_ring_size ? Number(message.ring_hash_lb_config.minimum_ring_size.value) : 1024;
+      if (minRingSize > 8_388_608) {
+        errors.push(`ring_hash_lb_config.minimum_ring_size is too large: ${minRingSize}`);
+      }
+      const maxRingSize = message.ring_hash_lb_config?.maximum_ring_size ? Number(message.ring_hash_lb_config.maximum_ring_size.value) : 8_388_608;
+      if (maxRingSize > 8_388_608) {
+        errors.push(`ring_hash_lb_config.maximum_ring_size is too large: ${maxRingSize}`);
+      }
+      lbPolicyConfig = {
+        ring_hash: {
+          min_ring_size: minRingSize,
+          max_ring_size: maxRingSize
+        }
+      };
     } else {
       if (EXPERIMENTAL_CUSTOM_LB_CONFIG) {
         errors.push(`load_balancing_policy unset and unsupported lb_policy: ${message.lb_policy}`);

--- a/packages/grpc-js-xds/src/xds-resource-type/endpoint-resource-type.ts
+++ b/packages/grpc-js-xds/src/xds-resource-type/endpoint-resource-type.ts
@@ -1,6 +1,6 @@
 import { experimental, logVerbosity } from "@grpc/grpc-js";
 import { ClusterLoadAssignment__Output } from "../generated/envoy/config/endpoint/v3/ClusterLoadAssignment";
-import { XdsDecodeContext, XdsDecodeResult, XdsResourceType } from "./xds-resource-type";
+import { ValidationResult, XdsDecodeContext, XdsDecodeResult, XdsResourceType } from "./xds-resource-type";
 import { Locality__Output } from "../generated/envoy/config/core/v3/Locality";
 import { SocketAddress__Output } from "../generated/envoy/config/core/v3/SocketAddress";
 import { isIPv4, isIPv6 } from "net";
@@ -40,78 +40,86 @@ export class EndpointResourceType extends XdsResourceType {
     return 'envoy.config.endpoint.v3.ClusterLoadAssignment';
   }
 
-  private validateAddress(socketAddress: SocketAddress__Output, seenAddresses: SocketAddress__Output[]): boolean {
+  /**
+   *
+   * @param socketAddress
+   * @param seenAddresses
+   * @returns A list of validation errors, if there are any. An empty list indicates success
+   */
+  private validateAddress(socketAddress: SocketAddress__Output, seenAddresses: SocketAddress__Output[]): string[] {
+    const errors: string[] = [];
     if (socketAddress.port_specifier !== 'port_value') {
-      trace('EDS validation: socket_address.port_specifier !== "port_value"');
-      return false;
+      errors.push(`Unsupported port_specifier: ${socketAddress.port_specifier}`);
     }
     if (!(isIPv4(socketAddress.address) || isIPv6(socketAddress.address))) {
-      trace('EDS validation: address not a valid IPv4 or IPv6 address: ' + socketAddress.address);
-      return false;
+      errors.push(`address is not a valid IPv4 or IPv6 address: ${socketAddress.address}`);
     }
     for (const address of seenAddresses) {
       if (addressesEqual(socketAddress, address)) {
-        trace('EDS validation: duplicate address seen: ' + address);
-        return false;
+        errors.push(`address is a duplicate of another address in the same endpoint: ${socketAddress.address}`);
       }
     }
-    return true;
+    return errors;
   }
 
-  private validateResource(message: ClusterLoadAssignment__Output): ClusterLoadAssignment__Output | null {
+  private validateResource(message: ClusterLoadAssignment__Output): ValidationResult<ClusterLoadAssignment__Output> {
+    const errors: string[] = [];
     const seenLocalities: {locality: Locality__Output, priority: number}[] = [];
     const seenAddresses: SocketAddress__Output[] = [];
     const priorityTotalWeights: Map<number,  number> = new Map();
-    for (const endpoint of message.endpoints) {
+    for (const [index, endpoint] of message.endpoints.entries()) {
+      const errorPrefix = `endpoints[${index}]`;
       if (!endpoint.locality) {
-        trace('EDS validation: endpoint locality unset');
-        return null;
+        errors.push(`${errorPrefix}.locality unset`);
+        continue;
       }
       for (const {locality, priority} of seenLocalities) {
         if (localitiesEqual(endpoint.locality, locality) && endpoint.priority === priority) {
-          trace('EDS validation: endpoint locality duplicated: ' + JSON.stringify(locality) + ', priority=' + priority);
-          return null;
+          errors.push(`${errorPrefix}.locality is a duplicate of another locality in the endpoint`);
         }
       }
       seenLocalities.push({locality: endpoint.locality, priority: endpoint.priority});
-      for (const lb of endpoint.lb_endpoints) {
+      for (const [lbIndex, lb] of endpoint.lb_endpoints.entries()) {
+        const lbErrorPrefix = `${errorPrefix}.lb_endpoints[${lbIndex}].endpoint`;
         const socketAddress = lb.endpoint?.address?.socket_address;
-        if (!socketAddress) {
-          trace('EDS validation: endpoint socket_address not set');
-          return null;
+        if (socketAddress) {
+          errors.push(...this.validateAddress(socketAddress, seenAddresses).map(error => `${lbErrorPrefix}: ${error}`));
+          seenAddresses.push(socketAddress);
+        } else {
+          errors.push(`${lbErrorPrefix}.socket_address not set`);
         }
-        if (!this.validateAddress(socketAddress, seenAddresses)) {
-          return null;
-        }
-        seenAddresses.push(socketAddress);
         if (EXPERIMENTAL_DUALSTACK_ENDPOINTS && lb.endpoint?.additional_addresses) {
-          for (const additionalAddress of lb.endpoint.additional_addresses) {
-            if (!additionalAddress.address?.socket_address) {
-              trace('EDS validation: endpoint additional_addresses socket_address not set');
-              return null;
+          for (const [addressIndex, additionalAddress] of lb.endpoint.additional_addresses.entries()) {
+            if (additionalAddress.address?.socket_address) {
+              errors.push(...this.validateAddress(additionalAddress.address.socket_address, seenAddresses).map(error => `${lbErrorPrefix}.additional_addresses[${addressIndex}].address.socket_address: ${error}`));
+              seenAddresses.push(additionalAddress.address.socket_address);
+            } else {
+              errors.push(`${lbErrorPrefix}.additional_addresses[${addressIndex}].address.socket_address unset`);
             }
-            if (!this.validateAddress(additionalAddress.address.socket_address, seenAddresses)) {
-              return null;
-            }
-            seenAddresses.push(additionalAddress.address.socket_address);
           }
         }
       }
       priorityTotalWeights.set(endpoint.priority, (priorityTotalWeights.get(endpoint.priority) ?? 0) + (endpoint.load_balancing_weight?.value ?? 0));
     }
-    for (const totalWeight of priorityTotalWeights.values()) {
+    for (const [priority, totalWeight] of priorityTotalWeights.entries()) {
       if (totalWeight > UINT32_MAX) {
-        trace('EDS validation: total weight > UINT32_MAX')
-        return null;
+        errors.push(`priority ${priority} has total weight greater than UINT32_MAX: ${totalWeight}`);
       }
-    }
-    for (const priority of priorityTotalWeights.keys()) {
       if (priority > 0 && !priorityTotalWeights.has(priority - 1)) {
-        trace('EDS validation: priorities not contiguous');
-        return null;
+        errors.push(`Endpoints have priority ${priority} but not ${priority - 1}`);
       }
     }
-    return message;
+    if (errors.length === 0) {
+      return {
+        valid: true,
+        result: message
+      };
+    } else {
+      return {
+        valid: false,
+        errors
+      };
+    }
   }
 
   decode(context: XdsDecodeContext, resource: Any__Output): XdsDecodeResult {
@@ -122,16 +130,16 @@ export class EndpointResourceType extends XdsResourceType {
     }
     const message = decodeSingleResource(EDS_TYPE_URL, resource.value);
     trace('Decoded raw resource of type ' + EDS_TYPE_URL + ': ' + JSON.stringify(message, undefined, 2));
-    const validatedMessage = this.validateResource(message);
-    if (validatedMessage) {
+    const validationResult = this.validateResource(message);
+    if (validationResult.valid) {
       return {
-        name: validatedMessage.cluster_name,
-        value: validatedMessage
+        name: validationResult.result.cluster_name,
+        value: validationResult.result
       };
     } else {
       return {
         name: message.cluster_name,
-        error: 'Endpoint message validation failed'
+        error: `ClusterLoadAssignment message validation failed: [${validationResult.errors}]`
       };
     }
   }

--- a/packages/grpc-js-xds/src/xds-resource-type/route-config-resource-type.ts
+++ b/packages/grpc-js-xds/src/xds-resource-type/route-config-resource-type.ts
@@ -24,7 +24,7 @@ import { Duration__Output } from "../generated/google/protobuf/Duration";
 import { validateOverrideFilter } from "../http-filter";
 import { RDS_TYPE_URL, decodeSingleResource } from "../resources";
 import { Watcher, XdsClient } from "../xds-client";
-import { XdsDecodeContext, XdsDecodeResult, XdsResourceType } from "./xds-resource-type";
+import { ValidationResult, XdsDecodeContext, XdsDecodeResult, XdsResourceType } from "./xds-resource-type";
 const TRACER_NAME = 'xds_client';
 
 function trace(text: string): void {
@@ -66,100 +66,114 @@ export class RouteConfigurationResourceType extends XdsResourceType {
     return 'envoy.config.route.v3.RouteConfiguration';
   }
 
-  private validateRetryPolicy(policy: RetryPolicy__Output | null): boolean {
+  /**
+   * @param policy
+   * @returns A list of validation errors, if there are any. An empty list indicates success
+   */
+  private validateRetryPolicy(policy: RetryPolicy__Output | null): string[] {
     if (policy === null) {
-      return true;
+      return [];
     }
+    const errors: string[] = [];
     const numRetries = policy.num_retries?.value ?? 1
     if (numRetries < 1) {
-      return false;
+      errors.push(`Invalid policy.num_retries.value: ${numRetries}`);
     }
     if (policy.retry_back_off) {
-      if (!policy.retry_back_off.base_interval) {
-        return false;
-      }
-      const baseInterval = durationToMs(policy.retry_back_off.base_interval)!;
-      const maxInterval = durationToMs(policy.retry_back_off.max_interval) ?? (10 * baseInterval);
-      if (!(maxInterval >= baseInterval) && (baseInterval > 0)) {
-        return false;
+      if (policy.retry_back_off.base_interval) {
+        const baseInterval = durationToMs(policy.retry_back_off.base_interval)!;
+        const maxInterval = durationToMs(policy.retry_back_off.max_interval) ?? (10 * baseInterval);
+        if (baseInterval <= 0) {
+          errors.push(`Invalid retry_back_off.base_interval: ${JSON.stringify(policy.retry_back_off.base_interval)}`);
+        }
+        if (maxInterval < baseInterval) {
+          errors.push(`retry_back_off.max_interval < retry_back_off.base_interval: ${JSON.stringify(policy.retry_back_off.max_interval)} vs ${JSON.stringify(policy.retry_back_off.base_interval)}`);
+        }
+      } else {
+        errors.push('retry_back_off.base_interval unset');
       }
     }
-    return true;
+    return errors;
   }
 
-  public validateResource(message: RouteConfiguration__Output): RouteConfiguration__Output | null {
+  public validateResource(message: RouteConfiguration__Output): ValidationResult<RouteConfiguration__Output> {
+    const errors: string[] = [];
     // https://github.com/grpc/proposal/blob/master/A28-xds-traffic-splitting-and-routing.md#response-validation
     for (const virtualHost of message.virtual_hosts) {
+      const errorPrefix = `virtual_hosts[${virtualHost.name}]`;
       for (const domainPattern of virtualHost.domains) {
         const starIndex = domainPattern.indexOf('*');
         const lastStarIndex = domainPattern.lastIndexOf('*');
         // A domain pattern can have at most one wildcard *
         if (starIndex !== lastStarIndex) {
-          return null;
+          errors.push(`${errorPrefix}: domains entry has multiple wildcards: ${domainPattern}`);
         }
         // A wildcard * can either be absent or at the beginning or end of the pattern
         if (!(starIndex === -1 || starIndex === 0 || starIndex === domainPattern.length - 1)) {
-          return null;
+          errors.push(`${errorPrefix}: domains entry has wildcard in the middle: ${domainPattern}`);
         }
       }
       if (EXPERIMENTAL_FAULT_INJECTION) {
         for (const filterConfig of Object.values(virtualHost.typed_per_filter_config ?? {})) {
           if (!validateOverrideFilter(filterConfig)) {
-            return null;
+            errors.push(`${errorPrefix}: typed_per_filter_config validation failed for type_url: ${filterConfig.type_url}`);
           }
         }
       }
       if (EXPERIMENTAL_RETRY) {
-        if (!this.validateRetryPolicy(virtualHost.retry_policy)) {
-          return null;
-        }
+        errors.push(...this.validateRetryPolicy(virtualHost.retry_policy).map(error => `${errorPrefix}.retry_policy: ${error}`));
       }
       for (const route of virtualHost.routes) {
+        const routeErrorPrefix = `${errorPrefix}.routes[${route.name}]`;
         const match = route.match;
-        if (!match) {
-          return null;
-        }
-        if (SUPPORTED_PATH_SPECIFIERS.indexOf(match.path_specifier) < 0) {
-          return null;
-        }
-        for (const headers of match.headers) {
-          if (SUPPPORTED_HEADER_MATCH_SPECIFIERS.indexOf(headers.header_match_specifier) < 0) {
-            return null;
+        if (match) {
+          if (SUPPORTED_PATH_SPECIFIERS.indexOf(match.path_specifier) < 0) {
+            errors.push(`${routeErrorPrefix}.match: unsupported path_specifier: ${match.path_specifier}`);
           }
+          for (const headers of match.headers) {
+            if (SUPPPORTED_HEADER_MATCH_SPECIFIERS.indexOf(headers.header_match_specifier) < 0) {
+              errors.push(`${routeErrorPrefix}.match.headers[${headers.name}]: unsupported header_match_specifier: ${headers.header_match_specifier}`);
+            }
+          }
+        } else {
+          errors.push(`${routeErrorPrefix}.match unset`);
         }
         switch (route.action) {
           case 'route': {
-            if (route.action !== 'route') {
-              return null;
+
+            if ((route.route === undefined) || (route.route === null)) {
+              errors.push(`${routeErrorPrefix}.route unset`);
+              break;
             }
-            if ((route.route === undefined) || (route.route === null) || SUPPORTED_CLUSTER_SPECIFIERS.indexOf(route.route.cluster_specifier) < 0) {
-              return null;
+            if (SUPPORTED_CLUSTER_SPECIFIERS.indexOf(route.route.cluster_specifier) < 0) {
+              errors.push(`${routeErrorPrefix}: unsupported route.cluster_specifier: ${route.route.cluster_specifier}`);
             }
             if (EXPERIMENTAL_FAULT_INJECTION) {
               for (const [name, filterConfig] of Object.entries(route.typed_per_filter_config ?? {})) {
                 if (!validateOverrideFilter(filterConfig)) {
-                  return null;
+                  errors.push(`${routeErrorPrefix}.typed_per_filter_config[${name}] validation failed`);
                 }
               }
             }
             if (EXPERIMENTAL_RETRY) {
-              if (!this.validateRetryPolicy(route.route.retry_policy)) {
-                return null;
-              }
+              errors.push(...this.validateRetryPolicy(route.route.retry_policy).map(error => `${routeErrorPrefix}.route.retry_policy: ${error}`));
             }
             if (route.route!.cluster_specifier === 'weighted_clusters') {
               let weightSum = 0;
               for (const clusterWeight of route.route.weighted_clusters!.clusters) {
                 weightSum += clusterWeight.weight?.value ?? 0;
               }
-              if (weightSum === 0 || weightSum > UINT32_MAX) {
-                return null;
+              if (weightSum === 0) {
+                errors.push(`${routeErrorPrefix}.route.weighted_clusters sum of weights is 0`);
+              }
+              if (weightSum > UINT32_MAX) {
+                errors.push(`${routeErrorPrefix}.route.weighted_clusters sum of weights is greater than UINT32_MAX`);
               }
               if (EXPERIMENTAL_FAULT_INJECTION) {
                 for (const weightedCluster of route.route!.weighted_clusters!.clusters) {
-                  for (const filterConfig of Object.values(weightedCluster.typed_per_filter_config ?? {})) {
+                  for (const [name, filterConfig] of Object.entries(weightedCluster.typed_per_filter_config ?? {})) {
                     if (!validateOverrideFilter(filterConfig)) {
-                      return null;
+                      errors.push(`${routeErrorPrefix}.route.weighted_clusters.clusters[${weightedCluster.name}].typed_per_filter_config[${name}] validation failed`);
                     }
                   }
                 }
@@ -170,11 +184,21 @@ export class RouteConfigurationResourceType extends XdsResourceType {
           case 'non_forwarding_action':
             continue;
           default:
-            return null;
+            errors.push(`${routeErrorPrefix}: unsupported action: ${route.action}`);
         }
       }
     }
-    return message;
+    if (errors.length === 0) {
+      return {
+        valid: true,
+        result: message
+      };
+    } else {
+      return {
+        valid: false,
+        errors
+      }
+    }
   }
 
   decode(context: XdsDecodeContext, resource: Any__Output): XdsDecodeResult {
@@ -185,16 +209,16 @@ export class RouteConfigurationResourceType extends XdsResourceType {
     }
     const message = decodeSingleResource(RDS_TYPE_URL, resource.value);
     trace('Decoded raw resource of type ' + RDS_TYPE_URL + ': ' + JSON.stringify(message, undefined, 2));
-    const validatedMessage = this.validateResource(message);
-    if (validatedMessage) {
+    const validationResult = this.validateResource(message);
+    if (validationResult.valid) {
       return {
-        name: validatedMessage.name,
-        value: validatedMessage
+        name: validationResult.result.name,
+        value: validationResult.result
       };
     } else {
       return {
         name: message.name,
-        error: 'Route configuration message validation failed'
+        error: `RouteConfiguration message validation failed: [${validationResult.errors}]`
       };
     }
   }

--- a/packages/grpc-js-xds/src/xds-resource-type/xds-resource-type.ts
+++ b/packages/grpc-js-xds/src/xds-resource-type/xds-resource-type.ts
@@ -69,6 +69,18 @@ function deepEqual(value1: ValueType, value2: ValueType): boolean {
   return false;
 }
 
+export interface ValidationSuccess<T> {
+  valid: true;
+  result: T;
+}
+
+export interface ValidationFailure {
+  valid: false;
+  errors: string[]
+}
+
+export type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
 export abstract class XdsResourceType {
   /**
    * The type URL as used in xdstp: names


### PR DESCRIPTION
Previously, when validating resources, the validation function would short circuit on the first error, and the NACK would contain a generic message indicating that the resource failed to validate. Now the validation functions find every validation error, and report the details of all of them.