### PR TITLE
Health list endpoint

### DIFF
--- a/packages/grpc-health-check/src/generated/grpc/health/v1/Health.ts
+++ b/packages/grpc-health-check/src/generated/grpc/health/v1/Health.ts
@@ -3,8 +3,11 @@
 import type { MethodDefinition } from '@grpc/proto-loader'
 import type { HealthCheckRequest as _grpc_health_v1_HealthCheckRequest, HealthCheckRequest__Output as _grpc_health_v1_HealthCheckRequest__Output } from '../../../grpc/health/v1/HealthCheckRequest';
 import type { HealthCheckResponse as _grpc_health_v1_HealthCheckResponse, HealthCheckResponse__Output as _grpc_health_v1_HealthCheckResponse__Output } from '../../../grpc/health/v1/HealthCheckResponse';
+import type { HealthListRequest as _grpc_health_v1_HealthListRequest, HealthListRequest__Output as _grpc_health_v1_HealthListRequest__Output } from '../../../grpc/health/v1/HealthListRequest';
+import type { HealthListResponse as _grpc_health_v1_HealthListResponse, HealthListResponse__Output as _grpc_health_v1_HealthListResponse__Output } from '../../../grpc/health/v1/HealthListResponse';
 
 export interface HealthDefinition {
   Check: MethodDefinition<_grpc_health_v1_HealthCheckRequest, _grpc_health_v1_HealthCheckResponse, _grpc_health_v1_HealthCheckRequest__Output, _grpc_health_v1_HealthCheckResponse__Output>
+  List: MethodDefinition<_grpc_health_v1_HealthListRequest, _grpc_health_v1_HealthListResponse, _grpc_health_v1_HealthListRequest__Output, _grpc_health_v1_HealthListResponse__Output>
   Watch: MethodDefinition<_grpc_health_v1_HealthCheckRequest, _grpc_health_v1_HealthCheckResponse, _grpc_health_v1_HealthCheckRequest__Output, _grpc_health_v1_HealthCheckResponse__Output>
 }

--- a/packages/grpc-health-check/src/generated/grpc/health/v1/HealthListRequest.ts
+++ b/packages/grpc-health-check/src/generated/grpc/health/v1/HealthListRequest.ts
@@ -1,0 +1,8 @@
+// Original file: proto/health/v1/health.proto
+
+
+export interface HealthListRequest {
+}
+
+export interface HealthListRequest__Output {
+}

--- a/packages/grpc-health-check/src/generated/grpc/health/v1/HealthListResponse.ts
+++ b/packages/grpc-health-check/src/generated/grpc/health/v1/HealthListResponse.ts
@@ -1,0 +1,17 @@
+// Original file: proto/health/v1/health.proto
+
+import type { HealthCheckResponse as _grpc_health_v1_HealthCheckResponse, HealthCheckResponse__Output as _grpc_health_v1_HealthCheckResponse__Output } from '../../../grpc/health/v1/HealthCheckResponse';
+
+export interface HealthListResponse {
+  /**
+   * statuses contains all the services and their respective status.
+   */
+  'statuses'?: ({[key: string]: _grpc_health_v1_HealthCheckResponse});
+}
+
+export interface HealthListResponse__Output {
+  /**
+   * statuses contains all the services and their respective status.
+   */
+  'statuses': ({[key: string]: _grpc_health_v1_HealthCheckResponse__Output});
+}

--- a/packages/grpc-health-check/test/generated/grpc/health/v1/Health.ts
+++ b/packages/grpc-health-check/test/generated/grpc/health/v1/Health.ts
@@ -4,6 +4,8 @@ import type * as grpc from '@grpc/grpc-js'
 import type { MethodDefinition } from '@grpc/proto-loader'
 import type { HealthCheckRequest as _grpc_health_v1_HealthCheckRequest, HealthCheckRequest__Output as _grpc_health_v1_HealthCheckRequest__Output } from '../../../grpc/health/v1/HealthCheckRequest';
 import type { HealthCheckResponse as _grpc_health_v1_HealthCheckResponse, HealthCheckResponse__Output as _grpc_health_v1_HealthCheckResponse__Output } from '../../../grpc/health/v1/HealthCheckResponse';
+import type { HealthListRequest as _grpc_health_v1_HealthListRequest, HealthListRequest__Output as _grpc_health_v1_HealthListRequest__Output } from '../../../grpc/health/v1/HealthListRequest';
+import type { HealthListResponse as _grpc_health_v1_HealthListResponse, HealthListResponse__Output as _grpc_health_v1_HealthListResponse__Output } from '../../../grpc/health/v1/HealthListResponse';
 
 /**
  * Health is gRPC's mechanism for checking whether a server is able to handle
@@ -41,6 +43,41 @@ export interface HealthClient extends grpc.Client {
   check(argument: _grpc_health_v1_HealthCheckRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_health_v1_HealthCheckResponse__Output>): grpc.ClientUnaryCall;
   check(argument: _grpc_health_v1_HealthCheckRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_health_v1_HealthCheckResponse__Output>): grpc.ClientUnaryCall;
   check(argument: _grpc_health_v1_HealthCheckRequest, callback: grpc.requestCallback<_grpc_health_v1_HealthCheckResponse__Output>): grpc.ClientUnaryCall;
+  
+  /**
+   * List provides a non-atomic snapshot of the health of all the available
+   * services.
+   * 
+   * The server may respond with a RESOURCE_EXHAUSTED error if too many services
+   * exist.
+   * 
+   * Clients should set a deadline when calling List, and can declare the server
+   * unhealthy if they do not receive a timely response.
+   * 
+   * Clients should keep in mind that the list of health services exposed by an
+   * application can change over the lifetime of the process.
+   */
+  List(argument: _grpc_health_v1_HealthListRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_health_v1_HealthListResponse__Output>): grpc.ClientUnaryCall;
+  List(argument: _grpc_health_v1_HealthListRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_health_v1_HealthListResponse__Output>): grpc.ClientUnaryCall;
+  List(argument: _grpc_health_v1_HealthListRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_health_v1_HealthListResponse__Output>): grpc.ClientUnaryCall;
+  List(argument: _grpc_health_v1_HealthListRequest, callback: grpc.requestCallback<_grpc_health_v1_HealthListResponse__Output>): grpc.ClientUnaryCall;
+  /**
+   * List provides a non-atomic snapshot of the health of all the available
+   * services.
+   * 
+   * The server may respond with a RESOURCE_EXHAUSTED error if too many services
+   * exist.
+   * 
+   * Clients should set a deadline when calling List, and can declare the server
+   * unhealthy if they do not receive a timely response.
+   * 
+   * Clients should keep in mind that the list of health services exposed by an
+   * application can change over the lifetime of the process.
+   */
+  list(argument: _grpc_health_v1_HealthListRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_health_v1_HealthListResponse__Output>): grpc.ClientUnaryCall;
+  list(argument: _grpc_health_v1_HealthListRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_grpc_health_v1_HealthListResponse__Output>): grpc.ClientUnaryCall;
+  list(argument: _grpc_health_v1_HealthListRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_grpc_health_v1_HealthListResponse__Output>): grpc.ClientUnaryCall;
+  list(argument: _grpc_health_v1_HealthListRequest, callback: grpc.requestCallback<_grpc_health_v1_HealthListResponse__Output>): grpc.ClientUnaryCall;
   
   /**
    * Performs a watch for the serving status of the requested service.
@@ -103,6 +140,21 @@ export interface HealthHandlers extends grpc.UntypedServiceImplementation {
   Check: grpc.handleUnaryCall<_grpc_health_v1_HealthCheckRequest__Output, _grpc_health_v1_HealthCheckResponse>;
   
   /**
+   * List provides a non-atomic snapshot of the health of all the available
+   * services.
+   * 
+   * The server may respond with a RESOURCE_EXHAUSTED error if too many services
+   * exist.
+   * 
+   * Clients should set a deadline when calling List, and can declare the server
+   * unhealthy if they do not receive a timely response.
+   * 
+   * Clients should keep in mind that the list of health services exposed by an
+   * application can change over the lifetime of the process.
+   */
+  List: grpc.handleUnaryCall<_grpc_health_v1_HealthListRequest__Output, _grpc_health_v1_HealthListResponse>;
+  
+  /**
    * Performs a watch for the serving status of the requested service.
    * The server will immediately send back a message indicating the current
    * serving status.  It will then subsequently send a new message whenever
@@ -125,5 +177,6 @@ export interface HealthHandlers extends grpc.UntypedServiceImplementation {
 
 export interface HealthDefinition extends grpc.ServiceDefinition {
   Check: MethodDefinition<_grpc_health_v1_HealthCheckRequest, _grpc_health_v1_HealthCheckResponse, _grpc_health_v1_HealthCheckRequest__Output, _grpc_health_v1_HealthCheckResponse__Output>
+  List: MethodDefinition<_grpc_health_v1_HealthListRequest, _grpc_health_v1_HealthListResponse, _grpc_health_v1_HealthListRequest__Output, _grpc_health_v1_HealthListResponse__Output>
   Watch: MethodDefinition<_grpc_health_v1_HealthCheckRequest, _grpc_health_v1_HealthCheckResponse, _grpc_health_v1_HealthCheckRequest__Output, _grpc_health_v1_HealthCheckResponse__Output>
 }

--- a/packages/grpc-health-check/test/generated/grpc/health/v1/HealthListRequest.ts
+++ b/packages/grpc-health-check/test/generated/grpc/health/v1/HealthListRequest.ts
@@ -1,0 +1,8 @@
+// Original file: proto/health/v1/health.proto
+
+
+export interface HealthListRequest {
+}
+
+export interface HealthListRequest__Output {
+}

--- a/packages/grpc-health-check/test/generated/grpc/health/v1/HealthListResponse.ts
+++ b/packages/grpc-health-check/test/generated/grpc/health/v1/HealthListResponse.ts
@@ -1,0 +1,17 @@
+// Original file: proto/health/v1/health.proto
+
+import type { HealthCheckResponse as _grpc_health_v1_HealthCheckResponse, HealthCheckResponse__Output as _grpc_health_v1_HealthCheckResponse__Output } from '../../../grpc/health/v1/HealthCheckResponse';
+
+export interface HealthListResponse {
+  /**
+   * statuses contains all the services and their respective status.
+   */
+  'statuses'?: ({[key: string]: _grpc_health_v1_HealthCheckResponse});
+}
+
+export interface HealthListResponse__Output {
+  /**
+   * statuses contains all the services and their respective status.
+   */
+  'statuses': ({[key: string]: _grpc_health_v1_HealthCheckResponse__Output});
+}

--- a/packages/grpc-health-check/test/generated/health.ts
+++ b/packages/grpc-health-check/test/generated/health.ts
@@ -19,6 +19,8 @@ export interface ProtoGrpcType {
         Health: SubtypeConstructor<typeof grpc.Client, _grpc_health_v1_HealthClient> & { service: _grpc_health_v1_HealthDefinition }
         HealthCheckRequest: MessageTypeDefinition
         HealthCheckResponse: MessageTypeDefinition
+        HealthListRequest: MessageTypeDefinition
+        HealthListResponse: MessageTypeDefinition
       }
     }
   }


### PR DESCRIPTION
# Change
This PR introduces the implementation of the new `List` endpoint to the `Health` service in order to list all the services that a certain server is watching to.

It also adds generated files for the endpoint and its tests. 

I would like to write some tests too but I couldn't run the test suite as it is as I get some errors, any help is appreciated.
```
gulpfile.ts:28:19 - error TS2339: Property 'parallel' does not exist on type 'Gulp'.
28 const lint = gulp.parallel(jsCore.lint);
gulpfile.ts:30:20 - error TS2339: Property 'series' does not exist on type 'Gulp'.
30 const build = gulp.series(protobuf.compile, jsCore.compile, jsXds.compile);
```

# Related PR
gRPC-proto added in https://github.com/grpc/grpc-node/pull/2951

# Proposal
https://github.com/grpc/proposal/pull/468