### PR TITLE
grpc-js: `ServerInterceptingCall`: add `getConnectionInfo` method

### DIFF
--- a/packages/grpc-js/test/common.ts
+++ b/packages/grpc-js/test/common.ts
@@ -150,15 +150,15 @@ export class TestClient {
     this.client.waitForReady(deadline, callback);
   }
 
-  sendRequest(callback: (error?: grpc.ServiceError) => void) {
-    this.client.echo({}, callback);
+  sendRequest(callback: (error?: grpc.ServiceError) => void): grpc.ClientUnaryCall {
+    return this.client.echo({}, callback);
   }
 
   sendRequestWithMetadata(
     metadata: grpc.Metadata,
     callback: (error?: grpc.ServiceError) => void
-  ) {
-    this.client.echo({}, metadata, callback);
+  ): grpc.ClientUnaryCall {
+    return this.client.echo({}, metadata, callback);
   }
 
   getChannelState() {


### PR DESCRIPTION
This method is described in https://github.com/grpc/proposal/pull/483. It will be needed for RBAC.