### PR TITLE
grpc-js-xds: ring_hash: Fix proactive connect logic when already connecting

### DIFF
--- a/packages/grpc-js-xds/src/load-balancer-ring-hash.ts
+++ b/packages/grpc-js-xds/src/load-balancer-ring-hash.ts
@@ -249,15 +249,19 @@ class RingHashLoadBalancer implements LoadBalancer {
     if (!(this.currentState === connectivityState.TRANSIENT_FAILURE || this.currentState === connectivityState.CONNECTING)) {
       return;
     }
+    let firstIdleChild: LeafLoadBalancer | null = null;
     for (const leaf of this.leafMap.values()) {
       const leafState = leaf.getConnectivityState();
       if (leafState === connectivityState.CONNECTING) {
+        firstIdleChild = null;
         break;
       }
-      if (leafState === connectivityState.IDLE) {
-        leaf.startConnecting();
-        break;
+      if (leafState === connectivityState.IDLE && !firstIdleChild) {
+        firstIdleChild = leaf;
       }
+    }
+    if (firstIdleChild) {
+      firstIdleChild.startConnecting();
     }
   }
 


### PR DESCRIPTION
This fixes a bug that causes ring_hash to proactively connect to a second backend if the first backend it connects to does not happen to be first in the list.