### PR TITLE
proto-loader: Apply targetFileExtension to root files

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -47,8 +47,8 @@ type GeneratorOptions = Protobuf.IParseOptions & Protobuf.IConversionOptions & {
   outputTemplate: string;
   inputBranded: boolean;
   outputBranded: boolean;
-  targetFileExtension?: string;
-  importFileExtension?: string;
+  targetFileExtension: string;
+  importFileExtension: string;
 }
 
 class TextFormatter {
@@ -832,7 +832,7 @@ async function writeAllFiles(protoFiles: string[], options: GeneratorOptions) {
   await fs.promises.mkdir(options.outDir, {recursive: true});
   const basenameMap = new Map<string, string[]>();
   for (const filename of protoFiles) {
-    const basename = path.basename(filename).replace(/\.proto$/, '.ts');
+    const basename = path.basename(filename).replace(/\.proto$/, options.targetFileExtension);
     if (basenameMap.has(basename)) {
       basenameMap.get(basename)!.push(filename);
     } else {

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "author": "Google Inc.",
   "contributors": [
     {


### PR DESCRIPTION
This is an update to the feature added in #2912 that fixes the oversight described in https://github.com/grpc/grpc-node/issues/2907#issuecomment-2815240648.