### PR TITLE
proto-loader: declare oneof fields as optional

### DIFF
--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/AccessLog.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/AccessLog.ts
@@ -34,5 +34,5 @@ export interface AccessLog__Output {
    * Custom configuration that must be set according to the access logger extension being instantiated.
    * [#extension-category: envoy.access_loggers]
    */
-  'config_type': "typed_config";
+  'config_type'?: "typed_config";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/AccessLogFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/AccessLogFilter.ts
@@ -131,5 +131,5 @@ export interface AccessLogFilter__Output {
    * Log Type Filter
    */
   'log_type_filter'?: (_envoy_config_accesslog_v3_LogTypeFilter__Output | null);
-  'filter_specifier': "status_code_filter"|"duration_filter"|"not_health_check_filter"|"traceable_filter"|"runtime_filter"|"and_filter"|"or_filter"|"header_filter"|"response_flag_filter"|"grpc_status_filter"|"extension_filter"|"metadata_filter"|"log_type_filter";
+  'filter_specifier'?: "status_code_filter"|"duration_filter"|"not_health_check_filter"|"traceable_filter"|"runtime_filter"|"and_filter"|"or_filter"|"header_filter"|"response_flag_filter"|"grpc_status_filter"|"extension_filter"|"metadata_filter"|"log_type_filter";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/ExtensionFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/accesslog/v3/ExtensionFilter.ts
@@ -31,5 +31,5 @@ export interface ExtensionFilter__Output {
   /**
    * Custom configuration that depends on the filter being instantiated.
    */
-  'config_type': "typed_config";
+  'config_type'?: "typed_config";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/Cluster.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/cluster/v3/Cluster.ts
@@ -179,7 +179,7 @@ export interface _envoy_config_cluster_v3_Cluster_CommonLbConfig__Output {
    * set with an empty set of statuses then host overrides will be ignored by the load balancing.
    */
   'override_host_status': (_envoy_config_core_v3_HealthStatusSet__Output | null);
-  'locality_config_specifier': "zone_aware_lb_config"|"locality_weighted_lb_config";
+  'locality_config_specifier'?: "zone_aware_lb_config"|"locality_weighted_lb_config";
 }
 
 /**
@@ -2702,7 +2702,7 @@ export interface Cluster__Output {
    * as the key.
    */
   'lrs_report_endpoint_metrics': (string)[];
-  'cluster_discovery_type': "type"|"cluster_type";
+  'cluster_discovery_type'?: "type"|"cluster_type";
   /**
    * Optional configuration for the load balancing algorithm selected by
    * LbPolicy. Currently only
@@ -2713,5 +2713,5 @@ export interface Cluster__Output {
    * Specifying ring_hash_lb_config or maglev_lb_config or least_request_lb_config without setting the corresponding
    * LbPolicy will generate an error at runtime.
    */
-  'lb_config': "ring_hash_lb_config"|"maglev_lb_config"|"original_dst_lb_config"|"least_request_lb_config"|"round_robin_lb_config";
+  'lb_config'?: "ring_hash_lb_config"|"maglev_lb_config"|"original_dst_lb_config"|"least_request_lb_config"|"round_robin_lb_config";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Address.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Address.ts
@@ -33,5 +33,5 @@ export interface Address__Output {
    * <envoy_v3_api_field_config.listener.v3.Listener.internal_listener>`.
    */
   'envoy_internal_address'?: (_envoy_config_core_v3_EnvoyInternalAddress__Output | null);
-  'address': "socket_address"|"pipe"|"envoy_internal_address";
+  'address'?: "socket_address"|"pipe"|"envoy_internal_address";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/AsyncDataSource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/AsyncDataSource.ts
@@ -30,5 +30,5 @@ export interface AsyncDataSource__Output {
    * Remote async data source.
    */
   'remote'?: (_envoy_config_core_v3_RemoteDataSource__Output | null);
-  'specifier': "local"|"remote";
+  'specifier'?: "local"|"remote";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/ConfigSource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/ConfigSource.ts
@@ -141,5 +141,5 @@ export interface ConfigSource__Output {
    * Local filesystem path configuration source.
    */
   'path_config_source'?: (_envoy_config_core_v3_PathConfigSource__Output | null);
-  'config_source_specifier': "path"|"path_config_source"|"api_config_source"|"ads"|"self";
+  'config_source_specifier'?: "path"|"path_config_source"|"api_config_source"|"ads"|"self";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/DataSource.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/DataSource.ts
@@ -81,5 +81,5 @@ export interface DataSource__Output {
    * details.
    */
   'watched_directory': (_envoy_config_core_v3_WatchedDirectory__Output | null);
-  'specifier': "filename"|"inline_bytes"|"inline_string"|"environment_variable";
+  'specifier'?: "filename"|"inline_bytes"|"inline_string"|"environment_variable";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/EnvoyInternalAddress.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/EnvoyInternalAddress.ts
@@ -36,5 +36,5 @@ export interface EnvoyInternalAddress__Output {
    * example, may be set to the final destination IP for the target internal listener.
    */
   'endpoint_id': (string);
-  'address_name_specifier': "server_listener_name";
+  'address_name_specifier'?: "server_listener_name";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/EventServiceConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/EventServiceConfig.ts
@@ -23,5 +23,5 @@ export interface EventServiceConfig__Output {
    * Specifies the gRPC service that hosts the event reporting service.
    */
   'grpc_service'?: (_envoy_config_core_v3_GrpcService__Output | null);
-  'config_source_specifier': "grpc_service";
+  'config_source_specifier'?: "grpc_service";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/GrpcService.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/GrpcService.ts
@@ -95,7 +95,7 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials__O
    * See https://github.com/grpc/grpc/pull/19587.
    */
   'sts_service'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_StsService__Output | null);
-  'credential_specifier': "access_token"|"google_compute_engine"|"google_refresh_token"|"service_account_jwt_access"|"google_iam"|"from_plugin"|"sts_service";
+  'credential_specifier'?: "access_token"|"google_compute_engine"|"google_refresh_token"|"service_account_jwt_access"|"google_iam"|"from_plugin"|"sts_service";
 }
 
 /**
@@ -143,7 +143,7 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelCredentials
    */
   'google_default'?: (_google_protobuf_Empty__Output | null);
   'local_credentials'?: (_envoy_config_core_v3_GrpcService_GoogleGrpc_GoogleLocalCredentials__Output | null);
-  'credential_specifier': "ssl_credentials"|"google_default"|"local_credentials";
+  'credential_specifier'?: "ssl_credentials"|"google_default"|"local_credentials";
 }
 
 /**
@@ -361,7 +361,7 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_Me
   /**
    * [#extension-category: envoy.grpc_credentials]
    */
-  'config_type': "typed_config";
+  'config_type'?: "typed_config";
 }
 
 export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJWTAccessCredentials {
@@ -535,7 +535,7 @@ export interface _envoy_config_core_v3_GrpcService_GoogleGrpc_ChannelArgs_Value_
    * Pointer values are not supported, since they don't make any sense when
    * delivered via the API.
    */
-  'value_specifier': "string_value"|"int_value";
+  'value_specifier'?: "string_value"|"int_value";
 }
 
 /**
@@ -613,5 +613,5 @@ export interface GrpcService__Output {
    * If an async stream doesn't have retry policy configured in its stream options, this retry policy is used.
    */
   'retry_policy': (_envoy_config_core_v3_RetryPolicy__Output | null);
-  'target_specifier': "envoy_grpc"|"google_grpc";
+  'target_specifier'?: "envoy_grpc"|"google_grpc";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HealthCheck.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HealthCheck.ts
@@ -46,7 +46,7 @@ export interface _envoy_config_core_v3_HealthCheck_CustomHealthCheck__Output {
    * being instantiated. See :api:`envoy/config/health_checker` for reference.
    * [#extension-category: envoy.health_checkers]
    */
-  'config_type': "typed_config";
+  'config_type'?: "typed_config";
 }
 
 /**
@@ -316,7 +316,7 @@ export interface _envoy_config_core_v3_HealthCheck_Payload__Output {
    * Binary payload.
    */
   'binary'?: (Buffer);
-  'payload': "text"|"binary";
+  'payload'?: "text"|"binary";
 }
 
 export interface _envoy_config_core_v3_HealthCheck_RedisHealthCheck {
@@ -804,5 +804,5 @@ export interface HealthCheck__Output {
    * The default value is false.
    */
   'always_log_health_check_success': (boolean);
-  'health_checker': "http_health_check"|"tcp_health_check"|"grpc_health_check"|"custom_health_check";
+  'health_checker'?: "http_health_check"|"tcp_health_check"|"grpc_health_check"|"custom_health_check";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Http1ProtocolOptions.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Http1ProtocolOptions.ts
@@ -42,7 +42,7 @@ export interface _envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat__Out
    * [#extension-category: envoy.http.stateful_header_formatters]
    */
   'stateful_formatter'?: (_envoy_config_core_v3_TypedExtensionConfig__Output | null);
-  'header_format': "proper_case_words"|"stateful_formatter";
+  'header_format'?: "proper_case_words"|"stateful_formatter";
 }
 
 export interface _envoy_config_core_v3_Http1ProtocolOptions_HeaderKeyFormat_ProperCaseWords {

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HttpUri.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/HttpUri.ts
@@ -75,5 +75,5 @@ export interface HttpUri__Output {
    * inline DNS resolution. See `issue
    * <https://github.com/envoyproxy/envoy/issues/1606>`_.
    */
-  'http_upstream_type': "cluster";
+  'http_upstream_type'?: "cluster";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Node.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/Node.ts
@@ -174,5 +174,5 @@ export interface Node__Output {
    * parameter then appears in this field during future discovery requests.
    */
   'dynamic_parameters': ({[key: string]: _xds_core_v3_ContextParams__Output});
-  'user_agent_version_type': "user_agent_version"|"user_agent_build_version";
+  'user_agent_version_type'?: "user_agent_version"|"user_agent_build_version";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RetryPolicy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/RetryPolicy.ts
@@ -20,7 +20,7 @@ export interface _envoy_config_core_v3_RetryPolicy_RetryHostPredicate {
 export interface _envoy_config_core_v3_RetryPolicy_RetryHostPredicate__Output {
   'name': (string);
   'typed_config'?: (_google_protobuf_Any__Output | null);
-  'config_type': "typed_config";
+  'config_type'?: "typed_config";
 }
 
 /**
@@ -38,7 +38,7 @@ export interface _envoy_config_core_v3_RetryPolicy_RetryPriority {
 export interface _envoy_config_core_v3_RetryPolicy_RetryPriority__Output {
   'name': (string);
   'typed_config'?: (_google_protobuf_Any__Output | null);
-  'config_type': "typed_config";
+  'config_type'?: "typed_config";
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SchemeHeaderTransformation.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SchemeHeaderTransformation.ts
@@ -36,5 +36,5 @@ export interface SchemeHeaderTransformation__Output {
    * If scheme_to_overwrite is set, this field is not used.
    */
   'match_upstream': (boolean);
-  'transformation': "scheme_to_overwrite";
+  'transformation'?: "scheme_to_overwrite";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SocketAddress.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SocketAddress.ts
@@ -101,5 +101,5 @@ export interface SocketAddress__Output {
    * IPv6 space as ``::FFFF:<IPv4-address>``.
    */
   'ipv4_compat': (boolean);
-  'port_specifier': "port_value"|"named_port";
+  'port_specifier'?: "port_value"|"named_port";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SocketOption.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SocketOption.ts
@@ -145,5 +145,5 @@ export interface SocketOption__Output {
    * STATE_PREBIND is currently the only valid value.
    */
   'state': (_envoy_config_core_v3_SocketOption_SocketState__Output);
-  'value': "int_value"|"buf_value";
+  'value'?: "int_value"|"buf_value";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SubstitutionFormatString.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/SubstitutionFormatString.ts
@@ -206,5 +206,5 @@ export interface SubstitutionFormatString__Output {
    * If json_format is used, the options will be applied to the output JSON string.
    */
   'json_format_options': (_envoy_config_core_v3_JsonFormatOptions__Output | null);
-  'format': "text_format"|"json_format"|"text_format_source";
+  'format'?: "text_format"|"json_format"|"text_format_source";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/core/v3/TransportSocket.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/core/v3/TransportSocket.ts
@@ -39,5 +39,5 @@ export interface TransportSocket__Output {
    * Implementation specific configuration which depends on the implementation being instantiated.
    * See the supported transport socket implementations for further documentation.
    */
-  'config_type': "typed_config";
+  'config_type'?: "typed_config";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/LbEndpoint.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/LbEndpoint.ts
@@ -86,5 +86,5 @@ export interface LbEndpoint__Output {
   /**
    * Upstream host identifier or a named reference.
    */
-  'host_identifier': "endpoint"|"endpoint_name";
+  'host_identifier'?: "endpoint"|"endpoint_name";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/LocalityLbEndpoints.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/endpoint/v3/LocalityLbEndpoints.ts
@@ -163,5 +163,5 @@ export interface LocalityLbEndpoints__Output {
   /**
    * [#not-implemented-hide:]
    */
-  'lb_config': "load_balancer_endpoints"|"leds_cluster_locality_config";
+  'lb_config'?: "load_balancer_endpoints"|"leds_cluster_locality_config";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Filter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Filter.ts
@@ -46,5 +46,5 @@ export interface Filter__Output {
    * listener closes the connections.
    */
   'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource__Output | null);
-  'config_type': "typed_config"|"config_discovery";
+  'config_type'?: "typed_config"|"config_discovery";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Listener.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/Listener.ts
@@ -47,7 +47,7 @@ export interface _envoy_config_listener_v3_Listener_ConnectionBalanceConfig__Out
    * [#extension-category: envoy.network.connection_balance]
    */
   'extend_balance'?: (_envoy_config_core_v3_TypedExtensionConfig__Output | null);
-  'balance_type': "exact_balance"|"extend_balance";
+  'balance_type'?: "exact_balance"|"extend_balance";
 }
 
 /**
@@ -768,5 +768,5 @@ export interface Listener__Output {
   /**
    * The exclusive listener type and the corresponding config.
    */
-  'listener_specifier': "internal_listener";
+  'listener_specifier'?: "internal_listener";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/ListenerFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/ListenerFilter.ts
@@ -59,5 +59,5 @@ export interface ListenerFilter__Output {
    * listener closes the connections.
    */
   'config_discovery'?: (_envoy_config_core_v3_ExtensionConfigSource__Output | null);
-  'config_type': "typed_config"|"config_discovery";
+  'config_type'?: "typed_config"|"config_discovery";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/ListenerFilterChainMatchPredicate.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/listener/v3/ListenerFilterChainMatchPredicate.ts
@@ -132,5 +132,5 @@ export interface ListenerFilterChainMatchPredicate__Output {
    * the owning listener filter is after :ref:`an original_dst listener filter <config_listener_filters_original_dst>`.
    */
   'destination_port_range'?: (_envoy_type_v3_Int32Range__Output | null);
-  'rule': "or_match"|"and_match"|"not_match"|"any_match"|"destination_port_range";
+  'rule'?: "or_match"|"and_match"|"not_match"|"any_match"|"destination_port_range";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/CorsPolicy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/CorsPolicy.ts
@@ -149,5 +149,5 @@ export interface CorsPolicy__Output {
    * to the upstream. Default is true.
    */
   'forward_not_matching_preflights': (_google_protobuf_BoolValue__Output | null);
-  'enabled_specifier': "filter_enabled";
+  'enabled_specifier'?: "filter_enabled";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/HeaderMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/HeaderMatcher.ts
@@ -299,5 +299,5 @@ export interface HeaderMatcher__Output {
   /**
    * Specifies how the header match will be performed to route the request.
    */
-  'header_match_specifier': "exact_match"|"safe_regex_match"|"range_match"|"present_match"|"prefix_match"|"suffix_match"|"contains_match"|"string_match";
+  'header_match_specifier'?: "exact_match"|"safe_regex_match"|"range_match"|"present_match"|"prefix_match"|"suffix_match"|"contains_match"|"string_match";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/QueryParameterMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/QueryParameterMatcher.ts
@@ -43,5 +43,5 @@ export interface QueryParameterMatcher__Output {
    * Specifies whether a query parameter should be present.
    */
   'present_match'?: (boolean);
-  'query_parameter_match_specifier': "string_match"|"present_match";
+  'query_parameter_match_specifier'?: "string_match"|"present_match";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RateLimit.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RateLimit.ts
@@ -128,7 +128,7 @@ export interface _envoy_config_route_v3_RateLimit_Action__Output {
    * Rate limit on the existence of query parameters.
    */
   'query_parameter_value_match'?: (_envoy_config_route_v3_RateLimit_Action_QueryParameterValueMatch__Output | null);
-  'action_specifier': "source_cluster"|"destination_cluster"|"request_headers"|"remote_address"|"generic_key"|"header_value_match"|"dynamic_metadata"|"metadata"|"extension"|"masked_remote_address"|"query_parameter_value_match";
+  'action_specifier'?: "source_cluster"|"destination_cluster"|"request_headers"|"remote_address"|"generic_key"|"header_value_match"|"dynamic_metadata"|"metadata"|"extension"|"masked_remote_address"|"query_parameter_value_match";
 }
 
 /**
@@ -498,7 +498,7 @@ export interface _envoy_config_route_v3_RateLimit_Override__Output {
    * Limit override from dynamic metadata.
    */
   'dynamic_metadata'?: (_envoy_config_route_v3_RateLimit_Override_DynamicMetadata__Output | null);
-  'override_specifier': "dynamic_metadata";
+  'override_specifier'?: "dynamic_metadata";
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RedirectAction.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RedirectAction.ts
@@ -246,6 +246,6 @@ export interface RedirectAction__Output {
    * 2. If the source URI scheme is ``https`` and the port is explicitly
    * set to ``:443``, the port will be removed after the redirection
    */
-  'scheme_rewrite_specifier': "https_redirect"|"scheme_redirect";
-  'path_rewrite_specifier': "path_redirect"|"prefix_rewrite"|"regex_rewrite";
+  'scheme_rewrite_specifier'?: "https_redirect"|"scheme_redirect";
+  'path_rewrite_specifier'?: "path_redirect"|"prefix_rewrite"|"regex_rewrite";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RetryPolicy.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RetryPolicy.ts
@@ -223,7 +223,7 @@ export interface _envoy_config_route_v3_RetryPolicy_RetryHostPredicate__Output {
   /**
    * [#extension-category: envoy.retry_host_predicates]
    */
-  'config_type': "typed_config";
+  'config_type'?: "typed_config";
 }
 
 export interface _envoy_config_route_v3_RetryPolicy_RetryPriority {
@@ -241,7 +241,7 @@ export interface _envoy_config_route_v3_RetryPolicy_RetryPriority__Output {
   /**
    * [#extension-category: envoy.retry_priorities]
    */
-  'config_type': "typed_config";
+  'config_type'?: "typed_config";
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Route.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/Route.ts
@@ -264,5 +264,5 @@ export interface Route__Output {
    * statistics use a non-trivial amount of memory(approximately 1KiB per route).
    */
   'stat_prefix': (string);
-  'action': "route"|"redirect"|"direct_response"|"filter_action"|"non_forwarding_action";
+  'action'?: "route"|"redirect"|"direct_response"|"filter_action"|"non_forwarding_action";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteAction.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteAction.ts
@@ -323,7 +323,7 @@ export interface _envoy_config_route_v3_RouteAction_HashPolicy__Output {
    * it's a terminal policy.
    */
   'terminal': (boolean);
-  'policy_specifier': "header"|"cookie"|"connection_properties"|"query_parameter"|"filter_state";
+  'policy_specifier'?: "header"|"cookie"|"connection_properties"|"query_parameter"|"filter_state";
 }
 
 export interface _envoy_config_route_v3_RouteAction_HashPolicy_Header {
@@ -1430,6 +1430,6 @@ export interface RouteAction__Output {
    * [#extension-category: envoy.path.rewrite]
    */
   'path_rewrite_policy': (_envoy_config_core_v3_TypedExtensionConfig__Output | null);
-  'cluster_specifier': "cluster"|"cluster_header"|"weighted_clusters"|"cluster_specifier_plugin"|"inline_cluster_specifier_plugin";
-  'host_rewrite_specifier': "host_rewrite_literal"|"auto_host_rewrite"|"host_rewrite_header"|"host_rewrite_path_regex";
+  'cluster_specifier'?: "cluster"|"cluster_header"|"weighted_clusters"|"cluster_specifier_plugin"|"inline_cluster_specifier_plugin";
+  'host_rewrite_specifier'?: "host_rewrite_literal"|"auto_host_rewrite"|"host_rewrite_header"|"host_rewrite_path_regex";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteMatch.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/RouteMatch.ts
@@ -325,5 +325,5 @@ export interface RouteMatch__Output {
    * [#extension-category: envoy.path.match]
    */
   'path_match_policy'?: (_envoy_config_core_v3_TypedExtensionConfig__Output | null);
-  'path_specifier': "prefix"|"path"|"safe_regex"|"connect_matcher"|"path_separated_prefix"|"path_match_policy";
+  'path_specifier'?: "prefix"|"path"|"safe_regex"|"connect_matcher"|"path_separated_prefix"|"path_match_policy";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/ScopedRouteConfiguration.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/ScopedRouteConfiguration.ts
@@ -15,7 +15,7 @@ export interface _envoy_config_route_v3_ScopedRouteConfiguration_Key_Fragment__O
    * A string to match against.
    */
   'string_key'?: (string);
-  'type': "string_key";
+  'type'?: "string_key";
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/config/route/v3/WeightedCluster.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/route/v3/WeightedCluster.ts
@@ -190,7 +190,7 @@ export interface _envoy_config_route_v3_WeightedCluster_ClusterWeight__Output {
    * this value.
    */
   'host_rewrite_literal'?: (string);
-  'host_rewrite_specifier': "host_rewrite_literal";
+  'host_rewrite_specifier'?: "host_rewrite_literal";
 }
 
 /**
@@ -276,5 +276,5 @@ export interface WeightedCluster__Output {
    * the process for the consistency. And the value is a unsigned number between 0 and UINT64_MAX.
    */
   'header_name'?: (string);
-  'random_value_specifier': "header_name";
+  'random_value_specifier'?: "header_name";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/config/trace/v3/Tracing.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/config/trace/v3/Tracing.ts
@@ -45,7 +45,7 @@ export interface _envoy_config_trace_v3_Tracing_Http__Output {
    * Trace driver specific configuration which must be set according to the driver being instantiated.
    * [#extension-category: envoy.tracers]
    */
-  'config_type': "typed_config";
+  'config_type'?: "typed_config";
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/data/accesslog/v3/TLSProperties.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/data/accesslog/v3/TLSProperties.ts
@@ -47,7 +47,7 @@ export interface _envoy_data_accesslog_v3_TLSProperties_CertificateProperties_Su
    * [#not-implemented-hide:]
    */
   'dns'?: (string);
-  'san': "uri"|"dns";
+  'san'?: "uri"|"dns";
 }
 
 // Original file: deps/envoy-api/envoy/data/accesslog/v3/accesslog.proto

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/common/fault/v3/FaultDelay.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/common/fault/v3/FaultDelay.ts
@@ -84,5 +84,5 @@ export interface FaultDelay__Output {
    * Fault delays are controlled via an HTTP header (if applicable).
    */
   'header_delay'?: (_envoy_extensions_filters_common_fault_v3_FaultDelay_HeaderDelay__Output | null);
-  'fault_delay_secifier': "fixed_delay"|"header_delay";
+  'fault_delay_secifier'?: "fixed_delay"|"header_delay";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/common/fault/v3/FaultRateLimit.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/common/fault/v3/FaultRateLimit.ts
@@ -74,5 +74,5 @@ export interface FaultRateLimit__Output {
    * Rate limits are controlled via an HTTP header (if applicable).
    */
   'header_limit'?: (_envoy_extensions_filters_common_fault_v3_FaultRateLimit_HeaderLimit__Output | null);
-  'limit_type': "fixed_limit"|"header_limit";
+  'limit_type'?: "fixed_limit"|"header_limit";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/http/fault/v3/FaultAbort.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/http/fault/v3/FaultAbort.ts
@@ -63,5 +63,5 @@ export interface FaultAbort__Output {
    * gRPC status code to use to abort the gRPC request.
    */
   'grpc_status'?: (number);
-  'error_type': "http_status"|"grpc_status"|"header_abort";
+  'error_type'?: "http_status"|"grpc_status"|"header_abort";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpConnectionManager.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpConnectionManager.ts
@@ -535,7 +535,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Ht
    * If neither of these values are set, this value defaults to ``server_name``,
    * which itself defaults to "envoy".
    */
-  'proxy_name': "use_node_id"|"literal_proxy_name";
+  'proxy_name'?: "use_node_id"|"literal_proxy_name";
 }
 
 // Original file: deps/envoy-api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -1946,6 +1946,6 @@ export interface HttpConnectionManager__Output {
    * the Overload Manager has been triggered.
    */
   'append_local_overload': (boolean);
-  'route_specifier': "rds"|"route_config"|"scoped_routes";
-  'strip_port_mode': "strip_any_host_port";
+  'route_specifier'?: "rds"|"route_config"|"scoped_routes";
+  'strip_port_mode'?: "strip_any_host_port";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpFilter.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/HttpFilter.ts
@@ -94,5 +94,5 @@ export interface HttpFilter__Output {
    * Terminal filters (e.g. ``envoy.filters.http.router``) cannot be marked as disabled.
    */
   'disabled': (boolean);
-  'config_type': "typed_config"|"config_discovery";
+  'config_type'?: "typed_config"|"config_discovery";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/ScopedRoutes.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/filters/network/http_connection_manager/v3/ScopedRoutes.ts
@@ -23,7 +23,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Sc
    * Specifies how a header field's value should be extracted.
    */
   'header_value_extractor'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor__Output | null);
-  'type': "header_value_extractor";
+  'type'?: "header_value_extractor";
 }
 
 /**
@@ -119,7 +119,7 @@ export interface _envoy_extensions_filters_network_http_connection_manager_v3_Sc
    * Specifies the key value pair to extract the value from.
    */
   'element'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_KvElement__Output | null);
-  'extract_type': "index"|"element";
+  'extract_type'?: "index"|"element";
 }
 
 /**
@@ -269,5 +269,5 @@ export interface ScopedRoutes__Output {
    * in this message.
    */
   'scoped_rds'?: (_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRds__Output | null);
-  'config_specifier': "scoped_route_configurations_list"|"scoped_rds";
+  'config_specifier'?: "scoped_route_configurations_list"|"scoped_rds";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/load_balancing_policies/common/v3/LocalityLbConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/load_balancing_policies/common/v3/LocalityLbConfig.ts
@@ -96,5 +96,5 @@ export interface LocalityLbConfig__Output {
    * Enable locality weighted load balancing.
    */
   'locality_weighted_lb_config'?: (_envoy_extensions_load_balancing_policies_common_v3_LocalityLbConfig_LocalityWeightedLbConfig__Output | null);
-  'locality_config_specifier': "zone_aware_lb_config"|"locality_weighted_lb_config";
+  'locality_config_specifier'?: "zone_aware_lb_config"|"locality_weighted_lb_config";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/transport_sockets/tls/v3/CommonTlsContext.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/transport_sockets/tls/v3/CommonTlsContext.ts
@@ -61,7 +61,7 @@ export interface _envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_Cer
    * certificate providers of a cluster.
    * This config could be supplied inline or (in future) a named xDS resource.
    */
-  'config': "typed_config";
+  'config'?: "typed_config";
 }
 
 /**
@@ -383,5 +383,5 @@ export interface CommonTlsContext__Output {
    * TLS key log configuration
    */
   'key_log': (_envoy_extensions_transport_sockets_tls_v3_TlsKeyLog__Output | null);
-  'validation_context_type': "validation_context"|"validation_context_sds_secret_config"|"combined_validation_context"|"validation_context_certificate_provider"|"validation_context_certificate_provider_instance";
+  'validation_context_type'?: "validation_context"|"validation_context_sds_secret_config"|"combined_validation_context"|"validation_context_certificate_provider"|"validation_context_certificate_provider_instance";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/transport_sockets/tls/v3/DownstreamTlsContext.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/transport_sockets/tls/v3/DownstreamTlsContext.ts
@@ -187,5 +187,5 @@ export interface DownstreamTlsContext__Output {
    * relevant only for TLSv1.2 and earlier.)
    */
   'disable_stateful_session_resumption': (boolean);
-  'session_ticket_keys_type': "session_ticket_keys"|"session_ticket_keys_sds_secret_config"|"disable_stateless_session_resumption";
+  'session_ticket_keys_type'?: "session_ticket_keys"|"session_ticket_keys_sds_secret_config"|"disable_stateless_session_resumption";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/transport_sockets/tls/v3/PrivateKeyProvider.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/transport_sockets/tls/v3/PrivateKeyProvider.ts
@@ -47,5 +47,5 @@ export interface PrivateKeyProvider__Output {
   /**
    * Private key method provider specific configuration.
    */
-  'config_type': "typed_config";
+  'config_type'?: "typed_config";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/extensions/transport_sockets/tls/v3/Secret.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/extensions/transport_sockets/tls/v3/Secret.ts
@@ -32,5 +32,5 @@ export interface Secret__Output {
   'session_ticket_keys'?: (_envoy_extensions_transport_sockets_tls_v3_TlsSessionTicketKeys__Output | null);
   'validation_context'?: (_envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext__Output | null);
   'generic_secret'?: (_envoy_extensions_transport_sockets_tls_v3_GenericSecret__Output | null);
-  'type': "tls_certificate"|"session_ticket_keys"|"validation_context"|"generic_secret";
+  'type'?: "tls_certificate"|"session_ticket_keys"|"validation_context"|"generic_secret";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/DynamicParameterConstraints.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/discovery/v3/DynamicParameterConstraints.ts
@@ -57,7 +57,7 @@ export interface _envoy_service_discovery_v3_DynamicParameterConstraints_SingleC
    * special configuration based on that key.
    */
   'exists'?: (_envoy_service_discovery_v3_DynamicParameterConstraints_SingleConstraint_Exists__Output | null);
-  'constraint_type': "value"|"exists";
+  'constraint_type'?: "value"|"exists";
 }
 
 /**
@@ -115,5 +115,5 @@ export interface DynamicParameterConstraints__Output {
    * The inverse (NOT) of a set of constraints.
    */
   'not_constraints'?: (_envoy_service_discovery_v3_DynamicParameterConstraints__Output | null);
-  'type': "constraint"|"or_constraints"|"and_constraints"|"not_constraints";
+  'type'?: "constraint"|"or_constraints"|"and_constraints"|"not_constraints";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/service/status/v3/PerXdsConfig.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/service/status/v3/PerXdsConfig.ts
@@ -65,5 +65,5 @@ export interface PerXdsConfig__Output {
    * @deprecated
    */
   'client_status': (_envoy_service_status_v3_ClientConfigStatus__Output);
-  'per_xds_config': "listener_config"|"cluster_config"|"route_config"|"scoped_route_config"|"endpoint_config";
+  'per_xds_config'?: "listener_config"|"cluster_config"|"route_config"|"scoped_route_config"|"endpoint_config";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/type/http/v3/PathTransformation.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/http/v3/PathTransformation.ts
@@ -74,7 +74,7 @@ export interface _envoy_type_http_v3_PathTransformation_Operation__Output {
    * Enable merging adjacent slashes.
    */
   'merge_slashes'?: (_envoy_type_http_v3_PathTransformation_Operation_MergeSlashes__Output | null);
-  'operation_specifier': "normalize_path_rfc_3986"|"merge_slashes";
+  'operation_specifier'?: "normalize_path_rfc_3986"|"merge_slashes";
 }
 
 export interface PathTransformation {

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/DoubleMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/DoubleMatcher.ts
@@ -31,5 +31,5 @@ export interface DoubleMatcher__Output {
    * If specified, the input double value must be equal to the value specified here.
    */
   'exact'?: (number);
-  'match_pattern': "range"|"exact";
+  'match_pattern'?: "range"|"exact";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/ListMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/ListMatcher.ts
@@ -21,5 +21,5 @@ export interface ListMatcher__Output {
    * If specified, at least one of the values in the list must match the value specified.
    */
   'one_of'?: (_envoy_type_matcher_v3_ValueMatcher__Output | null);
-  'match_pattern': "one_of";
+  'match_pattern'?: "one_of";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/MetadataMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/MetadataMatcher.ts
@@ -25,7 +25,7 @@ export interface _envoy_type_matcher_v3_MetadataMatcher_PathSegment__Output {
    * If specified, use the key to retrieve the value in a Struct.
    */
   'key'?: (string);
-  'segment': "key";
+  'segment'?: "key";
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/RegexMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/RegexMatcher.ts
@@ -101,5 +101,5 @@ export interface RegexMatcher__Output {
    * against the full string, not as a partial match.
    */
   'regex': (string);
-  'engine_type': "google_re2";
+  'engine_type'?: "google_re2";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/StringMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/StringMatcher.ts
@@ -116,5 +116,5 @@ export interface StringMatcher__Output {
    * [#extension-category: envoy.string_matcher]
    */
   'custom'?: (_xds_core_v3_TypedExtensionConfig__Output | null);
-  'match_pattern': "exact"|"prefix"|"suffix"|"safe_regex"|"contains"|"custom";
+  'match_pattern'?: "exact"|"prefix"|"suffix"|"safe_regex"|"contains"|"custom";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/StructMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/StructMatcher.ts
@@ -21,7 +21,7 @@ export interface _envoy_type_matcher_v3_StructMatcher_PathSegment__Output {
    * If specified, use the key to retrieve the value in a Struct.
    */
   'key'?: (string);
-  'segment': "key";
+  'segment'?: "key";
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/ValueMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/matcher/v3/ValueMatcher.ts
@@ -106,5 +106,5 @@ export interface ValueMatcher__Output {
   /**
    * Specifies how to match a value.
    */
-  'match_pattern': "null_match"|"double_match"|"string_match"|"bool_match"|"present_match"|"list_match"|"or_match";
+  'match_pattern'?: "null_match"|"double_match"|"string_match"|"bool_match"|"present_match"|"list_match"|"or_match";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/type/metadata/v3/MetadataKey.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/metadata/v3/MetadataKey.ts
@@ -22,7 +22,7 @@ export interface _envoy_type_metadata_v3_MetadataKey_PathSegment__Output {
    * If specified, use the key to retrieve the value in a Struct.
    */
   'key'?: (string);
-  'segment': "key";
+  'segment'?: "key";
 }
 
 /**

--- a/packages/grpc-js-xds/src/generated/envoy/type/metadata/v3/MetadataKind.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/metadata/v3/MetadataKind.ts
@@ -94,5 +94,5 @@ export interface MetadataKind__Output {
    * Host kind of metadata.
    */
   'host'?: (_envoy_type_metadata_v3_MetadataKind_Host__Output | null);
-  'kind': "request"|"route"|"cluster"|"host";
+  'kind'?: "request"|"route"|"cluster"|"host";
 }

--- a/packages/grpc-js-xds/src/generated/envoy/type/tracing/v3/CustomTag.ts
+++ b/packages/grpc-js-xds/src/generated/envoy/type/tracing/v3/CustomTag.ts
@@ -194,5 +194,5 @@ export interface CustomTag__Output {
   /**
    * Used to specify what kind of custom tag.
    */
-  'type': "literal"|"environment"|"request_header"|"metadata";
+  'type'?: "literal"|"environment"|"request_header"|"metadata";
 }

--- a/packages/grpc-js-xds/src/generated/google/api/HttpRule.ts
+++ b/packages/grpc-js-xds/src/generated/google/api/HttpRule.ts
@@ -676,5 +676,5 @@ export interface HttpRule__Output {
    * used with any of the {get|put|post|delete|patch} methods. A custom method
    * can be defined using the 'custom' field.
    */
-  'pattern': "get"|"put"|"post"|"delete"|"patch"|"custom";
+  'pattern'?: "get"|"put"|"post"|"delete"|"patch"|"custom";
 }

--- a/packages/grpc-js-xds/src/generated/google/protobuf/Value.ts
+++ b/packages/grpc-js-xds/src/generated/google/protobuf/Value.ts
@@ -21,5 +21,5 @@ export interface Value__Output {
   'boolValue'?: (boolean);
   'structValue'?: (_google_protobuf_Struct__Output | null);
   'listValue'?: (_google_protobuf_ListValue__Output | null);
-  'kind': "nullValue"|"numberValue"|"stringValue"|"boolValue"|"structValue"|"listValue";
+  'kind'?: "nullValue"|"numberValue"|"stringValue"|"boolValue"|"structValue"|"listValue";
 }

--- a/packages/grpc-js-xds/src/generated/validate/BytesRules.ts
+++ b/packages/grpc-js-xds/src/generated/validate/BytesRules.ts
@@ -149,5 +149,5 @@ export interface BytesRules__Output {
    * WellKnown rules provide advanced constraints against common byte
    * patterns
    */
-  'well_known': "ip"|"ipv4"|"ipv6";
+  'well_known'?: "ip"|"ipv4"|"ipv6";
 }

--- a/packages/grpc-js-xds/src/generated/validate/FieldRules.ts
+++ b/packages/grpc-js-xds/src/generated/validate/FieldRules.ts
@@ -98,5 +98,5 @@ export interface FieldRules__Output {
   'any'?: (_validate_AnyRules__Output | null);
   'duration'?: (_validate_DurationRules__Output | null);
   'timestamp'?: (_validate_TimestampRules__Output | null);
-  'type': "float"|"double"|"int32"|"int64"|"uint32"|"uint64"|"sint32"|"sint64"|"fixed32"|"fixed64"|"sfixed32"|"sfixed64"|"bool"|"string"|"bytes"|"enum"|"repeated"|"map"|"any"|"duration"|"timestamp";
+  'type'?: "float"|"double"|"int32"|"int64"|"uint32"|"uint64"|"sint32"|"sint64"|"fixed32"|"fixed64"|"sfixed32"|"sfixed64"|"bool"|"string"|"bytes"|"enum"|"repeated"|"map"|"any"|"duration"|"timestamp";
 }

--- a/packages/grpc-js-xds/src/generated/validate/StringRules.ts
+++ b/packages/grpc-js-xds/src/generated/validate/StringRules.ts
@@ -284,5 +284,5 @@ export interface StringRules__Output {
    * WellKnown rules provide advanced constraints against common string
    * patterns
    */
-  'well_known': "email"|"hostname"|"ip"|"ipv4"|"ipv6"|"uri"|"uri_ref"|"address"|"uuid"|"well_known_regex";
+  'well_known'?: "email"|"hostname"|"ip"|"ipv4"|"ipv6"|"uri"|"uri_ref"|"address"|"uuid"|"well_known_regex";
 }

--- a/packages/grpc-js-xds/src/generated/xds/core/v3/CollectionEntry.ts
+++ b/packages/grpc-js-xds/src/generated/xds/core/v3/CollectionEntry.ts
@@ -86,5 +86,5 @@ export interface CollectionEntry__Output {
    * The resource is inlined in the list collection.
    */
   'inline_entry'?: (_xds_core_v3_CollectionEntry_InlineEntry__Output | null);
-  'resource_specifier': "locator"|"inline_entry";
+  'resource_specifier'?: "locator"|"inline_entry";
 }

--- a/packages/grpc-js-xds/src/generated/xds/core/v3/ResourceLocator.ts
+++ b/packages/grpc-js-xds/src/generated/xds/core/v3/ResourceLocator.ts
@@ -92,7 +92,7 @@ export interface _xds_core_v3_ResourceLocator_Directive__Output {
    * xdstp://.../foo#entry=bar.
    */
   'entry'?: (string);
-  'directive': "alt"|"entry";
+  'directive'?: "alt"|"entry";
 }
 
 // Original file: deps/xds/xds/core/v3/resource_locator.proto
@@ -226,5 +226,5 @@ export interface ResourceLocator__Output {
    * separation.
    */
   'directives': (_xds_core_v3_ResourceLocator_Directive__Output)[];
-  'context_param_specifier': "exact_context";
+  'context_param_specifier'?: "exact_context";
 }

--- a/packages/grpc-js-xds/src/generated/xds/type/matcher/v3/Matcher.ts
+++ b/packages/grpc-js-xds/src/generated/xds/type/matcher/v3/Matcher.ts
@@ -111,7 +111,7 @@ export interface _xds_type_matcher_v3_Matcher_MatcherTree__Output {
    * If the lookup succeeds, the match is considered successful, and
    * the corresponding OnMatch is used.
    */
-  'tree_type': "exact_match_map"|"prefix_match_map"|"custom_match";
+  'tree_type'?: "exact_match_map"|"prefix_match_map"|"custom_match";
 }
 
 /**
@@ -149,7 +149,7 @@ export interface _xds_type_matcher_v3_Matcher_OnMatch__Output {
    * Protocol-specific action to take.
    */
   'action'?: (_xds_core_v3_TypedExtensionConfig__Output | null);
-  'on_match': "matcher"|"action";
+  'on_match'?: "matcher"|"action";
 }
 
 /**
@@ -195,7 +195,7 @@ export interface _xds_type_matcher_v3_Matcher_MatcherList_Predicate__Output {
    * The invert of a predicate
    */
   'not_matcher'?: (_xds_type_matcher_v3_Matcher_MatcherList_Predicate__Output | null);
-  'match_type': "single_predicate"|"or_matcher"|"and_matcher"|"not_matcher";
+  'match_type'?: "single_predicate"|"or_matcher"|"and_matcher"|"not_matcher";
 }
 
 /**
@@ -251,7 +251,7 @@ export interface _xds_type_matcher_v3_Matcher_MatcherList_Predicate_SinglePredic
    * [#extension-category: envoy.matching.input_matchers]
    */
   'custom_match'?: (_xds_core_v3_TypedExtensionConfig__Output | null);
-  'matcher': "value_match"|"custom_match";
+  'matcher'?: "value_match"|"custom_match";
 }
 
 /**
@@ -303,5 +303,5 @@ export interface Matcher__Output {
    * If not specified, the matcher is considered not to have matched.
    */
   'on_no_match': (_xds_type_matcher_v3_Matcher_OnMatch__Output | null);
-  'matcher_type': "matcher_list"|"matcher_tree";
+  'matcher_type'?: "matcher_list"|"matcher_tree";
 }

--- a/packages/grpc-js-xds/src/generated/xds/type/matcher/v3/RegexMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/xds/type/matcher/v3/RegexMatcher.ts
@@ -76,5 +76,5 @@ export interface RegexMatcher__Output {
    * engine.
    */
   'regex': (string);
-  'engine_type': "google_re2";
+  'engine_type'?: "google_re2";
 }

--- a/packages/grpc-js-xds/src/generated/xds/type/matcher/v3/StringMatcher.ts
+++ b/packages/grpc-js-xds/src/generated/xds/type/matcher/v3/StringMatcher.ts
@@ -105,5 +105,5 @@ export interface StringMatcher__Output {
    * * *abc* matches the value *xyz.abc.def*
    */
   'contains'?: (string);
-  'match_pattern': "exact"|"prefix"|"suffix"|"safe_regex"|"contains";
+  'match_pattern'?: "exact"|"prefix"|"suffix"|"safe_regex"|"contains";
 }

--- a/packages/grpc-js-xds/src/xds-dependency-manager.ts
+++ b/packages/grpc-js-xds/src/xds-dependency-manager.ts
@@ -792,8 +792,7 @@ export class XdsDependencyManager {
           }
           break;
         default:
-          /* The validation logic should prevent us from reaching this point.
-           * This is just for the type checker. */
+          // The cluster_specifier can be unset. If so, just ignore it
           break;
       }
     }

--- a/packages/grpc-js-xds/src/xds-resource-type/route-config-resource-type.ts
+++ b/packages/grpc-js-xds/src/xds-resource-type/route-config-resource-type.ts
@@ -127,11 +127,15 @@ export class RouteConfigurationResourceType extends XdsResourceType {
         const routeErrorPrefix = `${errorPrefix}.routes[${route.name}]`;
         const match = route.match;
         if (match) {
-          if (SUPPORTED_PATH_SPECIFIERS.indexOf(match.path_specifier) < 0) {
-            errors.push(`${routeErrorPrefix}.match: unsupported path_specifier: ${match.path_specifier}`);
+          if (match.path_specifier) {
+            if (SUPPORTED_PATH_SPECIFIERS.indexOf(match.path_specifier) < 0) {
+              errors.push(`${routeErrorPrefix}.match: unsupported path_specifier: ${match.path_specifier}`);
+            }
+          } else {
+            errors.push(`${routeErrorPrefix}.match: no path_specifier set`);
           }
           for (const headers of match.headers) {
-            if (SUPPPORTED_HEADER_MATCH_SPECIFIERS.indexOf(headers.header_match_specifier) < 0) {
+            if (headers.header_match_specifier && SUPPPORTED_HEADER_MATCH_SPECIFIERS.indexOf(headers.header_match_specifier) < 0) {
               errors.push(`${routeErrorPrefix}.match.headers[${headers.name}]: unsupported header_match_specifier: ${headers.header_match_specifier}`);
             }
           }
@@ -145,7 +149,7 @@ export class RouteConfigurationResourceType extends XdsResourceType {
               errors.push(`${routeErrorPrefix}.route unset`);
               break;
             }
-            if (SUPPORTED_CLUSTER_SPECIFIERS.indexOf(route.route.cluster_specifier) < 0) {
+            if (route.route.cluster_specifier && SUPPORTED_CLUSTER_SPECIFIERS.indexOf(route.route.cluster_specifier) < 0) {
               errors.push(`${routeErrorPrefix}: unsupported route.cluster_specifier: ${route.route.cluster_specifier}`);
             }
             if (EXPERIMENTAL_FAULT_INJECTION) {

--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -398,7 +398,7 @@ function generateRestrictedMessageInterface(formatter: TextFormatter, messageTyp
       if (options.includeComments) {
         formatComment(formatter, oneof.comment, oneof.options);
       }
-      formatter.writeLine(`'${oneof.name}': ${typeString};`);
+      formatter.writeLine(`'${oneof.name}'?: ${typeString};`);
     }
   }
   if (options.outputBranded) {

--- a/packages/proto-loader/golden-generated/google/api/HttpRule.ts
+++ b/packages/proto-loader/golden-generated/google/api/HttpRule.ts
@@ -676,5 +676,5 @@ export interface OHttpRule {
    * used with any of the {get|put|post|delete|patch} methods. A custom method
    * can be defined using the 'custom' field.
    */
-  'pattern': "get"|"put"|"post"|"delete"|"patch"|"custom";
+  'pattern'?: "get"|"put"|"post"|"delete"|"patch"|"custom";
 }

--- a/packages/proto-loader/golden-generated/google/longrunning/Operation.ts
+++ b/packages/proto-loader/golden-generated/google/longrunning/Operation.ts
@@ -94,5 +94,5 @@ export interface OOperation {
    * If `done` == `false`, neither `error` nor `response` is set.
    * If `done` == `true`, exactly one of `error` or `response` is set.
    */
-  'result': "error"|"response";
+  'result'?: "error"|"response";
 }

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/BlockRequest.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/BlockRequest.ts
@@ -41,5 +41,5 @@ export interface OBlockRequest {
    * The response to be returned that will signify successful method call.
    */
   'success'?: (O_google_showcase_v1beta1_BlockResponse | null);
-  'response': "error"|"success";
+  'response'?: "error"|"success";
 }

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/EchoRequest.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/EchoRequest.ts
@@ -44,5 +44,5 @@ export interface OEchoRequest {
    * The severity to be echoed by the server.
    */
   'severity': (O_google_showcase_v1beta1_Severity);
-  'response': "content"|"error";
+  'response'?: "content"|"error";
 }

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/WaitRequest.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/WaitRequest.ts
@@ -51,6 +51,6 @@ export interface OWaitRequest {
    * The duration of this operation.
    */
   'ttl'?: (O_google_protobuf_Duration | null);
-  'end': "end_time"|"ttl";
-  'response': "error"|"success";
+  'end'?: "end_time"|"ttl";
+  'response'?: "error"|"success";
 }


### PR DESCRIPTION
If none of the fields in a oneof group are set, the specifier field is unset in the parsed object.