### PR TITLE
grpc-js: Consistently reference the same options object in the channel constructor

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -297,16 +297,16 @@ export class InternalChannel {
     /* The global boolean parameter to getSubchannelPool has the inverse meaning to what
      * the grpc.use_local_subchannel_pool channel option means. */
     this.subchannelPool = getSubchannelPool(
-      (options['grpc.use_local_subchannel_pool'] ?? 0) === 0
+      (this.options['grpc.use_local_subchannel_pool'] ?? 0) === 0
     );
     this.retryBufferTracker = new MessageBufferTracker(
-      options['grpc.retry_buffer_size'] ?? DEFAULT_RETRY_BUFFER_SIZE_BYTES,
-      options['grpc.per_rpc_retry_buffer_size'] ??
+      this.options['grpc.retry_buffer_size'] ?? DEFAULT_RETRY_BUFFER_SIZE_BYTES,
+      this.options['grpc.per_rpc_retry_buffer_size'] ??
         DEFAULT_PER_RPC_RETRY_BUFFER_SIZE_BYTES
     );
-    this.keepaliveTime = options['grpc.keepalive_time_ms'] ?? -1;
+    this.keepaliveTime = this.options['grpc.keepalive_time_ms'] ?? -1;
     this.idleTimeoutMs = Math.max(
-      options['grpc.client_idle_timeout_ms'] ?? DEFAULT_IDLE_TIMEOUT_MS,
+      this.options['grpc.client_idle_timeout_ms'] ?? DEFAULT_IDLE_TIMEOUT_MS,
       MIN_IDLE_TIMEOUT_MS
     );
     const channelControlHelper: ChannelControlHelper = {
@@ -372,7 +372,7 @@ export class InternalChannel {
     this.resolvingLoadBalancer = new ResolvingLoadBalancer(
       this.target,
       channelControlHelper,
-      options,
+      this.options,
       (serviceConfig, configSelector) => {
         if (serviceConfig.retryThrottling) {
           RETRY_THROTTLER_MAP.set(


### PR DESCRIPTION
Since `this.options` is modified on line 295, all later uses of the `options` object should refer to `this.options` instead of the local `options` variable. In particular, the change to the `ResolvingLoadBalancer` constructor call fixes #2932, because after #2854 the channel options get to the subchannel constructor through the LB policy, instead of getting merged with the channel options in `channelControlHelper.createSubchannel`, and the `options` variable didn't contain the proxy information that the subchannel would use to connect through a proxy.