### PR TITLE
grpc-js: Fix ability to set SNI with ssl_target_name_override option

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",


### PR DESCRIPTION
This fixes #2955 (I think). The logic to set SNI from the proxy connection target was implemented twice, and the second one was overriding the setting from the `ssl_target_name_override` option. This change fixes that by removing the duplicate logic and rearranging the rest.