### PR TITLE
grpc-js-xds: Combine endpoints for LOGICAL_DNS clusters

### DIFF
--- a/packages/grpc-js-xds/src/xds-dependency-manager.ts
+++ b/packages/grpc-js-xds/src/xds-dependency-manager.ts
@@ -323,6 +323,9 @@ function getEdsResource(edsUpdate: ClusterLoadAssignment__Output): EndpointResou
 }
 
 function getDnsResource(endpoints: Endpoint[]): EndpointResource {
+  const endpoint: Endpoint = {
+    addresses: endpoints.map(endpoint => endpoint.addresses).flat()
+  }
   return {
     priorities: [{
       localities: [{
@@ -332,7 +335,7 @@ function getDnsResource(endpoints: Endpoint[]): EndpointResource {
           sub_zone: ''
         },
         weight: 1,
-        endpoints: endpoints.map(endpoint => ({endpoint: endpoint, weight: 1}))
+        endpoints: [{endpoint: endpoint, weight: 1}]
       }]
     }],
     dropCategories: []


### PR DESCRIPTION
This aligns LOGICAL_DNS handling with the changes described in https://github.com/grpc/proposal/pull/477. It looks like we previously did not have the old correct behavior, in that we were passing multiple endpoints without forcing the pick_first LB policy.