### PR TITLE
grpc-js: Fix reentrancy problem in backoff timer callback

### DIFF
--- a/packages/grpc-js/src/backoff-timeout.ts
+++ b/packages/grpc-js/src/backoff-timeout.ts
@@ -132,8 +132,8 @@ export class BackoffTimeout {
     clearTimeout(this.timerId);
     this.timerId = setTimeout(() => {
       this.trace('timer fired');
-      this.callback();
       this.running = false;
+      this.callback();
     }, delay);
     if (!this.hasRef) {
       this.timerId.unref?.();


### PR DESCRIPTION
If `runOnce` is called by the callback (which does happen in subchannels), it will set `running` to `true` before the timer handler sets it to `false`, resulting in an invalid `running` state. This change fixes that by resolving the state before calling the callback.