### PR TITLE
grpc-js-xds: Implement and enable security interop tests

### DIFF
--- a/packages/grpc-js-xds/interop/test-client.Dockerfile
+++ b/packages/grpc-js-xds/interop/test-client.Dockerfile
@@ -42,7 +42,7 @@ COPY --from=build /node/src/grpc-node/packages/grpc-js ./packages/grpc-js/
 COPY --from=build /node/src/grpc-node/packages/grpc-js-xds ./packages/grpc-js-xds/
 
 ENV GRPC_VERBOSITY="DEBUG"
-ENV GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager,cds_balancer,xds_cluster_resolver,xds_cluster_impl,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver,fault_injection,http_filter,csds,outlier_detection,server,server_call,ring_hash,transport,certificate_provider
+ENV GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager,cds_balancer,xds_cluster_resolver,xds_cluster_impl,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver,fault_injection,http_filter,csds,outlier_detection,server,server_call,ring_hash,transport,certificate_provider,xds_channel_credentials
 ENV NODE_XDS_INTEROP_VERBOSITY=1
 
 ENTRYPOINT [ "/nodejs/bin/node", "/node/src/grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client" ]

--- a/packages/grpc-js-xds/interop/test-client.Dockerfile
+++ b/packages/grpc-js-xds/interop/test-client.Dockerfile
@@ -42,7 +42,7 @@ COPY --from=build /node/src/grpc-node/packages/grpc-js ./packages/grpc-js/
 COPY --from=build /node/src/grpc-node/packages/grpc-js-xds ./packages/grpc-js-xds/
 
 ENV GRPC_VERBOSITY="DEBUG"
-ENV GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager,cds_balancer,xds_cluster_resolver,xds_cluster_impl,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver,fault_injection,http_filter,csds,outlier_detection,server,server_call,ring_hash
+ENV GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager,cds_balancer,xds_cluster_resolver,xds_cluster_impl,priority,weighted_target,round_robin,resolving_load_balancer,subchannel,keepalive,dns_resolver,fault_injection,http_filter,csds,outlier_detection,server,server_call,ring_hash,transport,certificate_provider
 ENV NODE_XDS_INTEROP_VERBOSITY=1
 
 ENTRYPOINT [ "/nodejs/bin/node", "/node/src/grpc-node/packages/grpc-js-xds/build/interop/xds-interop-client" ]

--- a/packages/grpc-js-xds/interop/test-server.Dockerfile
+++ b/packages/grpc-js-xds/interop/test-server.Dockerfile
@@ -46,7 +46,7 @@ COPY --from=build /node/src/grpc-node/packages/grpc-js ./packages/grpc-js/
 COPY --from=build /node/src/grpc-node/packages/grpc-js-xds ./packages/grpc-js-xds/
 
 ENV GRPC_VERBOSITY="DEBUG"
-ENV GRPC_TRACE=xds_client,server,xds_server
+ENV GRPC_TRACE=xds_client,server,xds_server,http_filter
 
 # tini serves as PID 1 and enables the server to properly respond to signals.
 COPY --from=build /tini /tini

--- a/packages/grpc-js-xds/interop/test-server.Dockerfile
+++ b/packages/grpc-js-xds/interop/test-server.Dockerfile
@@ -46,7 +46,7 @@ COPY --from=build /node/src/grpc-node/packages/grpc-js ./packages/grpc-js/
 COPY --from=build /node/src/grpc-node/packages/grpc-js-xds ./packages/grpc-js-xds/
 
 ENV GRPC_VERBOSITY="DEBUG"
-ENV GRPC_TRACE=xds_client,server,xds_server,http_filter
+ENV GRPC_TRACE=xds_client,server,xds_server,http_filter,certificate_provider
 
 # tini serves as PID 1 and enables the server to properly respond to signals.
 COPY --from=build /tini /tini

--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -519,7 +519,9 @@ function main() {
      * channels do not share any subchannels. It does not have any
      * inherent function. */
     console.log(`Interop client channel ${i} starting sending ${argv.qps} QPS to ${argv.server}`);
-    sendConstantQps(new loadedProto.grpc.testing.TestService(argv.server, grpc.credentials.createInsecure(), {'unique': i, 'grpc-node.tls_enable_trace': 1}),
+    const insecureCreds = grpc.credentials.createInsecure();
+    const creds = new grpc_xds.XdsChannelCredentials(insecureCreds);
+    sendConstantQps(new loadedProto.grpc.testing.TestService(argv.server, creds, {'unique': i}),
       argv.qps,
       argv.fail_on_failed_rpcs === 'true',
       callStatsTracker);

--- a/packages/grpc-js-xds/interop/xds-interop-client.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-client.ts
@@ -519,7 +519,7 @@ function main() {
      * channels do not share any subchannels. It does not have any
      * inherent function. */
     console.log(`Interop client channel ${i} starting sending ${argv.qps} QPS to ${argv.server}`);
-    sendConstantQps(new loadedProto.grpc.testing.TestService(argv.server, grpc.credentials.createInsecure(), {'unique': i}),
+    sendConstantQps(new loadedProto.grpc.testing.TestService(argv.server, grpc.credentials.createInsecure(), {'unique': i, 'grpc-node.tls_enable_trace': 1}),
       argv.qps,
       argv.fail_on_failed_rpcs === 'true',
       callStatsTracker);

--- a/packages/grpc-js-xds/interop/xds-interop-server.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-server.ts
@@ -30,6 +30,8 @@ import { SimpleRequest__Output } from './generated/grpc/testing/SimpleRequest';
 import { SimpleResponse } from './generated/grpc/testing/SimpleResponse';
 import { ReflectionService } from '@grpc/reflection';
 
+grpc_xds.register();
+
 const packageDefinition = protoLoader.loadSync('grpc/testing/test.proto', {
   keepCase: true,
   defaults: true,

--- a/packages/grpc-js-xds/interop/xds-interop-server.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-server.ts
@@ -262,7 +262,7 @@ async function main() {
     reflection.addToServer(maintenanceServer);
     grpc.addAdminServicesToServer(maintenanceServer);
 
-    const server = new grpc_xds.XdsServer({interceptors: [testInfoInterceptor]});
+    const server = new grpc_xds.XdsServer({interceptors: [testInfoInterceptor], 'grpc-node.tls_enable_trace': 1});
     server.addService(loadedProto.grpc.testing.TestService.service, testServiceHandler);
     const xdsCreds = new grpc_xds.XdsServerCredentials(grpc.ServerCredentials.createInsecure());
     await Promise.all([

--- a/packages/grpc-js-xds/interop/xds-interop-server.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-server.ts
@@ -228,11 +228,10 @@ function getIPv6Addresses(): string[] {
 
 async function main() {
   const argv = yargs
-    .string(['port', 'maintenance_port', 'address_type'])
-    .boolean(['secure_mode'])
+    .string(['port', 'maintenance_port', 'address_type', 'secure_mode'])
     .demandOption(['port'])
     .default('address_type', 'IPV4_IPV6')
-    .default('secure_mode', false)
+    .default('secure_mode', 'false')
     .parse()
     console.log('Starting xDS interop server. Args: ', argv);
   const healthImpl = new HealthImplementation({'': 'NOT_SERVING'});
@@ -250,7 +249,8 @@ async function main() {
     services: ['grpc.testing.TestService']
   })
   const addressType = argv.address_type.toUpperCase();
-  if (argv.secure_mode) {
+  const secureMode = argv.secure_mode.toLowerCase() == 'true';
+  if (secureMode) {
     if (addressType !== 'IPV4_IPV6') {
       throw new Error('Secure mode only supports IPV4_IPV6 address type');
     }

--- a/packages/grpc-js-xds/interop/xds-interop-server.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-server.ts
@@ -265,7 +265,7 @@ async function main() {
     const xdsCreds = new grpc_xds.XdsServerCredentials(grpc.ServerCredentials.createInsecure());
     await Promise.all([
       serverBindPromise(maintenanceServer, `[::]:${argv.maintenance_port}`, grpc.ServerCredentials.createInsecure()),
-      serverBindPromise(server, `[::]:${argv.port}`, xdsCreds)
+      serverBindPromise(server, `0.0.0.0:${argv.port}`, xdsCreds)
     ]);
   } else {
     const server = new grpc.Server({interceptors: [unifiedInterceptor]});

--- a/packages/grpc-js-xds/interop/xds-interop-server.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-server.ts
@@ -262,7 +262,7 @@ async function main() {
     reflection.addToServer(maintenanceServer);
     grpc.addAdminServicesToServer(maintenanceServer);
 
-    const server = new grpc_xds.XdsServer({interceptors: [testInfoInterceptor], 'grpc-node.tls_enable_trace': 1});
+    const server = new grpc_xds.XdsServer({interceptors: [testInfoInterceptor]});
     server.addService(loadedProto.grpc.testing.TestService.service, testServiceHandler);
     const xdsCreds = new grpc_xds.XdsServerCredentials(grpc.ServerCredentials.createInsecure());
     await Promise.all([

--- a/packages/grpc-js-xds/interop/xds-interop-server.ts
+++ b/packages/grpc-js-xds/interop/xds-interop-server.ts
@@ -160,6 +160,10 @@ function adminServiceInterceptor(methodDescriptor: grpc.ServerMethodDefinition<a
   const responder: grpc.Responder = {
     start: next => {
       next(listener);
+    },
+    sendMessage: (message, next) => {
+      console.log(`Responded to request to method ${methodDescriptor.path}: ${JSON.stringify(message)}`);
+      next(message);
     }
   };
   return new grpc.ServerInterceptingCall(call, responder);

--- a/packages/grpc-js-xds/src/index.ts
+++ b/packages/grpc-js-xds/src/index.ts
@@ -33,10 +33,16 @@ import * as pick_first_lb from './lb-policy-registry/pick-first';
 export { XdsServer } from './server';
 export { XdsChannelCredentials, XdsServerCredentials } from './xds-credentials';
 
+let registered = false;
+
 /**
  * Register the "xds:" name scheme with the @grpc/grpc-js library.
  */
 export function register() {
+  if (registered) {
+    return;
+  }
+  registered = true;
   resolver_xds.setup();
   load_balancer_cds.setup();
   xds_cluster_impl.setup();

--- a/packages/grpc-js-xds/src/load-balancer-cds.ts
+++ b/packages/grpc-js-xds/src/load-balancer-cds.ts
@@ -433,6 +433,7 @@ export class CdsLoadBalancer implements LoadBalancer {
         if (this.latestSanMatcher === null || !this.latestSanMatcher.equals(sanMatcher)) {
           this.latestSanMatcher = sanMatcher;
         }
+        trace('Configured subject alternative name matcher: ' + sanMatcher);
         childOptions[SAN_MATCHER_KEY] = this.latestSanMatcher;
       }
       this.childBalancer.updateAddressList(childEndpointList, typedChildConfig, childOptions);

--- a/packages/grpc-js-xds/src/load-balancer-cds.ts
+++ b/packages/grpc-js-xds/src/load-balancer-cds.ts
@@ -84,11 +84,13 @@ class DnsExactValueMatcher implements ValueMatcher {
     }
   }
   apply(entry: string): boolean {
-    let [type, value] = entry.split(':');
-    if (!isSupportedSanType(type)) {
+    const colonIndex = entry.indexOf(':');
+    if (colonIndex < 0) {
       return false;
     }
-    if (!value) {
+    const type = entry.substring(0, colonIndex);
+    let value = entry.substring(colonIndex + 1);
+    if (!isSupportedSanType(type)) {
       return false;
     }
     if (this.ignoreCase) {
@@ -137,14 +139,16 @@ class SanEntryMatcher implements ValueMatcher {
     }
   }
   apply(entry: string): boolean {
-    let [type, value] = entry.split(':');
+    const colonIndex = entry.indexOf(':');
+    if (colonIndex < 0) {
+      return false;
+    }
+    const type = entry.substring(0, colonIndex);
+    let value = entry.substring(colonIndex + 1);
     if (!isSupportedSanType(type)) {
       return false;
     }
     value = canonicalizeSanEntryValue(type, value);
-    if (!entry) {
-      return false;
-    }
     return this.childMatcher.apply(value);
   }
   toString(): string {

--- a/packages/grpc-js-xds/src/server.ts
+++ b/packages/grpc-js-xds/src/server.ts
@@ -628,8 +628,9 @@ export class XdsServer extends Server {
     if (!hostPort || !isValidIpPort(hostPort)) {
       throw new Error(`Listening port string must have the format IP:port with non-zero port, got ${port}`);
     }
+    const channelzRef = this.experimentalRegisterListenerToChannelz({host: hostPort.host, port: hostPort.port!});
     const configParameters: ConfigParameters = {
-      createConnectionInjector: (credentials) => this.createConnectionInjector(credentials),
+      createConnectionInjector: (credentials) => this.experimentalCreateConnectionInjectorWithChannelzRef(credentials, channelzRef),
       drainGraceTimeMs: this.drainGraceTimeMs,
       listenerResourceNameTemplate: this.listenerResourceNameTemplate,
       xdsClient: this.xdsClient

--- a/packages/grpc-js-xds/src/server.ts
+++ b/packages/grpc-js-xds/src/server.ts
@@ -83,6 +83,7 @@ interface ConfigParameters {
   createConnectionInjector: (credentials: ServerCredentials) => ConnectionInjector;
   drainGraceTimeMs: number;
   listenerResourceNameTemplate: string;
+  unregisterChannelzRef: () => void;
 }
 
 class FilterChainEntry {
@@ -452,6 +453,7 @@ class BoundPortEntry {
     this.tcpServer.close();
     const resourceName = formatTemplateString(this.configParameters.listenerResourceNameTemplate, this.boundAddress);
     ListenerResourceType.cancelWatch(this.configParameters.xdsClient, resourceName, this.listenerWatcher);
+    this.configParameters.unregisterChannelzRef();
   }
 }
 
@@ -633,7 +635,8 @@ export class XdsServer extends Server {
       createConnectionInjector: (credentials) => this.experimentalCreateConnectionInjectorWithChannelzRef(credentials, channelzRef),
       drainGraceTimeMs: this.drainGraceTimeMs,
       listenerResourceNameTemplate: this.listenerResourceNameTemplate,
-      xdsClient: this.xdsClient
+      xdsClient: this.xdsClient,
+      unregisterChannelzRef: () => this.experimentalUnregisterListenerFromChannelz(channelzRef)
     };
     const portEntry = new BoundPortEntry(configParameters, port, creds);
     const servingStatusListener: ServingStatusListener = statusObject => {

--- a/packages/grpc-js-xds/src/server.ts
+++ b/packages/grpc-js-xds/src/server.ts
@@ -159,6 +159,7 @@ class FilterChainEntry {
     }
     if (credentials instanceof XdsServerCredentials) {
       if (filterChain.transport_socket) {
+        trace('Using secure credentials');
         const downstreamTlsContext = decodeSingleResource(DOWNSTREAM_TLS_CONTEXT_TYPE_URL, filterChain.transport_socket.typed_config!.value);
         const commonTlsContext = downstreamTlsContext.common_tls_context!;
         const instanceCertificateProvider = configParameters.xdsClient.getCertificateProvider(commonTlsContext.tls_certificate_provider_instance!.instance_name);
@@ -185,6 +186,7 @@ class FilterChainEntry {
         }
         credentials = experimental.createCertificateProviderServerCredentials(instanceCertificateProvider, caCertificateProvider, downstreamTlsContext.require_client_certificate?.value ?? false);
       } else {
+        trace('Using fallback credentials');
         credentials = credentials.getFallbackCredentials();
       }
     }

--- a/packages/grpc-js-xds/src/server.ts
+++ b/packages/grpc-js-xds/src/server.ts
@@ -167,16 +167,18 @@ class FilterChainEntry {
         if (!instanceCertificateProvider) {
           throw new Error(`Invalid TLS context detected: unrecognized certificate instance name: ${commonTlsContext.tls_certificate_provider_instance!.instance_name}`);
         }
-        let validationContext: CertificateValidationContext__Output | null;
-        switch (commonTlsContext?.validation_context_type) {
-          case 'validation_context':
-            validationContext = commonTlsContext.validation_context!;
-            break;
-          case 'combined_validation_context':
-            validationContext = commonTlsContext.combined_validation_context!.default_validation_context;
-            break;
-          default:
-            throw new Error(`Invalid TLS context detected: invalid validation_context_type: ${commonTlsContext.validation_context_type}`);
+        let validationContext: CertificateValidationContext__Output | null = null;
+        if (commonTlsContext?.validation_context_type) {
+          switch (commonTlsContext?.validation_context_type) {
+            case 'validation_context':
+              validationContext = commonTlsContext.validation_context!;
+              break;
+            case 'combined_validation_context':
+              validationContext = commonTlsContext.combined_validation_context!.default_validation_context;
+              break;
+            default:
+              throw new Error(`Invalid TLS context detected: invalid validation_context_type: ${commonTlsContext.validation_context_type}`);
+          }
         }
         let caCertificateProvider: experimental.CertificateProvider | null = null;
         if (validationContext?.ca_certificate_provider_instance) {

--- a/packages/grpc-js-xds/src/server.ts
+++ b/packages/grpc-js-xds/src/server.ts
@@ -289,6 +289,7 @@ class ListenerConfig {
   handleConnection(socket: net.Socket) {
     const matchingFilter = selectMostSpecificallyMatchingFilter(this.filterChainEntries, socket) ?? this.defaultFilterChain;
     if (!matchingFilter) {
+      trace('Rejecting connection from ' + socket.remoteAddress + ': No filter matched');
       socket.destroy();
       return;
     }
@@ -456,7 +457,19 @@ class BoundPortEntry {
 
 function normalizeFilterChainMatch(filterChainMatch: FilterChainMatch__Output | null): NormalizedFilterChainMatch[] {
   if (!filterChainMatch) {
-    return [];
+    filterChainMatch = {
+      address_suffix: '',
+      application_protocols: [],
+      destination_port: null,
+      direct_source_prefix_ranges: [],
+      prefix_ranges: [],
+      server_names: [],
+      source_ports: [],
+      source_prefix_ranges: [],
+      source_type: 'ANY',
+      suffix_len: null,
+      transport_protocol: 'raw_buffer'
+    };
   }
   if (filterChainMatch.destination_port) {
     return [];

--- a/packages/grpc-js-xds/src/xds-credentials.ts
+++ b/packages/grpc-js-xds/src/xds-credentials.ts
@@ -64,7 +64,7 @@ export class XdsChannelCredentials extends ChannelCredentials {
 
 export class XdsServerCredentials extends ServerCredentials {
   constructor(private fallbackCredentials: ServerCredentials) {
-    super();
+    super({});
   }
 
   getFallbackCredentials() {

--- a/packages/grpc-js-xds/src/xds-dependency-manager.ts
+++ b/packages/grpc-js-xds/src/xds-dependency-manager.ts
@@ -360,6 +360,10 @@ export class XdsDependencyManager {
   constructor(private xdsClient: XdsClient, private listenerResourceName: string, private dataPlaneAuthority: string, private watcher: XdsConfigWatcher) {
     this.ldsWatcher = new Watcher<Listener__Output>({
       onResourceChanged: (update: Listener__Output) => {
+        if (!update.api_listener) {
+          this.trace('Received Listener resource not usable on client');
+          return;
+        }
         this.latestListener = update;
         const httpConnectionManager = decodeSingleResource(HTTP_CONNECTION_MANGER_TYPE_URL, update.api_listener!.api_listener!.value);
         switch (httpConnectionManager.route_specifier) {

--- a/packages/grpc-js-xds/src/xds-resource-type/listener-resource-type.ts
+++ b/packages/grpc-js-xds/src/xds-resource-type/listener-resource-type.ts
@@ -294,6 +294,9 @@ export class ListenerResourceType extends XdsResourceType {
     if (message.default_filter_chain) {
       errors.push(...validateFilterChain(context, message.default_filter_chain).map(error => `default_filter_chain: ${error}`));
     }
+    if (!message.api_listener && !message.default_filter_chain && message.filter_chains.length === 0) {
+      errors.push('No api_listener and no filter_chains and no default_filter_chain');
+    }
     if (errors.length === 0) {
       return {
         valid: true,

--- a/packages/grpc-js-xds/src/xds-resource-type/listener-resource-type.ts
+++ b/packages/grpc-js-xds/src/xds-resource-type/listener-resource-type.ts
@@ -152,6 +152,7 @@ function validateTransportSocket(context: XdsDecodeContext, transportSocket: Tra
     return errors;
   }
   const downstreamTlsContext = decodeSingleResource(DOWNSTREAM_TLS_CONTEXT_TYPE_URL, transportSocket.typed_config.value);
+  trace('Decoded DownstreamTlsContext: ' + JSON.stringify(downstreamTlsContext, undefined, 2));
   if (downstreamTlsContext.require_sni?.value) {
     errors.push(`DownstreamTlsContext.require_sni set`);
   }

--- a/packages/grpc-js-xds/src/xds-resource-type/listener-resource-type.ts
+++ b/packages/grpc-js-xds/src/xds-resource-type/listener-resource-type.ts
@@ -262,14 +262,15 @@ export class ListenerResourceType extends XdsResourceType {
 
   private validateResource(context: XdsDecodeContext, message: Listener__Output): ValidationResult<Listener__Output> {
     const errors: string[] = [];
-    if (
-      message.api_listener?.api_listener &&
-      message.api_listener.api_listener.type_url === HTTP_CONNECTION_MANGER_TYPE_URL
-    ) {
-      const httpConnectionManager = decodeSingleResource(HTTP_CONNECTION_MANGER_TYPE_URL, message.api_listener!.api_listener.value);
-      errors.push(...validateHttpConnectionManager(httpConnectionManager).map(error => `api_listener.api_listener: ${error}`));
-    } else {
-      errors.push(`api_listener.api_listener.type_url != ${HTTP_CONNECTION_MANGER_TYPE_URL}`);
+    if (message.api_listener?.api_listener) {
+      if (
+        message.api_listener.api_listener.type_url === HTTP_CONNECTION_MANGER_TYPE_URL
+      ) {
+        const httpConnectionManager = decodeSingleResource(HTTP_CONNECTION_MANGER_TYPE_URL, message.api_listener!.api_listener.value);
+        errors.push(...validateHttpConnectionManager(httpConnectionManager).map(error => `api_listener.api_listener: ${error}`));
+      } else {
+        errors.push(`api_listener.api_listener.type_url != ${HTTP_CONNECTION_MANGER_TYPE_URL}`);
+      }
     }
     if (message.listener_filters.length > 0) {
       errors.push('listener_filters populated');

--- a/packages/grpc-js-xds/src/xds-resource-type/listener-resource-type.ts
+++ b/packages/grpc-js-xds/src/xds-resource-type/listener-resource-type.ts
@@ -165,26 +165,28 @@ function validateTransportSocket(context: XdsDecodeContext, transportSocket: Tra
   }
   const commonTlsContext = downstreamTlsContext.common_tls_context;
   let validationContext: CertificateValidationContext__Output | null = null;
-  switch (commonTlsContext.validation_context_type) {
-    case 'validation_context_sds_secret_config':
-      errors.push('Unexpected DownstreamTlsContext.common_tls_context.validation_context_sds_secret_config');
-      break;
-    case 'validation_context':
-      if (!commonTlsContext.validation_context) {
-        errors.push('Empty DownstreamTlsContext.common_tls_context.validation_context');
+  if (commonTlsContext.validation_context_type) {
+    switch (commonTlsContext.validation_context_type) {
+      case 'validation_context_sds_secret_config':
+        errors.push('Unexpected DownstreamTlsContext.common_tls_context.validation_context_sds_secret_config');
         break;
-      }
-      validationContext = commonTlsContext.validation_context;
-      break;
-    case 'combined_validation_context':
-      if (!commonTlsContext.combined_validation_context) {
-        errors.push('Empty DownstreamTlsContext.common_tls_context.combined_validation_context')
+      case 'validation_context':
+        if (!commonTlsContext.validation_context) {
+          errors.push('Empty DownstreamTlsContext.common_tls_context.validation_context');
+          break;
+        }
+        validationContext = commonTlsContext.validation_context;
         break;
-      }
-      validationContext = commonTlsContext.combined_validation_context.default_validation_context;
-      break;
-    default:
-      errors.push(`Unsupported DownstreamTlsContext.common_tls_context.validation_context_type: ${commonTlsContext.validation_context_type}`);
+      case 'combined_validation_context':
+        if (!commonTlsContext.combined_validation_context) {
+          errors.push('Empty DownstreamTlsContext.common_tls_context.combined_validation_context')
+          break;
+        }
+        validationContext = commonTlsContext.combined_validation_context.default_validation_context;
+        break;
+      default:
+        errors.push(`Unsupported DownstreamTlsContext.common_tls_context.validation_context_type: ${commonTlsContext.validation_context_type}`);
+    }
   }
   if (downstreamTlsContext.require_client_certificate && !validationContext) {
     errors.push('DownstreamTlsContext.require_client_certificate set without any validationContext');

--- a/packages/grpc-js-xds/test/test-xds-credentials.ts
+++ b/packages/grpc-js-xds/test/test-xds-credentials.ts
@@ -21,7 +21,7 @@ import { FakeEdsCluster, FakeRouteGroup, FakeServerRoute } from './framework';
 import { ControlPlaneServer } from './xds-server';
 import { XdsTestClient } from './client';
 import { XdsChannelCredentials, XdsServerCredentials } from '../src';
-import { credentials, ServerCredentials, experimental } from '@grpc/grpc-js';
+import { credentials, ServerCredentials, experimental, status } from '@grpc/grpc-js';
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import { Listener } from '../src/generated/envoy/config/listener/v3/Listener';
@@ -441,6 +441,65 @@ describe('Client xDS credentials', () => {
       const error = await client.sendOneCallAsync();
       assert.strictEqual(error, null);
     });
-
+    it('Should fail when the server expects a certificate and does not get one', async () => {
+      const [backend] = await createBackends(1, true, new XdsServerCredentials(ServerCredentials.createInsecure()));
+      const downstreamTlsContext: DownstreamTlsContext & AnyExtension = {
+        '@type': DOWNSTREAM_TLS_CONTEXT_TYPE_URL,
+        common_tls_context: {
+          tls_certificate_provider_instance: {
+            instance_name: 'test_certificates'
+          },
+          validation_context: {
+            ca_certificate_provider_instance: {
+              instance_name: 'test_certificates'
+            }
+          }
+        },
+        ocsp_staple_policy: 'LENIENT_STAPLING',
+        require_client_certificate: {
+          value: true
+        }
+      }
+      const baseServerListener: Listener = {
+        default_filter_chain: {
+          filter_chain_match: {
+            source_type: 'SAME_IP_OR_LOOPBACK'
+          },
+          transport_socket: {
+            name: 'envoy.transport_sockets.tls',
+            typed_config: downstreamTlsContext
+          }
+        }
+      }
+      const serverRoute = new FakeServerRoute(backend.getPort(), 'serverRoute', baseServerListener);
+      xdsServer.setRdsResource(serverRoute.getRouteConfiguration());
+      xdsServer.setLdsResource(serverRoute.getListener());
+      xdsServer.addResponseListener((typeUrl, responseState) => {
+        if (responseState.state === 'NACKED') {
+          client?.stopCalls();
+          assert.fail(`Client NACKED ${typeUrl} resource with message ${responseState.errorMessage}`);
+        }
+      });
+      const upstreamTlsContext: UpstreamTlsContext = {
+        common_tls_context: {
+          validation_context: {
+            ca_certificate_provider_instance: {
+              instance_name: 'test_certificates'
+            }
+          }
+        }
+      };
+      const cluster = new FakeEdsCluster('cluster1', 'endpoint1', [{backends: [backend], locality:{region: 'region1'}}], undefined, upstreamTlsContext);
+      const routeGroup = new FakeRouteGroup('listener1', 'route1', [{cluster: cluster}]);
+      await routeGroup.startAllBackends(xdsServer);
+      xdsServer.setEdsResource(cluster.getEndpointConfig());
+      xdsServer.setCdsResource(cluster.getClusterConfig());
+      xdsServer.setRdsResource(routeGroup.getRouteConfiguration());
+      xdsServer.setLdsResource(routeGroup.getListener());
+      client = XdsTestClient.createFromServer('listener1', xdsServer, new XdsChannelCredentials(credentials.createInsecure()));
+      const error = await client.sendOneCallAsync();
+      assert(error);
+      assert.strictEqual(error.code, status.UNAVAILABLE);
+    });
   });
 });

--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -262,6 +262,10 @@ class SecureConnectorImpl implements SecureConnector {
     };
     return new Promise<SecureConnectResult>((resolve, reject) => {
       const tlsSocket = tlsConnect(tlsConnectOptions, () => {
+        if (!tlsSocket.authorized) {
+          reject(tlsSocket.authorizationError);
+          return;
+        }
         resolve({
           socket: tlsSocket,
           secure: true
@@ -340,6 +344,10 @@ class CertificateProviderChannelCredentialsImpl extends ChannelCredentials {
           ...connnectionOptions
         }
         const tlsSocket = tlsConnect(tlsConnectOptions, () => {
+          if (!tlsSocket.authorized) {
+            reject(tlsSocket.authorizationError);
+            return;
+          }
           resolve({
             socket: tlsSocket,
             secure: true

--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -31,6 +31,8 @@ import { Socket } from 'net';
 import { ChannelOptions } from './channel-options';
 import { GrpcUri, parseUri, splitHostPort } from './uri-parser';
 import { getDefaultAuthority } from './resolver';
+import { log } from './logging';
+import { LogVerbosity } from './constants';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function verifyIsBufferOrNull(obj: any, friendlyName: string): void {
@@ -475,12 +477,17 @@ class CertificateProviderChannelCredentialsImpl extends ChannelCredentials {
     if (this.identityCertificateProvider !== null && !this.latestIdentityUpdate) {
       return null;
     }
-    return createSecureContext({
-      ca: this.latestCaUpdate.caCertificate,
-      key: this.latestIdentityUpdate?.privateKey,
-      cert: this.latestIdentityUpdate?.certificate,
-      ciphers: CIPHER_SUITES
-    });
+    try {
+      return createSecureContext({
+        ca: this.latestCaUpdate.caCertificate,
+        key: this.latestIdentityUpdate?.privateKey,
+        cert: this.latestIdentityUpdate?.certificate,
+        ciphers: CIPHER_SUITES
+      });
+    } catch (e) {
+      log(LogVerbosity.ERROR, 'Failed to createSecureContext with error ' + (e as Error).message);
+      return null;
+    }
   }
 }
 

--- a/packages/grpc-js/src/channel-credentials.ts
+++ b/packages/grpc-js/src/channel-credentials.ts
@@ -339,7 +339,7 @@ class CertificateProviderChannelCredentialsImpl extends ChannelCredentials {
     constructor(private parent: CertificateProviderChannelCredentialsImpl, private channelTarget: GrpcUri, private options: ChannelOptions, private callCredentials: CallCredentials) {}
 
     connect(socket: Socket): Promise<SecureConnectResult> {
-      return new Promise(async (resolve, reject) => {
+      return new Promise((resolve, reject) => {
         const secureContext = this.parent.getLatestSecureContext();
         if (!secureContext) {
           reject(new Error('Failed to load credentials'));

--- a/packages/grpc-js/src/channelz.ts
+++ b/packages/grpc-js/src/channelz.ts
@@ -460,6 +460,23 @@ function parseIPv6Chunk(addressChunk: string): number[] {
   return result.concat(...bytePairs);
 }
 
+function isIPv6MappedIPv4(ipAddress: string) {
+  return isIPv6(ipAddress) && ipAddress.toLowerCase().startsWith('::ffff:') && isIPv4(ipAddress.substring(7));
+}
+
+/**
+ * Prerequisite: isIPv4(ipAddress)
+ * @param ipAddress
+ * @returns
+ */
+function ipv4AddressStringToBuffer(ipAddress: string): Buffer {
+  return Buffer.from(
+    Uint8Array.from(
+      ipAddress.split('.').map(segment => Number.parseInt(segment))
+    )
+  );
+}
+
 /**
  * Converts an IPv4 or IPv6 address from string representation to binary
  * representation
@@ -468,11 +485,9 @@ function parseIPv6Chunk(addressChunk: string): number[] {
  */
 function ipAddressStringToBuffer(ipAddress: string): Buffer | null {
   if (isIPv4(ipAddress)) {
-    return Buffer.from(
-      Uint8Array.from(
-        ipAddress.split('.').map(segment => Number.parseInt(segment))
-      )
-    );
+    return ipv4AddressStringToBuffer(ipAddress);
+  } else if (isIPv6MappedIPv4(ipAddress)) {
+    return ipv4AddressStringToBuffer(ipAddress.substring(7));
   } else if (isIPv6(ipAddress)) {
     let leftSection: string;
     let rightSection: string;

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -960,6 +960,9 @@ export class Server {
     if (credentials === null || !(credentials instanceof ServerCredentials)) {
       throw new TypeError('creds must be a ServerCredentials object');
     }
+    if (this.channelzEnabled) {
+      this.listenerChildrenTracker.refChild(channelzRef);
+    }
     const server = this.createHttp2Server(credentials);
     const sessionsSet: Set<http2.ServerHttp2Session> = new Set();
     this.http2Servers.set(server, {
@@ -994,9 +997,6 @@ export class Server {
       throw new TypeError('creds must be a ServerCredentials object');
     }
     const channelzRef = this.registerInjectorToChannelz();
-    if (this.channelzEnabled) {
-      this.listenerChildrenTracker.refChild(channelzRef);
-    }
     return this.experimentalCreateConnectionInjectorWithChannelzRef(credentials, channelzRef);
   }
 

--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -576,9 +576,11 @@ export class Server {
         enableTrace: this.options['grpc-node.tls_enable_trace'] === 1
       };
       let areCredentialsValid = credentialsSettings !== null;
+      this.trace('Initial credentials valid: ' + areCredentialsValid);
       http2Server = http2.createSecureServer(secureServerOptions);
-      http2Server.on('connection', (socket: Socket) => {
+      http2Server.prependListener('connection', (socket: Socket) => {
         if (!areCredentialsValid) {
+          this.trace('Dropped connection from ' + JSON.stringify(socket.address()) + ' due to unloaded credentials');
           socket.destroy();
         }
       });
@@ -596,6 +598,7 @@ export class Server {
           (http2Server as http2.Http2SecureServer).setSecureContext(options);
         }
         areCredentialsValid = options !== null;
+        this.trace('Post-update credentials valid: ' + areCredentialsValid);
       }
       credentials._addWatcher(credsWatcher);
       http2Server.on('close', () => {

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -225,8 +225,8 @@ class Http2Transport implements Transport {
       this.handleDisconnect();
     });
 
-    session.socket.once('close', () => {
-      this.trace('connection closed');
+    session.socket.once('close', (hadError) => {
+      this.trace('connection closed. hadError=' + hadError);
       this.handleDisconnect();
     });
 

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -738,7 +738,7 @@ export class Http2SubchannelConnector implements SubchannelConnector {
     }
     let tcpConnection: net.Socket | null = null;
     let secureConnectResult: SecureConnectResult | null  = null;
-    const addressString = this.trace(subchannelAddressToString(address));
+    const addressString = subchannelAddressToString(address);
     try {
       tcpConnection = await this.tcpConnect(address, options);
       this.trace(addressString + ' ' + 'Established TCP connection');

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -685,7 +685,7 @@ export class Http2SubchannelConnector implements SubchannelConnector {
       let errorMessage = 'Failed to connect';
       let reportedError = false;
       session.unref();
-      session.once('connect', () => {
+      session.once('remoteSettings', () => {
         session.removeAllListeners();
         resolve(new Http2Transport(session, address, options, remoteName));
         this.session = null;

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -738,9 +738,12 @@ export class Http2SubchannelConnector implements SubchannelConnector {
     }
     let tcpConnection: net.Socket | null = null;
     let secureConnectResult: SecureConnectResult | null  = null;
+    const addressString = this.trace(subchannelAddressToString(address));
     try {
       tcpConnection = await this.tcpConnect(address, options);
+      this.trace(addressString + ' ' + 'Established TCP connection');
       secureConnectResult = await secureConnector.connect(tcpConnection);
+      this.trace(addressString + ' ' + 'Established secure connection');
       return this.createSession(secureConnectResult, address, options);
     } catch (e) {
       tcpConnection?.destroy();

--- a/packages/grpc-js/test/test-channel-credentials.ts
+++ b/packages/grpc-js/test/test-channel-credentials.ts
@@ -201,6 +201,21 @@ describe('ChannelCredentials usage', () => {
         done();
       }
     );
-
-  })
+  });
+  it('Should never connect when using insecure creds with a secure server', done => {
+    const client = new echoService(`localhost:${portNum}`, grpc.credentials.createInsecure());
+    const deadline = new Date();
+    deadline.setSeconds(deadline.getSeconds() + 1);
+    client.echo(
+      { value: 'test value', value2: 3 },
+      new grpc.Metadata({waitForReady: true}),
+      {deadline},
+      (error: ServiceError, response: any) => {
+        client.close();
+        assert(error);
+        assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
+        done();
+      }
+    );
+  });
 });

--- a/packages/grpc-js/test/test-server-credentials.ts
+++ b/packages/grpc-js/test/test-server-credentials.ts
@@ -32,7 +32,7 @@ describe('Server Credentials', () => {
       const creds = ServerCredentials.createInsecure();
 
       assert.strictEqual(creds._isSecure(), false);
-      assert.strictEqual(creds._getSettings(), null);
+      assert.strictEqual(creds._getSecureContextOptions(), null);
     });
   });
 
@@ -41,16 +41,17 @@ describe('Server Credentials', () => {
       const creds = ServerCredentials.createSsl(ca, []);
 
       assert.strictEqual(creds._isSecure(), true);
-      assert.strictEqual(creds._getSettings()?.ca, ca);
+      assert.strictEqual(creds._getSecureContextOptions()?.ca, ca);
     });
 
     it('accepts a boolean as the third argument', () => {
       const creds = ServerCredentials.createSsl(ca, [], true);
 
       assert.strictEqual(creds._isSecure(), true);
-      const settings = creds._getSettings();
-      assert.strictEqual(settings?.ca, ca);
-      assert.strictEqual(settings?.requestCert, true);
+      const constructorOptions = creds._getConstructorOptions();
+      const contextOptions = creds._getSecureContextOptions();
+      assert.strictEqual(contextOptions?.ca, ca);
+      assert.strictEqual(constructorOptions?.requestCert, true);
     });
 
     it('accepts an object with two buffers in the second argument', () => {
@@ -58,9 +59,9 @@ describe('Server Credentials', () => {
       const creds = ServerCredentials.createSsl(null, keyCertPairs);
 
       assert.strictEqual(creds._isSecure(), true);
-      const settings = creds._getSettings();
-      assert.deepStrictEqual(settings?.cert, [cert]);
-      assert.deepStrictEqual(settings?.key, [key]);
+      const contextOptions = creds._getSecureContextOptions();
+      assert.deepStrictEqual(contextOptions?.cert, [cert]);
+      assert.deepStrictEqual(contextOptions?.key, [key]);
     });
 
     it('accepts multiple objects in the second argument', () => {
@@ -71,9 +72,9 @@ describe('Server Credentials', () => {
       const creds = ServerCredentials.createSsl(null, keyCertPairs, false);
 
       assert.strictEqual(creds._isSecure(), true);
-      const settings = creds._getSettings();
-      assert.deepStrictEqual(settings?.cert, [cert, cert]);
-      assert.deepStrictEqual(settings?.key, [key, key]);
+      const contextOptions = creds._getSecureContextOptions();
+      assert.deepStrictEqual(contextOptions?.cert, [cert, cert]);
+      assert.deepStrictEqual(contextOptions?.key, [key, key]);
     });
 
     it('fails if the second argument is not an Array', () => {

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -801,7 +801,7 @@ describe('Echo service', () => {
     class ToggleableSecureServerCredentials extends ServerCredentials {
       private contextOptions: SecureContextOptions;
       constructor(key: Buffer, cert: Buffer) {
-        super();
+        super({});
         this.contextOptions = {key, cert};
         this.enable();
       }

--- a/test/kokoro/psm-security.cfg
+++ b/test/kokoro/psm-security.cfg
@@ -1,0 +1,30 @@
+# Copyright 2025 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-node/packages/grpc-js-xds/scripts/psm-interop-test-node.sh"
+timeout_mins: 360
+action {
+  define_artifacts {
+    regex: "artifacts/**/*sponge_log.xml"
+    regex: "artifacts/**/*.log"
+    strip_prefix: "artifacts"
+  }
+}
+env_vars {
+  key: "PSM_TEST_SUITE"
+  value: "security"
+}


### PR DESCRIPTION
This change also includes a variety of fixes to make those tests pass:

 - Fix parsing of SAN entries to correctly handle colons in names.
 - Handle unset `CommonTlsContext.validation_context_type`.
 - Handle unset `filter_chain_match`.
 - Add `Server` protected methods `experimentalRegisterListenerToChannelz`, `experimentalUnregisterListenerFromChannelz`, and `experimentalCreateConnectionInjectorWithChannelzRef`.
 - Modify `ServerCredentials` to separate options that are used once on `Http2Server` construction from options that can be updated such as by a certificate provider.
 - Make transport and channel credentials connection establishment code handle and report more connection errors.
 - Wait for credentials information to be loaded from certificate providers before starting to connect, to avoid a time gap between creating a TCP connection and starting the TLS handshake.
 - Fix IPv6-mapped IPv4 address parsing in channelz, and represent them as IPv4 addresses.
 - Add error handling and logging for `tls.createSecureContext`.

- [x] [grpc/node/master/psm-security](https://source.cloud.google.com/results/invocations/369e192d-9c64-4475-b236-55ae6155410b)