### PR TITLE
fix(grpc-reflection): try to do FQN lookup with a leading period

### DIFF
--- a/packages/grpc-reflection/src/implementations/reflection-v1.ts
+++ b/packages/grpc-reflection/src/implementations/reflection-v1.ts
@@ -129,7 +129,7 @@ export class ReflectionV1Implementation {
 
         // if we didn't find anything then try just a FQN lookup
         if (!referencedFile) {
-          referencedFile = this.symbols[ref];
+          referencedFile = this.symbols[ref] ?? this.symbols[`.${ref}`];
         }
       }
 


### PR DESCRIPTION
This seems to fix a very specific issue, where if the custom field type doesn't have a package, it breaks the reflection API.

Please see this issue for more information: https://github.com/grpc/grpc-node/issues/2934

I haven't added any tests because I couldn't reproduce the issue using the test setup in [test-reflection-v1-implementation.ts](https://github.com/grpc/grpc-node/blob/master/packages/grpc-reflection/test/test-reflection-v1-implementation.ts).

But I did test it manually, and below you can find my test evidence.

## Testing

**Pre-requisite**: add a new imported message, which doesn't have a package. And make it a field of a request or response, e.g. this [diff](https://github.com/grpc/grpc-node/compare/master...matrosovs:grpc-node:example-broken-reflection-no-package?expand=1)

<details>

<summary>Also, here a complete diff in case my branch gets deleted (click to expand)</summary>

```diff
diff --git a/examples/protos/helloworld.proto b/examples/protos/helloworld.proto
index 7e50d0fc7..48c411c41 100644
--- a/examples/protos/helloworld.proto
+++ b/examples/protos/helloworld.proto
@@ -19,6 +19,8 @@ option java_package = "io.grpc.examples.helloworld";
 option java_outer_classname = "HelloWorldProto";
 option objc_class_prefix = "HLW";
 
+import "nopackage.proto";
+
 package helloworld;
 
 // The greeting service definition.
@@ -32,6 +34,7 @@ service Greeter {
 // The request message containing the user's name.
 message HelloRequest {
   string name = 1;
+  NoPackageMessage no_package = 2;
 }
 
 // The response message containing the greetings
diff --git a/examples/protos/nopackage.proto b/examples/protos/nopackage.proto
new file mode 100644
index 000000000..1a002b576
--- /dev/null
+++ b/examples/protos/nopackage.proto
@@ -0,0 +1,6 @@
+syntax = "proto3";
+
+message NoPackageMessage {
+    int32 code = 1;
+    string message = 2;
+ }
\ No newline at end of file
```

</details>

### Without the fix

**Running the application**

Warnigns are printed at the bottom because the reflection service couldn't find the reference for the message with no package:
```bash
$ node --no-deprecation examples/reflection/server.js
Debugger listening on ws://127.0.0.1:53772/97d86ad5-174e-45e9-9d34-7da3b690f67c
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
Could not find file associated with reference NoPackageMessage
Could not find file associated with reference NoPackageMessage
```

**Loading service definition via Reflection**
Postman fails to load the definition. And in the `[Service definitions]` tab it shows this error:
![image](https://github.com/user-attachments/assets/3dd3586d-f691-487d-b96e-5eab3319db58)

### With the fix

**Running the application**

Warnings no longer printed:
```bash
$ node --no-deprecation examples/reflection/server.js
Debugger listening on ws://127.0.0.1:53953/82c837c2-9c9f-49b4-962e-1d2b7653ee55
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
```

**Loading service definition via Reflection**
Postman can successfully load the definition.
![image](https://github.com/user-attachments/assets/e57f6149-4ad0-4dee-8e48-ec203c124c91)

Also, it understands the new nested field and can generate some example message.
![image](https://github.com/user-attachments/assets/5f601237-ae60-4049-8a81-657a38ee3b8b)
