### PR TITLE
grpc-js-xds: Add psm-light test job config

### DIFF
--- a/test/kokoro/psm-light.cfg
+++ b/test/kokoro/psm-light.cfg
@@ -1,0 +1,30 @@
+# Copyright 2024 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for Kokoro (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-node/packages/grpc-js-xds/scripts/psm-interop-test-node.sh"
+timeout_mins: 360
+action {
+  define_artifacts {
+    regex: "artifacts/**/*sponge_log.xml"
+    regex: "artifacts/**/*.log"
+    strip_prefix: "artifacts"
+  }
+}
+env_vars {
+  key: "PSM_TEST_SUITE"
+  value: "light"
+}


### PR DESCRIPTION
This is the test job to run the federation test, with https://github.com/grpc/psm-interop/pull/185.