### PR TITLE
Add List method to Health service

### DIFF
--- a/packages/grpc-health-check/proto/health/v1/health.proto
+++ b/packages/grpc-health-check/proto/health/v1/health.proto
@@ -25,6 +25,13 @@ option java_multiple_files = true;
 option java_outer_classname = "HealthProto";
 option java_package = "io.grpc.health.v1";
 
+message HealthListRequest {}
+
+message HealthListResponse {
+  // statuses contains all the services and their respective status.
+  map<string, HealthCheckResponse> statuses = 1;
+}
+
 message HealthCheckRequest {
   string service = 1;
 }
@@ -70,4 +77,17 @@ service Health {
   // call.  If the call terminates with any other status (including OK),
   // clients should retry the call with appropriate exponential backoff.
   rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+
+  // List provides a non-atomic snapshot of the health of all the available
+  // services.
+  //
+  // The server may respond with a RESOURCE_EXHAUSTED error if too many services
+  // exist.
+  //
+  // Clients should set a deadline when calling List, and can declare the server
+  // unhealthy if they do not receive a timely response.
+  //
+  // Clients should keep in mind that the list of health services exposed by an
+  // application can change over the lifetime of the process.
+  rpc List(HealthListRequest) returns (HealthListResponse);
 }


### PR DESCRIPTION
# Context

Clients cannot get a list of the services a certain server is watching to and their respective status.

In the context of Kubernetes, we have livez and readyz endpoints, by listing all the services a server is checking, we could return a response like the `/readyz?verbose` Kubernetes API returns:

```
[+]ping ok
[+]log ok
[+]etcd ok
[+]poststarthook/start-kube-apiserver-admission-initializer ok
[+]poststarthook/generic-apiserver-start-informers ok
[+]poststarthook/start-apiextensions-informers ok
[+]poststarthook/start-apiextensions-controllers ok
[+]poststarthook/crd-informer-synced ok
[+]poststarthook/bootstrap-controller ok
[+]poststarthook/rbac/bootstrap-roles ok
[+]poststarthook/scheduling/bootstrap-system-priority-classes ok
[+]poststarthook/start-cluster-authentication-info-controller ok
[+]poststarthook/start-kube-aggregator-informers ok
[+]poststarthook/apiservice-registration-controller ok
[+]poststarthook/apiservice-status-available-controller ok
[+]poststarthook/kube-apiserver-autoregistration ok
[+]autoregister-completion ok
[+]poststarthook/apiservice-openapi-controller ok
healthz check passed
```

# Use case
This is not only useful for having status reports like Kubernetes readyz endpoints; it also allows services to simplify the set up when creating microservices that publish their status to status page systems such as:

- https://cachethq.io/
- https://www.atlassian.com/software/statuspage

# Change
This PR introduces a new `List` endpoint to the `Health` service in order to list all the services that a certain server is watching to.

# Alternative solution
We could extract the `List` endpoint into a new service to avoid breaking the `v1` API. A new `HealthLister` (or any other name) must be created.

# Proposal
https://github.com/grpc/proposal/pull/468