### PR TITLE
proto-loader: Output functions to serialize and deserialize messages

### DIFF
--- a/packages/grpc-js-xds/interop/generated/test.ts
+++ b/packages/grpc-js-xds/interop/generated/test.ts
@@ -1,8 +1,27 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { BoolValue as _grpc_testing_BoolValue, BoolValue__Output as _grpc_testing_BoolValue__Output } from './grpc/testing/BoolValue';
+import type { ClientConfigureRequest as _grpc_testing_ClientConfigureRequest, ClientConfigureRequest__Output as _grpc_testing_ClientConfigureRequest__Output } from './grpc/testing/ClientConfigureRequest';
+import type { ClientConfigureResponse as _grpc_testing_ClientConfigureResponse, ClientConfigureResponse__Output as _grpc_testing_ClientConfigureResponse__Output } from './grpc/testing/ClientConfigureResponse';
+import type { EchoStatus as _grpc_testing_EchoStatus, EchoStatus__Output as _grpc_testing_EchoStatus__Output } from './grpc/testing/EchoStatus';
+import type { Empty as _grpc_testing_Empty, Empty__Output as _grpc_testing_Empty__Output } from './grpc/testing/Empty';
+import type { LoadBalancerAccumulatedStatsRequest as _grpc_testing_LoadBalancerAccumulatedStatsRequest, LoadBalancerAccumulatedStatsRequest__Output as _grpc_testing_LoadBalancerAccumulatedStatsRequest__Output } from './grpc/testing/LoadBalancerAccumulatedStatsRequest';
+import type { LoadBalancerAccumulatedStatsResponse as _grpc_testing_LoadBalancerAccumulatedStatsResponse, LoadBalancerAccumulatedStatsResponse__Output as _grpc_testing_LoadBalancerAccumulatedStatsResponse__Output } from './grpc/testing/LoadBalancerAccumulatedStatsResponse';
+import type { LoadBalancerStatsRequest as _grpc_testing_LoadBalancerStatsRequest, LoadBalancerStatsRequest__Output as _grpc_testing_LoadBalancerStatsRequest__Output } from './grpc/testing/LoadBalancerStatsRequest';
+import type { LoadBalancerStatsResponse as _grpc_testing_LoadBalancerStatsResponse, LoadBalancerStatsResponse__Output as _grpc_testing_LoadBalancerStatsResponse__Output } from './grpc/testing/LoadBalancerStatsResponse';
 import type { LoadBalancerStatsServiceClient as _grpc_testing_LoadBalancerStatsServiceClient, LoadBalancerStatsServiceDefinition as _grpc_testing_LoadBalancerStatsServiceDefinition } from './grpc/testing/LoadBalancerStatsService';
+import type { Payload as _grpc_testing_Payload, Payload__Output as _grpc_testing_Payload__Output } from './grpc/testing/Payload';
+import type { ReconnectInfo as _grpc_testing_ReconnectInfo, ReconnectInfo__Output as _grpc_testing_ReconnectInfo__Output } from './grpc/testing/ReconnectInfo';
+import type { ReconnectParams as _grpc_testing_ReconnectParams, ReconnectParams__Output as _grpc_testing_ReconnectParams__Output } from './grpc/testing/ReconnectParams';
 import type { ReconnectServiceClient as _grpc_testing_ReconnectServiceClient, ReconnectServiceDefinition as _grpc_testing_ReconnectServiceDefinition } from './grpc/testing/ReconnectService';
+import type { ResponseParameters as _grpc_testing_ResponseParameters, ResponseParameters__Output as _grpc_testing_ResponseParameters__Output } from './grpc/testing/ResponseParameters';
+import type { SimpleRequest as _grpc_testing_SimpleRequest, SimpleRequest__Output as _grpc_testing_SimpleRequest__Output } from './grpc/testing/SimpleRequest';
+import type { SimpleResponse as _grpc_testing_SimpleResponse, SimpleResponse__Output as _grpc_testing_SimpleResponse__Output } from './grpc/testing/SimpleResponse';
+import type { StreamingInputCallRequest as _grpc_testing_StreamingInputCallRequest, StreamingInputCallRequest__Output as _grpc_testing_StreamingInputCallRequest__Output } from './grpc/testing/StreamingInputCallRequest';
+import type { StreamingInputCallResponse as _grpc_testing_StreamingInputCallResponse, StreamingInputCallResponse__Output as _grpc_testing_StreamingInputCallResponse__Output } from './grpc/testing/StreamingInputCallResponse';
+import type { StreamingOutputCallRequest as _grpc_testing_StreamingOutputCallRequest, StreamingOutputCallRequest__Output as _grpc_testing_StreamingOutputCallRequest__Output } from './grpc/testing/StreamingOutputCallRequest';
+import type { StreamingOutputCallResponse as _grpc_testing_StreamingOutputCallResponse, StreamingOutputCallResponse__Output as _grpc_testing_StreamingOutputCallResponse__Output } from './grpc/testing/StreamingOutputCallResponse';
 import type { TestServiceClient as _grpc_testing_TestServiceClient, TestServiceDefinition as _grpc_testing_TestServiceDefinition } from './grpc/testing/TestService';
 import type { UnimplementedServiceClient as _grpc_testing_UnimplementedServiceClient, UnimplementedServiceDefinition as _grpc_testing_UnimplementedServiceDefinition } from './grpc/testing/UnimplementedService';
 import type { XdsUpdateClientConfigureServiceClient as _grpc_testing_XdsUpdateClientConfigureServiceClient, XdsUpdateClientConfigureServiceDefinition as _grpc_testing_XdsUpdateClientConfigureServiceDefinition } from './grpc/testing/XdsUpdateClientConfigureService';
@@ -15,35 +34,35 @@ type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> 
 export interface ProtoGrpcType {
   grpc: {
     testing: {
-      BoolValue: MessageTypeDefinition
-      ClientConfigureRequest: MessageTypeDefinition
-      ClientConfigureResponse: MessageTypeDefinition
-      EchoStatus: MessageTypeDefinition
-      Empty: MessageTypeDefinition
+      BoolValue: MessageTypeDefinition<_grpc_testing_BoolValue, _grpc_testing_BoolValue__Output>
+      ClientConfigureRequest: MessageTypeDefinition<_grpc_testing_ClientConfigureRequest, _grpc_testing_ClientConfigureRequest__Output>
+      ClientConfigureResponse: MessageTypeDefinition<_grpc_testing_ClientConfigureResponse, _grpc_testing_ClientConfigureResponse__Output>
+      EchoStatus: MessageTypeDefinition<_grpc_testing_EchoStatus, _grpc_testing_EchoStatus__Output>
+      Empty: MessageTypeDefinition<_grpc_testing_Empty, _grpc_testing_Empty__Output>
       GrpclbRouteType: EnumTypeDefinition
-      LoadBalancerAccumulatedStatsRequest: MessageTypeDefinition
-      LoadBalancerAccumulatedStatsResponse: MessageTypeDefinition
-      LoadBalancerStatsRequest: MessageTypeDefinition
-      LoadBalancerStatsResponse: MessageTypeDefinition
+      LoadBalancerAccumulatedStatsRequest: MessageTypeDefinition<_grpc_testing_LoadBalancerAccumulatedStatsRequest, _grpc_testing_LoadBalancerAccumulatedStatsRequest__Output>
+      LoadBalancerAccumulatedStatsResponse: MessageTypeDefinition<_grpc_testing_LoadBalancerAccumulatedStatsResponse, _grpc_testing_LoadBalancerAccumulatedStatsResponse__Output>
+      LoadBalancerStatsRequest: MessageTypeDefinition<_grpc_testing_LoadBalancerStatsRequest, _grpc_testing_LoadBalancerStatsRequest__Output>
+      LoadBalancerStatsResponse: MessageTypeDefinition<_grpc_testing_LoadBalancerStatsResponse, _grpc_testing_LoadBalancerStatsResponse__Output>
       /**
        * A service used to obtain stats for verifying LB behavior.
        */
       LoadBalancerStatsService: SubtypeConstructor<typeof grpc.Client, _grpc_testing_LoadBalancerStatsServiceClient> & { service: _grpc_testing_LoadBalancerStatsServiceDefinition }
-      Payload: MessageTypeDefinition
+      Payload: MessageTypeDefinition<_grpc_testing_Payload, _grpc_testing_Payload__Output>
       PayloadType: EnumTypeDefinition
-      ReconnectInfo: MessageTypeDefinition
-      ReconnectParams: MessageTypeDefinition
+      ReconnectInfo: MessageTypeDefinition<_grpc_testing_ReconnectInfo, _grpc_testing_ReconnectInfo__Output>
+      ReconnectParams: MessageTypeDefinition<_grpc_testing_ReconnectParams, _grpc_testing_ReconnectParams__Output>
       /**
        * A service used to control reconnect server.
        */
       ReconnectService: SubtypeConstructor<typeof grpc.Client, _grpc_testing_ReconnectServiceClient> & { service: _grpc_testing_ReconnectServiceDefinition }
-      ResponseParameters: MessageTypeDefinition
-      SimpleRequest: MessageTypeDefinition
-      SimpleResponse: MessageTypeDefinition
-      StreamingInputCallRequest: MessageTypeDefinition
-      StreamingInputCallResponse: MessageTypeDefinition
-      StreamingOutputCallRequest: MessageTypeDefinition
-      StreamingOutputCallResponse: MessageTypeDefinition
+      ResponseParameters: MessageTypeDefinition<_grpc_testing_ResponseParameters, _grpc_testing_ResponseParameters__Output>
+      SimpleRequest: MessageTypeDefinition<_grpc_testing_SimpleRequest, _grpc_testing_SimpleRequest__Output>
+      SimpleResponse: MessageTypeDefinition<_grpc_testing_SimpleResponse, _grpc_testing_SimpleResponse__Output>
+      StreamingInputCallRequest: MessageTypeDefinition<_grpc_testing_StreamingInputCallRequest, _grpc_testing_StreamingInputCallRequest__Output>
+      StreamingInputCallResponse: MessageTypeDefinition<_grpc_testing_StreamingInputCallResponse, _grpc_testing_StreamingInputCallResponse__Output>
+      StreamingOutputCallRequest: MessageTypeDefinition<_grpc_testing_StreamingOutputCallRequest, _grpc_testing_StreamingOutputCallRequest__Output>
+      StreamingOutputCallResponse: MessageTypeDefinition<_grpc_testing_StreamingOutputCallResponse, _grpc_testing_StreamingOutputCallResponse__Output>
       /**
        * A simple service to test the various types of RPCs and experiment with
        * performance with various types of payload.

--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -9,7 +9,7 @@
     "clean": "gts clean",
     "compile": "tsc",
     "fix": "gts fix",
-    "prepare": "npm run generate-types && npm run compile",
+    "prepare": "npm run generate-types && npm run generate-interop-types && npm run generate-test-types && npm run compile",
     "pretest": "npm run compile",
     "posttest": "npm run check",
     "generate-types": "proto-loader-gen-types --keepCase --longs String --enums String --defaults --oneofs --includeComments --includeDirs deps/envoy-api/ deps/xds/ deps/googleapis/ deps/protoc-gen-validate/ -O src/generated/ --grpcLib @grpc/grpc-js envoy/service/discovery/v3/ads.proto envoy/service/load_stats/v3/lrs.proto envoy/config/listener/v3/listener.proto envoy/config/route/v3/route.proto envoy/config/cluster/v3/cluster.proto envoy/config/endpoint/v3/endpoint.proto envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto udpa/type/v1/typed_struct.proto xds/type/v3/typed_struct.proto envoy/extensions/filters/http/fault/v3/fault.proto envoy/service/status/v3/csds.proto envoy/extensions/load_balancing_policies/wrr_locality/v3/wrr_locality.proto envoy/extensions/load_balancing_policies/ring_hash/v3/ring_hash.proto envoy/extensions/load_balancing_policies/pick_first/v3/pick_first.proto envoy/extensions/clusters/aggregate/v3/cluster.proto envoy/extensions/transport_sockets/tls/v3/tls.proto envoy/config/rbac/v3/rbac.proto envoy/extensions/filters/http/rbac/v3/rbac.proto",

--- a/packages/grpc-js-xds/src/generated/ads.ts
+++ b/packages/grpc-js-xds/src/generated/ads.ts
@@ -1,7 +1,128 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { AdsDummy as _envoy_service_discovery_v3_AdsDummy, AdsDummy__Output as _envoy_service_discovery_v3_AdsDummy__Output } from './envoy/service/discovery/v3/AdsDummy';
 import type { AggregatedDiscoveryServiceClient as _envoy_service_discovery_v3_AggregatedDiscoveryServiceClient, AggregatedDiscoveryServiceDefinition as _envoy_service_discovery_v3_AggregatedDiscoveryServiceDefinition } from './envoy/service/discovery/v3/AggregatedDiscoveryService';
+import type { DeltaDiscoveryRequest as _envoy_service_discovery_v3_DeltaDiscoveryRequest, DeltaDiscoveryRequest__Output as _envoy_service_discovery_v3_DeltaDiscoveryRequest__Output } from './envoy/service/discovery/v3/DeltaDiscoveryRequest';
+import type { DeltaDiscoveryResponse as _envoy_service_discovery_v3_DeltaDiscoveryResponse, DeltaDiscoveryResponse__Output as _envoy_service_discovery_v3_DeltaDiscoveryResponse__Output } from './envoy/service/discovery/v3/DeltaDiscoveryResponse';
+import type { DiscoveryRequest as _envoy_service_discovery_v3_DiscoveryRequest, DiscoveryRequest__Output as _envoy_service_discovery_v3_DiscoveryRequest__Output } from './envoy/service/discovery/v3/DiscoveryRequest';
+import type { DiscoveryResponse as _envoy_service_discovery_v3_DiscoveryResponse, DiscoveryResponse__Output as _envoy_service_discovery_v3_DiscoveryResponse__Output } from './envoy/service/discovery/v3/DiscoveryResponse';
+import type { DynamicParameterConstraints as _envoy_service_discovery_v3_DynamicParameterConstraints, DynamicParameterConstraints__Output as _envoy_service_discovery_v3_DynamicParameterConstraints__Output } from './envoy/service/discovery/v3/DynamicParameterConstraints';
+import type { Resource as _envoy_service_discovery_v3_Resource, Resource__Output as _envoy_service_discovery_v3_Resource__Output } from './envoy/service/discovery/v3/Resource';
+import type { ResourceLocator as _envoy_service_discovery_v3_ResourceLocator, ResourceLocator__Output as _envoy_service_discovery_v3_ResourceLocator__Output } from './envoy/service/discovery/v3/ResourceLocator';
+import type { ResourceName as _envoy_service_discovery_v3_ResourceName, ResourceName__Output as _envoy_service_discovery_v3_ResourceName__Output } from './envoy/service/discovery/v3/ResourceName';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { Status as _google_rpc_Status, Status__Output as _google_rpc_Status__Output } from './google/rpc/Status';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -14,53 +135,53 @@ export interface ProtoGrpcType {
     config: {
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
     }
     service: {
       discovery: {
         v3: {
-          AdsDummy: MessageTypeDefinition
+          AdsDummy: MessageTypeDefinition<_envoy_service_discovery_v3_AdsDummy, _envoy_service_discovery_v3_AdsDummy__Output>
           /**
            * See https://github.com/envoyproxy/envoy-api#apis for a description of the role of
            * ADS and how it is intended to be used by a management server. ADS requests
@@ -70,122 +191,122 @@ export interface ProtoGrpcType {
            * the multiplexed singleton APIs at the Envoy instance and management server.
            */
           AggregatedDiscoveryService: SubtypeConstructor<typeof grpc.Client, _envoy_service_discovery_v3_AggregatedDiscoveryServiceClient> & { service: _envoy_service_discovery_v3_AggregatedDiscoveryServiceDefinition }
-          DeltaDiscoveryRequest: MessageTypeDefinition
-          DeltaDiscoveryResponse: MessageTypeDefinition
-          DiscoveryRequest: MessageTypeDefinition
-          DiscoveryResponse: MessageTypeDefinition
-          DynamicParameterConstraints: MessageTypeDefinition
-          Resource: MessageTypeDefinition
-          ResourceLocator: MessageTypeDefinition
-          ResourceName: MessageTypeDefinition
+          DeltaDiscoveryRequest: MessageTypeDefinition<_envoy_service_discovery_v3_DeltaDiscoveryRequest, _envoy_service_discovery_v3_DeltaDiscoveryRequest__Output>
+          DeltaDiscoveryResponse: MessageTypeDefinition<_envoy_service_discovery_v3_DeltaDiscoveryResponse, _envoy_service_discovery_v3_DeltaDiscoveryResponse__Output>
+          DiscoveryRequest: MessageTypeDefinition<_envoy_service_discovery_v3_DiscoveryRequest, _envoy_service_discovery_v3_DiscoveryRequest__Output>
+          DiscoveryResponse: MessageTypeDefinition<_envoy_service_discovery_v3_DiscoveryResponse, _envoy_service_discovery_v3_DiscoveryResponse__Output>
+          DynamicParameterConstraints: MessageTypeDefinition<_envoy_service_discovery_v3_DynamicParameterConstraints, _envoy_service_discovery_v3_DynamicParameterConstraints__Output>
+          Resource: MessageTypeDefinition<_envoy_service_discovery_v3_Resource, _envoy_service_discovery_v3_Resource__Output>
+          ResourceLocator: MessageTypeDefinition<_envoy_service_discovery_v3_ResourceLocator, _envoy_service_discovery_v3_ResourceLocator__Output>
+          ResourceName: MessageTypeDefinition<_envoy_service_discovery_v3_ResourceName, _envoy_service_discovery_v3_ResourceName__Output>
         }
       }
     }
     type: {
       v3: {
-        FractionalPercent: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
     rpc: {
-      Status: MessageTypeDefinition
+      Status: MessageTypeDefinition<_google_rpc_Status, _google_rpc_Status__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        ContextParams: MessageTypeDefinition
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
       }
     }
   }

--- a/packages/grpc-js-xds/src/generated/cluster.ts
+++ b/packages/grpc-js-xds/src/generated/cluster.ts
@@ -1,6 +1,173 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { CircuitBreakers as _envoy_config_cluster_v3_CircuitBreakers, CircuitBreakers__Output as _envoy_config_cluster_v3_CircuitBreakers__Output } from './envoy/config/cluster/v3/CircuitBreakers';
+import type { Cluster as _envoy_config_cluster_v3_Cluster, Cluster__Output as _envoy_config_cluster_v3_Cluster__Output } from './envoy/config/cluster/v3/Cluster';
+import type { ClusterCollection as _envoy_config_cluster_v3_ClusterCollection, ClusterCollection__Output as _envoy_config_cluster_v3_ClusterCollection__Output } from './envoy/config/cluster/v3/ClusterCollection';
+import type { Filter as _envoy_config_cluster_v3_Filter, Filter__Output as _envoy_config_cluster_v3_Filter__Output } from './envoy/config/cluster/v3/Filter';
+import type { LoadBalancingPolicy as _envoy_config_cluster_v3_LoadBalancingPolicy, LoadBalancingPolicy__Output as _envoy_config_cluster_v3_LoadBalancingPolicy__Output } from './envoy/config/cluster/v3/LoadBalancingPolicy';
+import type { OutlierDetection as _envoy_config_cluster_v3_OutlierDetection, OutlierDetection__Output as _envoy_config_cluster_v3_OutlierDetection__Output } from './envoy/config/cluster/v3/OutlierDetection';
+import type { TrackClusterStats as _envoy_config_cluster_v3_TrackClusterStats, TrackClusterStats__Output as _envoy_config_cluster_v3_TrackClusterStats__Output } from './envoy/config/cluster/v3/TrackClusterStats';
+import type { UpstreamConnectionOptions as _envoy_config_cluster_v3_UpstreamConnectionOptions, UpstreamConnectionOptions__Output as _envoy_config_cluster_v3_UpstreamConnectionOptions__Output } from './envoy/config/cluster/v3/UpstreamConnectionOptions';
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AggregatedConfigSource as _envoy_config_core_v3_AggregatedConfigSource, AggregatedConfigSource__Output as _envoy_config_core_v3_AggregatedConfigSource__Output } from './envoy/config/core/v3/AggregatedConfigSource';
+import type { AlternateProtocolsCacheOptions as _envoy_config_core_v3_AlternateProtocolsCacheOptions, AlternateProtocolsCacheOptions__Output as _envoy_config_core_v3_AlternateProtocolsCacheOptions__Output } from './envoy/config/core/v3/AlternateProtocolsCacheOptions';
+import type { ApiConfigSource as _envoy_config_core_v3_ApiConfigSource, ApiConfigSource__Output as _envoy_config_core_v3_ApiConfigSource__Output } from './envoy/config/core/v3/ApiConfigSource';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ConfigSource as _envoy_config_core_v3_ConfigSource, ConfigSource__Output as _envoy_config_core_v3_ConfigSource__Output } from './envoy/config/core/v3/ConfigSource';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { DnsResolutionConfig as _envoy_config_core_v3_DnsResolutionConfig, DnsResolutionConfig__Output as _envoy_config_core_v3_DnsResolutionConfig__Output } from './envoy/config/core/v3/DnsResolutionConfig';
+import type { DnsResolverOptions as _envoy_config_core_v3_DnsResolverOptions, DnsResolverOptions__Output as _envoy_config_core_v3_DnsResolverOptions__Output } from './envoy/config/core/v3/DnsResolverOptions';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { EventServiceConfig as _envoy_config_core_v3_EventServiceConfig, EventServiceConfig__Output as _envoy_config_core_v3_EventServiceConfig__Output } from './envoy/config/core/v3/EventServiceConfig';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtensionConfigSource as _envoy_config_core_v3_ExtensionConfigSource, ExtensionConfigSource__Output as _envoy_config_core_v3_ExtensionConfigSource__Output } from './envoy/config/core/v3/ExtensionConfigSource';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { GrpcProtocolOptions as _envoy_config_core_v3_GrpcProtocolOptions, GrpcProtocolOptions__Output as _envoy_config_core_v3_GrpcProtocolOptions__Output } from './envoy/config/core/v3/GrpcProtocolOptions';
+import type { GrpcService as _envoy_config_core_v3_GrpcService, GrpcService__Output as _envoy_config_core_v3_GrpcService__Output } from './envoy/config/core/v3/GrpcService';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { HealthCheck as _envoy_config_core_v3_HealthCheck, HealthCheck__Output as _envoy_config_core_v3_HealthCheck__Output } from './envoy/config/core/v3/HealthCheck';
+import type { HealthStatusSet as _envoy_config_core_v3_HealthStatusSet, HealthStatusSet__Output as _envoy_config_core_v3_HealthStatusSet__Output } from './envoy/config/core/v3/HealthStatusSet';
+import type { Http1ProtocolOptions as _envoy_config_core_v3_Http1ProtocolOptions, Http1ProtocolOptions__Output as _envoy_config_core_v3_Http1ProtocolOptions__Output } from './envoy/config/core/v3/Http1ProtocolOptions';
+import type { Http2ProtocolOptions as _envoy_config_core_v3_Http2ProtocolOptions, Http2ProtocolOptions__Output as _envoy_config_core_v3_Http2ProtocolOptions__Output } from './envoy/config/core/v3/Http2ProtocolOptions';
+import type { Http3ProtocolOptions as _envoy_config_core_v3_Http3ProtocolOptions, Http3ProtocolOptions__Output as _envoy_config_core_v3_Http3ProtocolOptions__Output } from './envoy/config/core/v3/Http3ProtocolOptions';
+import type { HttpProtocolOptions as _envoy_config_core_v3_HttpProtocolOptions, HttpProtocolOptions__Output as _envoy_config_core_v3_HttpProtocolOptions__Output } from './envoy/config/core/v3/HttpProtocolOptions';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeepaliveSettings as _envoy_config_core_v3_KeepaliveSettings, KeepaliveSettings__Output as _envoy_config_core_v3_KeepaliveSettings__Output } from './envoy/config/core/v3/KeepaliveSettings';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { PathConfigSource as _envoy_config_core_v3_PathConfigSource, PathConfigSource__Output as _envoy_config_core_v3_PathConfigSource__Output } from './envoy/config/core/v3/PathConfigSource';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { ProxyProtocolConfig as _envoy_config_core_v3_ProxyProtocolConfig, ProxyProtocolConfig__Output as _envoy_config_core_v3_ProxyProtocolConfig__Output } from './envoy/config/core/v3/ProxyProtocolConfig';
+import type { ProxyProtocolPassThroughTLVs as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs, ProxyProtocolPassThroughTLVs__Output as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output } from './envoy/config/core/v3/ProxyProtocolPassThroughTLVs';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { QuicKeepAliveSettings as _envoy_config_core_v3_QuicKeepAliveSettings, QuicKeepAliveSettings__Output as _envoy_config_core_v3_QuicKeepAliveSettings__Output } from './envoy/config/core/v3/QuicKeepAliveSettings';
+import type { QuicProtocolOptions as _envoy_config_core_v3_QuicProtocolOptions, QuicProtocolOptions__Output as _envoy_config_core_v3_QuicProtocolOptions__Output } from './envoy/config/core/v3/QuicProtocolOptions';
+import type { RateLimitSettings as _envoy_config_core_v3_RateLimitSettings, RateLimitSettings__Output as _envoy_config_core_v3_RateLimitSettings__Output } from './envoy/config/core/v3/RateLimitSettings';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SchemeHeaderTransformation as _envoy_config_core_v3_SchemeHeaderTransformation, SchemeHeaderTransformation__Output as _envoy_config_core_v3_SchemeHeaderTransformation__Output } from './envoy/config/core/v3/SchemeHeaderTransformation';
+import type { SelfConfigSource as _envoy_config_core_v3_SelfConfigSource, SelfConfigSource__Output as _envoy_config_core_v3_SelfConfigSource__Output } from './envoy/config/core/v3/SelfConfigSource';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TcpProtocolOptions as _envoy_config_core_v3_TcpProtocolOptions, TcpProtocolOptions__Output as _envoy_config_core_v3_TcpProtocolOptions__Output } from './envoy/config/core/v3/TcpProtocolOptions';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { UpstreamHttpProtocolOptions as _envoy_config_core_v3_UpstreamHttpProtocolOptions, UpstreamHttpProtocolOptions__Output as _envoy_config_core_v3_UpstreamHttpProtocolOptions__Output } from './envoy/config/core/v3/UpstreamHttpProtocolOptions';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { ClusterLoadAssignment as _envoy_config_endpoint_v3_ClusterLoadAssignment, ClusterLoadAssignment__Output as _envoy_config_endpoint_v3_ClusterLoadAssignment__Output } from './envoy/config/endpoint/v3/ClusterLoadAssignment';
+import type { Endpoint as _envoy_config_endpoint_v3_Endpoint, Endpoint__Output as _envoy_config_endpoint_v3_Endpoint__Output } from './envoy/config/endpoint/v3/Endpoint';
+import type { LbEndpoint as _envoy_config_endpoint_v3_LbEndpoint, LbEndpoint__Output as _envoy_config_endpoint_v3_LbEndpoint__Output } from './envoy/config/endpoint/v3/LbEndpoint';
+import type { LedsClusterLocalityConfig as _envoy_config_endpoint_v3_LedsClusterLocalityConfig, LedsClusterLocalityConfig__Output as _envoy_config_endpoint_v3_LedsClusterLocalityConfig__Output } from './envoy/config/endpoint/v3/LedsClusterLocalityConfig';
+import type { LocalityLbEndpoints as _envoy_config_endpoint_v3_LocalityLbEndpoints, LocalityLbEndpoints__Output as _envoy_config_endpoint_v3_LocalityLbEndpoints__Output } from './envoy/config/endpoint/v3/LocalityLbEndpoints';
+import type { ClusterConfig as _envoy_extensions_clusters_aggregate_v3_ClusterConfig, ClusterConfig__Output as _envoy_extensions_clusters_aggregate_v3_ClusterConfig__Output } from './envoy/extensions/clusters/aggregate/v3/ClusterConfig';
+import type { ListStringMatcher as _envoy_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _envoy_type_matcher_v3_ListStringMatcher__Output } from './envoy/type/matcher/v3/ListStringMatcher';
+import type { RegexMatchAndSubstitute as _envoy_type_matcher_v3_RegexMatchAndSubstitute, RegexMatchAndSubstitute__Output as _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output } from './envoy/type/matcher/v3/RegexMatchAndSubstitute';
+import type { RegexMatcher as _envoy_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _envoy_type_matcher_v3_RegexMatcher__Output } from './envoy/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _envoy_type_matcher_v3_StringMatcher, StringMatcher__Output as _envoy_type_matcher_v3_StringMatcher__Output } from './envoy/type/matcher/v3/StringMatcher';
+import type { MetadataKey as _envoy_type_metadata_v3_MetadataKey, MetadataKey__Output as _envoy_type_metadata_v3_MetadataKey__Output } from './envoy/type/metadata/v3/MetadataKey';
+import type { MetadataKind as _envoy_type_metadata_v3_MetadataKind, MetadataKind__Output as _envoy_type_metadata_v3_MetadataKind__Output } from './envoy/type/metadata/v3/MetadataKind';
+import type { DoubleRange as _envoy_type_v3_DoubleRange, DoubleRange__Output as _envoy_type_v3_DoubleRange__Output } from './envoy/type/v3/DoubleRange';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Int32Range as _envoy_type_v3_Int32Range, Int32Range__Output as _envoy_type_v3_Int32Range__Output } from './envoy/type/v3/Int32Range';
+import type { Int64Range as _envoy_type_v3_Int64Range, Int64Range__Output as _envoy_type_v3_Int64Range__Output } from './envoy/type/v3/Int64Range';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from './google/protobuf/Empty';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FieldSecurityAnnotation as _udpa_annotations_FieldSecurityAnnotation, FieldSecurityAnnotation__Output as _udpa_annotations_FieldSecurityAnnotation__Output } from './udpa/annotations/FieldSecurityAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { Authority as _xds_core_v3_Authority, Authority__Output as _xds_core_v3_Authority__Output } from './xds/core/v3/Authority';
+import type { CollectionEntry as _xds_core_v3_CollectionEntry, CollectionEntry__Output as _xds_core_v3_CollectionEntry__Output } from './xds/core/v3/CollectionEntry';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
+import type { ResourceLocator as _xds_core_v3_ResourceLocator, ResourceLocator__Output as _xds_core_v3_ResourceLocator__Output } from './xds/core/v3/ResourceLocator';
+import type { TypedExtensionConfig as _xds_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _xds_core_v3_TypedExtensionConfig__Output } from './xds/core/v3/TypedExtensionConfig';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -13,96 +180,96 @@ export interface ProtoGrpcType {
     config: {
       cluster: {
         v3: {
-          CircuitBreakers: MessageTypeDefinition
-          Cluster: MessageTypeDefinition
-          ClusterCollection: MessageTypeDefinition
-          Filter: MessageTypeDefinition
-          LoadBalancingPolicy: MessageTypeDefinition
-          OutlierDetection: MessageTypeDefinition
-          TrackClusterStats: MessageTypeDefinition
-          UpstreamConnectionOptions: MessageTypeDefinition
+          CircuitBreakers: MessageTypeDefinition<_envoy_config_cluster_v3_CircuitBreakers, _envoy_config_cluster_v3_CircuitBreakers__Output>
+          Cluster: MessageTypeDefinition<_envoy_config_cluster_v3_Cluster, _envoy_config_cluster_v3_Cluster__Output>
+          ClusterCollection: MessageTypeDefinition<_envoy_config_cluster_v3_ClusterCollection, _envoy_config_cluster_v3_ClusterCollection__Output>
+          Filter: MessageTypeDefinition<_envoy_config_cluster_v3_Filter, _envoy_config_cluster_v3_Filter__Output>
+          LoadBalancingPolicy: MessageTypeDefinition<_envoy_config_cluster_v3_LoadBalancingPolicy, _envoy_config_cluster_v3_LoadBalancingPolicy__Output>
+          OutlierDetection: MessageTypeDefinition<_envoy_config_cluster_v3_OutlierDetection, _envoy_config_cluster_v3_OutlierDetection__Output>
+          TrackClusterStats: MessageTypeDefinition<_envoy_config_cluster_v3_TrackClusterStats, _envoy_config_cluster_v3_TrackClusterStats__Output>
+          UpstreamConnectionOptions: MessageTypeDefinition<_envoy_config_cluster_v3_UpstreamConnectionOptions, _envoy_config_cluster_v3_UpstreamConnectionOptions__Output>
         }
       }
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AggregatedConfigSource: MessageTypeDefinition
-          AlternateProtocolsCacheOptions: MessageTypeDefinition
-          ApiConfigSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AggregatedConfigSource: MessageTypeDefinition<_envoy_config_core_v3_AggregatedConfigSource, _envoy_config_core_v3_AggregatedConfigSource__Output>
+          AlternateProtocolsCacheOptions: MessageTypeDefinition<_envoy_config_core_v3_AlternateProtocolsCacheOptions, _envoy_config_core_v3_AlternateProtocolsCacheOptions__Output>
+          ApiConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ApiConfigSource, _envoy_config_core_v3_ApiConfigSource__Output>
           ApiVersion: EnumTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ConfigSource: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          DnsResolutionConfig: MessageTypeDefinition
-          DnsResolverOptions: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          EventServiceConfig: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtensionConfigSource: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          GrpcProtocolOptions: MessageTypeDefinition
-          GrpcService: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          HealthCheck: MessageTypeDefinition
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ConfigSource, _envoy_config_core_v3_ConfigSource__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          DnsResolutionConfig: MessageTypeDefinition<_envoy_config_core_v3_DnsResolutionConfig, _envoy_config_core_v3_DnsResolutionConfig__Output>
+          DnsResolverOptions: MessageTypeDefinition<_envoy_config_core_v3_DnsResolverOptions, _envoy_config_core_v3_DnsResolverOptions__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          EventServiceConfig: MessageTypeDefinition<_envoy_config_core_v3_EventServiceConfig, _envoy_config_core_v3_EventServiceConfig__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtensionConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ExtensionConfigSource, _envoy_config_core_v3_ExtensionConfigSource__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          GrpcProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_GrpcProtocolOptions, _envoy_config_core_v3_GrpcProtocolOptions__Output>
+          GrpcService: MessageTypeDefinition<_envoy_config_core_v3_GrpcService, _envoy_config_core_v3_GrpcService__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          HealthCheck: MessageTypeDefinition<_envoy_config_core_v3_HealthCheck, _envoy_config_core_v3_HealthCheck__Output>
           HealthStatus: EnumTypeDefinition
-          HealthStatusSet: MessageTypeDefinition
-          Http1ProtocolOptions: MessageTypeDefinition
-          Http2ProtocolOptions: MessageTypeDefinition
-          Http3ProtocolOptions: MessageTypeDefinition
-          HttpProtocolOptions: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeepaliveSettings: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          PathConfigSource: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          ProxyProtocolConfig: MessageTypeDefinition
-          ProxyProtocolPassThroughTLVs: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          QuicKeepAliveSettings: MessageTypeDefinition
-          QuicProtocolOptions: MessageTypeDefinition
-          RateLimitSettings: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          HealthStatusSet: MessageTypeDefinition<_envoy_config_core_v3_HealthStatusSet, _envoy_config_core_v3_HealthStatusSet__Output>
+          Http1ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http1ProtocolOptions, _envoy_config_core_v3_Http1ProtocolOptions__Output>
+          Http2ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http2ProtocolOptions, _envoy_config_core_v3_Http2ProtocolOptions__Output>
+          Http3ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http3ProtocolOptions, _envoy_config_core_v3_Http3ProtocolOptions__Output>
+          HttpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_HttpProtocolOptions, _envoy_config_core_v3_HttpProtocolOptions__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeepaliveSettings: MessageTypeDefinition<_envoy_config_core_v3_KeepaliveSettings, _envoy_config_core_v3_KeepaliveSettings__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          PathConfigSource: MessageTypeDefinition<_envoy_config_core_v3_PathConfigSource, _envoy_config_core_v3_PathConfigSource__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          ProxyProtocolConfig: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolConfig, _envoy_config_core_v3_ProxyProtocolConfig__Output>
+          ProxyProtocolPassThroughTLVs: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolPassThroughTLVs, _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          QuicKeepAliveSettings: MessageTypeDefinition<_envoy_config_core_v3_QuicKeepAliveSettings, _envoy_config_core_v3_QuicKeepAliveSettings__Output>
+          QuicProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_QuicProtocolOptions, _envoy_config_core_v3_QuicProtocolOptions__Output>
+          RateLimitSettings: MessageTypeDefinition<_envoy_config_core_v3_RateLimitSettings, _envoy_config_core_v3_RateLimitSettings__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SchemeHeaderTransformation: MessageTypeDefinition
-          SelfConfigSource: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
-          TcpProtocolOptions: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SchemeHeaderTransformation: MessageTypeDefinition<_envoy_config_core_v3_SchemeHeaderTransformation, _envoy_config_core_v3_SchemeHeaderTransformation__Output>
+          SelfConfigSource: MessageTypeDefinition<_envoy_config_core_v3_SelfConfigSource, _envoy_config_core_v3_SelfConfigSource__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
+          TcpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_TcpProtocolOptions, _envoy_config_core_v3_TcpProtocolOptions__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          UpstreamHttpProtocolOptions: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          UpstreamHttpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_UpstreamHttpProtocolOptions, _envoy_config_core_v3_UpstreamHttpProtocolOptions__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
       endpoint: {
         v3: {
-          ClusterLoadAssignment: MessageTypeDefinition
-          Endpoint: MessageTypeDefinition
-          LbEndpoint: MessageTypeDefinition
-          LedsClusterLocalityConfig: MessageTypeDefinition
-          LocalityLbEndpoints: MessageTypeDefinition
+          ClusterLoadAssignment: MessageTypeDefinition<_envoy_config_endpoint_v3_ClusterLoadAssignment, _envoy_config_endpoint_v3_ClusterLoadAssignment__Output>
+          Endpoint: MessageTypeDefinition<_envoy_config_endpoint_v3_Endpoint, _envoy_config_endpoint_v3_Endpoint__Output>
+          LbEndpoint: MessageTypeDefinition<_envoy_config_endpoint_v3_LbEndpoint, _envoy_config_endpoint_v3_LbEndpoint__Output>
+          LedsClusterLocalityConfig: MessageTypeDefinition<_envoy_config_endpoint_v3_LedsClusterLocalityConfig, _envoy_config_endpoint_v3_LedsClusterLocalityConfig__Output>
+          LocalityLbEndpoints: MessageTypeDefinition<_envoy_config_endpoint_v3_LocalityLbEndpoints, _envoy_config_endpoint_v3_LocalityLbEndpoints__Output>
         }
       }
     }
@@ -110,7 +277,7 @@ export interface ProtoGrpcType {
       clusters: {
         aggregate: {
           v3: {
-            ClusterConfig: MessageTypeDefinition
+            ClusterConfig: MessageTypeDefinition<_envoy_extensions_clusters_aggregate_v3_ClusterConfig, _envoy_extensions_clusters_aggregate_v3_ClusterConfig__Output>
           }
         }
       }
@@ -118,129 +285,129 @@ export interface ProtoGrpcType {
     type: {
       matcher: {
         v3: {
-          ListStringMatcher: MessageTypeDefinition
-          RegexMatchAndSubstitute: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
+          ListStringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListStringMatcher, _envoy_type_matcher_v3_ListStringMatcher__Output>
+          RegexMatchAndSubstitute: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatchAndSubstitute, _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output>
+          RegexMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatcher, _envoy_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_StringMatcher, _envoy_type_matcher_v3_StringMatcher__Output>
         }
       }
       metadata: {
         v3: {
-          MetadataKey: MessageTypeDefinition
-          MetadataKind: MessageTypeDefinition
+          MetadataKey: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKey, _envoy_type_metadata_v3_MetadataKey__Output>
+          MetadataKind: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKind, _envoy_type_metadata_v3_MetadataKind__Output>
         }
       }
       v3: {
         CodecClientType: EnumTypeDefinition
-        DoubleRange: MessageTypeDefinition
-        FractionalPercent: MessageTypeDefinition
-        Int32Range: MessageTypeDefinition
-        Int64Range: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        DoubleRange: MessageTypeDefinition<_envoy_type_v3_DoubleRange, _envoy_type_v3_DoubleRange__Output>
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Int32Range: MessageTypeDefinition<_envoy_type_v3_Int32Range, _envoy_type_v3_Int32Range__Output>
+        Int64Range: MessageTypeDefinition<_envoy_type_v3_Int64Range, _envoy_type_v3_Int64Range__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      Empty: MessageTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      Empty: MessageTypeDefinition<_google_protobuf_Empty, _google_protobuf_Empty__Output>
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FieldSecurityAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FieldSecurityAnnotation: MessageTypeDefinition<_udpa_annotations_FieldSecurityAnnotation, _udpa_annotations_FieldSecurityAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        Authority: MessageTypeDefinition
-        CollectionEntry: MessageTypeDefinition
-        ContextParams: MessageTypeDefinition
-        ResourceLocator: MessageTypeDefinition
-        TypedExtensionConfig: MessageTypeDefinition
+        Authority: MessageTypeDefinition<_xds_core_v3_Authority, _xds_core_v3_Authority__Output>
+        CollectionEntry: MessageTypeDefinition<_xds_core_v3_CollectionEntry, _xds_core_v3_CollectionEntry__Output>
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
+        ResourceLocator: MessageTypeDefinition<_xds_core_v3_ResourceLocator, _xds_core_v3_ResourceLocator__Output>
+        TypedExtensionConfig: MessageTypeDefinition<_xds_core_v3_TypedExtensionConfig, _xds_core_v3_TypedExtensionConfig__Output>
       }
     }
   }

--- a/packages/grpc-js-xds/src/generated/csds.ts
+++ b/packages/grpc-js-xds/src/generated/csds.ts
@@ -1,7 +1,146 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { ClustersConfigDump as _envoy_admin_v3_ClustersConfigDump, ClustersConfigDump__Output as _envoy_admin_v3_ClustersConfigDump__Output } from './envoy/admin/v3/ClustersConfigDump';
+import type { EcdsConfigDump as _envoy_admin_v3_EcdsConfigDump, EcdsConfigDump__Output as _envoy_admin_v3_EcdsConfigDump__Output } from './envoy/admin/v3/EcdsConfigDump';
+import type { EndpointsConfigDump as _envoy_admin_v3_EndpointsConfigDump, EndpointsConfigDump__Output as _envoy_admin_v3_EndpointsConfigDump__Output } from './envoy/admin/v3/EndpointsConfigDump';
+import type { ListenersConfigDump as _envoy_admin_v3_ListenersConfigDump, ListenersConfigDump__Output as _envoy_admin_v3_ListenersConfigDump__Output } from './envoy/admin/v3/ListenersConfigDump';
+import type { RoutesConfigDump as _envoy_admin_v3_RoutesConfigDump, RoutesConfigDump__Output as _envoy_admin_v3_RoutesConfigDump__Output } from './envoy/admin/v3/RoutesConfigDump';
+import type { ScopedRoutesConfigDump as _envoy_admin_v3_ScopedRoutesConfigDump, ScopedRoutesConfigDump__Output as _envoy_admin_v3_ScopedRoutesConfigDump__Output } from './envoy/admin/v3/ScopedRoutesConfigDump';
+import type { UpdateFailureState as _envoy_admin_v3_UpdateFailureState, UpdateFailureState__Output as _envoy_admin_v3_UpdateFailureState__Output } from './envoy/admin/v3/UpdateFailureState';
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { ClientConfig as _envoy_service_status_v3_ClientConfig, ClientConfig__Output as _envoy_service_status_v3_ClientConfig__Output } from './envoy/service/status/v3/ClientConfig';
 import type { ClientStatusDiscoveryServiceClient as _envoy_service_status_v3_ClientStatusDiscoveryServiceClient, ClientStatusDiscoveryServiceDefinition as _envoy_service_status_v3_ClientStatusDiscoveryServiceDefinition } from './envoy/service/status/v3/ClientStatusDiscoveryService';
+import type { ClientStatusRequest as _envoy_service_status_v3_ClientStatusRequest, ClientStatusRequest__Output as _envoy_service_status_v3_ClientStatusRequest__Output } from './envoy/service/status/v3/ClientStatusRequest';
+import type { ClientStatusResponse as _envoy_service_status_v3_ClientStatusResponse, ClientStatusResponse__Output as _envoy_service_status_v3_ClientStatusResponse__Output } from './envoy/service/status/v3/ClientStatusResponse';
+import type { PerXdsConfig as _envoy_service_status_v3_PerXdsConfig, PerXdsConfig__Output as _envoy_service_status_v3_PerXdsConfig__Output } from './envoy/service/status/v3/PerXdsConfig';
+import type { DoubleMatcher as _envoy_type_matcher_v3_DoubleMatcher, DoubleMatcher__Output as _envoy_type_matcher_v3_DoubleMatcher__Output } from './envoy/type/matcher/v3/DoubleMatcher';
+import type { ListMatcher as _envoy_type_matcher_v3_ListMatcher, ListMatcher__Output as _envoy_type_matcher_v3_ListMatcher__Output } from './envoy/type/matcher/v3/ListMatcher';
+import type { ListStringMatcher as _envoy_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _envoy_type_matcher_v3_ListStringMatcher__Output } from './envoy/type/matcher/v3/ListStringMatcher';
+import type { NodeMatcher as _envoy_type_matcher_v3_NodeMatcher, NodeMatcher__Output as _envoy_type_matcher_v3_NodeMatcher__Output } from './envoy/type/matcher/v3/NodeMatcher';
+import type { OrMatcher as _envoy_type_matcher_v3_OrMatcher, OrMatcher__Output as _envoy_type_matcher_v3_OrMatcher__Output } from './envoy/type/matcher/v3/OrMatcher';
+import type { RegexMatchAndSubstitute as _envoy_type_matcher_v3_RegexMatchAndSubstitute, RegexMatchAndSubstitute__Output as _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output } from './envoy/type/matcher/v3/RegexMatchAndSubstitute';
+import type { RegexMatcher as _envoy_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _envoy_type_matcher_v3_RegexMatcher__Output } from './envoy/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _envoy_type_matcher_v3_StringMatcher, StringMatcher__Output as _envoy_type_matcher_v3_StringMatcher__Output } from './envoy/type/matcher/v3/StringMatcher';
+import type { StructMatcher as _envoy_type_matcher_v3_StructMatcher, StructMatcher__Output as _envoy_type_matcher_v3_StructMatcher__Output } from './envoy/type/matcher/v3/StructMatcher';
+import type { ValueMatcher as _envoy_type_matcher_v3_ValueMatcher, ValueMatcher__Output as _envoy_type_matcher_v3_ValueMatcher__Output } from './envoy/type/matcher/v3/ValueMatcher';
+import type { DoubleRange as _envoy_type_v3_DoubleRange, DoubleRange__Output as _envoy_type_v3_DoubleRange__Output } from './envoy/type/v3/DoubleRange';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Int32Range as _envoy_type_v3_Int32Range, Int32Range__Output as _envoy_type_v3_Int32Range__Output } from './envoy/type/v3/Int32Range';
+import type { Int64Range as _envoy_type_v3_Int64Range, Int64Range__Output as _envoy_type_v3_Int64Range__Output } from './envoy/type/v3/Int64Range';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { CustomHttpPattern as _google_api_CustomHttpPattern, CustomHttpPattern__Output as _google_api_CustomHttpPattern__Output } from './google/api/CustomHttpPattern';
+import type { Http as _google_api_Http, Http__Output as _google_api_Http__Output } from './google/api/Http';
+import type { HttpRule as _google_api_HttpRule, HttpRule__Output as _google_api_HttpRule__Output } from './google/api/HttpRule';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
+import type { TypedExtensionConfig as _xds_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _xds_core_v3_TypedExtensionConfig__Output } from './xds/core/v3/TypedExtensionConfig';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -12,13 +151,13 @@ export interface ProtoGrpcType {
     admin: {
       v3: {
         ClientResourceStatus: EnumTypeDefinition
-        ClustersConfigDump: MessageTypeDefinition
-        EcdsConfigDump: MessageTypeDefinition
-        EndpointsConfigDump: MessageTypeDefinition
-        ListenersConfigDump: MessageTypeDefinition
-        RoutesConfigDump: MessageTypeDefinition
-        ScopedRoutesConfigDump: MessageTypeDefinition
-        UpdateFailureState: MessageTypeDefinition
+        ClustersConfigDump: MessageTypeDefinition<_envoy_admin_v3_ClustersConfigDump, _envoy_admin_v3_ClustersConfigDump__Output>
+        EcdsConfigDump: MessageTypeDefinition<_envoy_admin_v3_EcdsConfigDump, _envoy_admin_v3_EcdsConfigDump__Output>
+        EndpointsConfigDump: MessageTypeDefinition<_envoy_admin_v3_EndpointsConfigDump, _envoy_admin_v3_EndpointsConfigDump__Output>
+        ListenersConfigDump: MessageTypeDefinition<_envoy_admin_v3_ListenersConfigDump, _envoy_admin_v3_ListenersConfigDump__Output>
+        RoutesConfigDump: MessageTypeDefinition<_envoy_admin_v3_RoutesConfigDump, _envoy_admin_v3_RoutesConfigDump__Output>
+        ScopedRoutesConfigDump: MessageTypeDefinition<_envoy_admin_v3_ScopedRoutesConfigDump, _envoy_admin_v3_ScopedRoutesConfigDump__Output>
+        UpdateFailureState: MessageTypeDefinition<_envoy_admin_v3_UpdateFailureState, _envoy_admin_v3_UpdateFailureState__Output>
       }
     }
     annotations: {
@@ -26,53 +165,53 @@ export interface ProtoGrpcType {
     config: {
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
     }
     service: {
       status: {
         v3: {
-          ClientConfig: MessageTypeDefinition
+          ClientConfig: MessageTypeDefinition<_envoy_service_status_v3_ClientConfig, _envoy_service_status_v3_ClientConfig__Output>
           ClientConfigStatus: EnumTypeDefinition
           /**
            * CSDS is Client Status Discovery Service. It can be used to get the status of
@@ -80,138 +219,138 @@ export interface ProtoGrpcType {
            * also be used to get the current xDS states directly from the client.
            */
           ClientStatusDiscoveryService: SubtypeConstructor<typeof grpc.Client, _envoy_service_status_v3_ClientStatusDiscoveryServiceClient> & { service: _envoy_service_status_v3_ClientStatusDiscoveryServiceDefinition }
-          ClientStatusRequest: MessageTypeDefinition
-          ClientStatusResponse: MessageTypeDefinition
+          ClientStatusRequest: MessageTypeDefinition<_envoy_service_status_v3_ClientStatusRequest, _envoy_service_status_v3_ClientStatusRequest__Output>
+          ClientStatusResponse: MessageTypeDefinition<_envoy_service_status_v3_ClientStatusResponse, _envoy_service_status_v3_ClientStatusResponse__Output>
           ConfigStatus: EnumTypeDefinition
-          PerXdsConfig: MessageTypeDefinition
+          PerXdsConfig: MessageTypeDefinition<_envoy_service_status_v3_PerXdsConfig, _envoy_service_status_v3_PerXdsConfig__Output>
         }
       }
     }
     type: {
       matcher: {
         v3: {
-          DoubleMatcher: MessageTypeDefinition
-          ListMatcher: MessageTypeDefinition
-          ListStringMatcher: MessageTypeDefinition
-          NodeMatcher: MessageTypeDefinition
-          OrMatcher: MessageTypeDefinition
-          RegexMatchAndSubstitute: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
-          StructMatcher: MessageTypeDefinition
-          ValueMatcher: MessageTypeDefinition
+          DoubleMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_DoubleMatcher, _envoy_type_matcher_v3_DoubleMatcher__Output>
+          ListMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListMatcher, _envoy_type_matcher_v3_ListMatcher__Output>
+          ListStringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListStringMatcher, _envoy_type_matcher_v3_ListStringMatcher__Output>
+          NodeMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_NodeMatcher, _envoy_type_matcher_v3_NodeMatcher__Output>
+          OrMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_OrMatcher, _envoy_type_matcher_v3_OrMatcher__Output>
+          RegexMatchAndSubstitute: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatchAndSubstitute, _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output>
+          RegexMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatcher, _envoy_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_StringMatcher, _envoy_type_matcher_v3_StringMatcher__Output>
+          StructMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_StructMatcher, _envoy_type_matcher_v3_StructMatcher__Output>
+          ValueMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ValueMatcher, _envoy_type_matcher_v3_ValueMatcher__Output>
         }
       }
       v3: {
-        DoubleRange: MessageTypeDefinition
-        FractionalPercent: MessageTypeDefinition
-        Int32Range: MessageTypeDefinition
-        Int64Range: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        DoubleRange: MessageTypeDefinition<_envoy_type_v3_DoubleRange, _envoy_type_v3_DoubleRange__Output>
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Int32Range: MessageTypeDefinition<_envoy_type_v3_Int32Range, _envoy_type_v3_Int32Range__Output>
+        Int64Range: MessageTypeDefinition<_envoy_type_v3_Int64Range, _envoy_type_v3_Int64Range__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     api: {
-      CustomHttpPattern: MessageTypeDefinition
-      Http: MessageTypeDefinition
-      HttpRule: MessageTypeDefinition
+      CustomHttpPattern: MessageTypeDefinition<_google_api_CustomHttpPattern, _google_api_CustomHttpPattern__Output>
+      Http: MessageTypeDefinition<_google_api_Http, _google_api_Http__Output>
+      HttpRule: MessageTypeDefinition<_google_api_HttpRule, _google_api_HttpRule__Output>
     }
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        ContextParams: MessageTypeDefinition
-        TypedExtensionConfig: MessageTypeDefinition
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
+        TypedExtensionConfig: MessageTypeDefinition<_xds_core_v3_TypedExtensionConfig, _xds_core_v3_TypedExtensionConfig__Output>
       }
     }
   }

--- a/packages/grpc-js-xds/src/generated/endpoint.ts
+++ b/packages/grpc-js-xds/src/generated/endpoint.ts
@@ -1,6 +1,145 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AggregatedConfigSource as _envoy_config_core_v3_AggregatedConfigSource, AggregatedConfigSource__Output as _envoy_config_core_v3_AggregatedConfigSource__Output } from './envoy/config/core/v3/AggregatedConfigSource';
+import type { ApiConfigSource as _envoy_config_core_v3_ApiConfigSource, ApiConfigSource__Output as _envoy_config_core_v3_ApiConfigSource__Output } from './envoy/config/core/v3/ApiConfigSource';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ConfigSource as _envoy_config_core_v3_ConfigSource, ConfigSource__Output as _envoy_config_core_v3_ConfigSource__Output } from './envoy/config/core/v3/ConfigSource';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { EventServiceConfig as _envoy_config_core_v3_EventServiceConfig, EventServiceConfig__Output as _envoy_config_core_v3_EventServiceConfig__Output } from './envoy/config/core/v3/EventServiceConfig';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtensionConfigSource as _envoy_config_core_v3_ExtensionConfigSource, ExtensionConfigSource__Output as _envoy_config_core_v3_ExtensionConfigSource__Output } from './envoy/config/core/v3/ExtensionConfigSource';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { GrpcService as _envoy_config_core_v3_GrpcService, GrpcService__Output as _envoy_config_core_v3_GrpcService__Output } from './envoy/config/core/v3/GrpcService';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { HealthCheck as _envoy_config_core_v3_HealthCheck, HealthCheck__Output as _envoy_config_core_v3_HealthCheck__Output } from './envoy/config/core/v3/HealthCheck';
+import type { HealthStatusSet as _envoy_config_core_v3_HealthStatusSet, HealthStatusSet__Output as _envoy_config_core_v3_HealthStatusSet__Output } from './envoy/config/core/v3/HealthStatusSet';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { PathConfigSource as _envoy_config_core_v3_PathConfigSource, PathConfigSource__Output as _envoy_config_core_v3_PathConfigSource__Output } from './envoy/config/core/v3/PathConfigSource';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { ProxyProtocolConfig as _envoy_config_core_v3_ProxyProtocolConfig, ProxyProtocolConfig__Output as _envoy_config_core_v3_ProxyProtocolConfig__Output } from './envoy/config/core/v3/ProxyProtocolConfig';
+import type { ProxyProtocolPassThroughTLVs as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs, ProxyProtocolPassThroughTLVs__Output as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output } from './envoy/config/core/v3/ProxyProtocolPassThroughTLVs';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { RateLimitSettings as _envoy_config_core_v3_RateLimitSettings, RateLimitSettings__Output as _envoy_config_core_v3_RateLimitSettings__Output } from './envoy/config/core/v3/RateLimitSettings';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SelfConfigSource as _envoy_config_core_v3_SelfConfigSource, SelfConfigSource__Output as _envoy_config_core_v3_SelfConfigSource__Output } from './envoy/config/core/v3/SelfConfigSource';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { ClusterLoadAssignment as _envoy_config_endpoint_v3_ClusterLoadAssignment, ClusterLoadAssignment__Output as _envoy_config_endpoint_v3_ClusterLoadAssignment__Output } from './envoy/config/endpoint/v3/ClusterLoadAssignment';
+import type { Endpoint as _envoy_config_endpoint_v3_Endpoint, Endpoint__Output as _envoy_config_endpoint_v3_Endpoint__Output } from './envoy/config/endpoint/v3/Endpoint';
+import type { LbEndpoint as _envoy_config_endpoint_v3_LbEndpoint, LbEndpoint__Output as _envoy_config_endpoint_v3_LbEndpoint__Output } from './envoy/config/endpoint/v3/LbEndpoint';
+import type { LedsClusterLocalityConfig as _envoy_config_endpoint_v3_LedsClusterLocalityConfig, LedsClusterLocalityConfig__Output as _envoy_config_endpoint_v3_LedsClusterLocalityConfig__Output } from './envoy/config/endpoint/v3/LedsClusterLocalityConfig';
+import type { LocalityLbEndpoints as _envoy_config_endpoint_v3_LocalityLbEndpoints, LocalityLbEndpoints__Output as _envoy_config_endpoint_v3_LocalityLbEndpoints__Output } from './envoy/config/endpoint/v3/LocalityLbEndpoints';
+import type { ListStringMatcher as _envoy_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _envoy_type_matcher_v3_ListStringMatcher__Output } from './envoy/type/matcher/v3/ListStringMatcher';
+import type { RegexMatchAndSubstitute as _envoy_type_matcher_v3_RegexMatchAndSubstitute, RegexMatchAndSubstitute__Output as _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output } from './envoy/type/matcher/v3/RegexMatchAndSubstitute';
+import type { RegexMatcher as _envoy_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _envoy_type_matcher_v3_RegexMatcher__Output } from './envoy/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _envoy_type_matcher_v3_StringMatcher, StringMatcher__Output as _envoy_type_matcher_v3_StringMatcher__Output } from './envoy/type/matcher/v3/StringMatcher';
+import type { DoubleRange as _envoy_type_v3_DoubleRange, DoubleRange__Output as _envoy_type_v3_DoubleRange__Output } from './envoy/type/v3/DoubleRange';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Int32Range as _envoy_type_v3_Int32Range, Int32Range__Output as _envoy_type_v3_Int32Range__Output } from './envoy/type/v3/Int32Range';
+import type { Int64Range as _envoy_type_v3_Int64Range, Int64Range__Output as _envoy_type_v3_Int64Range__Output } from './envoy/type/v3/Int64Range';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from './google/protobuf/Empty';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { Authority as _xds_core_v3_Authority, Authority__Output as _xds_core_v3_Authority__Output } from './xds/core/v3/Authority';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
+import type { TypedExtensionConfig as _xds_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _xds_core_v3_TypedExtensionConfig__Output } from './xds/core/v3/TypedExtensionConfig';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -13,190 +152,190 @@ export interface ProtoGrpcType {
     config: {
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AggregatedConfigSource: MessageTypeDefinition
-          ApiConfigSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AggregatedConfigSource: MessageTypeDefinition<_envoy_config_core_v3_AggregatedConfigSource, _envoy_config_core_v3_AggregatedConfigSource__Output>
+          ApiConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ApiConfigSource, _envoy_config_core_v3_ApiConfigSource__Output>
           ApiVersion: EnumTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ConfigSource: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          EventServiceConfig: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtensionConfigSource: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          GrpcService: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          HealthCheck: MessageTypeDefinition
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ConfigSource, _envoy_config_core_v3_ConfigSource__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          EventServiceConfig: MessageTypeDefinition<_envoy_config_core_v3_EventServiceConfig, _envoy_config_core_v3_EventServiceConfig__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtensionConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ExtensionConfigSource, _envoy_config_core_v3_ExtensionConfigSource__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          GrpcService: MessageTypeDefinition<_envoy_config_core_v3_GrpcService, _envoy_config_core_v3_GrpcService__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          HealthCheck: MessageTypeDefinition<_envoy_config_core_v3_HealthCheck, _envoy_config_core_v3_HealthCheck__Output>
           HealthStatus: EnumTypeDefinition
-          HealthStatusSet: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          PathConfigSource: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          ProxyProtocolConfig: MessageTypeDefinition
-          ProxyProtocolPassThroughTLVs: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          RateLimitSettings: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          HealthStatusSet: MessageTypeDefinition<_envoy_config_core_v3_HealthStatusSet, _envoy_config_core_v3_HealthStatusSet__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          PathConfigSource: MessageTypeDefinition<_envoy_config_core_v3_PathConfigSource, _envoy_config_core_v3_PathConfigSource__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          ProxyProtocolConfig: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolConfig, _envoy_config_core_v3_ProxyProtocolConfig__Output>
+          ProxyProtocolPassThroughTLVs: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolPassThroughTLVs, _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          RateLimitSettings: MessageTypeDefinition<_envoy_config_core_v3_RateLimitSettings, _envoy_config_core_v3_RateLimitSettings__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SelfConfigSource: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SelfConfigSource: MessageTypeDefinition<_envoy_config_core_v3_SelfConfigSource, _envoy_config_core_v3_SelfConfigSource__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
       endpoint: {
         v3: {
-          ClusterLoadAssignment: MessageTypeDefinition
-          Endpoint: MessageTypeDefinition
-          LbEndpoint: MessageTypeDefinition
-          LedsClusterLocalityConfig: MessageTypeDefinition
-          LocalityLbEndpoints: MessageTypeDefinition
+          ClusterLoadAssignment: MessageTypeDefinition<_envoy_config_endpoint_v3_ClusterLoadAssignment, _envoy_config_endpoint_v3_ClusterLoadAssignment__Output>
+          Endpoint: MessageTypeDefinition<_envoy_config_endpoint_v3_Endpoint, _envoy_config_endpoint_v3_Endpoint__Output>
+          LbEndpoint: MessageTypeDefinition<_envoy_config_endpoint_v3_LbEndpoint, _envoy_config_endpoint_v3_LbEndpoint__Output>
+          LedsClusterLocalityConfig: MessageTypeDefinition<_envoy_config_endpoint_v3_LedsClusterLocalityConfig, _envoy_config_endpoint_v3_LedsClusterLocalityConfig__Output>
+          LocalityLbEndpoints: MessageTypeDefinition<_envoy_config_endpoint_v3_LocalityLbEndpoints, _envoy_config_endpoint_v3_LocalityLbEndpoints__Output>
         }
       }
     }
     type: {
       matcher: {
         v3: {
-          ListStringMatcher: MessageTypeDefinition
-          RegexMatchAndSubstitute: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
+          ListStringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListStringMatcher, _envoy_type_matcher_v3_ListStringMatcher__Output>
+          RegexMatchAndSubstitute: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatchAndSubstitute, _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output>
+          RegexMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatcher, _envoy_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_StringMatcher, _envoy_type_matcher_v3_StringMatcher__Output>
         }
       }
       v3: {
         CodecClientType: EnumTypeDefinition
-        DoubleRange: MessageTypeDefinition
-        FractionalPercent: MessageTypeDefinition
-        Int32Range: MessageTypeDefinition
-        Int64Range: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        DoubleRange: MessageTypeDefinition<_envoy_type_v3_DoubleRange, _envoy_type_v3_DoubleRange__Output>
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Int32Range: MessageTypeDefinition<_envoy_type_v3_Int32Range, _envoy_type_v3_Int32Range__Output>
+        Int64Range: MessageTypeDefinition<_envoy_type_v3_Int64Range, _envoy_type_v3_Int64Range__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      Empty: MessageTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      Empty: MessageTypeDefinition<_google_protobuf_Empty, _google_protobuf_Empty__Output>
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        Authority: MessageTypeDefinition
-        ContextParams: MessageTypeDefinition
-        TypedExtensionConfig: MessageTypeDefinition
+        Authority: MessageTypeDefinition<_xds_core_v3_Authority, _xds_core_v3_Authority__Output>
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
+        TypedExtensionConfig: MessageTypeDefinition<_xds_core_v3_TypedExtensionConfig, _xds_core_v3_TypedExtensionConfig__Output>
       }
     }
   }

--- a/packages/grpc-js-xds/src/generated/fault.ts
+++ b/packages/grpc-js-xds/src/generated/fault.ts
@@ -1,6 +1,165 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { ProxyProtocolConfig as _envoy_config_core_v3_ProxyProtocolConfig, ProxyProtocolConfig__Output as _envoy_config_core_v3_ProxyProtocolConfig__Output } from './envoy/config/core/v3/ProxyProtocolConfig';
+import type { ProxyProtocolPassThroughTLVs as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs, ProxyProtocolPassThroughTLVs__Output as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output } from './envoy/config/core/v3/ProxyProtocolPassThroughTLVs';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { ClusterSpecifierPlugin as _envoy_config_route_v3_ClusterSpecifierPlugin, ClusterSpecifierPlugin__Output as _envoy_config_route_v3_ClusterSpecifierPlugin__Output } from './envoy/config/route/v3/ClusterSpecifierPlugin';
+import type { CorsPolicy as _envoy_config_route_v3_CorsPolicy, CorsPolicy__Output as _envoy_config_route_v3_CorsPolicy__Output } from './envoy/config/route/v3/CorsPolicy';
+import type { Decorator as _envoy_config_route_v3_Decorator, Decorator__Output as _envoy_config_route_v3_Decorator__Output } from './envoy/config/route/v3/Decorator';
+import type { DirectResponseAction as _envoy_config_route_v3_DirectResponseAction, DirectResponseAction__Output as _envoy_config_route_v3_DirectResponseAction__Output } from './envoy/config/route/v3/DirectResponseAction';
+import type { FilterAction as _envoy_config_route_v3_FilterAction, FilterAction__Output as _envoy_config_route_v3_FilterAction__Output } from './envoy/config/route/v3/FilterAction';
+import type { FilterConfig as _envoy_config_route_v3_FilterConfig, FilterConfig__Output as _envoy_config_route_v3_FilterConfig__Output } from './envoy/config/route/v3/FilterConfig';
+import type { HeaderMatcher as _envoy_config_route_v3_HeaderMatcher, HeaderMatcher__Output as _envoy_config_route_v3_HeaderMatcher__Output } from './envoy/config/route/v3/HeaderMatcher';
+import type { HedgePolicy as _envoy_config_route_v3_HedgePolicy, HedgePolicy__Output as _envoy_config_route_v3_HedgePolicy__Output } from './envoy/config/route/v3/HedgePolicy';
+import type { InternalRedirectPolicy as _envoy_config_route_v3_InternalRedirectPolicy, InternalRedirectPolicy__Output as _envoy_config_route_v3_InternalRedirectPolicy__Output } from './envoy/config/route/v3/InternalRedirectPolicy';
+import type { NonForwardingAction as _envoy_config_route_v3_NonForwardingAction, NonForwardingAction__Output as _envoy_config_route_v3_NonForwardingAction__Output } from './envoy/config/route/v3/NonForwardingAction';
+import type { QueryParameterMatcher as _envoy_config_route_v3_QueryParameterMatcher, QueryParameterMatcher__Output as _envoy_config_route_v3_QueryParameterMatcher__Output } from './envoy/config/route/v3/QueryParameterMatcher';
+import type { RateLimit as _envoy_config_route_v3_RateLimit, RateLimit__Output as _envoy_config_route_v3_RateLimit__Output } from './envoy/config/route/v3/RateLimit';
+import type { RedirectAction as _envoy_config_route_v3_RedirectAction, RedirectAction__Output as _envoy_config_route_v3_RedirectAction__Output } from './envoy/config/route/v3/RedirectAction';
+import type { RetryPolicy as _envoy_config_route_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_route_v3_RetryPolicy__Output } from './envoy/config/route/v3/RetryPolicy';
+import type { Route as _envoy_config_route_v3_Route, Route__Output as _envoy_config_route_v3_Route__Output } from './envoy/config/route/v3/Route';
+import type { RouteAction as _envoy_config_route_v3_RouteAction, RouteAction__Output as _envoy_config_route_v3_RouteAction__Output } from './envoy/config/route/v3/RouteAction';
+import type { RouteList as _envoy_config_route_v3_RouteList, RouteList__Output as _envoy_config_route_v3_RouteList__Output } from './envoy/config/route/v3/RouteList';
+import type { RouteMatch as _envoy_config_route_v3_RouteMatch, RouteMatch__Output as _envoy_config_route_v3_RouteMatch__Output } from './envoy/config/route/v3/RouteMatch';
+import type { Tracing as _envoy_config_route_v3_Tracing, Tracing__Output as _envoy_config_route_v3_Tracing__Output } from './envoy/config/route/v3/Tracing';
+import type { VirtualCluster as _envoy_config_route_v3_VirtualCluster, VirtualCluster__Output as _envoy_config_route_v3_VirtualCluster__Output } from './envoy/config/route/v3/VirtualCluster';
+import type { VirtualHost as _envoy_config_route_v3_VirtualHost, VirtualHost__Output as _envoy_config_route_v3_VirtualHost__Output } from './envoy/config/route/v3/VirtualHost';
+import type { WeightedCluster as _envoy_config_route_v3_WeightedCluster, WeightedCluster__Output as _envoy_config_route_v3_WeightedCluster__Output } from './envoy/config/route/v3/WeightedCluster';
+import type { FaultDelay as _envoy_extensions_filters_common_fault_v3_FaultDelay, FaultDelay__Output as _envoy_extensions_filters_common_fault_v3_FaultDelay__Output } from './envoy/extensions/filters/common/fault/v3/FaultDelay';
+import type { FaultRateLimit as _envoy_extensions_filters_common_fault_v3_FaultRateLimit, FaultRateLimit__Output as _envoy_extensions_filters_common_fault_v3_FaultRateLimit__Output } from './envoy/extensions/filters/common/fault/v3/FaultRateLimit';
+import type { FaultAbort as _envoy_extensions_filters_http_fault_v3_FaultAbort, FaultAbort__Output as _envoy_extensions_filters_http_fault_v3_FaultAbort__Output } from './envoy/extensions/filters/http/fault/v3/FaultAbort';
+import type { HTTPFault as _envoy_extensions_filters_http_fault_v3_HTTPFault, HTTPFault__Output as _envoy_extensions_filters_http_fault_v3_HTTPFault__Output } from './envoy/extensions/filters/http/fault/v3/HTTPFault';
+import type { DoubleMatcher as _envoy_type_matcher_v3_DoubleMatcher, DoubleMatcher__Output as _envoy_type_matcher_v3_DoubleMatcher__Output } from './envoy/type/matcher/v3/DoubleMatcher';
+import type { ListMatcher as _envoy_type_matcher_v3_ListMatcher, ListMatcher__Output as _envoy_type_matcher_v3_ListMatcher__Output } from './envoy/type/matcher/v3/ListMatcher';
+import type { ListStringMatcher as _envoy_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _envoy_type_matcher_v3_ListStringMatcher__Output } from './envoy/type/matcher/v3/ListStringMatcher';
+import type { MetadataMatcher as _envoy_type_matcher_v3_MetadataMatcher, MetadataMatcher__Output as _envoy_type_matcher_v3_MetadataMatcher__Output } from './envoy/type/matcher/v3/MetadataMatcher';
+import type { OrMatcher as _envoy_type_matcher_v3_OrMatcher, OrMatcher__Output as _envoy_type_matcher_v3_OrMatcher__Output } from './envoy/type/matcher/v3/OrMatcher';
+import type { RegexMatchAndSubstitute as _envoy_type_matcher_v3_RegexMatchAndSubstitute, RegexMatchAndSubstitute__Output as _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output } from './envoy/type/matcher/v3/RegexMatchAndSubstitute';
+import type { RegexMatcher as _envoy_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _envoy_type_matcher_v3_RegexMatcher__Output } from './envoy/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _envoy_type_matcher_v3_StringMatcher, StringMatcher__Output as _envoy_type_matcher_v3_StringMatcher__Output } from './envoy/type/matcher/v3/StringMatcher';
+import type { ValueMatcher as _envoy_type_matcher_v3_ValueMatcher, ValueMatcher__Output as _envoy_type_matcher_v3_ValueMatcher__Output } from './envoy/type/matcher/v3/ValueMatcher';
+import type { MetadataKey as _envoy_type_metadata_v3_MetadataKey, MetadataKey__Output as _envoy_type_metadata_v3_MetadataKey__Output } from './envoy/type/metadata/v3/MetadataKey';
+import type { MetadataKind as _envoy_type_metadata_v3_MetadataKind, MetadataKind__Output as _envoy_type_metadata_v3_MetadataKind__Output } from './envoy/type/metadata/v3/MetadataKind';
+import type { CustomTag as _envoy_type_tracing_v3_CustomTag, CustomTag__Output as _envoy_type_tracing_v3_CustomTag__Output } from './envoy/type/tracing/v3/CustomTag';
+import type { DoubleRange as _envoy_type_v3_DoubleRange, DoubleRange__Output as _envoy_type_v3_DoubleRange__Output } from './envoy/type/v3/DoubleRange';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Int32Range as _envoy_type_v3_Int32Range, Int32Range__Output as _envoy_type_v3_Int32Range__Output } from './envoy/type/v3/Int32Range';
+import type { Int64Range as _envoy_type_v3_Int64Range, Int64Range__Output as _envoy_type_v3_Int64Range__Output } from './envoy/type/v3/Int64Range';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
+import type { TypedExtensionConfig as _xds_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _xds_core_v3_TypedExtensionConfig__Output } from './xds/core/v3/TypedExtensionConfig';
+import type { ListStringMatcher as _xds_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _xds_type_matcher_v3_ListStringMatcher__Output } from './xds/type/matcher/v3/ListStringMatcher';
+import type { Matcher as _xds_type_matcher_v3_Matcher, Matcher__Output as _xds_type_matcher_v3_Matcher__Output } from './xds/type/matcher/v3/Matcher';
+import type { RegexMatcher as _xds_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _xds_type_matcher_v3_RegexMatcher__Output } from './xds/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _xds_type_matcher_v3_StringMatcher, StringMatcher__Output as _xds_type_matcher_v3_StringMatcher__Output } from './xds/type/matcher/v3/StringMatcher';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -13,74 +172,74 @@ export interface ProtoGrpcType {
     config: {
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          ProxyProtocolConfig: MessageTypeDefinition
-          ProxyProtocolPassThroughTLVs: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          ProxyProtocolConfig: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolConfig, _envoy_config_core_v3_ProxyProtocolConfig__Output>
+          ProxyProtocolPassThroughTLVs: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolPassThroughTLVs, _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
       route: {
         v3: {
-          ClusterSpecifierPlugin: MessageTypeDefinition
-          CorsPolicy: MessageTypeDefinition
-          Decorator: MessageTypeDefinition
-          DirectResponseAction: MessageTypeDefinition
-          FilterAction: MessageTypeDefinition
-          FilterConfig: MessageTypeDefinition
-          HeaderMatcher: MessageTypeDefinition
-          HedgePolicy: MessageTypeDefinition
-          InternalRedirectPolicy: MessageTypeDefinition
-          NonForwardingAction: MessageTypeDefinition
-          QueryParameterMatcher: MessageTypeDefinition
-          RateLimit: MessageTypeDefinition
-          RedirectAction: MessageTypeDefinition
-          RetryPolicy: MessageTypeDefinition
-          Route: MessageTypeDefinition
-          RouteAction: MessageTypeDefinition
-          RouteList: MessageTypeDefinition
-          RouteMatch: MessageTypeDefinition
-          Tracing: MessageTypeDefinition
-          VirtualCluster: MessageTypeDefinition
-          VirtualHost: MessageTypeDefinition
-          WeightedCluster: MessageTypeDefinition
+          ClusterSpecifierPlugin: MessageTypeDefinition<_envoy_config_route_v3_ClusterSpecifierPlugin, _envoy_config_route_v3_ClusterSpecifierPlugin__Output>
+          CorsPolicy: MessageTypeDefinition<_envoy_config_route_v3_CorsPolicy, _envoy_config_route_v3_CorsPolicy__Output>
+          Decorator: MessageTypeDefinition<_envoy_config_route_v3_Decorator, _envoy_config_route_v3_Decorator__Output>
+          DirectResponseAction: MessageTypeDefinition<_envoy_config_route_v3_DirectResponseAction, _envoy_config_route_v3_DirectResponseAction__Output>
+          FilterAction: MessageTypeDefinition<_envoy_config_route_v3_FilterAction, _envoy_config_route_v3_FilterAction__Output>
+          FilterConfig: MessageTypeDefinition<_envoy_config_route_v3_FilterConfig, _envoy_config_route_v3_FilterConfig__Output>
+          HeaderMatcher: MessageTypeDefinition<_envoy_config_route_v3_HeaderMatcher, _envoy_config_route_v3_HeaderMatcher__Output>
+          HedgePolicy: MessageTypeDefinition<_envoy_config_route_v3_HedgePolicy, _envoy_config_route_v3_HedgePolicy__Output>
+          InternalRedirectPolicy: MessageTypeDefinition<_envoy_config_route_v3_InternalRedirectPolicy, _envoy_config_route_v3_InternalRedirectPolicy__Output>
+          NonForwardingAction: MessageTypeDefinition<_envoy_config_route_v3_NonForwardingAction, _envoy_config_route_v3_NonForwardingAction__Output>
+          QueryParameterMatcher: MessageTypeDefinition<_envoy_config_route_v3_QueryParameterMatcher, _envoy_config_route_v3_QueryParameterMatcher__Output>
+          RateLimit: MessageTypeDefinition<_envoy_config_route_v3_RateLimit, _envoy_config_route_v3_RateLimit__Output>
+          RedirectAction: MessageTypeDefinition<_envoy_config_route_v3_RedirectAction, _envoy_config_route_v3_RedirectAction__Output>
+          RetryPolicy: MessageTypeDefinition<_envoy_config_route_v3_RetryPolicy, _envoy_config_route_v3_RetryPolicy__Output>
+          Route: MessageTypeDefinition<_envoy_config_route_v3_Route, _envoy_config_route_v3_Route__Output>
+          RouteAction: MessageTypeDefinition<_envoy_config_route_v3_RouteAction, _envoy_config_route_v3_RouteAction__Output>
+          RouteList: MessageTypeDefinition<_envoy_config_route_v3_RouteList, _envoy_config_route_v3_RouteList__Output>
+          RouteMatch: MessageTypeDefinition<_envoy_config_route_v3_RouteMatch, _envoy_config_route_v3_RouteMatch__Output>
+          Tracing: MessageTypeDefinition<_envoy_config_route_v3_Tracing, _envoy_config_route_v3_Tracing__Output>
+          VirtualCluster: MessageTypeDefinition<_envoy_config_route_v3_VirtualCluster, _envoy_config_route_v3_VirtualCluster__Output>
+          VirtualHost: MessageTypeDefinition<_envoy_config_route_v3_VirtualHost, _envoy_config_route_v3_VirtualHost__Output>
+          WeightedCluster: MessageTypeDefinition<_envoy_config_route_v3_WeightedCluster, _envoy_config_route_v3_WeightedCluster__Output>
         }
       }
     }
@@ -89,16 +248,16 @@ export interface ProtoGrpcType {
         common: {
           fault: {
             v3: {
-              FaultDelay: MessageTypeDefinition
-              FaultRateLimit: MessageTypeDefinition
+              FaultDelay: MessageTypeDefinition<_envoy_extensions_filters_common_fault_v3_FaultDelay, _envoy_extensions_filters_common_fault_v3_FaultDelay__Output>
+              FaultRateLimit: MessageTypeDefinition<_envoy_extensions_filters_common_fault_v3_FaultRateLimit, _envoy_extensions_filters_common_fault_v3_FaultRateLimit__Output>
             }
           }
         }
         http: {
           fault: {
             v3: {
-              FaultAbort: MessageTypeDefinition
-              HTTPFault: MessageTypeDefinition
+              FaultAbort: MessageTypeDefinition<_envoy_extensions_filters_http_fault_v3_FaultAbort, _envoy_extensions_filters_http_fault_v3_FaultAbort__Output>
+              HTTPFault: MessageTypeDefinition<_envoy_extensions_filters_http_fault_v3_HTTPFault, _envoy_extensions_filters_http_fault_v3_HTTPFault__Output>
             }
           }
         }
@@ -107,142 +266,142 @@ export interface ProtoGrpcType {
     type: {
       matcher: {
         v3: {
-          DoubleMatcher: MessageTypeDefinition
-          ListMatcher: MessageTypeDefinition
-          ListStringMatcher: MessageTypeDefinition
-          MetadataMatcher: MessageTypeDefinition
-          OrMatcher: MessageTypeDefinition
-          RegexMatchAndSubstitute: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
-          ValueMatcher: MessageTypeDefinition
+          DoubleMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_DoubleMatcher, _envoy_type_matcher_v3_DoubleMatcher__Output>
+          ListMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListMatcher, _envoy_type_matcher_v3_ListMatcher__Output>
+          ListStringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListStringMatcher, _envoy_type_matcher_v3_ListStringMatcher__Output>
+          MetadataMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_MetadataMatcher, _envoy_type_matcher_v3_MetadataMatcher__Output>
+          OrMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_OrMatcher, _envoy_type_matcher_v3_OrMatcher__Output>
+          RegexMatchAndSubstitute: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatchAndSubstitute, _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output>
+          RegexMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatcher, _envoy_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_StringMatcher, _envoy_type_matcher_v3_StringMatcher__Output>
+          ValueMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ValueMatcher, _envoy_type_matcher_v3_ValueMatcher__Output>
         }
       }
       metadata: {
         v3: {
-          MetadataKey: MessageTypeDefinition
-          MetadataKind: MessageTypeDefinition
+          MetadataKey: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKey, _envoy_type_metadata_v3_MetadataKey__Output>
+          MetadataKind: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKind, _envoy_type_metadata_v3_MetadataKind__Output>
         }
       }
       tracing: {
         v3: {
-          CustomTag: MessageTypeDefinition
+          CustomTag: MessageTypeDefinition<_envoy_type_tracing_v3_CustomTag, _envoy_type_tracing_v3_CustomTag__Output>
         }
       }
       v3: {
-        DoubleRange: MessageTypeDefinition
-        FractionalPercent: MessageTypeDefinition
-        Int32Range: MessageTypeDefinition
-        Int64Range: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        DoubleRange: MessageTypeDefinition<_envoy_type_v3_DoubleRange, _envoy_type_v3_DoubleRange__Output>
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Int32Range: MessageTypeDefinition<_envoy_type_v3_Int32Range, _envoy_type_v3_Int32Range__Output>
+        Int64Range: MessageTypeDefinition<_envoy_type_v3_Int64Range, _envoy_type_v3_Int64Range__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        ContextParams: MessageTypeDefinition
-        TypedExtensionConfig: MessageTypeDefinition
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
+        TypedExtensionConfig: MessageTypeDefinition<_xds_core_v3_TypedExtensionConfig, _xds_core_v3_TypedExtensionConfig__Output>
       }
     }
     type: {
       matcher: {
         v3: {
-          ListStringMatcher: MessageTypeDefinition
-          Matcher: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
+          ListStringMatcher: MessageTypeDefinition<_xds_type_matcher_v3_ListStringMatcher, _xds_type_matcher_v3_ListStringMatcher__Output>
+          Matcher: MessageTypeDefinition<_xds_type_matcher_v3_Matcher, _xds_type_matcher_v3_Matcher__Output>
+          RegexMatcher: MessageTypeDefinition<_xds_type_matcher_v3_RegexMatcher, _xds_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_xds_type_matcher_v3_StringMatcher, _xds_type_matcher_v3_StringMatcher__Output>
         }
       }
     }

--- a/packages/grpc-js-xds/src/generated/http_connection_manager.ts
+++ b/packages/grpc-js-xds/src/generated/http_connection_manager.ts
@@ -1,6 +1,225 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { AccessLog as _envoy_config_accesslog_v3_AccessLog, AccessLog__Output as _envoy_config_accesslog_v3_AccessLog__Output } from './envoy/config/accesslog/v3/AccessLog';
+import type { AccessLogFilter as _envoy_config_accesslog_v3_AccessLogFilter, AccessLogFilter__Output as _envoy_config_accesslog_v3_AccessLogFilter__Output } from './envoy/config/accesslog/v3/AccessLogFilter';
+import type { AndFilter as _envoy_config_accesslog_v3_AndFilter, AndFilter__Output as _envoy_config_accesslog_v3_AndFilter__Output } from './envoy/config/accesslog/v3/AndFilter';
+import type { ComparisonFilter as _envoy_config_accesslog_v3_ComparisonFilter, ComparisonFilter__Output as _envoy_config_accesslog_v3_ComparisonFilter__Output } from './envoy/config/accesslog/v3/ComparisonFilter';
+import type { DurationFilter as _envoy_config_accesslog_v3_DurationFilter, DurationFilter__Output as _envoy_config_accesslog_v3_DurationFilter__Output } from './envoy/config/accesslog/v3/DurationFilter';
+import type { ExtensionFilter as _envoy_config_accesslog_v3_ExtensionFilter, ExtensionFilter__Output as _envoy_config_accesslog_v3_ExtensionFilter__Output } from './envoy/config/accesslog/v3/ExtensionFilter';
+import type { GrpcStatusFilter as _envoy_config_accesslog_v3_GrpcStatusFilter, GrpcStatusFilter__Output as _envoy_config_accesslog_v3_GrpcStatusFilter__Output } from './envoy/config/accesslog/v3/GrpcStatusFilter';
+import type { HeaderFilter as _envoy_config_accesslog_v3_HeaderFilter, HeaderFilter__Output as _envoy_config_accesslog_v3_HeaderFilter__Output } from './envoy/config/accesslog/v3/HeaderFilter';
+import type { LogTypeFilter as _envoy_config_accesslog_v3_LogTypeFilter, LogTypeFilter__Output as _envoy_config_accesslog_v3_LogTypeFilter__Output } from './envoy/config/accesslog/v3/LogTypeFilter';
+import type { MetadataFilter as _envoy_config_accesslog_v3_MetadataFilter, MetadataFilter__Output as _envoy_config_accesslog_v3_MetadataFilter__Output } from './envoy/config/accesslog/v3/MetadataFilter';
+import type { NotHealthCheckFilter as _envoy_config_accesslog_v3_NotHealthCheckFilter, NotHealthCheckFilter__Output as _envoy_config_accesslog_v3_NotHealthCheckFilter__Output } from './envoy/config/accesslog/v3/NotHealthCheckFilter';
+import type { OrFilter as _envoy_config_accesslog_v3_OrFilter, OrFilter__Output as _envoy_config_accesslog_v3_OrFilter__Output } from './envoy/config/accesslog/v3/OrFilter';
+import type { ResponseFlagFilter as _envoy_config_accesslog_v3_ResponseFlagFilter, ResponseFlagFilter__Output as _envoy_config_accesslog_v3_ResponseFlagFilter__Output } from './envoy/config/accesslog/v3/ResponseFlagFilter';
+import type { RuntimeFilter as _envoy_config_accesslog_v3_RuntimeFilter, RuntimeFilter__Output as _envoy_config_accesslog_v3_RuntimeFilter__Output } from './envoy/config/accesslog/v3/RuntimeFilter';
+import type { StatusCodeFilter as _envoy_config_accesslog_v3_StatusCodeFilter, StatusCodeFilter__Output as _envoy_config_accesslog_v3_StatusCodeFilter__Output } from './envoy/config/accesslog/v3/StatusCodeFilter';
+import type { TraceableFilter as _envoy_config_accesslog_v3_TraceableFilter, TraceableFilter__Output as _envoy_config_accesslog_v3_TraceableFilter__Output } from './envoy/config/accesslog/v3/TraceableFilter';
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AggregatedConfigSource as _envoy_config_core_v3_AggregatedConfigSource, AggregatedConfigSource__Output as _envoy_config_core_v3_AggregatedConfigSource__Output } from './envoy/config/core/v3/AggregatedConfigSource';
+import type { AlternateProtocolsCacheOptions as _envoy_config_core_v3_AlternateProtocolsCacheOptions, AlternateProtocolsCacheOptions__Output as _envoy_config_core_v3_AlternateProtocolsCacheOptions__Output } from './envoy/config/core/v3/AlternateProtocolsCacheOptions';
+import type { ApiConfigSource as _envoy_config_core_v3_ApiConfigSource, ApiConfigSource__Output as _envoy_config_core_v3_ApiConfigSource__Output } from './envoy/config/core/v3/ApiConfigSource';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ConfigSource as _envoy_config_core_v3_ConfigSource, ConfigSource__Output as _envoy_config_core_v3_ConfigSource__Output } from './envoy/config/core/v3/ConfigSource';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtensionConfigSource as _envoy_config_core_v3_ExtensionConfigSource, ExtensionConfigSource__Output as _envoy_config_core_v3_ExtensionConfigSource__Output } from './envoy/config/core/v3/ExtensionConfigSource';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { GrpcProtocolOptions as _envoy_config_core_v3_GrpcProtocolOptions, GrpcProtocolOptions__Output as _envoy_config_core_v3_GrpcProtocolOptions__Output } from './envoy/config/core/v3/GrpcProtocolOptions';
+import type { GrpcService as _envoy_config_core_v3_GrpcService, GrpcService__Output as _envoy_config_core_v3_GrpcService__Output } from './envoy/config/core/v3/GrpcService';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { Http1ProtocolOptions as _envoy_config_core_v3_Http1ProtocolOptions, Http1ProtocolOptions__Output as _envoy_config_core_v3_Http1ProtocolOptions__Output } from './envoy/config/core/v3/Http1ProtocolOptions';
+import type { Http2ProtocolOptions as _envoy_config_core_v3_Http2ProtocolOptions, Http2ProtocolOptions__Output as _envoy_config_core_v3_Http2ProtocolOptions__Output } from './envoy/config/core/v3/Http2ProtocolOptions';
+import type { Http3ProtocolOptions as _envoy_config_core_v3_Http3ProtocolOptions, Http3ProtocolOptions__Output as _envoy_config_core_v3_Http3ProtocolOptions__Output } from './envoy/config/core/v3/Http3ProtocolOptions';
+import type { HttpProtocolOptions as _envoy_config_core_v3_HttpProtocolOptions, HttpProtocolOptions__Output as _envoy_config_core_v3_HttpProtocolOptions__Output } from './envoy/config/core/v3/HttpProtocolOptions';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { JsonFormatOptions as _envoy_config_core_v3_JsonFormatOptions, JsonFormatOptions__Output as _envoy_config_core_v3_JsonFormatOptions__Output } from './envoy/config/core/v3/JsonFormatOptions';
+import type { KeepaliveSettings as _envoy_config_core_v3_KeepaliveSettings, KeepaliveSettings__Output as _envoy_config_core_v3_KeepaliveSettings__Output } from './envoy/config/core/v3/KeepaliveSettings';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { PathConfigSource as _envoy_config_core_v3_PathConfigSource, PathConfigSource__Output as _envoy_config_core_v3_PathConfigSource__Output } from './envoy/config/core/v3/PathConfigSource';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { ProxyProtocolConfig as _envoy_config_core_v3_ProxyProtocolConfig, ProxyProtocolConfig__Output as _envoy_config_core_v3_ProxyProtocolConfig__Output } from './envoy/config/core/v3/ProxyProtocolConfig';
+import type { ProxyProtocolPassThroughTLVs as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs, ProxyProtocolPassThroughTLVs__Output as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output } from './envoy/config/core/v3/ProxyProtocolPassThroughTLVs';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { QuicKeepAliveSettings as _envoy_config_core_v3_QuicKeepAliveSettings, QuicKeepAliveSettings__Output as _envoy_config_core_v3_QuicKeepAliveSettings__Output } from './envoy/config/core/v3/QuicKeepAliveSettings';
+import type { QuicProtocolOptions as _envoy_config_core_v3_QuicProtocolOptions, QuicProtocolOptions__Output as _envoy_config_core_v3_QuicProtocolOptions__Output } from './envoy/config/core/v3/QuicProtocolOptions';
+import type { RateLimitSettings as _envoy_config_core_v3_RateLimitSettings, RateLimitSettings__Output as _envoy_config_core_v3_RateLimitSettings__Output } from './envoy/config/core/v3/RateLimitSettings';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SchemeHeaderTransformation as _envoy_config_core_v3_SchemeHeaderTransformation, SchemeHeaderTransformation__Output as _envoy_config_core_v3_SchemeHeaderTransformation__Output } from './envoy/config/core/v3/SchemeHeaderTransformation';
+import type { SelfConfigSource as _envoy_config_core_v3_SelfConfigSource, SelfConfigSource__Output as _envoy_config_core_v3_SelfConfigSource__Output } from './envoy/config/core/v3/SelfConfigSource';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { SubstitutionFormatString as _envoy_config_core_v3_SubstitutionFormatString, SubstitutionFormatString__Output as _envoy_config_core_v3_SubstitutionFormatString__Output } from './envoy/config/core/v3/SubstitutionFormatString';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TcpProtocolOptions as _envoy_config_core_v3_TcpProtocolOptions, TcpProtocolOptions__Output as _envoy_config_core_v3_TcpProtocolOptions__Output } from './envoy/config/core/v3/TcpProtocolOptions';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { UpstreamHttpProtocolOptions as _envoy_config_core_v3_UpstreamHttpProtocolOptions, UpstreamHttpProtocolOptions__Output as _envoy_config_core_v3_UpstreamHttpProtocolOptions__Output } from './envoy/config/core/v3/UpstreamHttpProtocolOptions';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { ClusterSpecifierPlugin as _envoy_config_route_v3_ClusterSpecifierPlugin, ClusterSpecifierPlugin__Output as _envoy_config_route_v3_ClusterSpecifierPlugin__Output } from './envoy/config/route/v3/ClusterSpecifierPlugin';
+import type { CorsPolicy as _envoy_config_route_v3_CorsPolicy, CorsPolicy__Output as _envoy_config_route_v3_CorsPolicy__Output } from './envoy/config/route/v3/CorsPolicy';
+import type { Decorator as _envoy_config_route_v3_Decorator, Decorator__Output as _envoy_config_route_v3_Decorator__Output } from './envoy/config/route/v3/Decorator';
+import type { DirectResponseAction as _envoy_config_route_v3_DirectResponseAction, DirectResponseAction__Output as _envoy_config_route_v3_DirectResponseAction__Output } from './envoy/config/route/v3/DirectResponseAction';
+import type { FilterAction as _envoy_config_route_v3_FilterAction, FilterAction__Output as _envoy_config_route_v3_FilterAction__Output } from './envoy/config/route/v3/FilterAction';
+import type { FilterConfig as _envoy_config_route_v3_FilterConfig, FilterConfig__Output as _envoy_config_route_v3_FilterConfig__Output } from './envoy/config/route/v3/FilterConfig';
+import type { HeaderMatcher as _envoy_config_route_v3_HeaderMatcher, HeaderMatcher__Output as _envoy_config_route_v3_HeaderMatcher__Output } from './envoy/config/route/v3/HeaderMatcher';
+import type { HedgePolicy as _envoy_config_route_v3_HedgePolicy, HedgePolicy__Output as _envoy_config_route_v3_HedgePolicy__Output } from './envoy/config/route/v3/HedgePolicy';
+import type { InternalRedirectPolicy as _envoy_config_route_v3_InternalRedirectPolicy, InternalRedirectPolicy__Output as _envoy_config_route_v3_InternalRedirectPolicy__Output } from './envoy/config/route/v3/InternalRedirectPolicy';
+import type { NonForwardingAction as _envoy_config_route_v3_NonForwardingAction, NonForwardingAction__Output as _envoy_config_route_v3_NonForwardingAction__Output } from './envoy/config/route/v3/NonForwardingAction';
+import type { QueryParameterMatcher as _envoy_config_route_v3_QueryParameterMatcher, QueryParameterMatcher__Output as _envoy_config_route_v3_QueryParameterMatcher__Output } from './envoy/config/route/v3/QueryParameterMatcher';
+import type { RateLimit as _envoy_config_route_v3_RateLimit, RateLimit__Output as _envoy_config_route_v3_RateLimit__Output } from './envoy/config/route/v3/RateLimit';
+import type { RedirectAction as _envoy_config_route_v3_RedirectAction, RedirectAction__Output as _envoy_config_route_v3_RedirectAction__Output } from './envoy/config/route/v3/RedirectAction';
+import type { RetryPolicy as _envoy_config_route_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_route_v3_RetryPolicy__Output } from './envoy/config/route/v3/RetryPolicy';
+import type { Route as _envoy_config_route_v3_Route, Route__Output as _envoy_config_route_v3_Route__Output } from './envoy/config/route/v3/Route';
+import type { RouteAction as _envoy_config_route_v3_RouteAction, RouteAction__Output as _envoy_config_route_v3_RouteAction__Output } from './envoy/config/route/v3/RouteAction';
+import type { RouteConfiguration as _envoy_config_route_v3_RouteConfiguration, RouteConfiguration__Output as _envoy_config_route_v3_RouteConfiguration__Output } from './envoy/config/route/v3/RouteConfiguration';
+import type { RouteList as _envoy_config_route_v3_RouteList, RouteList__Output as _envoy_config_route_v3_RouteList__Output } from './envoy/config/route/v3/RouteList';
+import type { RouteMatch as _envoy_config_route_v3_RouteMatch, RouteMatch__Output as _envoy_config_route_v3_RouteMatch__Output } from './envoy/config/route/v3/RouteMatch';
+import type { ScopedRouteConfiguration as _envoy_config_route_v3_ScopedRouteConfiguration, ScopedRouteConfiguration__Output as _envoy_config_route_v3_ScopedRouteConfiguration__Output } from './envoy/config/route/v3/ScopedRouteConfiguration';
+import type { Tracing as _envoy_config_route_v3_Tracing, Tracing__Output as _envoy_config_route_v3_Tracing__Output } from './envoy/config/route/v3/Tracing';
+import type { Vhds as _envoy_config_route_v3_Vhds, Vhds__Output as _envoy_config_route_v3_Vhds__Output } from './envoy/config/route/v3/Vhds';
+import type { VirtualCluster as _envoy_config_route_v3_VirtualCluster, VirtualCluster__Output as _envoy_config_route_v3_VirtualCluster__Output } from './envoy/config/route/v3/VirtualCluster';
+import type { VirtualHost as _envoy_config_route_v3_VirtualHost, VirtualHost__Output as _envoy_config_route_v3_VirtualHost__Output } from './envoy/config/route/v3/VirtualHost';
+import type { WeightedCluster as _envoy_config_route_v3_WeightedCluster, WeightedCluster__Output as _envoy_config_route_v3_WeightedCluster__Output } from './envoy/config/route/v3/WeightedCluster';
+import type { Tracing as _envoy_config_trace_v3_Tracing, Tracing__Output as _envoy_config_trace_v3_Tracing__Output } from './envoy/config/trace/v3/Tracing';
+import type { AccessLogCommon as _envoy_data_accesslog_v3_AccessLogCommon, AccessLogCommon__Output as _envoy_data_accesslog_v3_AccessLogCommon__Output } from './envoy/data/accesslog/v3/AccessLogCommon';
+import type { ConnectionProperties as _envoy_data_accesslog_v3_ConnectionProperties, ConnectionProperties__Output as _envoy_data_accesslog_v3_ConnectionProperties__Output } from './envoy/data/accesslog/v3/ConnectionProperties';
+import type { HTTPAccessLogEntry as _envoy_data_accesslog_v3_HTTPAccessLogEntry, HTTPAccessLogEntry__Output as _envoy_data_accesslog_v3_HTTPAccessLogEntry__Output } from './envoy/data/accesslog/v3/HTTPAccessLogEntry';
+import type { HTTPRequestProperties as _envoy_data_accesslog_v3_HTTPRequestProperties, HTTPRequestProperties__Output as _envoy_data_accesslog_v3_HTTPRequestProperties__Output } from './envoy/data/accesslog/v3/HTTPRequestProperties';
+import type { HTTPResponseProperties as _envoy_data_accesslog_v3_HTTPResponseProperties, HTTPResponseProperties__Output as _envoy_data_accesslog_v3_HTTPResponseProperties__Output } from './envoy/data/accesslog/v3/HTTPResponseProperties';
+import type { ResponseFlags as _envoy_data_accesslog_v3_ResponseFlags, ResponseFlags__Output as _envoy_data_accesslog_v3_ResponseFlags__Output } from './envoy/data/accesslog/v3/ResponseFlags';
+import type { TCPAccessLogEntry as _envoy_data_accesslog_v3_TCPAccessLogEntry, TCPAccessLogEntry__Output as _envoy_data_accesslog_v3_TCPAccessLogEntry__Output } from './envoy/data/accesslog/v3/TCPAccessLogEntry';
+import type { TLSProperties as _envoy_data_accesslog_v3_TLSProperties, TLSProperties__Output as _envoy_data_accesslog_v3_TLSProperties__Output } from './envoy/data/accesslog/v3/TLSProperties';
+import type { EnvoyMobileHttpConnectionManager as _envoy_extensions_filters_network_http_connection_manager_v3_EnvoyMobileHttpConnectionManager, EnvoyMobileHttpConnectionManager__Output as _envoy_extensions_filters_network_http_connection_manager_v3_EnvoyMobileHttpConnectionManager__Output } from './envoy/extensions/filters/network/http_connection_manager/v3/EnvoyMobileHttpConnectionManager';
+import type { HttpConnectionManager as _envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager, HttpConnectionManager__Output as _envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager__Output } from './envoy/extensions/filters/network/http_connection_manager/v3/HttpConnectionManager';
+import type { HttpFilter as _envoy_extensions_filters_network_http_connection_manager_v3_HttpFilter, HttpFilter__Output as _envoy_extensions_filters_network_http_connection_manager_v3_HttpFilter__Output } from './envoy/extensions/filters/network/http_connection_manager/v3/HttpFilter';
+import type { LocalReplyConfig as _envoy_extensions_filters_network_http_connection_manager_v3_LocalReplyConfig, LocalReplyConfig__Output as _envoy_extensions_filters_network_http_connection_manager_v3_LocalReplyConfig__Output } from './envoy/extensions/filters/network/http_connection_manager/v3/LocalReplyConfig';
+import type { Rds as _envoy_extensions_filters_network_http_connection_manager_v3_Rds, Rds__Output as _envoy_extensions_filters_network_http_connection_manager_v3_Rds__Output } from './envoy/extensions/filters/network/http_connection_manager/v3/Rds';
+import type { RequestIDExtension as _envoy_extensions_filters_network_http_connection_manager_v3_RequestIDExtension, RequestIDExtension__Output as _envoy_extensions_filters_network_http_connection_manager_v3_RequestIDExtension__Output } from './envoy/extensions/filters/network/http_connection_manager/v3/RequestIDExtension';
+import type { ResponseMapper as _envoy_extensions_filters_network_http_connection_manager_v3_ResponseMapper, ResponseMapper__Output as _envoy_extensions_filters_network_http_connection_manager_v3_ResponseMapper__Output } from './envoy/extensions/filters/network/http_connection_manager/v3/ResponseMapper';
+import type { ScopedRds as _envoy_extensions_filters_network_http_connection_manager_v3_ScopedRds, ScopedRds__Output as _envoy_extensions_filters_network_http_connection_manager_v3_ScopedRds__Output } from './envoy/extensions/filters/network/http_connection_manager/v3/ScopedRds';
+import type { ScopedRouteConfigurationsList as _envoy_extensions_filters_network_http_connection_manager_v3_ScopedRouteConfigurationsList, ScopedRouteConfigurationsList__Output as _envoy_extensions_filters_network_http_connection_manager_v3_ScopedRouteConfigurationsList__Output } from './envoy/extensions/filters/network/http_connection_manager/v3/ScopedRouteConfigurationsList';
+import type { ScopedRoutes as _envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes, ScopedRoutes__Output as _envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes__Output } from './envoy/extensions/filters/network/http_connection_manager/v3/ScopedRoutes';
+import type { PathTransformation as _envoy_type_http_v3_PathTransformation, PathTransformation__Output as _envoy_type_http_v3_PathTransformation__Output } from './envoy/type/http/v3/PathTransformation';
+import type { DoubleMatcher as _envoy_type_matcher_v3_DoubleMatcher, DoubleMatcher__Output as _envoy_type_matcher_v3_DoubleMatcher__Output } from './envoy/type/matcher/v3/DoubleMatcher';
+import type { ListMatcher as _envoy_type_matcher_v3_ListMatcher, ListMatcher__Output as _envoy_type_matcher_v3_ListMatcher__Output } from './envoy/type/matcher/v3/ListMatcher';
+import type { ListStringMatcher as _envoy_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _envoy_type_matcher_v3_ListStringMatcher__Output } from './envoy/type/matcher/v3/ListStringMatcher';
+import type { MetadataMatcher as _envoy_type_matcher_v3_MetadataMatcher, MetadataMatcher__Output as _envoy_type_matcher_v3_MetadataMatcher__Output } from './envoy/type/matcher/v3/MetadataMatcher';
+import type { OrMatcher as _envoy_type_matcher_v3_OrMatcher, OrMatcher__Output as _envoy_type_matcher_v3_OrMatcher__Output } from './envoy/type/matcher/v3/OrMatcher';
+import type { RegexMatchAndSubstitute as _envoy_type_matcher_v3_RegexMatchAndSubstitute, RegexMatchAndSubstitute__Output as _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output } from './envoy/type/matcher/v3/RegexMatchAndSubstitute';
+import type { RegexMatcher as _envoy_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _envoy_type_matcher_v3_RegexMatcher__Output } from './envoy/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _envoy_type_matcher_v3_StringMatcher, StringMatcher__Output as _envoy_type_matcher_v3_StringMatcher__Output } from './envoy/type/matcher/v3/StringMatcher';
+import type { ValueMatcher as _envoy_type_matcher_v3_ValueMatcher, ValueMatcher__Output as _envoy_type_matcher_v3_ValueMatcher__Output } from './envoy/type/matcher/v3/ValueMatcher';
+import type { MetadataKey as _envoy_type_metadata_v3_MetadataKey, MetadataKey__Output as _envoy_type_metadata_v3_MetadataKey__Output } from './envoy/type/metadata/v3/MetadataKey';
+import type { MetadataKind as _envoy_type_metadata_v3_MetadataKind, MetadataKind__Output as _envoy_type_metadata_v3_MetadataKind__Output } from './envoy/type/metadata/v3/MetadataKind';
+import type { CustomTag as _envoy_type_tracing_v3_CustomTag, CustomTag__Output as _envoy_type_tracing_v3_CustomTag__Output } from './envoy/type/tracing/v3/CustomTag';
+import type { DoubleRange as _envoy_type_v3_DoubleRange, DoubleRange__Output as _envoy_type_v3_DoubleRange__Output } from './envoy/type/v3/DoubleRange';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Int32Range as _envoy_type_v3_Int32Range, Int32Range__Output as _envoy_type_v3_Int32Range__Output } from './envoy/type/v3/Int32Range';
+import type { Int64Range as _envoy_type_v3_Int64Range, Int64Range__Output as _envoy_type_v3_Int64Range__Output } from './envoy/type/v3/Int64Range';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from './google/protobuf/Empty';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FieldSecurityAnnotation as _udpa_annotations_FieldSecurityAnnotation, FieldSecurityAnnotation__Output as _udpa_annotations_FieldSecurityAnnotation__Output } from './udpa/annotations/FieldSecurityAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { Authority as _xds_core_v3_Authority, Authority__Output as _xds_core_v3_Authority__Output } from './xds/core/v3/Authority';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
+import type { TypedExtensionConfig as _xds_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _xds_core_v3_TypedExtensionConfig__Output } from './xds/core/v3/TypedExtensionConfig';
+import type { ListStringMatcher as _xds_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _xds_type_matcher_v3_ListStringMatcher__Output } from './xds/type/matcher/v3/ListStringMatcher';
+import type { Matcher as _xds_type_matcher_v3_Matcher, Matcher__Output as _xds_type_matcher_v3_Matcher__Output } from './xds/type/matcher/v3/Matcher';
+import type { RegexMatcher as _xds_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _xds_type_matcher_v3_RegexMatcher__Output } from './xds/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _xds_type_matcher_v3_StringMatcher, StringMatcher__Output as _xds_type_matcher_v3_StringMatcher__Output } from './xds/type/matcher/v3/StringMatcher';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -13,140 +232,140 @@ export interface ProtoGrpcType {
     config: {
       accesslog: {
         v3: {
-          AccessLog: MessageTypeDefinition
-          AccessLogFilter: MessageTypeDefinition
-          AndFilter: MessageTypeDefinition
-          ComparisonFilter: MessageTypeDefinition
-          DurationFilter: MessageTypeDefinition
-          ExtensionFilter: MessageTypeDefinition
-          GrpcStatusFilter: MessageTypeDefinition
-          HeaderFilter: MessageTypeDefinition
-          LogTypeFilter: MessageTypeDefinition
-          MetadataFilter: MessageTypeDefinition
-          NotHealthCheckFilter: MessageTypeDefinition
-          OrFilter: MessageTypeDefinition
-          ResponseFlagFilter: MessageTypeDefinition
-          RuntimeFilter: MessageTypeDefinition
-          StatusCodeFilter: MessageTypeDefinition
-          TraceableFilter: MessageTypeDefinition
+          AccessLog: MessageTypeDefinition<_envoy_config_accesslog_v3_AccessLog, _envoy_config_accesslog_v3_AccessLog__Output>
+          AccessLogFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_AccessLogFilter, _envoy_config_accesslog_v3_AccessLogFilter__Output>
+          AndFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_AndFilter, _envoy_config_accesslog_v3_AndFilter__Output>
+          ComparisonFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_ComparisonFilter, _envoy_config_accesslog_v3_ComparisonFilter__Output>
+          DurationFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_DurationFilter, _envoy_config_accesslog_v3_DurationFilter__Output>
+          ExtensionFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_ExtensionFilter, _envoy_config_accesslog_v3_ExtensionFilter__Output>
+          GrpcStatusFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_GrpcStatusFilter, _envoy_config_accesslog_v3_GrpcStatusFilter__Output>
+          HeaderFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_HeaderFilter, _envoy_config_accesslog_v3_HeaderFilter__Output>
+          LogTypeFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_LogTypeFilter, _envoy_config_accesslog_v3_LogTypeFilter__Output>
+          MetadataFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_MetadataFilter, _envoy_config_accesslog_v3_MetadataFilter__Output>
+          NotHealthCheckFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_NotHealthCheckFilter, _envoy_config_accesslog_v3_NotHealthCheckFilter__Output>
+          OrFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_OrFilter, _envoy_config_accesslog_v3_OrFilter__Output>
+          ResponseFlagFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_ResponseFlagFilter, _envoy_config_accesslog_v3_ResponseFlagFilter__Output>
+          RuntimeFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_RuntimeFilter, _envoy_config_accesslog_v3_RuntimeFilter__Output>
+          StatusCodeFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_StatusCodeFilter, _envoy_config_accesslog_v3_StatusCodeFilter__Output>
+          TraceableFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_TraceableFilter, _envoy_config_accesslog_v3_TraceableFilter__Output>
         }
       }
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AggregatedConfigSource: MessageTypeDefinition
-          AlternateProtocolsCacheOptions: MessageTypeDefinition
-          ApiConfigSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AggregatedConfigSource: MessageTypeDefinition<_envoy_config_core_v3_AggregatedConfigSource, _envoy_config_core_v3_AggregatedConfigSource__Output>
+          AlternateProtocolsCacheOptions: MessageTypeDefinition<_envoy_config_core_v3_AlternateProtocolsCacheOptions, _envoy_config_core_v3_AlternateProtocolsCacheOptions__Output>
+          ApiConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ApiConfigSource, _envoy_config_core_v3_ApiConfigSource__Output>
           ApiVersion: EnumTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ConfigSource: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtensionConfigSource: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          GrpcProtocolOptions: MessageTypeDefinition
-          GrpcService: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          Http1ProtocolOptions: MessageTypeDefinition
-          Http2ProtocolOptions: MessageTypeDefinition
-          Http3ProtocolOptions: MessageTypeDefinition
-          HttpProtocolOptions: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          JsonFormatOptions: MessageTypeDefinition
-          KeepaliveSettings: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          PathConfigSource: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          ProxyProtocolConfig: MessageTypeDefinition
-          ProxyProtocolPassThroughTLVs: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          QuicKeepAliveSettings: MessageTypeDefinition
-          QuicProtocolOptions: MessageTypeDefinition
-          RateLimitSettings: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ConfigSource, _envoy_config_core_v3_ConfigSource__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtensionConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ExtensionConfigSource, _envoy_config_core_v3_ExtensionConfigSource__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          GrpcProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_GrpcProtocolOptions, _envoy_config_core_v3_GrpcProtocolOptions__Output>
+          GrpcService: MessageTypeDefinition<_envoy_config_core_v3_GrpcService, _envoy_config_core_v3_GrpcService__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          Http1ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http1ProtocolOptions, _envoy_config_core_v3_Http1ProtocolOptions__Output>
+          Http2ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http2ProtocolOptions, _envoy_config_core_v3_Http2ProtocolOptions__Output>
+          Http3ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http3ProtocolOptions, _envoy_config_core_v3_Http3ProtocolOptions__Output>
+          HttpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_HttpProtocolOptions, _envoy_config_core_v3_HttpProtocolOptions__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          JsonFormatOptions: MessageTypeDefinition<_envoy_config_core_v3_JsonFormatOptions, _envoy_config_core_v3_JsonFormatOptions__Output>
+          KeepaliveSettings: MessageTypeDefinition<_envoy_config_core_v3_KeepaliveSettings, _envoy_config_core_v3_KeepaliveSettings__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          PathConfigSource: MessageTypeDefinition<_envoy_config_core_v3_PathConfigSource, _envoy_config_core_v3_PathConfigSource__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          ProxyProtocolConfig: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolConfig, _envoy_config_core_v3_ProxyProtocolConfig__Output>
+          ProxyProtocolPassThroughTLVs: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolPassThroughTLVs, _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          QuicKeepAliveSettings: MessageTypeDefinition<_envoy_config_core_v3_QuicKeepAliveSettings, _envoy_config_core_v3_QuicKeepAliveSettings__Output>
+          QuicProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_QuicProtocolOptions, _envoy_config_core_v3_QuicProtocolOptions__Output>
+          RateLimitSettings: MessageTypeDefinition<_envoy_config_core_v3_RateLimitSettings, _envoy_config_core_v3_RateLimitSettings__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SchemeHeaderTransformation: MessageTypeDefinition
-          SelfConfigSource: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          SubstitutionFormatString: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
-          TcpProtocolOptions: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SchemeHeaderTransformation: MessageTypeDefinition<_envoy_config_core_v3_SchemeHeaderTransformation, _envoy_config_core_v3_SchemeHeaderTransformation__Output>
+          SelfConfigSource: MessageTypeDefinition<_envoy_config_core_v3_SelfConfigSource, _envoy_config_core_v3_SelfConfigSource__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          SubstitutionFormatString: MessageTypeDefinition<_envoy_config_core_v3_SubstitutionFormatString, _envoy_config_core_v3_SubstitutionFormatString__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
+          TcpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_TcpProtocolOptions, _envoy_config_core_v3_TcpProtocolOptions__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          UpstreamHttpProtocolOptions: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          UpstreamHttpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_UpstreamHttpProtocolOptions, _envoy_config_core_v3_UpstreamHttpProtocolOptions__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
       route: {
         v3: {
-          ClusterSpecifierPlugin: MessageTypeDefinition
-          CorsPolicy: MessageTypeDefinition
-          Decorator: MessageTypeDefinition
-          DirectResponseAction: MessageTypeDefinition
-          FilterAction: MessageTypeDefinition
-          FilterConfig: MessageTypeDefinition
-          HeaderMatcher: MessageTypeDefinition
-          HedgePolicy: MessageTypeDefinition
-          InternalRedirectPolicy: MessageTypeDefinition
-          NonForwardingAction: MessageTypeDefinition
-          QueryParameterMatcher: MessageTypeDefinition
-          RateLimit: MessageTypeDefinition
-          RedirectAction: MessageTypeDefinition
-          RetryPolicy: MessageTypeDefinition
-          Route: MessageTypeDefinition
-          RouteAction: MessageTypeDefinition
-          RouteConfiguration: MessageTypeDefinition
-          RouteList: MessageTypeDefinition
-          RouteMatch: MessageTypeDefinition
-          ScopedRouteConfiguration: MessageTypeDefinition
-          Tracing: MessageTypeDefinition
-          Vhds: MessageTypeDefinition
-          VirtualCluster: MessageTypeDefinition
-          VirtualHost: MessageTypeDefinition
-          WeightedCluster: MessageTypeDefinition
+          ClusterSpecifierPlugin: MessageTypeDefinition<_envoy_config_route_v3_ClusterSpecifierPlugin, _envoy_config_route_v3_ClusterSpecifierPlugin__Output>
+          CorsPolicy: MessageTypeDefinition<_envoy_config_route_v3_CorsPolicy, _envoy_config_route_v3_CorsPolicy__Output>
+          Decorator: MessageTypeDefinition<_envoy_config_route_v3_Decorator, _envoy_config_route_v3_Decorator__Output>
+          DirectResponseAction: MessageTypeDefinition<_envoy_config_route_v3_DirectResponseAction, _envoy_config_route_v3_DirectResponseAction__Output>
+          FilterAction: MessageTypeDefinition<_envoy_config_route_v3_FilterAction, _envoy_config_route_v3_FilterAction__Output>
+          FilterConfig: MessageTypeDefinition<_envoy_config_route_v3_FilterConfig, _envoy_config_route_v3_FilterConfig__Output>
+          HeaderMatcher: MessageTypeDefinition<_envoy_config_route_v3_HeaderMatcher, _envoy_config_route_v3_HeaderMatcher__Output>
+          HedgePolicy: MessageTypeDefinition<_envoy_config_route_v3_HedgePolicy, _envoy_config_route_v3_HedgePolicy__Output>
+          InternalRedirectPolicy: MessageTypeDefinition<_envoy_config_route_v3_InternalRedirectPolicy, _envoy_config_route_v3_InternalRedirectPolicy__Output>
+          NonForwardingAction: MessageTypeDefinition<_envoy_config_route_v3_NonForwardingAction, _envoy_config_route_v3_NonForwardingAction__Output>
+          QueryParameterMatcher: MessageTypeDefinition<_envoy_config_route_v3_QueryParameterMatcher, _envoy_config_route_v3_QueryParameterMatcher__Output>
+          RateLimit: MessageTypeDefinition<_envoy_config_route_v3_RateLimit, _envoy_config_route_v3_RateLimit__Output>
+          RedirectAction: MessageTypeDefinition<_envoy_config_route_v3_RedirectAction, _envoy_config_route_v3_RedirectAction__Output>
+          RetryPolicy: MessageTypeDefinition<_envoy_config_route_v3_RetryPolicy, _envoy_config_route_v3_RetryPolicy__Output>
+          Route: MessageTypeDefinition<_envoy_config_route_v3_Route, _envoy_config_route_v3_Route__Output>
+          RouteAction: MessageTypeDefinition<_envoy_config_route_v3_RouteAction, _envoy_config_route_v3_RouteAction__Output>
+          RouteConfiguration: MessageTypeDefinition<_envoy_config_route_v3_RouteConfiguration, _envoy_config_route_v3_RouteConfiguration__Output>
+          RouteList: MessageTypeDefinition<_envoy_config_route_v3_RouteList, _envoy_config_route_v3_RouteList__Output>
+          RouteMatch: MessageTypeDefinition<_envoy_config_route_v3_RouteMatch, _envoy_config_route_v3_RouteMatch__Output>
+          ScopedRouteConfiguration: MessageTypeDefinition<_envoy_config_route_v3_ScopedRouteConfiguration, _envoy_config_route_v3_ScopedRouteConfiguration__Output>
+          Tracing: MessageTypeDefinition<_envoy_config_route_v3_Tracing, _envoy_config_route_v3_Tracing__Output>
+          Vhds: MessageTypeDefinition<_envoy_config_route_v3_Vhds, _envoy_config_route_v3_Vhds__Output>
+          VirtualCluster: MessageTypeDefinition<_envoy_config_route_v3_VirtualCluster, _envoy_config_route_v3_VirtualCluster__Output>
+          VirtualHost: MessageTypeDefinition<_envoy_config_route_v3_VirtualHost, _envoy_config_route_v3_VirtualHost__Output>
+          WeightedCluster: MessageTypeDefinition<_envoy_config_route_v3_WeightedCluster, _envoy_config_route_v3_WeightedCluster__Output>
         }
       }
       trace: {
         v3: {
-          Tracing: MessageTypeDefinition
+          Tracing: MessageTypeDefinition<_envoy_config_trace_v3_Tracing, _envoy_config_trace_v3_Tracing__Output>
         }
       }
     }
     data: {
       accesslog: {
         v3: {
-          AccessLogCommon: MessageTypeDefinition
+          AccessLogCommon: MessageTypeDefinition<_envoy_data_accesslog_v3_AccessLogCommon, _envoy_data_accesslog_v3_AccessLogCommon__Output>
           AccessLogType: EnumTypeDefinition
-          ConnectionProperties: MessageTypeDefinition
-          HTTPAccessLogEntry: MessageTypeDefinition
-          HTTPRequestProperties: MessageTypeDefinition
-          HTTPResponseProperties: MessageTypeDefinition
-          ResponseFlags: MessageTypeDefinition
-          TCPAccessLogEntry: MessageTypeDefinition
-          TLSProperties: MessageTypeDefinition
+          ConnectionProperties: MessageTypeDefinition<_envoy_data_accesslog_v3_ConnectionProperties, _envoy_data_accesslog_v3_ConnectionProperties__Output>
+          HTTPAccessLogEntry: MessageTypeDefinition<_envoy_data_accesslog_v3_HTTPAccessLogEntry, _envoy_data_accesslog_v3_HTTPAccessLogEntry__Output>
+          HTTPRequestProperties: MessageTypeDefinition<_envoy_data_accesslog_v3_HTTPRequestProperties, _envoy_data_accesslog_v3_HTTPRequestProperties__Output>
+          HTTPResponseProperties: MessageTypeDefinition<_envoy_data_accesslog_v3_HTTPResponseProperties, _envoy_data_accesslog_v3_HTTPResponseProperties__Output>
+          ResponseFlags: MessageTypeDefinition<_envoy_data_accesslog_v3_ResponseFlags, _envoy_data_accesslog_v3_ResponseFlags__Output>
+          TCPAccessLogEntry: MessageTypeDefinition<_envoy_data_accesslog_v3_TCPAccessLogEntry, _envoy_data_accesslog_v3_TCPAccessLogEntry__Output>
+          TLSProperties: MessageTypeDefinition<_envoy_data_accesslog_v3_TLSProperties, _envoy_data_accesslog_v3_TLSProperties__Output>
         }
       }
     }
@@ -155,16 +374,16 @@ export interface ProtoGrpcType {
         network: {
           http_connection_manager: {
             v3: {
-              EnvoyMobileHttpConnectionManager: MessageTypeDefinition
-              HttpConnectionManager: MessageTypeDefinition
-              HttpFilter: MessageTypeDefinition
-              LocalReplyConfig: MessageTypeDefinition
-              Rds: MessageTypeDefinition
-              RequestIDExtension: MessageTypeDefinition
-              ResponseMapper: MessageTypeDefinition
-              ScopedRds: MessageTypeDefinition
-              ScopedRouteConfigurationsList: MessageTypeDefinition
-              ScopedRoutes: MessageTypeDefinition
+              EnvoyMobileHttpConnectionManager: MessageTypeDefinition<_envoy_extensions_filters_network_http_connection_manager_v3_EnvoyMobileHttpConnectionManager, _envoy_extensions_filters_network_http_connection_manager_v3_EnvoyMobileHttpConnectionManager__Output>
+              HttpConnectionManager: MessageTypeDefinition<_envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager, _envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager__Output>
+              HttpFilter: MessageTypeDefinition<_envoy_extensions_filters_network_http_connection_manager_v3_HttpFilter, _envoy_extensions_filters_network_http_connection_manager_v3_HttpFilter__Output>
+              LocalReplyConfig: MessageTypeDefinition<_envoy_extensions_filters_network_http_connection_manager_v3_LocalReplyConfig, _envoy_extensions_filters_network_http_connection_manager_v3_LocalReplyConfig__Output>
+              Rds: MessageTypeDefinition<_envoy_extensions_filters_network_http_connection_manager_v3_Rds, _envoy_extensions_filters_network_http_connection_manager_v3_Rds__Output>
+              RequestIDExtension: MessageTypeDefinition<_envoy_extensions_filters_network_http_connection_manager_v3_RequestIDExtension, _envoy_extensions_filters_network_http_connection_manager_v3_RequestIDExtension__Output>
+              ResponseMapper: MessageTypeDefinition<_envoy_extensions_filters_network_http_connection_manager_v3_ResponseMapper, _envoy_extensions_filters_network_http_connection_manager_v3_ResponseMapper__Output>
+              ScopedRds: MessageTypeDefinition<_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRds, _envoy_extensions_filters_network_http_connection_manager_v3_ScopedRds__Output>
+              ScopedRouteConfigurationsList: MessageTypeDefinition<_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRouteConfigurationsList, _envoy_extensions_filters_network_http_connection_manager_v3_ScopedRouteConfigurationsList__Output>
+              ScopedRoutes: MessageTypeDefinition<_envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes, _envoy_extensions_filters_network_http_connection_manager_v3_ScopedRoutes__Output>
             }
           }
         }
@@ -173,150 +392,150 @@ export interface ProtoGrpcType {
     type: {
       http: {
         v3: {
-          PathTransformation: MessageTypeDefinition
+          PathTransformation: MessageTypeDefinition<_envoy_type_http_v3_PathTransformation, _envoy_type_http_v3_PathTransformation__Output>
         }
       }
       matcher: {
         v3: {
-          DoubleMatcher: MessageTypeDefinition
-          ListMatcher: MessageTypeDefinition
-          ListStringMatcher: MessageTypeDefinition
-          MetadataMatcher: MessageTypeDefinition
-          OrMatcher: MessageTypeDefinition
-          RegexMatchAndSubstitute: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
-          ValueMatcher: MessageTypeDefinition
+          DoubleMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_DoubleMatcher, _envoy_type_matcher_v3_DoubleMatcher__Output>
+          ListMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListMatcher, _envoy_type_matcher_v3_ListMatcher__Output>
+          ListStringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListStringMatcher, _envoy_type_matcher_v3_ListStringMatcher__Output>
+          MetadataMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_MetadataMatcher, _envoy_type_matcher_v3_MetadataMatcher__Output>
+          OrMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_OrMatcher, _envoy_type_matcher_v3_OrMatcher__Output>
+          RegexMatchAndSubstitute: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatchAndSubstitute, _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output>
+          RegexMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatcher, _envoy_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_StringMatcher, _envoy_type_matcher_v3_StringMatcher__Output>
+          ValueMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ValueMatcher, _envoy_type_matcher_v3_ValueMatcher__Output>
         }
       }
       metadata: {
         v3: {
-          MetadataKey: MessageTypeDefinition
-          MetadataKind: MessageTypeDefinition
+          MetadataKey: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKey, _envoy_type_metadata_v3_MetadataKey__Output>
+          MetadataKind: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKind, _envoy_type_metadata_v3_MetadataKind__Output>
         }
       }
       tracing: {
         v3: {
-          CustomTag: MessageTypeDefinition
+          CustomTag: MessageTypeDefinition<_envoy_type_tracing_v3_CustomTag, _envoy_type_tracing_v3_CustomTag__Output>
         }
       }
       v3: {
-        DoubleRange: MessageTypeDefinition
-        FractionalPercent: MessageTypeDefinition
-        Int32Range: MessageTypeDefinition
-        Int64Range: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        DoubleRange: MessageTypeDefinition<_envoy_type_v3_DoubleRange, _envoy_type_v3_DoubleRange__Output>
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Int32Range: MessageTypeDefinition<_envoy_type_v3_Int32Range, _envoy_type_v3_Int32Range__Output>
+        Int64Range: MessageTypeDefinition<_envoy_type_v3_Int64Range, _envoy_type_v3_Int64Range__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      Empty: MessageTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      Empty: MessageTypeDefinition<_google_protobuf_Empty, _google_protobuf_Empty__Output>
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FieldSecurityAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FieldSecurityAnnotation: MessageTypeDefinition<_udpa_annotations_FieldSecurityAnnotation, _udpa_annotations_FieldSecurityAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        Authority: MessageTypeDefinition
-        ContextParams: MessageTypeDefinition
-        TypedExtensionConfig: MessageTypeDefinition
+        Authority: MessageTypeDefinition<_xds_core_v3_Authority, _xds_core_v3_Authority__Output>
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
+        TypedExtensionConfig: MessageTypeDefinition<_xds_core_v3_TypedExtensionConfig, _xds_core_v3_TypedExtensionConfig__Output>
       }
     }
     type: {
       matcher: {
         v3: {
-          ListStringMatcher: MessageTypeDefinition
-          Matcher: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
+          ListStringMatcher: MessageTypeDefinition<_xds_type_matcher_v3_ListStringMatcher, _xds_type_matcher_v3_ListStringMatcher__Output>
+          Matcher: MessageTypeDefinition<_xds_type_matcher_v3_Matcher, _xds_type_matcher_v3_Matcher__Output>
+          RegexMatcher: MessageTypeDefinition<_xds_type_matcher_v3_RegexMatcher, _xds_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_xds_type_matcher_v3_StringMatcher, _xds_type_matcher_v3_StringMatcher__Output>
         }
       }
     }

--- a/packages/grpc-js-xds/src/generated/listener.ts
+++ b/packages/grpc-js-xds/src/generated/listener.ts
@@ -1,6 +1,226 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { AccessLog as _envoy_config_accesslog_v3_AccessLog, AccessLog__Output as _envoy_config_accesslog_v3_AccessLog__Output } from './envoy/config/accesslog/v3/AccessLog';
+import type { AccessLogFilter as _envoy_config_accesslog_v3_AccessLogFilter, AccessLogFilter__Output as _envoy_config_accesslog_v3_AccessLogFilter__Output } from './envoy/config/accesslog/v3/AccessLogFilter';
+import type { AndFilter as _envoy_config_accesslog_v3_AndFilter, AndFilter__Output as _envoy_config_accesslog_v3_AndFilter__Output } from './envoy/config/accesslog/v3/AndFilter';
+import type { ComparisonFilter as _envoy_config_accesslog_v3_ComparisonFilter, ComparisonFilter__Output as _envoy_config_accesslog_v3_ComparisonFilter__Output } from './envoy/config/accesslog/v3/ComparisonFilter';
+import type { DurationFilter as _envoy_config_accesslog_v3_DurationFilter, DurationFilter__Output as _envoy_config_accesslog_v3_DurationFilter__Output } from './envoy/config/accesslog/v3/DurationFilter';
+import type { ExtensionFilter as _envoy_config_accesslog_v3_ExtensionFilter, ExtensionFilter__Output as _envoy_config_accesslog_v3_ExtensionFilter__Output } from './envoy/config/accesslog/v3/ExtensionFilter';
+import type { GrpcStatusFilter as _envoy_config_accesslog_v3_GrpcStatusFilter, GrpcStatusFilter__Output as _envoy_config_accesslog_v3_GrpcStatusFilter__Output } from './envoy/config/accesslog/v3/GrpcStatusFilter';
+import type { HeaderFilter as _envoy_config_accesslog_v3_HeaderFilter, HeaderFilter__Output as _envoy_config_accesslog_v3_HeaderFilter__Output } from './envoy/config/accesslog/v3/HeaderFilter';
+import type { LogTypeFilter as _envoy_config_accesslog_v3_LogTypeFilter, LogTypeFilter__Output as _envoy_config_accesslog_v3_LogTypeFilter__Output } from './envoy/config/accesslog/v3/LogTypeFilter';
+import type { MetadataFilter as _envoy_config_accesslog_v3_MetadataFilter, MetadataFilter__Output as _envoy_config_accesslog_v3_MetadataFilter__Output } from './envoy/config/accesslog/v3/MetadataFilter';
+import type { NotHealthCheckFilter as _envoy_config_accesslog_v3_NotHealthCheckFilter, NotHealthCheckFilter__Output as _envoy_config_accesslog_v3_NotHealthCheckFilter__Output } from './envoy/config/accesslog/v3/NotHealthCheckFilter';
+import type { OrFilter as _envoy_config_accesslog_v3_OrFilter, OrFilter__Output as _envoy_config_accesslog_v3_OrFilter__Output } from './envoy/config/accesslog/v3/OrFilter';
+import type { ResponseFlagFilter as _envoy_config_accesslog_v3_ResponseFlagFilter, ResponseFlagFilter__Output as _envoy_config_accesslog_v3_ResponseFlagFilter__Output } from './envoy/config/accesslog/v3/ResponseFlagFilter';
+import type { RuntimeFilter as _envoy_config_accesslog_v3_RuntimeFilter, RuntimeFilter__Output as _envoy_config_accesslog_v3_RuntimeFilter__Output } from './envoy/config/accesslog/v3/RuntimeFilter';
+import type { StatusCodeFilter as _envoy_config_accesslog_v3_StatusCodeFilter, StatusCodeFilter__Output as _envoy_config_accesslog_v3_StatusCodeFilter__Output } from './envoy/config/accesslog/v3/StatusCodeFilter';
+import type { TraceableFilter as _envoy_config_accesslog_v3_TraceableFilter, TraceableFilter__Output as _envoy_config_accesslog_v3_TraceableFilter__Output } from './envoy/config/accesslog/v3/TraceableFilter';
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AggregatedConfigSource as _envoy_config_core_v3_AggregatedConfigSource, AggregatedConfigSource__Output as _envoy_config_core_v3_AggregatedConfigSource__Output } from './envoy/config/core/v3/AggregatedConfigSource';
+import type { AlternateProtocolsCacheOptions as _envoy_config_core_v3_AlternateProtocolsCacheOptions, AlternateProtocolsCacheOptions__Output as _envoy_config_core_v3_AlternateProtocolsCacheOptions__Output } from './envoy/config/core/v3/AlternateProtocolsCacheOptions';
+import type { ApiConfigSource as _envoy_config_core_v3_ApiConfigSource, ApiConfigSource__Output as _envoy_config_core_v3_ApiConfigSource__Output } from './envoy/config/core/v3/ApiConfigSource';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ConfigSource as _envoy_config_core_v3_ConfigSource, ConfigSource__Output as _envoy_config_core_v3_ConfigSource__Output } from './envoy/config/core/v3/ConfigSource';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtensionConfigSource as _envoy_config_core_v3_ExtensionConfigSource, ExtensionConfigSource__Output as _envoy_config_core_v3_ExtensionConfigSource__Output } from './envoy/config/core/v3/ExtensionConfigSource';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { GrpcProtocolOptions as _envoy_config_core_v3_GrpcProtocolOptions, GrpcProtocolOptions__Output as _envoy_config_core_v3_GrpcProtocolOptions__Output } from './envoy/config/core/v3/GrpcProtocolOptions';
+import type { GrpcService as _envoy_config_core_v3_GrpcService, GrpcService__Output as _envoy_config_core_v3_GrpcService__Output } from './envoy/config/core/v3/GrpcService';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { Http1ProtocolOptions as _envoy_config_core_v3_Http1ProtocolOptions, Http1ProtocolOptions__Output as _envoy_config_core_v3_Http1ProtocolOptions__Output } from './envoy/config/core/v3/Http1ProtocolOptions';
+import type { Http2ProtocolOptions as _envoy_config_core_v3_Http2ProtocolOptions, Http2ProtocolOptions__Output as _envoy_config_core_v3_Http2ProtocolOptions__Output } from './envoy/config/core/v3/Http2ProtocolOptions';
+import type { Http3ProtocolOptions as _envoy_config_core_v3_Http3ProtocolOptions, Http3ProtocolOptions__Output as _envoy_config_core_v3_Http3ProtocolOptions__Output } from './envoy/config/core/v3/Http3ProtocolOptions';
+import type { HttpProtocolOptions as _envoy_config_core_v3_HttpProtocolOptions, HttpProtocolOptions__Output as _envoy_config_core_v3_HttpProtocolOptions__Output } from './envoy/config/core/v3/HttpProtocolOptions';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeepaliveSettings as _envoy_config_core_v3_KeepaliveSettings, KeepaliveSettings__Output as _envoy_config_core_v3_KeepaliveSettings__Output } from './envoy/config/core/v3/KeepaliveSettings';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { PathConfigSource as _envoy_config_core_v3_PathConfigSource, PathConfigSource__Output as _envoy_config_core_v3_PathConfigSource__Output } from './envoy/config/core/v3/PathConfigSource';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { ProxyProtocolConfig as _envoy_config_core_v3_ProxyProtocolConfig, ProxyProtocolConfig__Output as _envoy_config_core_v3_ProxyProtocolConfig__Output } from './envoy/config/core/v3/ProxyProtocolConfig';
+import type { ProxyProtocolPassThroughTLVs as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs, ProxyProtocolPassThroughTLVs__Output as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output } from './envoy/config/core/v3/ProxyProtocolPassThroughTLVs';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { QuicKeepAliveSettings as _envoy_config_core_v3_QuicKeepAliveSettings, QuicKeepAliveSettings__Output as _envoy_config_core_v3_QuicKeepAliveSettings__Output } from './envoy/config/core/v3/QuicKeepAliveSettings';
+import type { QuicProtocolOptions as _envoy_config_core_v3_QuicProtocolOptions, QuicProtocolOptions__Output as _envoy_config_core_v3_QuicProtocolOptions__Output } from './envoy/config/core/v3/QuicProtocolOptions';
+import type { RateLimitSettings as _envoy_config_core_v3_RateLimitSettings, RateLimitSettings__Output as _envoy_config_core_v3_RateLimitSettings__Output } from './envoy/config/core/v3/RateLimitSettings';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SchemeHeaderTransformation as _envoy_config_core_v3_SchemeHeaderTransformation, SchemeHeaderTransformation__Output as _envoy_config_core_v3_SchemeHeaderTransformation__Output } from './envoy/config/core/v3/SchemeHeaderTransformation';
+import type { SelfConfigSource as _envoy_config_core_v3_SelfConfigSource, SelfConfigSource__Output as _envoy_config_core_v3_SelfConfigSource__Output } from './envoy/config/core/v3/SelfConfigSource';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TcpProtocolOptions as _envoy_config_core_v3_TcpProtocolOptions, TcpProtocolOptions__Output as _envoy_config_core_v3_TcpProtocolOptions__Output } from './envoy/config/core/v3/TcpProtocolOptions';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { UdpSocketConfig as _envoy_config_core_v3_UdpSocketConfig, UdpSocketConfig__Output as _envoy_config_core_v3_UdpSocketConfig__Output } from './envoy/config/core/v3/UdpSocketConfig';
+import type { UpstreamHttpProtocolOptions as _envoy_config_core_v3_UpstreamHttpProtocolOptions, UpstreamHttpProtocolOptions__Output as _envoy_config_core_v3_UpstreamHttpProtocolOptions__Output } from './envoy/config/core/v3/UpstreamHttpProtocolOptions';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { ActiveRawUdpListenerConfig as _envoy_config_listener_v3_ActiveRawUdpListenerConfig, ActiveRawUdpListenerConfig__Output as _envoy_config_listener_v3_ActiveRawUdpListenerConfig__Output } from './envoy/config/listener/v3/ActiveRawUdpListenerConfig';
+import type { AdditionalAddress as _envoy_config_listener_v3_AdditionalAddress, AdditionalAddress__Output as _envoy_config_listener_v3_AdditionalAddress__Output } from './envoy/config/listener/v3/AdditionalAddress';
+import type { ApiListener as _envoy_config_listener_v3_ApiListener, ApiListener__Output as _envoy_config_listener_v3_ApiListener__Output } from './envoy/config/listener/v3/ApiListener';
+import type { ApiListenerManager as _envoy_config_listener_v3_ApiListenerManager, ApiListenerManager__Output as _envoy_config_listener_v3_ApiListenerManager__Output } from './envoy/config/listener/v3/ApiListenerManager';
+import type { Filter as _envoy_config_listener_v3_Filter, Filter__Output as _envoy_config_listener_v3_Filter__Output } from './envoy/config/listener/v3/Filter';
+import type { FilterChain as _envoy_config_listener_v3_FilterChain, FilterChain__Output as _envoy_config_listener_v3_FilterChain__Output } from './envoy/config/listener/v3/FilterChain';
+import type { FilterChainMatch as _envoy_config_listener_v3_FilterChainMatch, FilterChainMatch__Output as _envoy_config_listener_v3_FilterChainMatch__Output } from './envoy/config/listener/v3/FilterChainMatch';
+import type { Listener as _envoy_config_listener_v3_Listener, Listener__Output as _envoy_config_listener_v3_Listener__Output } from './envoy/config/listener/v3/Listener';
+import type { ListenerCollection as _envoy_config_listener_v3_ListenerCollection, ListenerCollection__Output as _envoy_config_listener_v3_ListenerCollection__Output } from './envoy/config/listener/v3/ListenerCollection';
+import type { ListenerFilter as _envoy_config_listener_v3_ListenerFilter, ListenerFilter__Output as _envoy_config_listener_v3_ListenerFilter__Output } from './envoy/config/listener/v3/ListenerFilter';
+import type { ListenerFilterChainMatchPredicate as _envoy_config_listener_v3_ListenerFilterChainMatchPredicate, ListenerFilterChainMatchPredicate__Output as _envoy_config_listener_v3_ListenerFilterChainMatchPredicate__Output } from './envoy/config/listener/v3/ListenerFilterChainMatchPredicate';
+import type { ListenerManager as _envoy_config_listener_v3_ListenerManager, ListenerManager__Output as _envoy_config_listener_v3_ListenerManager__Output } from './envoy/config/listener/v3/ListenerManager';
+import type { QuicProtocolOptions as _envoy_config_listener_v3_QuicProtocolOptions, QuicProtocolOptions__Output as _envoy_config_listener_v3_QuicProtocolOptions__Output } from './envoy/config/listener/v3/QuicProtocolOptions';
+import type { UdpListenerConfig as _envoy_config_listener_v3_UdpListenerConfig, UdpListenerConfig__Output as _envoy_config_listener_v3_UdpListenerConfig__Output } from './envoy/config/listener/v3/UdpListenerConfig';
+import type { ValidationListenerManager as _envoy_config_listener_v3_ValidationListenerManager, ValidationListenerManager__Output as _envoy_config_listener_v3_ValidationListenerManager__Output } from './envoy/config/listener/v3/ValidationListenerManager';
+import type { ClusterSpecifierPlugin as _envoy_config_route_v3_ClusterSpecifierPlugin, ClusterSpecifierPlugin__Output as _envoy_config_route_v3_ClusterSpecifierPlugin__Output } from './envoy/config/route/v3/ClusterSpecifierPlugin';
+import type { CorsPolicy as _envoy_config_route_v3_CorsPolicy, CorsPolicy__Output as _envoy_config_route_v3_CorsPolicy__Output } from './envoy/config/route/v3/CorsPolicy';
+import type { Decorator as _envoy_config_route_v3_Decorator, Decorator__Output as _envoy_config_route_v3_Decorator__Output } from './envoy/config/route/v3/Decorator';
+import type { DirectResponseAction as _envoy_config_route_v3_DirectResponseAction, DirectResponseAction__Output as _envoy_config_route_v3_DirectResponseAction__Output } from './envoy/config/route/v3/DirectResponseAction';
+import type { FilterAction as _envoy_config_route_v3_FilterAction, FilterAction__Output as _envoy_config_route_v3_FilterAction__Output } from './envoy/config/route/v3/FilterAction';
+import type { FilterConfig as _envoy_config_route_v3_FilterConfig, FilterConfig__Output as _envoy_config_route_v3_FilterConfig__Output } from './envoy/config/route/v3/FilterConfig';
+import type { HeaderMatcher as _envoy_config_route_v3_HeaderMatcher, HeaderMatcher__Output as _envoy_config_route_v3_HeaderMatcher__Output } from './envoy/config/route/v3/HeaderMatcher';
+import type { HedgePolicy as _envoy_config_route_v3_HedgePolicy, HedgePolicy__Output as _envoy_config_route_v3_HedgePolicy__Output } from './envoy/config/route/v3/HedgePolicy';
+import type { InternalRedirectPolicy as _envoy_config_route_v3_InternalRedirectPolicy, InternalRedirectPolicy__Output as _envoy_config_route_v3_InternalRedirectPolicy__Output } from './envoy/config/route/v3/InternalRedirectPolicy';
+import type { NonForwardingAction as _envoy_config_route_v3_NonForwardingAction, NonForwardingAction__Output as _envoy_config_route_v3_NonForwardingAction__Output } from './envoy/config/route/v3/NonForwardingAction';
+import type { QueryParameterMatcher as _envoy_config_route_v3_QueryParameterMatcher, QueryParameterMatcher__Output as _envoy_config_route_v3_QueryParameterMatcher__Output } from './envoy/config/route/v3/QueryParameterMatcher';
+import type { RateLimit as _envoy_config_route_v3_RateLimit, RateLimit__Output as _envoy_config_route_v3_RateLimit__Output } from './envoy/config/route/v3/RateLimit';
+import type { RedirectAction as _envoy_config_route_v3_RedirectAction, RedirectAction__Output as _envoy_config_route_v3_RedirectAction__Output } from './envoy/config/route/v3/RedirectAction';
+import type { RetryPolicy as _envoy_config_route_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_route_v3_RetryPolicy__Output } from './envoy/config/route/v3/RetryPolicy';
+import type { Route as _envoy_config_route_v3_Route, Route__Output as _envoy_config_route_v3_Route__Output } from './envoy/config/route/v3/Route';
+import type { RouteAction as _envoy_config_route_v3_RouteAction, RouteAction__Output as _envoy_config_route_v3_RouteAction__Output } from './envoy/config/route/v3/RouteAction';
+import type { RouteList as _envoy_config_route_v3_RouteList, RouteList__Output as _envoy_config_route_v3_RouteList__Output } from './envoy/config/route/v3/RouteList';
+import type { RouteMatch as _envoy_config_route_v3_RouteMatch, RouteMatch__Output as _envoy_config_route_v3_RouteMatch__Output } from './envoy/config/route/v3/RouteMatch';
+import type { Tracing as _envoy_config_route_v3_Tracing, Tracing__Output as _envoy_config_route_v3_Tracing__Output } from './envoy/config/route/v3/Tracing';
+import type { VirtualCluster as _envoy_config_route_v3_VirtualCluster, VirtualCluster__Output as _envoy_config_route_v3_VirtualCluster__Output } from './envoy/config/route/v3/VirtualCluster';
+import type { VirtualHost as _envoy_config_route_v3_VirtualHost, VirtualHost__Output as _envoy_config_route_v3_VirtualHost__Output } from './envoy/config/route/v3/VirtualHost';
+import type { WeightedCluster as _envoy_config_route_v3_WeightedCluster, WeightedCluster__Output as _envoy_config_route_v3_WeightedCluster__Output } from './envoy/config/route/v3/WeightedCluster';
+import type { AccessLogCommon as _envoy_data_accesslog_v3_AccessLogCommon, AccessLogCommon__Output as _envoy_data_accesslog_v3_AccessLogCommon__Output } from './envoy/data/accesslog/v3/AccessLogCommon';
+import type { ConnectionProperties as _envoy_data_accesslog_v3_ConnectionProperties, ConnectionProperties__Output as _envoy_data_accesslog_v3_ConnectionProperties__Output } from './envoy/data/accesslog/v3/ConnectionProperties';
+import type { HTTPAccessLogEntry as _envoy_data_accesslog_v3_HTTPAccessLogEntry, HTTPAccessLogEntry__Output as _envoy_data_accesslog_v3_HTTPAccessLogEntry__Output } from './envoy/data/accesslog/v3/HTTPAccessLogEntry';
+import type { HTTPRequestProperties as _envoy_data_accesslog_v3_HTTPRequestProperties, HTTPRequestProperties__Output as _envoy_data_accesslog_v3_HTTPRequestProperties__Output } from './envoy/data/accesslog/v3/HTTPRequestProperties';
+import type { HTTPResponseProperties as _envoy_data_accesslog_v3_HTTPResponseProperties, HTTPResponseProperties__Output as _envoy_data_accesslog_v3_HTTPResponseProperties__Output } from './envoy/data/accesslog/v3/HTTPResponseProperties';
+import type { ResponseFlags as _envoy_data_accesslog_v3_ResponseFlags, ResponseFlags__Output as _envoy_data_accesslog_v3_ResponseFlags__Output } from './envoy/data/accesslog/v3/ResponseFlags';
+import type { TCPAccessLogEntry as _envoy_data_accesslog_v3_TCPAccessLogEntry, TCPAccessLogEntry__Output as _envoy_data_accesslog_v3_TCPAccessLogEntry__Output } from './envoy/data/accesslog/v3/TCPAccessLogEntry';
+import type { TLSProperties as _envoy_data_accesslog_v3_TLSProperties, TLSProperties__Output as _envoy_data_accesslog_v3_TLSProperties__Output } from './envoy/data/accesslog/v3/TLSProperties';
+import type { DoubleMatcher as _envoy_type_matcher_v3_DoubleMatcher, DoubleMatcher__Output as _envoy_type_matcher_v3_DoubleMatcher__Output } from './envoy/type/matcher/v3/DoubleMatcher';
+import type { ListMatcher as _envoy_type_matcher_v3_ListMatcher, ListMatcher__Output as _envoy_type_matcher_v3_ListMatcher__Output } from './envoy/type/matcher/v3/ListMatcher';
+import type { ListStringMatcher as _envoy_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _envoy_type_matcher_v3_ListStringMatcher__Output } from './envoy/type/matcher/v3/ListStringMatcher';
+import type { MetadataMatcher as _envoy_type_matcher_v3_MetadataMatcher, MetadataMatcher__Output as _envoy_type_matcher_v3_MetadataMatcher__Output } from './envoy/type/matcher/v3/MetadataMatcher';
+import type { OrMatcher as _envoy_type_matcher_v3_OrMatcher, OrMatcher__Output as _envoy_type_matcher_v3_OrMatcher__Output } from './envoy/type/matcher/v3/OrMatcher';
+import type { RegexMatchAndSubstitute as _envoy_type_matcher_v3_RegexMatchAndSubstitute, RegexMatchAndSubstitute__Output as _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output } from './envoy/type/matcher/v3/RegexMatchAndSubstitute';
+import type { RegexMatcher as _envoy_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _envoy_type_matcher_v3_RegexMatcher__Output } from './envoy/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _envoy_type_matcher_v3_StringMatcher, StringMatcher__Output as _envoy_type_matcher_v3_StringMatcher__Output } from './envoy/type/matcher/v3/StringMatcher';
+import type { ValueMatcher as _envoy_type_matcher_v3_ValueMatcher, ValueMatcher__Output as _envoy_type_matcher_v3_ValueMatcher__Output } from './envoy/type/matcher/v3/ValueMatcher';
+import type { MetadataKey as _envoy_type_metadata_v3_MetadataKey, MetadataKey__Output as _envoy_type_metadata_v3_MetadataKey__Output } from './envoy/type/metadata/v3/MetadataKey';
+import type { MetadataKind as _envoy_type_metadata_v3_MetadataKind, MetadataKind__Output as _envoy_type_metadata_v3_MetadataKind__Output } from './envoy/type/metadata/v3/MetadataKind';
+import type { CustomTag as _envoy_type_tracing_v3_CustomTag, CustomTag__Output as _envoy_type_tracing_v3_CustomTag__Output } from './envoy/type/tracing/v3/CustomTag';
+import type { DoubleRange as _envoy_type_v3_DoubleRange, DoubleRange__Output as _envoy_type_v3_DoubleRange__Output } from './envoy/type/v3/DoubleRange';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Int32Range as _envoy_type_v3_Int32Range, Int32Range__Output as _envoy_type_v3_Int32Range__Output } from './envoy/type/v3/Int32Range';
+import type { Int64Range as _envoy_type_v3_Int64Range, Int64Range__Output as _envoy_type_v3_Int64Range__Output } from './envoy/type/v3/Int64Range';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from './google/protobuf/Empty';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FieldSecurityAnnotation as _udpa_annotations_FieldSecurityAnnotation, FieldSecurityAnnotation__Output as _udpa_annotations_FieldSecurityAnnotation__Output } from './udpa/annotations/FieldSecurityAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { Authority as _xds_core_v3_Authority, Authority__Output as _xds_core_v3_Authority__Output } from './xds/core/v3/Authority';
+import type { CollectionEntry as _xds_core_v3_CollectionEntry, CollectionEntry__Output as _xds_core_v3_CollectionEntry__Output } from './xds/core/v3/CollectionEntry';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
+import type { ResourceLocator as _xds_core_v3_ResourceLocator, ResourceLocator__Output as _xds_core_v3_ResourceLocator__Output } from './xds/core/v3/ResourceLocator';
+import type { TypedExtensionConfig as _xds_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _xds_core_v3_TypedExtensionConfig__Output } from './xds/core/v3/TypedExtensionConfig';
+import type { ListStringMatcher as _xds_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _xds_type_matcher_v3_ListStringMatcher__Output } from './xds/type/matcher/v3/ListStringMatcher';
+import type { Matcher as _xds_type_matcher_v3_Matcher, Matcher__Output as _xds_type_matcher_v3_Matcher__Output } from './xds/type/matcher/v3/Matcher';
+import type { RegexMatcher as _xds_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _xds_type_matcher_v3_RegexMatcher__Output } from './xds/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _xds_type_matcher_v3_StringMatcher, StringMatcher__Output as _xds_type_matcher_v3_StringMatcher__Output } from './xds/type/matcher/v3/StringMatcher';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -13,297 +233,297 @@ export interface ProtoGrpcType {
     config: {
       accesslog: {
         v3: {
-          AccessLog: MessageTypeDefinition
-          AccessLogFilter: MessageTypeDefinition
-          AndFilter: MessageTypeDefinition
-          ComparisonFilter: MessageTypeDefinition
-          DurationFilter: MessageTypeDefinition
-          ExtensionFilter: MessageTypeDefinition
-          GrpcStatusFilter: MessageTypeDefinition
-          HeaderFilter: MessageTypeDefinition
-          LogTypeFilter: MessageTypeDefinition
-          MetadataFilter: MessageTypeDefinition
-          NotHealthCheckFilter: MessageTypeDefinition
-          OrFilter: MessageTypeDefinition
-          ResponseFlagFilter: MessageTypeDefinition
-          RuntimeFilter: MessageTypeDefinition
-          StatusCodeFilter: MessageTypeDefinition
-          TraceableFilter: MessageTypeDefinition
+          AccessLog: MessageTypeDefinition<_envoy_config_accesslog_v3_AccessLog, _envoy_config_accesslog_v3_AccessLog__Output>
+          AccessLogFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_AccessLogFilter, _envoy_config_accesslog_v3_AccessLogFilter__Output>
+          AndFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_AndFilter, _envoy_config_accesslog_v3_AndFilter__Output>
+          ComparisonFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_ComparisonFilter, _envoy_config_accesslog_v3_ComparisonFilter__Output>
+          DurationFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_DurationFilter, _envoy_config_accesslog_v3_DurationFilter__Output>
+          ExtensionFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_ExtensionFilter, _envoy_config_accesslog_v3_ExtensionFilter__Output>
+          GrpcStatusFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_GrpcStatusFilter, _envoy_config_accesslog_v3_GrpcStatusFilter__Output>
+          HeaderFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_HeaderFilter, _envoy_config_accesslog_v3_HeaderFilter__Output>
+          LogTypeFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_LogTypeFilter, _envoy_config_accesslog_v3_LogTypeFilter__Output>
+          MetadataFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_MetadataFilter, _envoy_config_accesslog_v3_MetadataFilter__Output>
+          NotHealthCheckFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_NotHealthCheckFilter, _envoy_config_accesslog_v3_NotHealthCheckFilter__Output>
+          OrFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_OrFilter, _envoy_config_accesslog_v3_OrFilter__Output>
+          ResponseFlagFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_ResponseFlagFilter, _envoy_config_accesslog_v3_ResponseFlagFilter__Output>
+          RuntimeFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_RuntimeFilter, _envoy_config_accesslog_v3_RuntimeFilter__Output>
+          StatusCodeFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_StatusCodeFilter, _envoy_config_accesslog_v3_StatusCodeFilter__Output>
+          TraceableFilter: MessageTypeDefinition<_envoy_config_accesslog_v3_TraceableFilter, _envoy_config_accesslog_v3_TraceableFilter__Output>
         }
       }
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AggregatedConfigSource: MessageTypeDefinition
-          AlternateProtocolsCacheOptions: MessageTypeDefinition
-          ApiConfigSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AggregatedConfigSource: MessageTypeDefinition<_envoy_config_core_v3_AggregatedConfigSource, _envoy_config_core_v3_AggregatedConfigSource__Output>
+          AlternateProtocolsCacheOptions: MessageTypeDefinition<_envoy_config_core_v3_AlternateProtocolsCacheOptions, _envoy_config_core_v3_AlternateProtocolsCacheOptions__Output>
+          ApiConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ApiConfigSource, _envoy_config_core_v3_ApiConfigSource__Output>
           ApiVersion: EnumTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ConfigSource: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtensionConfigSource: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          GrpcProtocolOptions: MessageTypeDefinition
-          GrpcService: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          Http1ProtocolOptions: MessageTypeDefinition
-          Http2ProtocolOptions: MessageTypeDefinition
-          Http3ProtocolOptions: MessageTypeDefinition
-          HttpProtocolOptions: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeepaliveSettings: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          PathConfigSource: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          ProxyProtocolConfig: MessageTypeDefinition
-          ProxyProtocolPassThroughTLVs: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          QuicKeepAliveSettings: MessageTypeDefinition
-          QuicProtocolOptions: MessageTypeDefinition
-          RateLimitSettings: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ConfigSource, _envoy_config_core_v3_ConfigSource__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtensionConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ExtensionConfigSource, _envoy_config_core_v3_ExtensionConfigSource__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          GrpcProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_GrpcProtocolOptions, _envoy_config_core_v3_GrpcProtocolOptions__Output>
+          GrpcService: MessageTypeDefinition<_envoy_config_core_v3_GrpcService, _envoy_config_core_v3_GrpcService__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          Http1ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http1ProtocolOptions, _envoy_config_core_v3_Http1ProtocolOptions__Output>
+          Http2ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http2ProtocolOptions, _envoy_config_core_v3_Http2ProtocolOptions__Output>
+          Http3ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http3ProtocolOptions, _envoy_config_core_v3_Http3ProtocolOptions__Output>
+          HttpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_HttpProtocolOptions, _envoy_config_core_v3_HttpProtocolOptions__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeepaliveSettings: MessageTypeDefinition<_envoy_config_core_v3_KeepaliveSettings, _envoy_config_core_v3_KeepaliveSettings__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          PathConfigSource: MessageTypeDefinition<_envoy_config_core_v3_PathConfigSource, _envoy_config_core_v3_PathConfigSource__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          ProxyProtocolConfig: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolConfig, _envoy_config_core_v3_ProxyProtocolConfig__Output>
+          ProxyProtocolPassThroughTLVs: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolPassThroughTLVs, _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          QuicKeepAliveSettings: MessageTypeDefinition<_envoy_config_core_v3_QuicKeepAliveSettings, _envoy_config_core_v3_QuicKeepAliveSettings__Output>
+          QuicProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_QuicProtocolOptions, _envoy_config_core_v3_QuicProtocolOptions__Output>
+          RateLimitSettings: MessageTypeDefinition<_envoy_config_core_v3_RateLimitSettings, _envoy_config_core_v3_RateLimitSettings__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SchemeHeaderTransformation: MessageTypeDefinition
-          SelfConfigSource: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
-          TcpProtocolOptions: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SchemeHeaderTransformation: MessageTypeDefinition<_envoy_config_core_v3_SchemeHeaderTransformation, _envoy_config_core_v3_SchemeHeaderTransformation__Output>
+          SelfConfigSource: MessageTypeDefinition<_envoy_config_core_v3_SelfConfigSource, _envoy_config_core_v3_SelfConfigSource__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
+          TcpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_TcpProtocolOptions, _envoy_config_core_v3_TcpProtocolOptions__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          UdpSocketConfig: MessageTypeDefinition
-          UpstreamHttpProtocolOptions: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          UdpSocketConfig: MessageTypeDefinition<_envoy_config_core_v3_UdpSocketConfig, _envoy_config_core_v3_UdpSocketConfig__Output>
+          UpstreamHttpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_UpstreamHttpProtocolOptions, _envoy_config_core_v3_UpstreamHttpProtocolOptions__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
       listener: {
         v3: {
-          ActiveRawUdpListenerConfig: MessageTypeDefinition
-          AdditionalAddress: MessageTypeDefinition
-          ApiListener: MessageTypeDefinition
-          ApiListenerManager: MessageTypeDefinition
-          Filter: MessageTypeDefinition
-          FilterChain: MessageTypeDefinition
-          FilterChainMatch: MessageTypeDefinition
-          Listener: MessageTypeDefinition
-          ListenerCollection: MessageTypeDefinition
-          ListenerFilter: MessageTypeDefinition
-          ListenerFilterChainMatchPredicate: MessageTypeDefinition
-          ListenerManager: MessageTypeDefinition
-          QuicProtocolOptions: MessageTypeDefinition
-          UdpListenerConfig: MessageTypeDefinition
-          ValidationListenerManager: MessageTypeDefinition
+          ActiveRawUdpListenerConfig: MessageTypeDefinition<_envoy_config_listener_v3_ActiveRawUdpListenerConfig, _envoy_config_listener_v3_ActiveRawUdpListenerConfig__Output>
+          AdditionalAddress: MessageTypeDefinition<_envoy_config_listener_v3_AdditionalAddress, _envoy_config_listener_v3_AdditionalAddress__Output>
+          ApiListener: MessageTypeDefinition<_envoy_config_listener_v3_ApiListener, _envoy_config_listener_v3_ApiListener__Output>
+          ApiListenerManager: MessageTypeDefinition<_envoy_config_listener_v3_ApiListenerManager, _envoy_config_listener_v3_ApiListenerManager__Output>
+          Filter: MessageTypeDefinition<_envoy_config_listener_v3_Filter, _envoy_config_listener_v3_Filter__Output>
+          FilterChain: MessageTypeDefinition<_envoy_config_listener_v3_FilterChain, _envoy_config_listener_v3_FilterChain__Output>
+          FilterChainMatch: MessageTypeDefinition<_envoy_config_listener_v3_FilterChainMatch, _envoy_config_listener_v3_FilterChainMatch__Output>
+          Listener: MessageTypeDefinition<_envoy_config_listener_v3_Listener, _envoy_config_listener_v3_Listener__Output>
+          ListenerCollection: MessageTypeDefinition<_envoy_config_listener_v3_ListenerCollection, _envoy_config_listener_v3_ListenerCollection__Output>
+          ListenerFilter: MessageTypeDefinition<_envoy_config_listener_v3_ListenerFilter, _envoy_config_listener_v3_ListenerFilter__Output>
+          ListenerFilterChainMatchPredicate: MessageTypeDefinition<_envoy_config_listener_v3_ListenerFilterChainMatchPredicate, _envoy_config_listener_v3_ListenerFilterChainMatchPredicate__Output>
+          ListenerManager: MessageTypeDefinition<_envoy_config_listener_v3_ListenerManager, _envoy_config_listener_v3_ListenerManager__Output>
+          QuicProtocolOptions: MessageTypeDefinition<_envoy_config_listener_v3_QuicProtocolOptions, _envoy_config_listener_v3_QuicProtocolOptions__Output>
+          UdpListenerConfig: MessageTypeDefinition<_envoy_config_listener_v3_UdpListenerConfig, _envoy_config_listener_v3_UdpListenerConfig__Output>
+          ValidationListenerManager: MessageTypeDefinition<_envoy_config_listener_v3_ValidationListenerManager, _envoy_config_listener_v3_ValidationListenerManager__Output>
         }
       }
       route: {
         v3: {
-          ClusterSpecifierPlugin: MessageTypeDefinition
-          CorsPolicy: MessageTypeDefinition
-          Decorator: MessageTypeDefinition
-          DirectResponseAction: MessageTypeDefinition
-          FilterAction: MessageTypeDefinition
-          FilterConfig: MessageTypeDefinition
-          HeaderMatcher: MessageTypeDefinition
-          HedgePolicy: MessageTypeDefinition
-          InternalRedirectPolicy: MessageTypeDefinition
-          NonForwardingAction: MessageTypeDefinition
-          QueryParameterMatcher: MessageTypeDefinition
-          RateLimit: MessageTypeDefinition
-          RedirectAction: MessageTypeDefinition
-          RetryPolicy: MessageTypeDefinition
-          Route: MessageTypeDefinition
-          RouteAction: MessageTypeDefinition
-          RouteList: MessageTypeDefinition
-          RouteMatch: MessageTypeDefinition
-          Tracing: MessageTypeDefinition
-          VirtualCluster: MessageTypeDefinition
-          VirtualHost: MessageTypeDefinition
-          WeightedCluster: MessageTypeDefinition
+          ClusterSpecifierPlugin: MessageTypeDefinition<_envoy_config_route_v3_ClusterSpecifierPlugin, _envoy_config_route_v3_ClusterSpecifierPlugin__Output>
+          CorsPolicy: MessageTypeDefinition<_envoy_config_route_v3_CorsPolicy, _envoy_config_route_v3_CorsPolicy__Output>
+          Decorator: MessageTypeDefinition<_envoy_config_route_v3_Decorator, _envoy_config_route_v3_Decorator__Output>
+          DirectResponseAction: MessageTypeDefinition<_envoy_config_route_v3_DirectResponseAction, _envoy_config_route_v3_DirectResponseAction__Output>
+          FilterAction: MessageTypeDefinition<_envoy_config_route_v3_FilterAction, _envoy_config_route_v3_FilterAction__Output>
+          FilterConfig: MessageTypeDefinition<_envoy_config_route_v3_FilterConfig, _envoy_config_route_v3_FilterConfig__Output>
+          HeaderMatcher: MessageTypeDefinition<_envoy_config_route_v3_HeaderMatcher, _envoy_config_route_v3_HeaderMatcher__Output>
+          HedgePolicy: MessageTypeDefinition<_envoy_config_route_v3_HedgePolicy, _envoy_config_route_v3_HedgePolicy__Output>
+          InternalRedirectPolicy: MessageTypeDefinition<_envoy_config_route_v3_InternalRedirectPolicy, _envoy_config_route_v3_InternalRedirectPolicy__Output>
+          NonForwardingAction: MessageTypeDefinition<_envoy_config_route_v3_NonForwardingAction, _envoy_config_route_v3_NonForwardingAction__Output>
+          QueryParameterMatcher: MessageTypeDefinition<_envoy_config_route_v3_QueryParameterMatcher, _envoy_config_route_v3_QueryParameterMatcher__Output>
+          RateLimit: MessageTypeDefinition<_envoy_config_route_v3_RateLimit, _envoy_config_route_v3_RateLimit__Output>
+          RedirectAction: MessageTypeDefinition<_envoy_config_route_v3_RedirectAction, _envoy_config_route_v3_RedirectAction__Output>
+          RetryPolicy: MessageTypeDefinition<_envoy_config_route_v3_RetryPolicy, _envoy_config_route_v3_RetryPolicy__Output>
+          Route: MessageTypeDefinition<_envoy_config_route_v3_Route, _envoy_config_route_v3_Route__Output>
+          RouteAction: MessageTypeDefinition<_envoy_config_route_v3_RouteAction, _envoy_config_route_v3_RouteAction__Output>
+          RouteList: MessageTypeDefinition<_envoy_config_route_v3_RouteList, _envoy_config_route_v3_RouteList__Output>
+          RouteMatch: MessageTypeDefinition<_envoy_config_route_v3_RouteMatch, _envoy_config_route_v3_RouteMatch__Output>
+          Tracing: MessageTypeDefinition<_envoy_config_route_v3_Tracing, _envoy_config_route_v3_Tracing__Output>
+          VirtualCluster: MessageTypeDefinition<_envoy_config_route_v3_VirtualCluster, _envoy_config_route_v3_VirtualCluster__Output>
+          VirtualHost: MessageTypeDefinition<_envoy_config_route_v3_VirtualHost, _envoy_config_route_v3_VirtualHost__Output>
+          WeightedCluster: MessageTypeDefinition<_envoy_config_route_v3_WeightedCluster, _envoy_config_route_v3_WeightedCluster__Output>
         }
       }
     }
     data: {
       accesslog: {
         v3: {
-          AccessLogCommon: MessageTypeDefinition
+          AccessLogCommon: MessageTypeDefinition<_envoy_data_accesslog_v3_AccessLogCommon, _envoy_data_accesslog_v3_AccessLogCommon__Output>
           AccessLogType: EnumTypeDefinition
-          ConnectionProperties: MessageTypeDefinition
-          HTTPAccessLogEntry: MessageTypeDefinition
-          HTTPRequestProperties: MessageTypeDefinition
-          HTTPResponseProperties: MessageTypeDefinition
-          ResponseFlags: MessageTypeDefinition
-          TCPAccessLogEntry: MessageTypeDefinition
-          TLSProperties: MessageTypeDefinition
+          ConnectionProperties: MessageTypeDefinition<_envoy_data_accesslog_v3_ConnectionProperties, _envoy_data_accesslog_v3_ConnectionProperties__Output>
+          HTTPAccessLogEntry: MessageTypeDefinition<_envoy_data_accesslog_v3_HTTPAccessLogEntry, _envoy_data_accesslog_v3_HTTPAccessLogEntry__Output>
+          HTTPRequestProperties: MessageTypeDefinition<_envoy_data_accesslog_v3_HTTPRequestProperties, _envoy_data_accesslog_v3_HTTPRequestProperties__Output>
+          HTTPResponseProperties: MessageTypeDefinition<_envoy_data_accesslog_v3_HTTPResponseProperties, _envoy_data_accesslog_v3_HTTPResponseProperties__Output>
+          ResponseFlags: MessageTypeDefinition<_envoy_data_accesslog_v3_ResponseFlags, _envoy_data_accesslog_v3_ResponseFlags__Output>
+          TCPAccessLogEntry: MessageTypeDefinition<_envoy_data_accesslog_v3_TCPAccessLogEntry, _envoy_data_accesslog_v3_TCPAccessLogEntry__Output>
+          TLSProperties: MessageTypeDefinition<_envoy_data_accesslog_v3_TLSProperties, _envoy_data_accesslog_v3_TLSProperties__Output>
         }
       }
     }
     type: {
       matcher: {
         v3: {
-          DoubleMatcher: MessageTypeDefinition
-          ListMatcher: MessageTypeDefinition
-          ListStringMatcher: MessageTypeDefinition
-          MetadataMatcher: MessageTypeDefinition
-          OrMatcher: MessageTypeDefinition
-          RegexMatchAndSubstitute: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
-          ValueMatcher: MessageTypeDefinition
+          DoubleMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_DoubleMatcher, _envoy_type_matcher_v3_DoubleMatcher__Output>
+          ListMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListMatcher, _envoy_type_matcher_v3_ListMatcher__Output>
+          ListStringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListStringMatcher, _envoy_type_matcher_v3_ListStringMatcher__Output>
+          MetadataMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_MetadataMatcher, _envoy_type_matcher_v3_MetadataMatcher__Output>
+          OrMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_OrMatcher, _envoy_type_matcher_v3_OrMatcher__Output>
+          RegexMatchAndSubstitute: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatchAndSubstitute, _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output>
+          RegexMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatcher, _envoy_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_StringMatcher, _envoy_type_matcher_v3_StringMatcher__Output>
+          ValueMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ValueMatcher, _envoy_type_matcher_v3_ValueMatcher__Output>
         }
       }
       metadata: {
         v3: {
-          MetadataKey: MessageTypeDefinition
-          MetadataKind: MessageTypeDefinition
+          MetadataKey: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKey, _envoy_type_metadata_v3_MetadataKey__Output>
+          MetadataKind: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKind, _envoy_type_metadata_v3_MetadataKind__Output>
         }
       }
       tracing: {
         v3: {
-          CustomTag: MessageTypeDefinition
+          CustomTag: MessageTypeDefinition<_envoy_type_tracing_v3_CustomTag, _envoy_type_tracing_v3_CustomTag__Output>
         }
       }
       v3: {
-        DoubleRange: MessageTypeDefinition
-        FractionalPercent: MessageTypeDefinition
-        Int32Range: MessageTypeDefinition
-        Int64Range: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        DoubleRange: MessageTypeDefinition<_envoy_type_v3_DoubleRange, _envoy_type_v3_DoubleRange__Output>
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Int32Range: MessageTypeDefinition<_envoy_type_v3_Int32Range, _envoy_type_v3_Int32Range__Output>
+        Int64Range: MessageTypeDefinition<_envoy_type_v3_Int64Range, _envoy_type_v3_Int64Range__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      Empty: MessageTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      Empty: MessageTypeDefinition<_google_protobuf_Empty, _google_protobuf_Empty__Output>
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FieldSecurityAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FieldSecurityAnnotation: MessageTypeDefinition<_udpa_annotations_FieldSecurityAnnotation, _udpa_annotations_FieldSecurityAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        Authority: MessageTypeDefinition
-        CollectionEntry: MessageTypeDefinition
-        ContextParams: MessageTypeDefinition
-        ResourceLocator: MessageTypeDefinition
-        TypedExtensionConfig: MessageTypeDefinition
+        Authority: MessageTypeDefinition<_xds_core_v3_Authority, _xds_core_v3_Authority__Output>
+        CollectionEntry: MessageTypeDefinition<_xds_core_v3_CollectionEntry, _xds_core_v3_CollectionEntry__Output>
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
+        ResourceLocator: MessageTypeDefinition<_xds_core_v3_ResourceLocator, _xds_core_v3_ResourceLocator__Output>
+        TypedExtensionConfig: MessageTypeDefinition<_xds_core_v3_TypedExtensionConfig, _xds_core_v3_TypedExtensionConfig__Output>
       }
     }
     type: {
       matcher: {
         v3: {
-          ListStringMatcher: MessageTypeDefinition
-          Matcher: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
+          ListStringMatcher: MessageTypeDefinition<_xds_type_matcher_v3_ListStringMatcher, _xds_type_matcher_v3_ListStringMatcher__Output>
+          Matcher: MessageTypeDefinition<_xds_type_matcher_v3_Matcher, _xds_type_matcher_v3_Matcher__Output>
+          RegexMatcher: MessageTypeDefinition<_xds_type_matcher_v3_RegexMatcher, _xds_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_xds_type_matcher_v3_StringMatcher, _xds_type_matcher_v3_StringMatcher__Output>
         }
       }
     }

--- a/packages/grpc-js-xds/src/generated/lrs.ts
+++ b/packages/grpc-js-xds/src/generated/lrs.ts
@@ -1,7 +1,125 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { ClusterStats as _envoy_config_endpoint_v3_ClusterStats, ClusterStats__Output as _envoy_config_endpoint_v3_ClusterStats__Output } from './envoy/config/endpoint/v3/ClusterStats';
+import type { EndpointLoadMetricStats as _envoy_config_endpoint_v3_EndpointLoadMetricStats, EndpointLoadMetricStats__Output as _envoy_config_endpoint_v3_EndpointLoadMetricStats__Output } from './envoy/config/endpoint/v3/EndpointLoadMetricStats';
+import type { UnnamedEndpointLoadMetricStats as _envoy_config_endpoint_v3_UnnamedEndpointLoadMetricStats, UnnamedEndpointLoadMetricStats__Output as _envoy_config_endpoint_v3_UnnamedEndpointLoadMetricStats__Output } from './envoy/config/endpoint/v3/UnnamedEndpointLoadMetricStats';
+import type { UpstreamEndpointStats as _envoy_config_endpoint_v3_UpstreamEndpointStats, UpstreamEndpointStats__Output as _envoy_config_endpoint_v3_UpstreamEndpointStats__Output } from './envoy/config/endpoint/v3/UpstreamEndpointStats';
+import type { UpstreamLocalityStats as _envoy_config_endpoint_v3_UpstreamLocalityStats, UpstreamLocalityStats__Output as _envoy_config_endpoint_v3_UpstreamLocalityStats__Output } from './envoy/config/endpoint/v3/UpstreamLocalityStats';
 import type { LoadReportingServiceClient as _envoy_service_load_stats_v3_LoadReportingServiceClient, LoadReportingServiceDefinition as _envoy_service_load_stats_v3_LoadReportingServiceDefinition } from './envoy/service/load_stats/v3/LoadReportingService';
+import type { LoadStatsRequest as _envoy_service_load_stats_v3_LoadStatsRequest, LoadStatsRequest__Output as _envoy_service_load_stats_v3_LoadStatsRequest__Output } from './envoy/service/load_stats/v3/LoadStatsRequest';
+import type { LoadStatsResponse as _envoy_service_load_stats_v3_LoadStatsResponse, LoadStatsResponse__Output as _envoy_service_load_stats_v3_LoadStatsResponse__Output } from './envoy/service/load_stats/v3/LoadStatsResponse';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -14,55 +132,55 @@ export interface ProtoGrpcType {
     config: {
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
       endpoint: {
         v3: {
-          ClusterStats: MessageTypeDefinition
-          EndpointLoadMetricStats: MessageTypeDefinition
-          UnnamedEndpointLoadMetricStats: MessageTypeDefinition
-          UpstreamEndpointStats: MessageTypeDefinition
-          UpstreamLocalityStats: MessageTypeDefinition
+          ClusterStats: MessageTypeDefinition<_envoy_config_endpoint_v3_ClusterStats, _envoy_config_endpoint_v3_ClusterStats__Output>
+          EndpointLoadMetricStats: MessageTypeDefinition<_envoy_config_endpoint_v3_EndpointLoadMetricStats, _envoy_config_endpoint_v3_EndpointLoadMetricStats__Output>
+          UnnamedEndpointLoadMetricStats: MessageTypeDefinition<_envoy_config_endpoint_v3_UnnamedEndpointLoadMetricStats, _envoy_config_endpoint_v3_UnnamedEndpointLoadMetricStats__Output>
+          UpstreamEndpointStats: MessageTypeDefinition<_envoy_config_endpoint_v3_UpstreamEndpointStats, _envoy_config_endpoint_v3_UpstreamEndpointStats__Output>
+          UpstreamLocalityStats: MessageTypeDefinition<_envoy_config_endpoint_v3_UpstreamLocalityStats, _envoy_config_endpoint_v3_UpstreamLocalityStats__Output>
         }
       }
     }
@@ -70,113 +188,113 @@ export interface ProtoGrpcType {
       load_stats: {
         v3: {
           LoadReportingService: SubtypeConstructor<typeof grpc.Client, _envoy_service_load_stats_v3_LoadReportingServiceClient> & { service: _envoy_service_load_stats_v3_LoadReportingServiceDefinition }
-          LoadStatsRequest: MessageTypeDefinition
-          LoadStatsResponse: MessageTypeDefinition
+          LoadStatsRequest: MessageTypeDefinition<_envoy_service_load_stats_v3_LoadStatsRequest, _envoy_service_load_stats_v3_LoadStatsRequest__Output>
+          LoadStatsResponse: MessageTypeDefinition<_envoy_service_load_stats_v3_LoadStatsResponse, _envoy_service_load_stats_v3_LoadStatsResponse__Output>
         }
       }
     }
     type: {
       v3: {
-        FractionalPercent: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        ContextParams: MessageTypeDefinition
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
       }
     }
   }

--- a/packages/grpc-js-xds/src/generated/pick_first.ts
+++ b/packages/grpc-js-xds/src/generated/pick_first.ts
@@ -1,6 +1,31 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { PickFirst as _envoy_extensions_load_balancing_policies_pick_first_v3_PickFirst, PickFirst__Output as _envoy_extensions_load_balancing_policies_pick_first_v3_PickFirst__Output } from './envoy/extensions/load_balancing_policies/pick_first/v3/PickFirst';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -12,7 +37,7 @@ export interface ProtoGrpcType {
       load_balancing_policies: {
         pick_first: {
           v3: {
-            PickFirst: MessageTypeDefinition
+            PickFirst: MessageTypeDefinition<_envoy_extensions_load_balancing_policies_pick_first_v3_PickFirst, _envoy_extensions_load_balancing_policies_pick_first_v3_PickFirst__Output>
           }
         }
       }
@@ -20,37 +45,37 @@ export interface ProtoGrpcType {
   }
   google: {
     protobuf: {
-      DescriptorProto: MessageTypeDefinition
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
       Edition: EnumTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
       SymbolVisibility: EnumTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
     }
   }
   udpa: {
     annotations: {
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
     }
   }
 }

--- a/packages/grpc-js-xds/src/generated/rbac.ts
+++ b/packages/grpc-js-xds/src/generated/rbac.ts
@@ -1,6 +1,180 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { ProxyProtocolConfig as _envoy_config_core_v3_ProxyProtocolConfig, ProxyProtocolConfig__Output as _envoy_config_core_v3_ProxyProtocolConfig__Output } from './envoy/config/core/v3/ProxyProtocolConfig';
+import type { ProxyProtocolPassThroughTLVs as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs, ProxyProtocolPassThroughTLVs__Output as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output } from './envoy/config/core/v3/ProxyProtocolPassThroughTLVs';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { Action as _envoy_config_rbac_v3_Action, Action__Output as _envoy_config_rbac_v3_Action__Output } from './envoy/config/rbac/v3/Action';
+import type { Permission as _envoy_config_rbac_v3_Permission, Permission__Output as _envoy_config_rbac_v3_Permission__Output } from './envoy/config/rbac/v3/Permission';
+import type { Policy as _envoy_config_rbac_v3_Policy, Policy__Output as _envoy_config_rbac_v3_Policy__Output } from './envoy/config/rbac/v3/Policy';
+import type { Principal as _envoy_config_rbac_v3_Principal, Principal__Output as _envoy_config_rbac_v3_Principal__Output } from './envoy/config/rbac/v3/Principal';
+import type { RBAC as _envoy_config_rbac_v3_RBAC, RBAC__Output as _envoy_config_rbac_v3_RBAC__Output } from './envoy/config/rbac/v3/RBAC';
+import type { ClusterSpecifierPlugin as _envoy_config_route_v3_ClusterSpecifierPlugin, ClusterSpecifierPlugin__Output as _envoy_config_route_v3_ClusterSpecifierPlugin__Output } from './envoy/config/route/v3/ClusterSpecifierPlugin';
+import type { CorsPolicy as _envoy_config_route_v3_CorsPolicy, CorsPolicy__Output as _envoy_config_route_v3_CorsPolicy__Output } from './envoy/config/route/v3/CorsPolicy';
+import type { Decorator as _envoy_config_route_v3_Decorator, Decorator__Output as _envoy_config_route_v3_Decorator__Output } from './envoy/config/route/v3/Decorator';
+import type { DirectResponseAction as _envoy_config_route_v3_DirectResponseAction, DirectResponseAction__Output as _envoy_config_route_v3_DirectResponseAction__Output } from './envoy/config/route/v3/DirectResponseAction';
+import type { FilterAction as _envoy_config_route_v3_FilterAction, FilterAction__Output as _envoy_config_route_v3_FilterAction__Output } from './envoy/config/route/v3/FilterAction';
+import type { FilterConfig as _envoy_config_route_v3_FilterConfig, FilterConfig__Output as _envoy_config_route_v3_FilterConfig__Output } from './envoy/config/route/v3/FilterConfig';
+import type { HeaderMatcher as _envoy_config_route_v3_HeaderMatcher, HeaderMatcher__Output as _envoy_config_route_v3_HeaderMatcher__Output } from './envoy/config/route/v3/HeaderMatcher';
+import type { HedgePolicy as _envoy_config_route_v3_HedgePolicy, HedgePolicy__Output as _envoy_config_route_v3_HedgePolicy__Output } from './envoy/config/route/v3/HedgePolicy';
+import type { InternalRedirectPolicy as _envoy_config_route_v3_InternalRedirectPolicy, InternalRedirectPolicy__Output as _envoy_config_route_v3_InternalRedirectPolicy__Output } from './envoy/config/route/v3/InternalRedirectPolicy';
+import type { NonForwardingAction as _envoy_config_route_v3_NonForwardingAction, NonForwardingAction__Output as _envoy_config_route_v3_NonForwardingAction__Output } from './envoy/config/route/v3/NonForwardingAction';
+import type { QueryParameterMatcher as _envoy_config_route_v3_QueryParameterMatcher, QueryParameterMatcher__Output as _envoy_config_route_v3_QueryParameterMatcher__Output } from './envoy/config/route/v3/QueryParameterMatcher';
+import type { RateLimit as _envoy_config_route_v3_RateLimit, RateLimit__Output as _envoy_config_route_v3_RateLimit__Output } from './envoy/config/route/v3/RateLimit';
+import type { RedirectAction as _envoy_config_route_v3_RedirectAction, RedirectAction__Output as _envoy_config_route_v3_RedirectAction__Output } from './envoy/config/route/v3/RedirectAction';
+import type { RetryPolicy as _envoy_config_route_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_route_v3_RetryPolicy__Output } from './envoy/config/route/v3/RetryPolicy';
+import type { Route as _envoy_config_route_v3_Route, Route__Output as _envoy_config_route_v3_Route__Output } from './envoy/config/route/v3/Route';
+import type { RouteAction as _envoy_config_route_v3_RouteAction, RouteAction__Output as _envoy_config_route_v3_RouteAction__Output } from './envoy/config/route/v3/RouteAction';
+import type { RouteList as _envoy_config_route_v3_RouteList, RouteList__Output as _envoy_config_route_v3_RouteList__Output } from './envoy/config/route/v3/RouteList';
+import type { RouteMatch as _envoy_config_route_v3_RouteMatch, RouteMatch__Output as _envoy_config_route_v3_RouteMatch__Output } from './envoy/config/route/v3/RouteMatch';
+import type { Tracing as _envoy_config_route_v3_Tracing, Tracing__Output as _envoy_config_route_v3_Tracing__Output } from './envoy/config/route/v3/Tracing';
+import type { VirtualCluster as _envoy_config_route_v3_VirtualCluster, VirtualCluster__Output as _envoy_config_route_v3_VirtualCluster__Output } from './envoy/config/route/v3/VirtualCluster';
+import type { VirtualHost as _envoy_config_route_v3_VirtualHost, VirtualHost__Output as _envoy_config_route_v3_VirtualHost__Output } from './envoy/config/route/v3/VirtualHost';
+import type { WeightedCluster as _envoy_config_route_v3_WeightedCluster, WeightedCluster__Output as _envoy_config_route_v3_WeightedCluster__Output } from './envoy/config/route/v3/WeightedCluster';
+import type { RBAC as _envoy_extensions_filters_http_rbac_v3_RBAC, RBAC__Output as _envoy_extensions_filters_http_rbac_v3_RBAC__Output } from './envoy/extensions/filters/http/rbac/v3/RBAC';
+import type { RBACPerRoute as _envoy_extensions_filters_http_rbac_v3_RBACPerRoute, RBACPerRoute__Output as _envoy_extensions_filters_http_rbac_v3_RBACPerRoute__Output } from './envoy/extensions/filters/http/rbac/v3/RBACPerRoute';
+import type { DoubleMatcher as _envoy_type_matcher_v3_DoubleMatcher, DoubleMatcher__Output as _envoy_type_matcher_v3_DoubleMatcher__Output } from './envoy/type/matcher/v3/DoubleMatcher';
+import type { FilterStateMatcher as _envoy_type_matcher_v3_FilterStateMatcher, FilterStateMatcher__Output as _envoy_type_matcher_v3_FilterStateMatcher__Output } from './envoy/type/matcher/v3/FilterStateMatcher';
+import type { ListMatcher as _envoy_type_matcher_v3_ListMatcher, ListMatcher__Output as _envoy_type_matcher_v3_ListMatcher__Output } from './envoy/type/matcher/v3/ListMatcher';
+import type { ListStringMatcher as _envoy_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _envoy_type_matcher_v3_ListStringMatcher__Output } from './envoy/type/matcher/v3/ListStringMatcher';
+import type { MetadataMatcher as _envoy_type_matcher_v3_MetadataMatcher, MetadataMatcher__Output as _envoy_type_matcher_v3_MetadataMatcher__Output } from './envoy/type/matcher/v3/MetadataMatcher';
+import type { OrMatcher as _envoy_type_matcher_v3_OrMatcher, OrMatcher__Output as _envoy_type_matcher_v3_OrMatcher__Output } from './envoy/type/matcher/v3/OrMatcher';
+import type { PathMatcher as _envoy_type_matcher_v3_PathMatcher, PathMatcher__Output as _envoy_type_matcher_v3_PathMatcher__Output } from './envoy/type/matcher/v3/PathMatcher';
+import type { RegexMatchAndSubstitute as _envoy_type_matcher_v3_RegexMatchAndSubstitute, RegexMatchAndSubstitute__Output as _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output } from './envoy/type/matcher/v3/RegexMatchAndSubstitute';
+import type { RegexMatcher as _envoy_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _envoy_type_matcher_v3_RegexMatcher__Output } from './envoy/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _envoy_type_matcher_v3_StringMatcher, StringMatcher__Output as _envoy_type_matcher_v3_StringMatcher__Output } from './envoy/type/matcher/v3/StringMatcher';
+import type { ValueMatcher as _envoy_type_matcher_v3_ValueMatcher, ValueMatcher__Output as _envoy_type_matcher_v3_ValueMatcher__Output } from './envoy/type/matcher/v3/ValueMatcher';
+import type { MetadataKey as _envoy_type_metadata_v3_MetadataKey, MetadataKey__Output as _envoy_type_metadata_v3_MetadataKey__Output } from './envoy/type/metadata/v3/MetadataKey';
+import type { MetadataKind as _envoy_type_metadata_v3_MetadataKind, MetadataKind__Output as _envoy_type_metadata_v3_MetadataKind__Output } from './envoy/type/metadata/v3/MetadataKind';
+import type { CustomTag as _envoy_type_tracing_v3_CustomTag, CustomTag__Output as _envoy_type_tracing_v3_CustomTag__Output } from './envoy/type/tracing/v3/CustomTag';
+import type { DoubleRange as _envoy_type_v3_DoubleRange, DoubleRange__Output as _envoy_type_v3_DoubleRange__Output } from './envoy/type/v3/DoubleRange';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Int32Range as _envoy_type_v3_Int32Range, Int32Range__Output as _envoy_type_v3_Int32Range__Output } from './envoy/type/v3/Int32Range';
+import type { Int64Range as _envoy_type_v3_Int64Range, Int64Range__Output as _envoy_type_v3_Int64Range__Output } from './envoy/type/v3/Int64Range';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { CheckedExpr as _google_api_expr_v1alpha1_CheckedExpr, CheckedExpr__Output as _google_api_expr_v1alpha1_CheckedExpr__Output } from './google/api/expr/v1alpha1/CheckedExpr';
+import type { Constant as _google_api_expr_v1alpha1_Constant, Constant__Output as _google_api_expr_v1alpha1_Constant__Output } from './google/api/expr/v1alpha1/Constant';
+import type { Decl as _google_api_expr_v1alpha1_Decl, Decl__Output as _google_api_expr_v1alpha1_Decl__Output } from './google/api/expr/v1alpha1/Decl';
+import type { Expr as _google_api_expr_v1alpha1_Expr, Expr__Output as _google_api_expr_v1alpha1_Expr__Output } from './google/api/expr/v1alpha1/Expr';
+import type { ParsedExpr as _google_api_expr_v1alpha1_ParsedExpr, ParsedExpr__Output as _google_api_expr_v1alpha1_ParsedExpr__Output } from './google/api/expr/v1alpha1/ParsedExpr';
+import type { Reference as _google_api_expr_v1alpha1_Reference, Reference__Output as _google_api_expr_v1alpha1_Reference__Output } from './google/api/expr/v1alpha1/Reference';
+import type { SourceInfo as _google_api_expr_v1alpha1_SourceInfo, SourceInfo__Output as _google_api_expr_v1alpha1_SourceInfo__Output } from './google/api/expr/v1alpha1/SourceInfo';
+import type { SourcePosition as _google_api_expr_v1alpha1_SourcePosition, SourcePosition__Output as _google_api_expr_v1alpha1_SourcePosition__Output } from './google/api/expr/v1alpha1/SourcePosition';
+import type { Type as _google_api_expr_v1alpha1_Type, Type__Output as _google_api_expr_v1alpha1_Type__Output } from './google/api/expr/v1alpha1/Type';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from './google/protobuf/Empty';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
+import type { TypedExtensionConfig as _xds_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _xds_core_v3_TypedExtensionConfig__Output } from './xds/core/v3/TypedExtensionConfig';
+import type { ListStringMatcher as _xds_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _xds_type_matcher_v3_ListStringMatcher__Output } from './xds/type/matcher/v3/ListStringMatcher';
+import type { Matcher as _xds_type_matcher_v3_Matcher, Matcher__Output as _xds_type_matcher_v3_Matcher__Output } from './xds/type/matcher/v3/Matcher';
+import type { RegexMatcher as _xds_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _xds_type_matcher_v3_RegexMatcher__Output } from './xds/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _xds_type_matcher_v3_StringMatcher, StringMatcher__Output as _xds_type_matcher_v3_StringMatcher__Output } from './xds/type/matcher/v3/StringMatcher';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -13,83 +187,83 @@ export interface ProtoGrpcType {
     config: {
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          ProxyProtocolConfig: MessageTypeDefinition
-          ProxyProtocolPassThroughTLVs: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          ProxyProtocolConfig: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolConfig, _envoy_config_core_v3_ProxyProtocolConfig__Output>
+          ProxyProtocolPassThroughTLVs: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolPassThroughTLVs, _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
       rbac: {
         v3: {
-          Action: MessageTypeDefinition
-          Permission: MessageTypeDefinition
-          Policy: MessageTypeDefinition
-          Principal: MessageTypeDefinition
-          RBAC: MessageTypeDefinition
+          Action: MessageTypeDefinition<_envoy_config_rbac_v3_Action, _envoy_config_rbac_v3_Action__Output>
+          Permission: MessageTypeDefinition<_envoy_config_rbac_v3_Permission, _envoy_config_rbac_v3_Permission__Output>
+          Policy: MessageTypeDefinition<_envoy_config_rbac_v3_Policy, _envoy_config_rbac_v3_Policy__Output>
+          Principal: MessageTypeDefinition<_envoy_config_rbac_v3_Principal, _envoy_config_rbac_v3_Principal__Output>
+          RBAC: MessageTypeDefinition<_envoy_config_rbac_v3_RBAC, _envoy_config_rbac_v3_RBAC__Output>
         }
       }
       route: {
         v3: {
-          ClusterSpecifierPlugin: MessageTypeDefinition
-          CorsPolicy: MessageTypeDefinition
-          Decorator: MessageTypeDefinition
-          DirectResponseAction: MessageTypeDefinition
-          FilterAction: MessageTypeDefinition
-          FilterConfig: MessageTypeDefinition
-          HeaderMatcher: MessageTypeDefinition
-          HedgePolicy: MessageTypeDefinition
-          InternalRedirectPolicy: MessageTypeDefinition
-          NonForwardingAction: MessageTypeDefinition
-          QueryParameterMatcher: MessageTypeDefinition
-          RateLimit: MessageTypeDefinition
-          RedirectAction: MessageTypeDefinition
-          RetryPolicy: MessageTypeDefinition
-          Route: MessageTypeDefinition
-          RouteAction: MessageTypeDefinition
-          RouteList: MessageTypeDefinition
-          RouteMatch: MessageTypeDefinition
-          Tracing: MessageTypeDefinition
-          VirtualCluster: MessageTypeDefinition
-          VirtualHost: MessageTypeDefinition
-          WeightedCluster: MessageTypeDefinition
+          ClusterSpecifierPlugin: MessageTypeDefinition<_envoy_config_route_v3_ClusterSpecifierPlugin, _envoy_config_route_v3_ClusterSpecifierPlugin__Output>
+          CorsPolicy: MessageTypeDefinition<_envoy_config_route_v3_CorsPolicy, _envoy_config_route_v3_CorsPolicy__Output>
+          Decorator: MessageTypeDefinition<_envoy_config_route_v3_Decorator, _envoy_config_route_v3_Decorator__Output>
+          DirectResponseAction: MessageTypeDefinition<_envoy_config_route_v3_DirectResponseAction, _envoy_config_route_v3_DirectResponseAction__Output>
+          FilterAction: MessageTypeDefinition<_envoy_config_route_v3_FilterAction, _envoy_config_route_v3_FilterAction__Output>
+          FilterConfig: MessageTypeDefinition<_envoy_config_route_v3_FilterConfig, _envoy_config_route_v3_FilterConfig__Output>
+          HeaderMatcher: MessageTypeDefinition<_envoy_config_route_v3_HeaderMatcher, _envoy_config_route_v3_HeaderMatcher__Output>
+          HedgePolicy: MessageTypeDefinition<_envoy_config_route_v3_HedgePolicy, _envoy_config_route_v3_HedgePolicy__Output>
+          InternalRedirectPolicy: MessageTypeDefinition<_envoy_config_route_v3_InternalRedirectPolicy, _envoy_config_route_v3_InternalRedirectPolicy__Output>
+          NonForwardingAction: MessageTypeDefinition<_envoy_config_route_v3_NonForwardingAction, _envoy_config_route_v3_NonForwardingAction__Output>
+          QueryParameterMatcher: MessageTypeDefinition<_envoy_config_route_v3_QueryParameterMatcher, _envoy_config_route_v3_QueryParameterMatcher__Output>
+          RateLimit: MessageTypeDefinition<_envoy_config_route_v3_RateLimit, _envoy_config_route_v3_RateLimit__Output>
+          RedirectAction: MessageTypeDefinition<_envoy_config_route_v3_RedirectAction, _envoy_config_route_v3_RedirectAction__Output>
+          RetryPolicy: MessageTypeDefinition<_envoy_config_route_v3_RetryPolicy, _envoy_config_route_v3_RetryPolicy__Output>
+          Route: MessageTypeDefinition<_envoy_config_route_v3_Route, _envoy_config_route_v3_Route__Output>
+          RouteAction: MessageTypeDefinition<_envoy_config_route_v3_RouteAction, _envoy_config_route_v3_RouteAction__Output>
+          RouteList: MessageTypeDefinition<_envoy_config_route_v3_RouteList, _envoy_config_route_v3_RouteList__Output>
+          RouteMatch: MessageTypeDefinition<_envoy_config_route_v3_RouteMatch, _envoy_config_route_v3_RouteMatch__Output>
+          Tracing: MessageTypeDefinition<_envoy_config_route_v3_Tracing, _envoy_config_route_v3_Tracing__Output>
+          VirtualCluster: MessageTypeDefinition<_envoy_config_route_v3_VirtualCluster, _envoy_config_route_v3_VirtualCluster__Output>
+          VirtualHost: MessageTypeDefinition<_envoy_config_route_v3_VirtualHost, _envoy_config_route_v3_VirtualHost__Output>
+          WeightedCluster: MessageTypeDefinition<_envoy_config_route_v3_WeightedCluster, _envoy_config_route_v3_WeightedCluster__Output>
         }
       }
     }
@@ -98,8 +272,8 @@ export interface ProtoGrpcType {
         http: {
           rbac: {
             v3: {
-              RBAC: MessageTypeDefinition
-              RBACPerRoute: MessageTypeDefinition
+              RBAC: MessageTypeDefinition<_envoy_extensions_filters_http_rbac_v3_RBAC, _envoy_extensions_filters_http_rbac_v3_RBAC__Output>
+              RBACPerRoute: MessageTypeDefinition<_envoy_extensions_filters_http_rbac_v3_RBACPerRoute, _envoy_extensions_filters_http_rbac_v3_RBACPerRoute__Output>
             }
           }
         }
@@ -108,37 +282,37 @@ export interface ProtoGrpcType {
     type: {
       matcher: {
         v3: {
-          DoubleMatcher: MessageTypeDefinition
-          FilterStateMatcher: MessageTypeDefinition
-          ListMatcher: MessageTypeDefinition
-          ListStringMatcher: MessageTypeDefinition
-          MetadataMatcher: MessageTypeDefinition
-          OrMatcher: MessageTypeDefinition
-          PathMatcher: MessageTypeDefinition
-          RegexMatchAndSubstitute: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
-          ValueMatcher: MessageTypeDefinition
+          DoubleMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_DoubleMatcher, _envoy_type_matcher_v3_DoubleMatcher__Output>
+          FilterStateMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_FilterStateMatcher, _envoy_type_matcher_v3_FilterStateMatcher__Output>
+          ListMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListMatcher, _envoy_type_matcher_v3_ListMatcher__Output>
+          ListStringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListStringMatcher, _envoy_type_matcher_v3_ListStringMatcher__Output>
+          MetadataMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_MetadataMatcher, _envoy_type_matcher_v3_MetadataMatcher__Output>
+          OrMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_OrMatcher, _envoy_type_matcher_v3_OrMatcher__Output>
+          PathMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_PathMatcher, _envoy_type_matcher_v3_PathMatcher__Output>
+          RegexMatchAndSubstitute: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatchAndSubstitute, _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output>
+          RegexMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatcher, _envoy_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_StringMatcher, _envoy_type_matcher_v3_StringMatcher__Output>
+          ValueMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ValueMatcher, _envoy_type_matcher_v3_ValueMatcher__Output>
         }
       }
       metadata: {
         v3: {
-          MetadataKey: MessageTypeDefinition
-          MetadataKind: MessageTypeDefinition
+          MetadataKey: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKey, _envoy_type_metadata_v3_MetadataKey__Output>
+          MetadataKind: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKind, _envoy_type_metadata_v3_MetadataKind__Output>
         }
       }
       tracing: {
         v3: {
-          CustomTag: MessageTypeDefinition
+          CustomTag: MessageTypeDefinition<_envoy_type_tracing_v3_CustomTag, _envoy_type_tracing_v3_CustomTag__Output>
         }
       }
       v3: {
-        DoubleRange: MessageTypeDefinition
-        FractionalPercent: MessageTypeDefinition
-        Int32Range: MessageTypeDefinition
-        Int64Range: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        DoubleRange: MessageTypeDefinition<_envoy_type_v3_DoubleRange, _envoy_type_v3_DoubleRange__Output>
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Int32Range: MessageTypeDefinition<_envoy_type_v3_Int32Range, _envoy_type_v3_Int32Range__Output>
+        Int64Range: MessageTypeDefinition<_envoy_type_v3_Int64Range, _envoy_type_v3_Int64Range__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
@@ -146,122 +320,122 @@ export interface ProtoGrpcType {
     api: {
       expr: {
         v1alpha1: {
-          CheckedExpr: MessageTypeDefinition
-          Constant: MessageTypeDefinition
-          Decl: MessageTypeDefinition
-          Expr: MessageTypeDefinition
-          ParsedExpr: MessageTypeDefinition
-          Reference: MessageTypeDefinition
-          SourceInfo: MessageTypeDefinition
-          SourcePosition: MessageTypeDefinition
-          Type: MessageTypeDefinition
+          CheckedExpr: MessageTypeDefinition<_google_api_expr_v1alpha1_CheckedExpr, _google_api_expr_v1alpha1_CheckedExpr__Output>
+          Constant: MessageTypeDefinition<_google_api_expr_v1alpha1_Constant, _google_api_expr_v1alpha1_Constant__Output>
+          Decl: MessageTypeDefinition<_google_api_expr_v1alpha1_Decl, _google_api_expr_v1alpha1_Decl__Output>
+          Expr: MessageTypeDefinition<_google_api_expr_v1alpha1_Expr, _google_api_expr_v1alpha1_Expr__Output>
+          ParsedExpr: MessageTypeDefinition<_google_api_expr_v1alpha1_ParsedExpr, _google_api_expr_v1alpha1_ParsedExpr__Output>
+          Reference: MessageTypeDefinition<_google_api_expr_v1alpha1_Reference, _google_api_expr_v1alpha1_Reference__Output>
+          SourceInfo: MessageTypeDefinition<_google_api_expr_v1alpha1_SourceInfo, _google_api_expr_v1alpha1_SourceInfo__Output>
+          SourcePosition: MessageTypeDefinition<_google_api_expr_v1alpha1_SourcePosition, _google_api_expr_v1alpha1_SourcePosition__Output>
+          Type: MessageTypeDefinition<_google_api_expr_v1alpha1_Type, _google_api_expr_v1alpha1_Type__Output>
         }
       }
     }
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      Empty: MessageTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      Empty: MessageTypeDefinition<_google_protobuf_Empty, _google_protobuf_Empty__Output>
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        ContextParams: MessageTypeDefinition
-        TypedExtensionConfig: MessageTypeDefinition
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
+        TypedExtensionConfig: MessageTypeDefinition<_xds_core_v3_TypedExtensionConfig, _xds_core_v3_TypedExtensionConfig__Output>
       }
     }
     type: {
       matcher: {
         v3: {
-          ListStringMatcher: MessageTypeDefinition
-          Matcher: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
+          ListStringMatcher: MessageTypeDefinition<_xds_type_matcher_v3_ListStringMatcher, _xds_type_matcher_v3_ListStringMatcher__Output>
+          Matcher: MessageTypeDefinition<_xds_type_matcher_v3_Matcher, _xds_type_matcher_v3_Matcher__Output>
+          RegexMatcher: MessageTypeDefinition<_xds_type_matcher_v3_RegexMatcher, _xds_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_xds_type_matcher_v3_StringMatcher, _xds_type_matcher_v3_StringMatcher__Output>
         }
       }
     }

--- a/packages/grpc-js-xds/src/generated/ring_hash.ts
+++ b/packages/grpc-js-xds/src/generated/ring_hash.ts
@@ -1,6 +1,121 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { ConsistentHashingLbConfig as _envoy_extensions_load_balancing_policies_common_v3_ConsistentHashingLbConfig, ConsistentHashingLbConfig__Output as _envoy_extensions_load_balancing_policies_common_v3_ConsistentHashingLbConfig__Output } from './envoy/extensions/load_balancing_policies/common/v3/ConsistentHashingLbConfig';
+import type { LocalityLbConfig as _envoy_extensions_load_balancing_policies_common_v3_LocalityLbConfig, LocalityLbConfig__Output as _envoy_extensions_load_balancing_policies_common_v3_LocalityLbConfig__Output } from './envoy/extensions/load_balancing_policies/common/v3/LocalityLbConfig';
+import type { SlowStartConfig as _envoy_extensions_load_balancing_policies_common_v3_SlowStartConfig, SlowStartConfig__Output as _envoy_extensions_load_balancing_policies_common_v3_SlowStartConfig__Output } from './envoy/extensions/load_balancing_policies/common/v3/SlowStartConfig';
+import type { RingHash as _envoy_extensions_load_balancing_policies_ring_hash_v3_RingHash, RingHash__Output as _envoy_extensions_load_balancing_policies_ring_hash_v3_RingHash__Output } from './envoy/extensions/load_balancing_policies/ring_hash/v3/RingHash';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -13,46 +128,46 @@ export interface ProtoGrpcType {
     config: {
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
     }
@@ -60,120 +175,120 @@ export interface ProtoGrpcType {
       load_balancing_policies: {
         common: {
           v3: {
-            ConsistentHashingLbConfig: MessageTypeDefinition
-            LocalityLbConfig: MessageTypeDefinition
-            SlowStartConfig: MessageTypeDefinition
+            ConsistentHashingLbConfig: MessageTypeDefinition<_envoy_extensions_load_balancing_policies_common_v3_ConsistentHashingLbConfig, _envoy_extensions_load_balancing_policies_common_v3_ConsistentHashingLbConfig__Output>
+            LocalityLbConfig: MessageTypeDefinition<_envoy_extensions_load_balancing_policies_common_v3_LocalityLbConfig, _envoy_extensions_load_balancing_policies_common_v3_LocalityLbConfig__Output>
+            SlowStartConfig: MessageTypeDefinition<_envoy_extensions_load_balancing_policies_common_v3_SlowStartConfig, _envoy_extensions_load_balancing_policies_common_v3_SlowStartConfig__Output>
           }
         }
         ring_hash: {
           v3: {
-            RingHash: MessageTypeDefinition
+            RingHash: MessageTypeDefinition<_envoy_extensions_load_balancing_policies_ring_hash_v3_RingHash, _envoy_extensions_load_balancing_policies_ring_hash_v3_RingHash__Output>
           }
         }
       }
     }
     type: {
       v3: {
-        FractionalPercent: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        ContextParams: MessageTypeDefinition
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
       }
     }
   }

--- a/packages/grpc-js-xds/src/generated/route.ts
+++ b/packages/grpc-js-xds/src/generated/route.ts
@@ -1,6 +1,173 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AggregatedConfigSource as _envoy_config_core_v3_AggregatedConfigSource, AggregatedConfigSource__Output as _envoy_config_core_v3_AggregatedConfigSource__Output } from './envoy/config/core/v3/AggregatedConfigSource';
+import type { ApiConfigSource as _envoy_config_core_v3_ApiConfigSource, ApiConfigSource__Output as _envoy_config_core_v3_ApiConfigSource__Output } from './envoy/config/core/v3/ApiConfigSource';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ConfigSource as _envoy_config_core_v3_ConfigSource, ConfigSource__Output as _envoy_config_core_v3_ConfigSource__Output } from './envoy/config/core/v3/ConfigSource';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtensionConfigSource as _envoy_config_core_v3_ExtensionConfigSource, ExtensionConfigSource__Output as _envoy_config_core_v3_ExtensionConfigSource__Output } from './envoy/config/core/v3/ExtensionConfigSource';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { GrpcService as _envoy_config_core_v3_GrpcService, GrpcService__Output as _envoy_config_core_v3_GrpcService__Output } from './envoy/config/core/v3/GrpcService';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { PathConfigSource as _envoy_config_core_v3_PathConfigSource, PathConfigSource__Output as _envoy_config_core_v3_PathConfigSource__Output } from './envoy/config/core/v3/PathConfigSource';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { ProxyProtocolConfig as _envoy_config_core_v3_ProxyProtocolConfig, ProxyProtocolConfig__Output as _envoy_config_core_v3_ProxyProtocolConfig__Output } from './envoy/config/core/v3/ProxyProtocolConfig';
+import type { ProxyProtocolPassThroughTLVs as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs, ProxyProtocolPassThroughTLVs__Output as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output } from './envoy/config/core/v3/ProxyProtocolPassThroughTLVs';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { RateLimitSettings as _envoy_config_core_v3_RateLimitSettings, RateLimitSettings__Output as _envoy_config_core_v3_RateLimitSettings__Output } from './envoy/config/core/v3/RateLimitSettings';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SelfConfigSource as _envoy_config_core_v3_SelfConfigSource, SelfConfigSource__Output as _envoy_config_core_v3_SelfConfigSource__Output } from './envoy/config/core/v3/SelfConfigSource';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { ClusterSpecifierPlugin as _envoy_config_route_v3_ClusterSpecifierPlugin, ClusterSpecifierPlugin__Output as _envoy_config_route_v3_ClusterSpecifierPlugin__Output } from './envoy/config/route/v3/ClusterSpecifierPlugin';
+import type { CorsPolicy as _envoy_config_route_v3_CorsPolicy, CorsPolicy__Output as _envoy_config_route_v3_CorsPolicy__Output } from './envoy/config/route/v3/CorsPolicy';
+import type { Decorator as _envoy_config_route_v3_Decorator, Decorator__Output as _envoy_config_route_v3_Decorator__Output } from './envoy/config/route/v3/Decorator';
+import type { DirectResponseAction as _envoy_config_route_v3_DirectResponseAction, DirectResponseAction__Output as _envoy_config_route_v3_DirectResponseAction__Output } from './envoy/config/route/v3/DirectResponseAction';
+import type { FilterAction as _envoy_config_route_v3_FilterAction, FilterAction__Output as _envoy_config_route_v3_FilterAction__Output } from './envoy/config/route/v3/FilterAction';
+import type { FilterConfig as _envoy_config_route_v3_FilterConfig, FilterConfig__Output as _envoy_config_route_v3_FilterConfig__Output } from './envoy/config/route/v3/FilterConfig';
+import type { HeaderMatcher as _envoy_config_route_v3_HeaderMatcher, HeaderMatcher__Output as _envoy_config_route_v3_HeaderMatcher__Output } from './envoy/config/route/v3/HeaderMatcher';
+import type { HedgePolicy as _envoy_config_route_v3_HedgePolicy, HedgePolicy__Output as _envoy_config_route_v3_HedgePolicy__Output } from './envoy/config/route/v3/HedgePolicy';
+import type { InternalRedirectPolicy as _envoy_config_route_v3_InternalRedirectPolicy, InternalRedirectPolicy__Output as _envoy_config_route_v3_InternalRedirectPolicy__Output } from './envoy/config/route/v3/InternalRedirectPolicy';
+import type { NonForwardingAction as _envoy_config_route_v3_NonForwardingAction, NonForwardingAction__Output as _envoy_config_route_v3_NonForwardingAction__Output } from './envoy/config/route/v3/NonForwardingAction';
+import type { QueryParameterMatcher as _envoy_config_route_v3_QueryParameterMatcher, QueryParameterMatcher__Output as _envoy_config_route_v3_QueryParameterMatcher__Output } from './envoy/config/route/v3/QueryParameterMatcher';
+import type { RateLimit as _envoy_config_route_v3_RateLimit, RateLimit__Output as _envoy_config_route_v3_RateLimit__Output } from './envoy/config/route/v3/RateLimit';
+import type { RedirectAction as _envoy_config_route_v3_RedirectAction, RedirectAction__Output as _envoy_config_route_v3_RedirectAction__Output } from './envoy/config/route/v3/RedirectAction';
+import type { RetryPolicy as _envoy_config_route_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_route_v3_RetryPolicy__Output } from './envoy/config/route/v3/RetryPolicy';
+import type { Route as _envoy_config_route_v3_Route, Route__Output as _envoy_config_route_v3_Route__Output } from './envoy/config/route/v3/Route';
+import type { RouteAction as _envoy_config_route_v3_RouteAction, RouteAction__Output as _envoy_config_route_v3_RouteAction__Output } from './envoy/config/route/v3/RouteAction';
+import type { RouteConfiguration as _envoy_config_route_v3_RouteConfiguration, RouteConfiguration__Output as _envoy_config_route_v3_RouteConfiguration__Output } from './envoy/config/route/v3/RouteConfiguration';
+import type { RouteList as _envoy_config_route_v3_RouteList, RouteList__Output as _envoy_config_route_v3_RouteList__Output } from './envoy/config/route/v3/RouteList';
+import type { RouteMatch as _envoy_config_route_v3_RouteMatch, RouteMatch__Output as _envoy_config_route_v3_RouteMatch__Output } from './envoy/config/route/v3/RouteMatch';
+import type { Tracing as _envoy_config_route_v3_Tracing, Tracing__Output as _envoy_config_route_v3_Tracing__Output } from './envoy/config/route/v3/Tracing';
+import type { Vhds as _envoy_config_route_v3_Vhds, Vhds__Output as _envoy_config_route_v3_Vhds__Output } from './envoy/config/route/v3/Vhds';
+import type { VirtualCluster as _envoy_config_route_v3_VirtualCluster, VirtualCluster__Output as _envoy_config_route_v3_VirtualCluster__Output } from './envoy/config/route/v3/VirtualCluster';
+import type { VirtualHost as _envoy_config_route_v3_VirtualHost, VirtualHost__Output as _envoy_config_route_v3_VirtualHost__Output } from './envoy/config/route/v3/VirtualHost';
+import type { WeightedCluster as _envoy_config_route_v3_WeightedCluster, WeightedCluster__Output as _envoy_config_route_v3_WeightedCluster__Output } from './envoy/config/route/v3/WeightedCluster';
+import type { DoubleMatcher as _envoy_type_matcher_v3_DoubleMatcher, DoubleMatcher__Output as _envoy_type_matcher_v3_DoubleMatcher__Output } from './envoy/type/matcher/v3/DoubleMatcher';
+import type { ListMatcher as _envoy_type_matcher_v3_ListMatcher, ListMatcher__Output as _envoy_type_matcher_v3_ListMatcher__Output } from './envoy/type/matcher/v3/ListMatcher';
+import type { ListStringMatcher as _envoy_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _envoy_type_matcher_v3_ListStringMatcher__Output } from './envoy/type/matcher/v3/ListStringMatcher';
+import type { MetadataMatcher as _envoy_type_matcher_v3_MetadataMatcher, MetadataMatcher__Output as _envoy_type_matcher_v3_MetadataMatcher__Output } from './envoy/type/matcher/v3/MetadataMatcher';
+import type { OrMatcher as _envoy_type_matcher_v3_OrMatcher, OrMatcher__Output as _envoy_type_matcher_v3_OrMatcher__Output } from './envoy/type/matcher/v3/OrMatcher';
+import type { RegexMatchAndSubstitute as _envoy_type_matcher_v3_RegexMatchAndSubstitute, RegexMatchAndSubstitute__Output as _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output } from './envoy/type/matcher/v3/RegexMatchAndSubstitute';
+import type { RegexMatcher as _envoy_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _envoy_type_matcher_v3_RegexMatcher__Output } from './envoy/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _envoy_type_matcher_v3_StringMatcher, StringMatcher__Output as _envoy_type_matcher_v3_StringMatcher__Output } from './envoy/type/matcher/v3/StringMatcher';
+import type { ValueMatcher as _envoy_type_matcher_v3_ValueMatcher, ValueMatcher__Output as _envoy_type_matcher_v3_ValueMatcher__Output } from './envoy/type/matcher/v3/ValueMatcher';
+import type { MetadataKey as _envoy_type_metadata_v3_MetadataKey, MetadataKey__Output as _envoy_type_metadata_v3_MetadataKey__Output } from './envoy/type/metadata/v3/MetadataKey';
+import type { MetadataKind as _envoy_type_metadata_v3_MetadataKind, MetadataKind__Output as _envoy_type_metadata_v3_MetadataKind__Output } from './envoy/type/metadata/v3/MetadataKind';
+import type { CustomTag as _envoy_type_tracing_v3_CustomTag, CustomTag__Output as _envoy_type_tracing_v3_CustomTag__Output } from './envoy/type/tracing/v3/CustomTag';
+import type { DoubleRange as _envoy_type_v3_DoubleRange, DoubleRange__Output as _envoy_type_v3_DoubleRange__Output } from './envoy/type/v3/DoubleRange';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Int32Range as _envoy_type_v3_Int32Range, Int32Range__Output as _envoy_type_v3_Int32Range__Output } from './envoy/type/v3/Int32Range';
+import type { Int64Range as _envoy_type_v3_Int64Range, Int64Range__Output as _envoy_type_v3_Int64Range__Output } from './envoy/type/v3/Int64Range';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from './google/protobuf/Empty';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { Authority as _xds_core_v3_Authority, Authority__Output as _xds_core_v3_Authority__Output } from './xds/core/v3/Authority';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
+import type { TypedExtensionConfig as _xds_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _xds_core_v3_TypedExtensionConfig__Output } from './xds/core/v3/TypedExtensionConfig';
+import type { ListStringMatcher as _xds_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _xds_type_matcher_v3_ListStringMatcher__Output } from './xds/type/matcher/v3/ListStringMatcher';
+import type { Matcher as _xds_type_matcher_v3_Matcher, Matcher__Output as _xds_type_matcher_v3_Matcher__Output } from './xds/type/matcher/v3/Matcher';
+import type { RegexMatcher as _xds_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _xds_type_matcher_v3_RegexMatcher__Output } from './xds/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _xds_type_matcher_v3_StringMatcher, StringMatcher__Output as _xds_type_matcher_v3_StringMatcher__Output } from './xds/type/matcher/v3/StringMatcher';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -13,229 +180,229 @@ export interface ProtoGrpcType {
     config: {
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AggregatedConfigSource: MessageTypeDefinition
-          ApiConfigSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AggregatedConfigSource: MessageTypeDefinition<_envoy_config_core_v3_AggregatedConfigSource, _envoy_config_core_v3_AggregatedConfigSource__Output>
+          ApiConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ApiConfigSource, _envoy_config_core_v3_ApiConfigSource__Output>
           ApiVersion: EnumTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ConfigSource: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtensionConfigSource: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          GrpcService: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          PathConfigSource: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          ProxyProtocolConfig: MessageTypeDefinition
-          ProxyProtocolPassThroughTLVs: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          RateLimitSettings: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ConfigSource, _envoy_config_core_v3_ConfigSource__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtensionConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ExtensionConfigSource, _envoy_config_core_v3_ExtensionConfigSource__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          GrpcService: MessageTypeDefinition<_envoy_config_core_v3_GrpcService, _envoy_config_core_v3_GrpcService__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          PathConfigSource: MessageTypeDefinition<_envoy_config_core_v3_PathConfigSource, _envoy_config_core_v3_PathConfigSource__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          ProxyProtocolConfig: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolConfig, _envoy_config_core_v3_ProxyProtocolConfig__Output>
+          ProxyProtocolPassThroughTLVs: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolPassThroughTLVs, _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          RateLimitSettings: MessageTypeDefinition<_envoy_config_core_v3_RateLimitSettings, _envoy_config_core_v3_RateLimitSettings__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SelfConfigSource: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SelfConfigSource: MessageTypeDefinition<_envoy_config_core_v3_SelfConfigSource, _envoy_config_core_v3_SelfConfigSource__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
       route: {
         v3: {
-          ClusterSpecifierPlugin: MessageTypeDefinition
-          CorsPolicy: MessageTypeDefinition
-          Decorator: MessageTypeDefinition
-          DirectResponseAction: MessageTypeDefinition
-          FilterAction: MessageTypeDefinition
-          FilterConfig: MessageTypeDefinition
-          HeaderMatcher: MessageTypeDefinition
-          HedgePolicy: MessageTypeDefinition
-          InternalRedirectPolicy: MessageTypeDefinition
-          NonForwardingAction: MessageTypeDefinition
-          QueryParameterMatcher: MessageTypeDefinition
-          RateLimit: MessageTypeDefinition
-          RedirectAction: MessageTypeDefinition
-          RetryPolicy: MessageTypeDefinition
-          Route: MessageTypeDefinition
-          RouteAction: MessageTypeDefinition
-          RouteConfiguration: MessageTypeDefinition
-          RouteList: MessageTypeDefinition
-          RouteMatch: MessageTypeDefinition
-          Tracing: MessageTypeDefinition
-          Vhds: MessageTypeDefinition
-          VirtualCluster: MessageTypeDefinition
-          VirtualHost: MessageTypeDefinition
-          WeightedCluster: MessageTypeDefinition
+          ClusterSpecifierPlugin: MessageTypeDefinition<_envoy_config_route_v3_ClusterSpecifierPlugin, _envoy_config_route_v3_ClusterSpecifierPlugin__Output>
+          CorsPolicy: MessageTypeDefinition<_envoy_config_route_v3_CorsPolicy, _envoy_config_route_v3_CorsPolicy__Output>
+          Decorator: MessageTypeDefinition<_envoy_config_route_v3_Decorator, _envoy_config_route_v3_Decorator__Output>
+          DirectResponseAction: MessageTypeDefinition<_envoy_config_route_v3_DirectResponseAction, _envoy_config_route_v3_DirectResponseAction__Output>
+          FilterAction: MessageTypeDefinition<_envoy_config_route_v3_FilterAction, _envoy_config_route_v3_FilterAction__Output>
+          FilterConfig: MessageTypeDefinition<_envoy_config_route_v3_FilterConfig, _envoy_config_route_v3_FilterConfig__Output>
+          HeaderMatcher: MessageTypeDefinition<_envoy_config_route_v3_HeaderMatcher, _envoy_config_route_v3_HeaderMatcher__Output>
+          HedgePolicy: MessageTypeDefinition<_envoy_config_route_v3_HedgePolicy, _envoy_config_route_v3_HedgePolicy__Output>
+          InternalRedirectPolicy: MessageTypeDefinition<_envoy_config_route_v3_InternalRedirectPolicy, _envoy_config_route_v3_InternalRedirectPolicy__Output>
+          NonForwardingAction: MessageTypeDefinition<_envoy_config_route_v3_NonForwardingAction, _envoy_config_route_v3_NonForwardingAction__Output>
+          QueryParameterMatcher: MessageTypeDefinition<_envoy_config_route_v3_QueryParameterMatcher, _envoy_config_route_v3_QueryParameterMatcher__Output>
+          RateLimit: MessageTypeDefinition<_envoy_config_route_v3_RateLimit, _envoy_config_route_v3_RateLimit__Output>
+          RedirectAction: MessageTypeDefinition<_envoy_config_route_v3_RedirectAction, _envoy_config_route_v3_RedirectAction__Output>
+          RetryPolicy: MessageTypeDefinition<_envoy_config_route_v3_RetryPolicy, _envoy_config_route_v3_RetryPolicy__Output>
+          Route: MessageTypeDefinition<_envoy_config_route_v3_Route, _envoy_config_route_v3_Route__Output>
+          RouteAction: MessageTypeDefinition<_envoy_config_route_v3_RouteAction, _envoy_config_route_v3_RouteAction__Output>
+          RouteConfiguration: MessageTypeDefinition<_envoy_config_route_v3_RouteConfiguration, _envoy_config_route_v3_RouteConfiguration__Output>
+          RouteList: MessageTypeDefinition<_envoy_config_route_v3_RouteList, _envoy_config_route_v3_RouteList__Output>
+          RouteMatch: MessageTypeDefinition<_envoy_config_route_v3_RouteMatch, _envoy_config_route_v3_RouteMatch__Output>
+          Tracing: MessageTypeDefinition<_envoy_config_route_v3_Tracing, _envoy_config_route_v3_Tracing__Output>
+          Vhds: MessageTypeDefinition<_envoy_config_route_v3_Vhds, _envoy_config_route_v3_Vhds__Output>
+          VirtualCluster: MessageTypeDefinition<_envoy_config_route_v3_VirtualCluster, _envoy_config_route_v3_VirtualCluster__Output>
+          VirtualHost: MessageTypeDefinition<_envoy_config_route_v3_VirtualHost, _envoy_config_route_v3_VirtualHost__Output>
+          WeightedCluster: MessageTypeDefinition<_envoy_config_route_v3_WeightedCluster, _envoy_config_route_v3_WeightedCluster__Output>
         }
       }
     }
     type: {
       matcher: {
         v3: {
-          DoubleMatcher: MessageTypeDefinition
-          ListMatcher: MessageTypeDefinition
-          ListStringMatcher: MessageTypeDefinition
-          MetadataMatcher: MessageTypeDefinition
-          OrMatcher: MessageTypeDefinition
-          RegexMatchAndSubstitute: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
-          ValueMatcher: MessageTypeDefinition
+          DoubleMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_DoubleMatcher, _envoy_type_matcher_v3_DoubleMatcher__Output>
+          ListMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListMatcher, _envoy_type_matcher_v3_ListMatcher__Output>
+          ListStringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListStringMatcher, _envoy_type_matcher_v3_ListStringMatcher__Output>
+          MetadataMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_MetadataMatcher, _envoy_type_matcher_v3_MetadataMatcher__Output>
+          OrMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_OrMatcher, _envoy_type_matcher_v3_OrMatcher__Output>
+          RegexMatchAndSubstitute: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatchAndSubstitute, _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output>
+          RegexMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatcher, _envoy_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_StringMatcher, _envoy_type_matcher_v3_StringMatcher__Output>
+          ValueMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ValueMatcher, _envoy_type_matcher_v3_ValueMatcher__Output>
         }
       }
       metadata: {
         v3: {
-          MetadataKey: MessageTypeDefinition
-          MetadataKind: MessageTypeDefinition
+          MetadataKey: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKey, _envoy_type_metadata_v3_MetadataKey__Output>
+          MetadataKind: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKind, _envoy_type_metadata_v3_MetadataKind__Output>
         }
       }
       tracing: {
         v3: {
-          CustomTag: MessageTypeDefinition
+          CustomTag: MessageTypeDefinition<_envoy_type_tracing_v3_CustomTag, _envoy_type_tracing_v3_CustomTag__Output>
         }
       }
       v3: {
-        DoubleRange: MessageTypeDefinition
-        FractionalPercent: MessageTypeDefinition
-        Int32Range: MessageTypeDefinition
-        Int64Range: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        DoubleRange: MessageTypeDefinition<_envoy_type_v3_DoubleRange, _envoy_type_v3_DoubleRange__Output>
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Int32Range: MessageTypeDefinition<_envoy_type_v3_Int32Range, _envoy_type_v3_Int32Range__Output>
+        Int64Range: MessageTypeDefinition<_envoy_type_v3_Int64Range, _envoy_type_v3_Int64Range__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      Empty: MessageTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      Empty: MessageTypeDefinition<_google_protobuf_Empty, _google_protobuf_Empty__Output>
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        Authority: MessageTypeDefinition
-        ContextParams: MessageTypeDefinition
-        TypedExtensionConfig: MessageTypeDefinition
+        Authority: MessageTypeDefinition<_xds_core_v3_Authority, _xds_core_v3_Authority__Output>
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
+        TypedExtensionConfig: MessageTypeDefinition<_xds_core_v3_TypedExtensionConfig, _xds_core_v3_TypedExtensionConfig__Output>
       }
     }
     type: {
       matcher: {
         v3: {
-          ListStringMatcher: MessageTypeDefinition
-          Matcher: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
+          ListStringMatcher: MessageTypeDefinition<_xds_type_matcher_v3_ListStringMatcher, _xds_type_matcher_v3_ListStringMatcher__Output>
+          Matcher: MessageTypeDefinition<_xds_type_matcher_v3_Matcher, _xds_type_matcher_v3_Matcher__Output>
+          RegexMatcher: MessageTypeDefinition<_xds_type_matcher_v3_RegexMatcher, _xds_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_xds_type_matcher_v3_StringMatcher, _xds_type_matcher_v3_StringMatcher__Output>
         }
       }
     }

--- a/packages/grpc-js-xds/src/generated/tls.ts
+++ b/packages/grpc-js-xds/src/generated/tls.ts
@@ -1,6 +1,146 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AggregatedConfigSource as _envoy_config_core_v3_AggregatedConfigSource, AggregatedConfigSource__Output as _envoy_config_core_v3_AggregatedConfigSource__Output } from './envoy/config/core/v3/AggregatedConfigSource';
+import type { ApiConfigSource as _envoy_config_core_v3_ApiConfigSource, ApiConfigSource__Output as _envoy_config_core_v3_ApiConfigSource__Output } from './envoy/config/core/v3/ApiConfigSource';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ConfigSource as _envoy_config_core_v3_ConfigSource, ConfigSource__Output as _envoy_config_core_v3_ConfigSource__Output } from './envoy/config/core/v3/ConfigSource';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtensionConfigSource as _envoy_config_core_v3_ExtensionConfigSource, ExtensionConfigSource__Output as _envoy_config_core_v3_ExtensionConfigSource__Output } from './envoy/config/core/v3/ExtensionConfigSource';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { GrpcService as _envoy_config_core_v3_GrpcService, GrpcService__Output as _envoy_config_core_v3_GrpcService__Output } from './envoy/config/core/v3/GrpcService';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { PathConfigSource as _envoy_config_core_v3_PathConfigSource, PathConfigSource__Output as _envoy_config_core_v3_PathConfigSource__Output } from './envoy/config/core/v3/PathConfigSource';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { RateLimitSettings as _envoy_config_core_v3_RateLimitSettings, RateLimitSettings__Output as _envoy_config_core_v3_RateLimitSettings__Output } from './envoy/config/core/v3/RateLimitSettings';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SelfConfigSource as _envoy_config_core_v3_SelfConfigSource, SelfConfigSource__Output as _envoy_config_core_v3_SelfConfigSource__Output } from './envoy/config/core/v3/SelfConfigSource';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { CertificateProviderPluginInstance as _envoy_extensions_transport_sockets_tls_v3_CertificateProviderPluginInstance, CertificateProviderPluginInstance__Output as _envoy_extensions_transport_sockets_tls_v3_CertificateProviderPluginInstance__Output } from './envoy/extensions/transport_sockets/tls/v3/CertificateProviderPluginInstance';
+import type { CertificateValidationContext as _envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext, CertificateValidationContext__Output as _envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext__Output } from './envoy/extensions/transport_sockets/tls/v3/CertificateValidationContext';
+import type { CommonTlsContext as _envoy_extensions_transport_sockets_tls_v3_CommonTlsContext, CommonTlsContext__Output as _envoy_extensions_transport_sockets_tls_v3_CommonTlsContext__Output } from './envoy/extensions/transport_sockets/tls/v3/CommonTlsContext';
+import type { DownstreamTlsContext as _envoy_extensions_transport_sockets_tls_v3_DownstreamTlsContext, DownstreamTlsContext__Output as _envoy_extensions_transport_sockets_tls_v3_DownstreamTlsContext__Output } from './envoy/extensions/transport_sockets/tls/v3/DownstreamTlsContext';
+import type { GenericSecret as _envoy_extensions_transport_sockets_tls_v3_GenericSecret, GenericSecret__Output as _envoy_extensions_transport_sockets_tls_v3_GenericSecret__Output } from './envoy/extensions/transport_sockets/tls/v3/GenericSecret';
+import type { PrivateKeyProvider as _envoy_extensions_transport_sockets_tls_v3_PrivateKeyProvider, PrivateKeyProvider__Output as _envoy_extensions_transport_sockets_tls_v3_PrivateKeyProvider__Output } from './envoy/extensions/transport_sockets/tls/v3/PrivateKeyProvider';
+import type { SdsSecretConfig as _envoy_extensions_transport_sockets_tls_v3_SdsSecretConfig, SdsSecretConfig__Output as _envoy_extensions_transport_sockets_tls_v3_SdsSecretConfig__Output } from './envoy/extensions/transport_sockets/tls/v3/SdsSecretConfig';
+import type { Secret as _envoy_extensions_transport_sockets_tls_v3_Secret, Secret__Output as _envoy_extensions_transport_sockets_tls_v3_Secret__Output } from './envoy/extensions/transport_sockets/tls/v3/Secret';
+import type { SubjectAltNameMatcher as _envoy_extensions_transport_sockets_tls_v3_SubjectAltNameMatcher, SubjectAltNameMatcher__Output as _envoy_extensions_transport_sockets_tls_v3_SubjectAltNameMatcher__Output } from './envoy/extensions/transport_sockets/tls/v3/SubjectAltNameMatcher';
+import type { TlsCertificate as _envoy_extensions_transport_sockets_tls_v3_TlsCertificate, TlsCertificate__Output as _envoy_extensions_transport_sockets_tls_v3_TlsCertificate__Output } from './envoy/extensions/transport_sockets/tls/v3/TlsCertificate';
+import type { TlsKeyLog as _envoy_extensions_transport_sockets_tls_v3_TlsKeyLog, TlsKeyLog__Output as _envoy_extensions_transport_sockets_tls_v3_TlsKeyLog__Output } from './envoy/extensions/transport_sockets/tls/v3/TlsKeyLog';
+import type { TlsParameters as _envoy_extensions_transport_sockets_tls_v3_TlsParameters, TlsParameters__Output as _envoy_extensions_transport_sockets_tls_v3_TlsParameters__Output } from './envoy/extensions/transport_sockets/tls/v3/TlsParameters';
+import type { TlsSessionTicketKeys as _envoy_extensions_transport_sockets_tls_v3_TlsSessionTicketKeys, TlsSessionTicketKeys__Output as _envoy_extensions_transport_sockets_tls_v3_TlsSessionTicketKeys__Output } from './envoy/extensions/transport_sockets/tls/v3/TlsSessionTicketKeys';
+import type { UpstreamTlsContext as _envoy_extensions_transport_sockets_tls_v3_UpstreamTlsContext, UpstreamTlsContext__Output as _envoy_extensions_transport_sockets_tls_v3_UpstreamTlsContext__Output } from './envoy/extensions/transport_sockets/tls/v3/UpstreamTlsContext';
+import type { ListStringMatcher as _envoy_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _envoy_type_matcher_v3_ListStringMatcher__Output } from './envoy/type/matcher/v3/ListStringMatcher';
+import type { RegexMatchAndSubstitute as _envoy_type_matcher_v3_RegexMatchAndSubstitute, RegexMatchAndSubstitute__Output as _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output } from './envoy/type/matcher/v3/RegexMatchAndSubstitute';
+import type { RegexMatcher as _envoy_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _envoy_type_matcher_v3_RegexMatcher__Output } from './envoy/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _envoy_type_matcher_v3_StringMatcher, StringMatcher__Output as _envoy_type_matcher_v3_StringMatcher__Output } from './envoy/type/matcher/v3/StringMatcher';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from './google/protobuf/Empty';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { Authority as _xds_core_v3_Authority, Authority__Output as _xds_core_v3_Authority__Output } from './xds/core/v3/Authority';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
+import type { TypedExtensionConfig as _xds_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _xds_core_v3_TypedExtensionConfig__Output } from './xds/core/v3/TypedExtensionConfig';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -13,55 +153,55 @@ export interface ProtoGrpcType {
     config: {
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AggregatedConfigSource: MessageTypeDefinition
-          ApiConfigSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AggregatedConfigSource: MessageTypeDefinition<_envoy_config_core_v3_AggregatedConfigSource, _envoy_config_core_v3_AggregatedConfigSource__Output>
+          ApiConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ApiConfigSource, _envoy_config_core_v3_ApiConfigSource__Output>
           ApiVersion: EnumTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ConfigSource: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtensionConfigSource: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          GrpcService: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          PathConfigSource: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          RateLimitSettings: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ConfigSource, _envoy_config_core_v3_ConfigSource__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtensionConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ExtensionConfigSource, _envoy_config_core_v3_ExtensionConfigSource__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          GrpcService: MessageTypeDefinition<_envoy_config_core_v3_GrpcService, _envoy_config_core_v3_GrpcService__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          PathConfigSource: MessageTypeDefinition<_envoy_config_core_v3_PathConfigSource, _envoy_config_core_v3_PathConfigSource__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          RateLimitSettings: MessageTypeDefinition<_envoy_config_core_v3_RateLimitSettings, _envoy_config_core_v3_RateLimitSettings__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SelfConfigSource: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SelfConfigSource: MessageTypeDefinition<_envoy_config_core_v3_SelfConfigSource, _envoy_config_core_v3_SelfConfigSource__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
     }
@@ -69,20 +209,20 @@ export interface ProtoGrpcType {
       transport_sockets: {
         tls: {
           v3: {
-            CertificateProviderPluginInstance: MessageTypeDefinition
-            CertificateValidationContext: MessageTypeDefinition
-            CommonTlsContext: MessageTypeDefinition
-            DownstreamTlsContext: MessageTypeDefinition
-            GenericSecret: MessageTypeDefinition
-            PrivateKeyProvider: MessageTypeDefinition
-            SdsSecretConfig: MessageTypeDefinition
-            Secret: MessageTypeDefinition
-            SubjectAltNameMatcher: MessageTypeDefinition
-            TlsCertificate: MessageTypeDefinition
-            TlsKeyLog: MessageTypeDefinition
-            TlsParameters: MessageTypeDefinition
-            TlsSessionTicketKeys: MessageTypeDefinition
-            UpstreamTlsContext: MessageTypeDefinition
+            CertificateProviderPluginInstance: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_CertificateProviderPluginInstance, _envoy_extensions_transport_sockets_tls_v3_CertificateProviderPluginInstance__Output>
+            CertificateValidationContext: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext, _envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext__Output>
+            CommonTlsContext: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_CommonTlsContext, _envoy_extensions_transport_sockets_tls_v3_CommonTlsContext__Output>
+            DownstreamTlsContext: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_DownstreamTlsContext, _envoy_extensions_transport_sockets_tls_v3_DownstreamTlsContext__Output>
+            GenericSecret: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_GenericSecret, _envoy_extensions_transport_sockets_tls_v3_GenericSecret__Output>
+            PrivateKeyProvider: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_PrivateKeyProvider, _envoy_extensions_transport_sockets_tls_v3_PrivateKeyProvider__Output>
+            SdsSecretConfig: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_SdsSecretConfig, _envoy_extensions_transport_sockets_tls_v3_SdsSecretConfig__Output>
+            Secret: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_Secret, _envoy_extensions_transport_sockets_tls_v3_Secret__Output>
+            SubjectAltNameMatcher: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_SubjectAltNameMatcher, _envoy_extensions_transport_sockets_tls_v3_SubjectAltNameMatcher__Output>
+            TlsCertificate: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_TlsCertificate, _envoy_extensions_transport_sockets_tls_v3_TlsCertificate__Output>
+            TlsKeyLog: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_TlsKeyLog, _envoy_extensions_transport_sockets_tls_v3_TlsKeyLog__Output>
+            TlsParameters: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_TlsParameters, _envoy_extensions_transport_sockets_tls_v3_TlsParameters__Output>
+            TlsSessionTicketKeys: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_TlsSessionTicketKeys, _envoy_extensions_transport_sockets_tls_v3_TlsSessionTicketKeys__Output>
+            UpstreamTlsContext: MessageTypeDefinition<_envoy_extensions_transport_sockets_tls_v3_UpstreamTlsContext, _envoy_extensions_transport_sockets_tls_v3_UpstreamTlsContext__Output>
           }
         }
       }
@@ -90,116 +230,116 @@ export interface ProtoGrpcType {
     type: {
       matcher: {
         v3: {
-          ListStringMatcher: MessageTypeDefinition
-          RegexMatchAndSubstitute: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
+          ListStringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListStringMatcher, _envoy_type_matcher_v3_ListStringMatcher__Output>
+          RegexMatchAndSubstitute: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatchAndSubstitute, _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output>
+          RegexMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatcher, _envoy_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_StringMatcher, _envoy_type_matcher_v3_StringMatcher__Output>
         }
       }
       v3: {
-        FractionalPercent: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      Empty: MessageTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      Empty: MessageTypeDefinition<_google_protobuf_Empty, _google_protobuf_Empty__Output>
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        Authority: MessageTypeDefinition
-        ContextParams: MessageTypeDefinition
-        TypedExtensionConfig: MessageTypeDefinition
+        Authority: MessageTypeDefinition<_xds_core_v3_Authority, _xds_core_v3_Authority__Output>
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
+        TypedExtensionConfig: MessageTypeDefinition<_xds_core_v3_TypedExtensionConfig, _xds_core_v3_TypedExtensionConfig__Output>
       }
     }
   }

--- a/packages/grpc-js-xds/src/generated/typed_struct.ts
+++ b/packages/grpc-js-xds/src/generated/typed_struct.ts
@@ -1,6 +1,59 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { TypedStruct as _udpa_type_v1_TypedStruct, TypedStruct__Output as _udpa_type_v1_TypedStruct__Output } from './udpa/type/v1/TypedStruct';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { TypedStruct as _xds_type_v3_TypedStruct, TypedStruct__Output as _xds_type_v3_TypedStruct__Output } from './xds/type/v3/TypedStruct';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -9,76 +62,76 @@ type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> 
 export interface ProtoGrpcType {
   google: {
     protobuf: {
-      DescriptorProto: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     type: {
       v1: {
-        TypedStruct: MessageTypeDefinition
+        TypedStruct: MessageTypeDefinition<_udpa_type_v1_TypedStruct, _udpa_type_v1_TypedStruct__Output>
       }
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     type: {
       v3: {
-        TypedStruct: MessageTypeDefinition
+        TypedStruct: MessageTypeDefinition<_xds_type_v3_TypedStruct, _xds_type_v3_TypedStruct__Output>
       }
     }
   }

--- a/packages/grpc-js-xds/src/generated/wrr_locality.ts
+++ b/packages/grpc-js-xds/src/generated/wrr_locality.ts
@@ -1,6 +1,173 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { CircuitBreakers as _envoy_config_cluster_v3_CircuitBreakers, CircuitBreakers__Output as _envoy_config_cluster_v3_CircuitBreakers__Output } from './envoy/config/cluster/v3/CircuitBreakers';
+import type { Cluster as _envoy_config_cluster_v3_Cluster, Cluster__Output as _envoy_config_cluster_v3_Cluster__Output } from './envoy/config/cluster/v3/Cluster';
+import type { ClusterCollection as _envoy_config_cluster_v3_ClusterCollection, ClusterCollection__Output as _envoy_config_cluster_v3_ClusterCollection__Output } from './envoy/config/cluster/v3/ClusterCollection';
+import type { Filter as _envoy_config_cluster_v3_Filter, Filter__Output as _envoy_config_cluster_v3_Filter__Output } from './envoy/config/cluster/v3/Filter';
+import type { LoadBalancingPolicy as _envoy_config_cluster_v3_LoadBalancingPolicy, LoadBalancingPolicy__Output as _envoy_config_cluster_v3_LoadBalancingPolicy__Output } from './envoy/config/cluster/v3/LoadBalancingPolicy';
+import type { OutlierDetection as _envoy_config_cluster_v3_OutlierDetection, OutlierDetection__Output as _envoy_config_cluster_v3_OutlierDetection__Output } from './envoy/config/cluster/v3/OutlierDetection';
+import type { TrackClusterStats as _envoy_config_cluster_v3_TrackClusterStats, TrackClusterStats__Output as _envoy_config_cluster_v3_TrackClusterStats__Output } from './envoy/config/cluster/v3/TrackClusterStats';
+import type { UpstreamConnectionOptions as _envoy_config_cluster_v3_UpstreamConnectionOptions, UpstreamConnectionOptions__Output as _envoy_config_cluster_v3_UpstreamConnectionOptions__Output } from './envoy/config/cluster/v3/UpstreamConnectionOptions';
+import type { Address as _envoy_config_core_v3_Address, Address__Output as _envoy_config_core_v3_Address__Output } from './envoy/config/core/v3/Address';
+import type { AggregatedConfigSource as _envoy_config_core_v3_AggregatedConfigSource, AggregatedConfigSource__Output as _envoy_config_core_v3_AggregatedConfigSource__Output } from './envoy/config/core/v3/AggregatedConfigSource';
+import type { AlternateProtocolsCacheOptions as _envoy_config_core_v3_AlternateProtocolsCacheOptions, AlternateProtocolsCacheOptions__Output as _envoy_config_core_v3_AlternateProtocolsCacheOptions__Output } from './envoy/config/core/v3/AlternateProtocolsCacheOptions';
+import type { ApiConfigSource as _envoy_config_core_v3_ApiConfigSource, ApiConfigSource__Output as _envoy_config_core_v3_ApiConfigSource__Output } from './envoy/config/core/v3/ApiConfigSource';
+import type { AsyncDataSource as _envoy_config_core_v3_AsyncDataSource, AsyncDataSource__Output as _envoy_config_core_v3_AsyncDataSource__Output } from './envoy/config/core/v3/AsyncDataSource';
+import type { BackoffStrategy as _envoy_config_core_v3_BackoffStrategy, BackoffStrategy__Output as _envoy_config_core_v3_BackoffStrategy__Output } from './envoy/config/core/v3/BackoffStrategy';
+import type { BindConfig as _envoy_config_core_v3_BindConfig, BindConfig__Output as _envoy_config_core_v3_BindConfig__Output } from './envoy/config/core/v3/BindConfig';
+import type { BuildVersion as _envoy_config_core_v3_BuildVersion, BuildVersion__Output as _envoy_config_core_v3_BuildVersion__Output } from './envoy/config/core/v3/BuildVersion';
+import type { CidrRange as _envoy_config_core_v3_CidrRange, CidrRange__Output as _envoy_config_core_v3_CidrRange__Output } from './envoy/config/core/v3/CidrRange';
+import type { ConfigSource as _envoy_config_core_v3_ConfigSource, ConfigSource__Output as _envoy_config_core_v3_ConfigSource__Output } from './envoy/config/core/v3/ConfigSource';
+import type { ControlPlane as _envoy_config_core_v3_ControlPlane, ControlPlane__Output as _envoy_config_core_v3_ControlPlane__Output } from './envoy/config/core/v3/ControlPlane';
+import type { DataSource as _envoy_config_core_v3_DataSource, DataSource__Output as _envoy_config_core_v3_DataSource__Output } from './envoy/config/core/v3/DataSource';
+import type { DnsResolutionConfig as _envoy_config_core_v3_DnsResolutionConfig, DnsResolutionConfig__Output as _envoy_config_core_v3_DnsResolutionConfig__Output } from './envoy/config/core/v3/DnsResolutionConfig';
+import type { DnsResolverOptions as _envoy_config_core_v3_DnsResolverOptions, DnsResolverOptions__Output as _envoy_config_core_v3_DnsResolverOptions__Output } from './envoy/config/core/v3/DnsResolverOptions';
+import type { EnvoyInternalAddress as _envoy_config_core_v3_EnvoyInternalAddress, EnvoyInternalAddress__Output as _envoy_config_core_v3_EnvoyInternalAddress__Output } from './envoy/config/core/v3/EnvoyInternalAddress';
+import type { EventServiceConfig as _envoy_config_core_v3_EventServiceConfig, EventServiceConfig__Output as _envoy_config_core_v3_EventServiceConfig__Output } from './envoy/config/core/v3/EventServiceConfig';
+import type { Extension as _envoy_config_core_v3_Extension, Extension__Output as _envoy_config_core_v3_Extension__Output } from './envoy/config/core/v3/Extension';
+import type { ExtensionConfigSource as _envoy_config_core_v3_ExtensionConfigSource, ExtensionConfigSource__Output as _envoy_config_core_v3_ExtensionConfigSource__Output } from './envoy/config/core/v3/ExtensionConfigSource';
+import type { ExtraSourceAddress as _envoy_config_core_v3_ExtraSourceAddress, ExtraSourceAddress__Output as _envoy_config_core_v3_ExtraSourceAddress__Output } from './envoy/config/core/v3/ExtraSourceAddress';
+import type { GrpcProtocolOptions as _envoy_config_core_v3_GrpcProtocolOptions, GrpcProtocolOptions__Output as _envoy_config_core_v3_GrpcProtocolOptions__Output } from './envoy/config/core/v3/GrpcProtocolOptions';
+import type { GrpcService as _envoy_config_core_v3_GrpcService, GrpcService__Output as _envoy_config_core_v3_GrpcService__Output } from './envoy/config/core/v3/GrpcService';
+import type { HeaderMap as _envoy_config_core_v3_HeaderMap, HeaderMap__Output as _envoy_config_core_v3_HeaderMap__Output } from './envoy/config/core/v3/HeaderMap';
+import type { HeaderValue as _envoy_config_core_v3_HeaderValue, HeaderValue__Output as _envoy_config_core_v3_HeaderValue__Output } from './envoy/config/core/v3/HeaderValue';
+import type { HeaderValueOption as _envoy_config_core_v3_HeaderValueOption, HeaderValueOption__Output as _envoy_config_core_v3_HeaderValueOption__Output } from './envoy/config/core/v3/HeaderValueOption';
+import type { HealthCheck as _envoy_config_core_v3_HealthCheck, HealthCheck__Output as _envoy_config_core_v3_HealthCheck__Output } from './envoy/config/core/v3/HealthCheck';
+import type { HealthStatusSet as _envoy_config_core_v3_HealthStatusSet, HealthStatusSet__Output as _envoy_config_core_v3_HealthStatusSet__Output } from './envoy/config/core/v3/HealthStatusSet';
+import type { Http1ProtocolOptions as _envoy_config_core_v3_Http1ProtocolOptions, Http1ProtocolOptions__Output as _envoy_config_core_v3_Http1ProtocolOptions__Output } from './envoy/config/core/v3/Http1ProtocolOptions';
+import type { Http2ProtocolOptions as _envoy_config_core_v3_Http2ProtocolOptions, Http2ProtocolOptions__Output as _envoy_config_core_v3_Http2ProtocolOptions__Output } from './envoy/config/core/v3/Http2ProtocolOptions';
+import type { Http3ProtocolOptions as _envoy_config_core_v3_Http3ProtocolOptions, Http3ProtocolOptions__Output as _envoy_config_core_v3_Http3ProtocolOptions__Output } from './envoy/config/core/v3/Http3ProtocolOptions';
+import type { HttpProtocolOptions as _envoy_config_core_v3_HttpProtocolOptions, HttpProtocolOptions__Output as _envoy_config_core_v3_HttpProtocolOptions__Output } from './envoy/config/core/v3/HttpProtocolOptions';
+import type { HttpUri as _envoy_config_core_v3_HttpUri, HttpUri__Output as _envoy_config_core_v3_HttpUri__Output } from './envoy/config/core/v3/HttpUri';
+import type { KeepaliveSettings as _envoy_config_core_v3_KeepaliveSettings, KeepaliveSettings__Output as _envoy_config_core_v3_KeepaliveSettings__Output } from './envoy/config/core/v3/KeepaliveSettings';
+import type { KeyValue as _envoy_config_core_v3_KeyValue, KeyValue__Output as _envoy_config_core_v3_KeyValue__Output } from './envoy/config/core/v3/KeyValue';
+import type { KeyValueAppend as _envoy_config_core_v3_KeyValueAppend, KeyValueAppend__Output as _envoy_config_core_v3_KeyValueAppend__Output } from './envoy/config/core/v3/KeyValueAppend';
+import type { KeyValueMutation as _envoy_config_core_v3_KeyValueMutation, KeyValueMutation__Output as _envoy_config_core_v3_KeyValueMutation__Output } from './envoy/config/core/v3/KeyValueMutation';
+import type { Locality as _envoy_config_core_v3_Locality, Locality__Output as _envoy_config_core_v3_Locality__Output } from './envoy/config/core/v3/Locality';
+import type { Metadata as _envoy_config_core_v3_Metadata, Metadata__Output as _envoy_config_core_v3_Metadata__Output } from './envoy/config/core/v3/Metadata';
+import type { Node as _envoy_config_core_v3_Node, Node__Output as _envoy_config_core_v3_Node__Output } from './envoy/config/core/v3/Node';
+import type { PathConfigSource as _envoy_config_core_v3_PathConfigSource, PathConfigSource__Output as _envoy_config_core_v3_PathConfigSource__Output } from './envoy/config/core/v3/PathConfigSource';
+import type { Pipe as _envoy_config_core_v3_Pipe, Pipe__Output as _envoy_config_core_v3_Pipe__Output } from './envoy/config/core/v3/Pipe';
+import type { ProxyProtocolConfig as _envoy_config_core_v3_ProxyProtocolConfig, ProxyProtocolConfig__Output as _envoy_config_core_v3_ProxyProtocolConfig__Output } from './envoy/config/core/v3/ProxyProtocolConfig';
+import type { ProxyProtocolPassThroughTLVs as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs, ProxyProtocolPassThroughTLVs__Output as _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output } from './envoy/config/core/v3/ProxyProtocolPassThroughTLVs';
+import type { QueryParameter as _envoy_config_core_v3_QueryParameter, QueryParameter__Output as _envoy_config_core_v3_QueryParameter__Output } from './envoy/config/core/v3/QueryParameter';
+import type { QuicKeepAliveSettings as _envoy_config_core_v3_QuicKeepAliveSettings, QuicKeepAliveSettings__Output as _envoy_config_core_v3_QuicKeepAliveSettings__Output } from './envoy/config/core/v3/QuicKeepAliveSettings';
+import type { QuicProtocolOptions as _envoy_config_core_v3_QuicProtocolOptions, QuicProtocolOptions__Output as _envoy_config_core_v3_QuicProtocolOptions__Output } from './envoy/config/core/v3/QuicProtocolOptions';
+import type { RateLimitSettings as _envoy_config_core_v3_RateLimitSettings, RateLimitSettings__Output as _envoy_config_core_v3_RateLimitSettings__Output } from './envoy/config/core/v3/RateLimitSettings';
+import type { RemoteDataSource as _envoy_config_core_v3_RemoteDataSource, RemoteDataSource__Output as _envoy_config_core_v3_RemoteDataSource__Output } from './envoy/config/core/v3/RemoteDataSource';
+import type { RetryPolicy as _envoy_config_core_v3_RetryPolicy, RetryPolicy__Output as _envoy_config_core_v3_RetryPolicy__Output } from './envoy/config/core/v3/RetryPolicy';
+import type { RuntimeDouble as _envoy_config_core_v3_RuntimeDouble, RuntimeDouble__Output as _envoy_config_core_v3_RuntimeDouble__Output } from './envoy/config/core/v3/RuntimeDouble';
+import type { RuntimeFeatureFlag as _envoy_config_core_v3_RuntimeFeatureFlag, RuntimeFeatureFlag__Output as _envoy_config_core_v3_RuntimeFeatureFlag__Output } from './envoy/config/core/v3/RuntimeFeatureFlag';
+import type { RuntimeFractionalPercent as _envoy_config_core_v3_RuntimeFractionalPercent, RuntimeFractionalPercent__Output as _envoy_config_core_v3_RuntimeFractionalPercent__Output } from './envoy/config/core/v3/RuntimeFractionalPercent';
+import type { RuntimePercent as _envoy_config_core_v3_RuntimePercent, RuntimePercent__Output as _envoy_config_core_v3_RuntimePercent__Output } from './envoy/config/core/v3/RuntimePercent';
+import type { RuntimeUInt32 as _envoy_config_core_v3_RuntimeUInt32, RuntimeUInt32__Output as _envoy_config_core_v3_RuntimeUInt32__Output } from './envoy/config/core/v3/RuntimeUInt32';
+import type { SchemeHeaderTransformation as _envoy_config_core_v3_SchemeHeaderTransformation, SchemeHeaderTransformation__Output as _envoy_config_core_v3_SchemeHeaderTransformation__Output } from './envoy/config/core/v3/SchemeHeaderTransformation';
+import type { SelfConfigSource as _envoy_config_core_v3_SelfConfigSource, SelfConfigSource__Output as _envoy_config_core_v3_SelfConfigSource__Output } from './envoy/config/core/v3/SelfConfigSource';
+import type { SocketAddress as _envoy_config_core_v3_SocketAddress, SocketAddress__Output as _envoy_config_core_v3_SocketAddress__Output } from './envoy/config/core/v3/SocketAddress';
+import type { SocketOption as _envoy_config_core_v3_SocketOption, SocketOption__Output as _envoy_config_core_v3_SocketOption__Output } from './envoy/config/core/v3/SocketOption';
+import type { SocketOptionsOverride as _envoy_config_core_v3_SocketOptionsOverride, SocketOptionsOverride__Output as _envoy_config_core_v3_SocketOptionsOverride__Output } from './envoy/config/core/v3/SocketOptionsOverride';
+import type { TcpKeepalive as _envoy_config_core_v3_TcpKeepalive, TcpKeepalive__Output as _envoy_config_core_v3_TcpKeepalive__Output } from './envoy/config/core/v3/TcpKeepalive';
+import type { TcpProtocolOptions as _envoy_config_core_v3_TcpProtocolOptions, TcpProtocolOptions__Output as _envoy_config_core_v3_TcpProtocolOptions__Output } from './envoy/config/core/v3/TcpProtocolOptions';
+import type { TransportSocket as _envoy_config_core_v3_TransportSocket, TransportSocket__Output as _envoy_config_core_v3_TransportSocket__Output } from './envoy/config/core/v3/TransportSocket';
+import type { TypedExtensionConfig as _envoy_config_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _envoy_config_core_v3_TypedExtensionConfig__Output } from './envoy/config/core/v3/TypedExtensionConfig';
+import type { UpstreamHttpProtocolOptions as _envoy_config_core_v3_UpstreamHttpProtocolOptions, UpstreamHttpProtocolOptions__Output as _envoy_config_core_v3_UpstreamHttpProtocolOptions__Output } from './envoy/config/core/v3/UpstreamHttpProtocolOptions';
+import type { WatchedDirectory as _envoy_config_core_v3_WatchedDirectory, WatchedDirectory__Output as _envoy_config_core_v3_WatchedDirectory__Output } from './envoy/config/core/v3/WatchedDirectory';
+import type { ClusterLoadAssignment as _envoy_config_endpoint_v3_ClusterLoadAssignment, ClusterLoadAssignment__Output as _envoy_config_endpoint_v3_ClusterLoadAssignment__Output } from './envoy/config/endpoint/v3/ClusterLoadAssignment';
+import type { Endpoint as _envoy_config_endpoint_v3_Endpoint, Endpoint__Output as _envoy_config_endpoint_v3_Endpoint__Output } from './envoy/config/endpoint/v3/Endpoint';
+import type { LbEndpoint as _envoy_config_endpoint_v3_LbEndpoint, LbEndpoint__Output as _envoy_config_endpoint_v3_LbEndpoint__Output } from './envoy/config/endpoint/v3/LbEndpoint';
+import type { LedsClusterLocalityConfig as _envoy_config_endpoint_v3_LedsClusterLocalityConfig, LedsClusterLocalityConfig__Output as _envoy_config_endpoint_v3_LedsClusterLocalityConfig__Output } from './envoy/config/endpoint/v3/LedsClusterLocalityConfig';
+import type { LocalityLbEndpoints as _envoy_config_endpoint_v3_LocalityLbEndpoints, LocalityLbEndpoints__Output as _envoy_config_endpoint_v3_LocalityLbEndpoints__Output } from './envoy/config/endpoint/v3/LocalityLbEndpoints';
+import type { WrrLocality as _envoy_extensions_load_balancing_policies_wrr_locality_v3_WrrLocality, WrrLocality__Output as _envoy_extensions_load_balancing_policies_wrr_locality_v3_WrrLocality__Output } from './envoy/extensions/load_balancing_policies/wrr_locality/v3/WrrLocality';
+import type { ListStringMatcher as _envoy_type_matcher_v3_ListStringMatcher, ListStringMatcher__Output as _envoy_type_matcher_v3_ListStringMatcher__Output } from './envoy/type/matcher/v3/ListStringMatcher';
+import type { RegexMatchAndSubstitute as _envoy_type_matcher_v3_RegexMatchAndSubstitute, RegexMatchAndSubstitute__Output as _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output } from './envoy/type/matcher/v3/RegexMatchAndSubstitute';
+import type { RegexMatcher as _envoy_type_matcher_v3_RegexMatcher, RegexMatcher__Output as _envoy_type_matcher_v3_RegexMatcher__Output } from './envoy/type/matcher/v3/RegexMatcher';
+import type { StringMatcher as _envoy_type_matcher_v3_StringMatcher, StringMatcher__Output as _envoy_type_matcher_v3_StringMatcher__Output } from './envoy/type/matcher/v3/StringMatcher';
+import type { MetadataKey as _envoy_type_metadata_v3_MetadataKey, MetadataKey__Output as _envoy_type_metadata_v3_MetadataKey__Output } from './envoy/type/metadata/v3/MetadataKey';
+import type { MetadataKind as _envoy_type_metadata_v3_MetadataKind, MetadataKind__Output as _envoy_type_metadata_v3_MetadataKind__Output } from './envoy/type/metadata/v3/MetadataKind';
+import type { DoubleRange as _envoy_type_v3_DoubleRange, DoubleRange__Output as _envoy_type_v3_DoubleRange__Output } from './envoy/type/v3/DoubleRange';
+import type { FractionalPercent as _envoy_type_v3_FractionalPercent, FractionalPercent__Output as _envoy_type_v3_FractionalPercent__Output } from './envoy/type/v3/FractionalPercent';
+import type { Int32Range as _envoy_type_v3_Int32Range, Int32Range__Output as _envoy_type_v3_Int32Range__Output } from './envoy/type/v3/Int32Range';
+import type { Int64Range as _envoy_type_v3_Int64Range, Int64Range__Output as _envoy_type_v3_Int64Range__Output } from './envoy/type/v3/Int64Range';
+import type { Percent as _envoy_type_v3_Percent, Percent__Output as _envoy_type_v3_Percent__Output } from './envoy/type/v3/Percent';
+import type { SemanticVersion as _envoy_type_v3_SemanticVersion, SemanticVersion__Output as _envoy_type_v3_SemanticVersion__Output } from './envoy/type/v3/SemanticVersion';
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DescriptorProto as _google_protobuf_DescriptorProto, DescriptorProto__Output as _google_protobuf_DescriptorProto__Output } from './google/protobuf/DescriptorProto';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from './google/protobuf/Empty';
+import type { EnumDescriptorProto as _google_protobuf_EnumDescriptorProto, EnumDescriptorProto__Output as _google_protobuf_EnumDescriptorProto__Output } from './google/protobuf/EnumDescriptorProto';
+import type { EnumOptions as _google_protobuf_EnumOptions, EnumOptions__Output as _google_protobuf_EnumOptions__Output } from './google/protobuf/EnumOptions';
+import type { EnumValueDescriptorProto as _google_protobuf_EnumValueDescriptorProto, EnumValueDescriptorProto__Output as _google_protobuf_EnumValueDescriptorProto__Output } from './google/protobuf/EnumValueDescriptorProto';
+import type { EnumValueOptions as _google_protobuf_EnumValueOptions, EnumValueOptions__Output as _google_protobuf_EnumValueOptions__Output } from './google/protobuf/EnumValueOptions';
+import type { ExtensionRangeOptions as _google_protobuf_ExtensionRangeOptions, ExtensionRangeOptions__Output as _google_protobuf_ExtensionRangeOptions__Output } from './google/protobuf/ExtensionRangeOptions';
+import type { FeatureSet as _google_protobuf_FeatureSet, FeatureSet__Output as _google_protobuf_FeatureSet__Output } from './google/protobuf/FeatureSet';
+import type { FeatureSetDefaults as _google_protobuf_FeatureSetDefaults, FeatureSetDefaults__Output as _google_protobuf_FeatureSetDefaults__Output } from './google/protobuf/FeatureSetDefaults';
+import type { FieldDescriptorProto as _google_protobuf_FieldDescriptorProto, FieldDescriptorProto__Output as _google_protobuf_FieldDescriptorProto__Output } from './google/protobuf/FieldDescriptorProto';
+import type { FieldOptions as _google_protobuf_FieldOptions, FieldOptions__Output as _google_protobuf_FieldOptions__Output } from './google/protobuf/FieldOptions';
+import type { FileDescriptorProto as _google_protobuf_FileDescriptorProto, FileDescriptorProto__Output as _google_protobuf_FileDescriptorProto__Output } from './google/protobuf/FileDescriptorProto';
+import type { FileDescriptorSet as _google_protobuf_FileDescriptorSet, FileDescriptorSet__Output as _google_protobuf_FileDescriptorSet__Output } from './google/protobuf/FileDescriptorSet';
+import type { FileOptions as _google_protobuf_FileOptions, FileOptions__Output as _google_protobuf_FileOptions__Output } from './google/protobuf/FileOptions';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { GeneratedCodeInfo as _google_protobuf_GeneratedCodeInfo, GeneratedCodeInfo__Output as _google_protobuf_GeneratedCodeInfo__Output } from './google/protobuf/GeneratedCodeInfo';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { ListValue as _google_protobuf_ListValue, ListValue__Output as _google_protobuf_ListValue__Output } from './google/protobuf/ListValue';
+import type { MessageOptions as _google_protobuf_MessageOptions, MessageOptions__Output as _google_protobuf_MessageOptions__Output } from './google/protobuf/MessageOptions';
+import type { MethodDescriptorProto as _google_protobuf_MethodDescriptorProto, MethodDescriptorProto__Output as _google_protobuf_MethodDescriptorProto__Output } from './google/protobuf/MethodDescriptorProto';
+import type { MethodOptions as _google_protobuf_MethodOptions, MethodOptions__Output as _google_protobuf_MethodOptions__Output } from './google/protobuf/MethodOptions';
+import type { OneofDescriptorProto as _google_protobuf_OneofDescriptorProto, OneofDescriptorProto__Output as _google_protobuf_OneofDescriptorProto__Output } from './google/protobuf/OneofDescriptorProto';
+import type { OneofOptions as _google_protobuf_OneofOptions, OneofOptions__Output as _google_protobuf_OneofOptions__Output } from './google/protobuf/OneofOptions';
+import type { ServiceDescriptorProto as _google_protobuf_ServiceDescriptorProto, ServiceDescriptorProto__Output as _google_protobuf_ServiceDescriptorProto__Output } from './google/protobuf/ServiceDescriptorProto';
+import type { ServiceOptions as _google_protobuf_ServiceOptions, ServiceOptions__Output as _google_protobuf_ServiceOptions__Output } from './google/protobuf/ServiceOptions';
+import type { SourceCodeInfo as _google_protobuf_SourceCodeInfo, SourceCodeInfo__Output as _google_protobuf_SourceCodeInfo__Output } from './google/protobuf/SourceCodeInfo';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Struct as _google_protobuf_Struct, Struct__Output as _google_protobuf_Struct__Output } from './google/protobuf/Struct';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { UninterpretedOption as _google_protobuf_UninterpretedOption, UninterpretedOption__Output as _google_protobuf_UninterpretedOption__Output } from './google/protobuf/UninterpretedOption';
+import type { Value as _google_protobuf_Value, Value__Output as _google_protobuf_Value__Output } from './google/protobuf/Value';
+import type { FieldMigrateAnnotation as _udpa_annotations_FieldMigrateAnnotation, FieldMigrateAnnotation__Output as _udpa_annotations_FieldMigrateAnnotation__Output } from './udpa/annotations/FieldMigrateAnnotation';
+import type { FieldSecurityAnnotation as _udpa_annotations_FieldSecurityAnnotation, FieldSecurityAnnotation__Output as _udpa_annotations_FieldSecurityAnnotation__Output } from './udpa/annotations/FieldSecurityAnnotation';
+import type { FileMigrateAnnotation as _udpa_annotations_FileMigrateAnnotation, FileMigrateAnnotation__Output as _udpa_annotations_FileMigrateAnnotation__Output } from './udpa/annotations/FileMigrateAnnotation';
+import type { MigrateAnnotation as _udpa_annotations_MigrateAnnotation, MigrateAnnotation__Output as _udpa_annotations_MigrateAnnotation__Output } from './udpa/annotations/MigrateAnnotation';
+import type { StatusAnnotation as _udpa_annotations_StatusAnnotation, StatusAnnotation__Output as _udpa_annotations_StatusAnnotation__Output } from './udpa/annotations/StatusAnnotation';
+import type { VersioningAnnotation as _udpa_annotations_VersioningAnnotation, VersioningAnnotation__Output as _udpa_annotations_VersioningAnnotation__Output } from './udpa/annotations/VersioningAnnotation';
+import type { AnyRules as _validate_AnyRules, AnyRules__Output as _validate_AnyRules__Output } from './validate/AnyRules';
+import type { BoolRules as _validate_BoolRules, BoolRules__Output as _validate_BoolRules__Output } from './validate/BoolRules';
+import type { BytesRules as _validate_BytesRules, BytesRules__Output as _validate_BytesRules__Output } from './validate/BytesRules';
+import type { DoubleRules as _validate_DoubleRules, DoubleRules__Output as _validate_DoubleRules__Output } from './validate/DoubleRules';
+import type { DurationRules as _validate_DurationRules, DurationRules__Output as _validate_DurationRules__Output } from './validate/DurationRules';
+import type { EnumRules as _validate_EnumRules, EnumRules__Output as _validate_EnumRules__Output } from './validate/EnumRules';
+import type { FieldRules as _validate_FieldRules, FieldRules__Output as _validate_FieldRules__Output } from './validate/FieldRules';
+import type { Fixed32Rules as _validate_Fixed32Rules, Fixed32Rules__Output as _validate_Fixed32Rules__Output } from './validate/Fixed32Rules';
+import type { Fixed64Rules as _validate_Fixed64Rules, Fixed64Rules__Output as _validate_Fixed64Rules__Output } from './validate/Fixed64Rules';
+import type { FloatRules as _validate_FloatRules, FloatRules__Output as _validate_FloatRules__Output } from './validate/FloatRules';
+import type { Int32Rules as _validate_Int32Rules, Int32Rules__Output as _validate_Int32Rules__Output } from './validate/Int32Rules';
+import type { Int64Rules as _validate_Int64Rules, Int64Rules__Output as _validate_Int64Rules__Output } from './validate/Int64Rules';
+import type { MapRules as _validate_MapRules, MapRules__Output as _validate_MapRules__Output } from './validate/MapRules';
+import type { MessageRules as _validate_MessageRules, MessageRules__Output as _validate_MessageRules__Output } from './validate/MessageRules';
+import type { RepeatedRules as _validate_RepeatedRules, RepeatedRules__Output as _validate_RepeatedRules__Output } from './validate/RepeatedRules';
+import type { SFixed32Rules as _validate_SFixed32Rules, SFixed32Rules__Output as _validate_SFixed32Rules__Output } from './validate/SFixed32Rules';
+import type { SFixed64Rules as _validate_SFixed64Rules, SFixed64Rules__Output as _validate_SFixed64Rules__Output } from './validate/SFixed64Rules';
+import type { SInt32Rules as _validate_SInt32Rules, SInt32Rules__Output as _validate_SInt32Rules__Output } from './validate/SInt32Rules';
+import type { SInt64Rules as _validate_SInt64Rules, SInt64Rules__Output as _validate_SInt64Rules__Output } from './validate/SInt64Rules';
+import type { StringRules as _validate_StringRules, StringRules__Output as _validate_StringRules__Output } from './validate/StringRules';
+import type { TimestampRules as _validate_TimestampRules, TimestampRules__Output as _validate_TimestampRules__Output } from './validate/TimestampRules';
+import type { UInt32Rules as _validate_UInt32Rules, UInt32Rules__Output as _validate_UInt32Rules__Output } from './validate/UInt32Rules';
+import type { UInt64Rules as _validate_UInt64Rules, UInt64Rules__Output as _validate_UInt64Rules__Output } from './validate/UInt64Rules';
+import type { FieldStatusAnnotation as _xds_annotations_v3_FieldStatusAnnotation, FieldStatusAnnotation__Output as _xds_annotations_v3_FieldStatusAnnotation__Output } from './xds/annotations/v3/FieldStatusAnnotation';
+import type { FileStatusAnnotation as _xds_annotations_v3_FileStatusAnnotation, FileStatusAnnotation__Output as _xds_annotations_v3_FileStatusAnnotation__Output } from './xds/annotations/v3/FileStatusAnnotation';
+import type { MessageStatusAnnotation as _xds_annotations_v3_MessageStatusAnnotation, MessageStatusAnnotation__Output as _xds_annotations_v3_MessageStatusAnnotation__Output } from './xds/annotations/v3/MessageStatusAnnotation';
+import type { StatusAnnotation as _xds_annotations_v3_StatusAnnotation, StatusAnnotation__Output as _xds_annotations_v3_StatusAnnotation__Output } from './xds/annotations/v3/StatusAnnotation';
+import type { Authority as _xds_core_v3_Authority, Authority__Output as _xds_core_v3_Authority__Output } from './xds/core/v3/Authority';
+import type { CollectionEntry as _xds_core_v3_CollectionEntry, CollectionEntry__Output as _xds_core_v3_CollectionEntry__Output } from './xds/core/v3/CollectionEntry';
+import type { ContextParams as _xds_core_v3_ContextParams, ContextParams__Output as _xds_core_v3_ContextParams__Output } from './xds/core/v3/ContextParams';
+import type { ResourceLocator as _xds_core_v3_ResourceLocator, ResourceLocator__Output as _xds_core_v3_ResourceLocator__Output } from './xds/core/v3/ResourceLocator';
+import type { TypedExtensionConfig as _xds_core_v3_TypedExtensionConfig, TypedExtensionConfig__Output as _xds_core_v3_TypedExtensionConfig__Output } from './xds/core/v3/TypedExtensionConfig';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -13,96 +180,96 @@ export interface ProtoGrpcType {
     config: {
       cluster: {
         v3: {
-          CircuitBreakers: MessageTypeDefinition
-          Cluster: MessageTypeDefinition
-          ClusterCollection: MessageTypeDefinition
-          Filter: MessageTypeDefinition
-          LoadBalancingPolicy: MessageTypeDefinition
-          OutlierDetection: MessageTypeDefinition
-          TrackClusterStats: MessageTypeDefinition
-          UpstreamConnectionOptions: MessageTypeDefinition
+          CircuitBreakers: MessageTypeDefinition<_envoy_config_cluster_v3_CircuitBreakers, _envoy_config_cluster_v3_CircuitBreakers__Output>
+          Cluster: MessageTypeDefinition<_envoy_config_cluster_v3_Cluster, _envoy_config_cluster_v3_Cluster__Output>
+          ClusterCollection: MessageTypeDefinition<_envoy_config_cluster_v3_ClusterCollection, _envoy_config_cluster_v3_ClusterCollection__Output>
+          Filter: MessageTypeDefinition<_envoy_config_cluster_v3_Filter, _envoy_config_cluster_v3_Filter__Output>
+          LoadBalancingPolicy: MessageTypeDefinition<_envoy_config_cluster_v3_LoadBalancingPolicy, _envoy_config_cluster_v3_LoadBalancingPolicy__Output>
+          OutlierDetection: MessageTypeDefinition<_envoy_config_cluster_v3_OutlierDetection, _envoy_config_cluster_v3_OutlierDetection__Output>
+          TrackClusterStats: MessageTypeDefinition<_envoy_config_cluster_v3_TrackClusterStats, _envoy_config_cluster_v3_TrackClusterStats__Output>
+          UpstreamConnectionOptions: MessageTypeDefinition<_envoy_config_cluster_v3_UpstreamConnectionOptions, _envoy_config_cluster_v3_UpstreamConnectionOptions__Output>
         }
       }
       core: {
         v3: {
-          Address: MessageTypeDefinition
-          AggregatedConfigSource: MessageTypeDefinition
-          AlternateProtocolsCacheOptions: MessageTypeDefinition
-          ApiConfigSource: MessageTypeDefinition
+          Address: MessageTypeDefinition<_envoy_config_core_v3_Address, _envoy_config_core_v3_Address__Output>
+          AggregatedConfigSource: MessageTypeDefinition<_envoy_config_core_v3_AggregatedConfigSource, _envoy_config_core_v3_AggregatedConfigSource__Output>
+          AlternateProtocolsCacheOptions: MessageTypeDefinition<_envoy_config_core_v3_AlternateProtocolsCacheOptions, _envoy_config_core_v3_AlternateProtocolsCacheOptions__Output>
+          ApiConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ApiConfigSource, _envoy_config_core_v3_ApiConfigSource__Output>
           ApiVersion: EnumTypeDefinition
-          AsyncDataSource: MessageTypeDefinition
-          BackoffStrategy: MessageTypeDefinition
-          BindConfig: MessageTypeDefinition
-          BuildVersion: MessageTypeDefinition
-          CidrRange: MessageTypeDefinition
-          ConfigSource: MessageTypeDefinition
-          ControlPlane: MessageTypeDefinition
-          DataSource: MessageTypeDefinition
-          DnsResolutionConfig: MessageTypeDefinition
-          DnsResolverOptions: MessageTypeDefinition
-          EnvoyInternalAddress: MessageTypeDefinition
-          EventServiceConfig: MessageTypeDefinition
-          Extension: MessageTypeDefinition
-          ExtensionConfigSource: MessageTypeDefinition
-          ExtraSourceAddress: MessageTypeDefinition
-          GrpcProtocolOptions: MessageTypeDefinition
-          GrpcService: MessageTypeDefinition
-          HeaderMap: MessageTypeDefinition
-          HeaderValue: MessageTypeDefinition
-          HeaderValueOption: MessageTypeDefinition
-          HealthCheck: MessageTypeDefinition
+          AsyncDataSource: MessageTypeDefinition<_envoy_config_core_v3_AsyncDataSource, _envoy_config_core_v3_AsyncDataSource__Output>
+          BackoffStrategy: MessageTypeDefinition<_envoy_config_core_v3_BackoffStrategy, _envoy_config_core_v3_BackoffStrategy__Output>
+          BindConfig: MessageTypeDefinition<_envoy_config_core_v3_BindConfig, _envoy_config_core_v3_BindConfig__Output>
+          BuildVersion: MessageTypeDefinition<_envoy_config_core_v3_BuildVersion, _envoy_config_core_v3_BuildVersion__Output>
+          CidrRange: MessageTypeDefinition<_envoy_config_core_v3_CidrRange, _envoy_config_core_v3_CidrRange__Output>
+          ConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ConfigSource, _envoy_config_core_v3_ConfigSource__Output>
+          ControlPlane: MessageTypeDefinition<_envoy_config_core_v3_ControlPlane, _envoy_config_core_v3_ControlPlane__Output>
+          DataSource: MessageTypeDefinition<_envoy_config_core_v3_DataSource, _envoy_config_core_v3_DataSource__Output>
+          DnsResolutionConfig: MessageTypeDefinition<_envoy_config_core_v3_DnsResolutionConfig, _envoy_config_core_v3_DnsResolutionConfig__Output>
+          DnsResolverOptions: MessageTypeDefinition<_envoy_config_core_v3_DnsResolverOptions, _envoy_config_core_v3_DnsResolverOptions__Output>
+          EnvoyInternalAddress: MessageTypeDefinition<_envoy_config_core_v3_EnvoyInternalAddress, _envoy_config_core_v3_EnvoyInternalAddress__Output>
+          EventServiceConfig: MessageTypeDefinition<_envoy_config_core_v3_EventServiceConfig, _envoy_config_core_v3_EventServiceConfig__Output>
+          Extension: MessageTypeDefinition<_envoy_config_core_v3_Extension, _envoy_config_core_v3_Extension__Output>
+          ExtensionConfigSource: MessageTypeDefinition<_envoy_config_core_v3_ExtensionConfigSource, _envoy_config_core_v3_ExtensionConfigSource__Output>
+          ExtraSourceAddress: MessageTypeDefinition<_envoy_config_core_v3_ExtraSourceAddress, _envoy_config_core_v3_ExtraSourceAddress__Output>
+          GrpcProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_GrpcProtocolOptions, _envoy_config_core_v3_GrpcProtocolOptions__Output>
+          GrpcService: MessageTypeDefinition<_envoy_config_core_v3_GrpcService, _envoy_config_core_v3_GrpcService__Output>
+          HeaderMap: MessageTypeDefinition<_envoy_config_core_v3_HeaderMap, _envoy_config_core_v3_HeaderMap__Output>
+          HeaderValue: MessageTypeDefinition<_envoy_config_core_v3_HeaderValue, _envoy_config_core_v3_HeaderValue__Output>
+          HeaderValueOption: MessageTypeDefinition<_envoy_config_core_v3_HeaderValueOption, _envoy_config_core_v3_HeaderValueOption__Output>
+          HealthCheck: MessageTypeDefinition<_envoy_config_core_v3_HealthCheck, _envoy_config_core_v3_HealthCheck__Output>
           HealthStatus: EnumTypeDefinition
-          HealthStatusSet: MessageTypeDefinition
-          Http1ProtocolOptions: MessageTypeDefinition
-          Http2ProtocolOptions: MessageTypeDefinition
-          Http3ProtocolOptions: MessageTypeDefinition
-          HttpProtocolOptions: MessageTypeDefinition
-          HttpUri: MessageTypeDefinition
-          KeepaliveSettings: MessageTypeDefinition
-          KeyValue: MessageTypeDefinition
-          KeyValueAppend: MessageTypeDefinition
-          KeyValueMutation: MessageTypeDefinition
-          Locality: MessageTypeDefinition
-          Metadata: MessageTypeDefinition
-          Node: MessageTypeDefinition
-          PathConfigSource: MessageTypeDefinition
-          Pipe: MessageTypeDefinition
-          ProxyProtocolConfig: MessageTypeDefinition
-          ProxyProtocolPassThroughTLVs: MessageTypeDefinition
-          QueryParameter: MessageTypeDefinition
-          QuicKeepAliveSettings: MessageTypeDefinition
-          QuicProtocolOptions: MessageTypeDefinition
-          RateLimitSettings: MessageTypeDefinition
-          RemoteDataSource: MessageTypeDefinition
+          HealthStatusSet: MessageTypeDefinition<_envoy_config_core_v3_HealthStatusSet, _envoy_config_core_v3_HealthStatusSet__Output>
+          Http1ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http1ProtocolOptions, _envoy_config_core_v3_Http1ProtocolOptions__Output>
+          Http2ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http2ProtocolOptions, _envoy_config_core_v3_Http2ProtocolOptions__Output>
+          Http3ProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_Http3ProtocolOptions, _envoy_config_core_v3_Http3ProtocolOptions__Output>
+          HttpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_HttpProtocolOptions, _envoy_config_core_v3_HttpProtocolOptions__Output>
+          HttpUri: MessageTypeDefinition<_envoy_config_core_v3_HttpUri, _envoy_config_core_v3_HttpUri__Output>
+          KeepaliveSettings: MessageTypeDefinition<_envoy_config_core_v3_KeepaliveSettings, _envoy_config_core_v3_KeepaliveSettings__Output>
+          KeyValue: MessageTypeDefinition<_envoy_config_core_v3_KeyValue, _envoy_config_core_v3_KeyValue__Output>
+          KeyValueAppend: MessageTypeDefinition<_envoy_config_core_v3_KeyValueAppend, _envoy_config_core_v3_KeyValueAppend__Output>
+          KeyValueMutation: MessageTypeDefinition<_envoy_config_core_v3_KeyValueMutation, _envoy_config_core_v3_KeyValueMutation__Output>
+          Locality: MessageTypeDefinition<_envoy_config_core_v3_Locality, _envoy_config_core_v3_Locality__Output>
+          Metadata: MessageTypeDefinition<_envoy_config_core_v3_Metadata, _envoy_config_core_v3_Metadata__Output>
+          Node: MessageTypeDefinition<_envoy_config_core_v3_Node, _envoy_config_core_v3_Node__Output>
+          PathConfigSource: MessageTypeDefinition<_envoy_config_core_v3_PathConfigSource, _envoy_config_core_v3_PathConfigSource__Output>
+          Pipe: MessageTypeDefinition<_envoy_config_core_v3_Pipe, _envoy_config_core_v3_Pipe__Output>
+          ProxyProtocolConfig: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolConfig, _envoy_config_core_v3_ProxyProtocolConfig__Output>
+          ProxyProtocolPassThroughTLVs: MessageTypeDefinition<_envoy_config_core_v3_ProxyProtocolPassThroughTLVs, _envoy_config_core_v3_ProxyProtocolPassThroughTLVs__Output>
+          QueryParameter: MessageTypeDefinition<_envoy_config_core_v3_QueryParameter, _envoy_config_core_v3_QueryParameter__Output>
+          QuicKeepAliveSettings: MessageTypeDefinition<_envoy_config_core_v3_QuicKeepAliveSettings, _envoy_config_core_v3_QuicKeepAliveSettings__Output>
+          QuicProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_QuicProtocolOptions, _envoy_config_core_v3_QuicProtocolOptions__Output>
+          RateLimitSettings: MessageTypeDefinition<_envoy_config_core_v3_RateLimitSettings, _envoy_config_core_v3_RateLimitSettings__Output>
+          RemoteDataSource: MessageTypeDefinition<_envoy_config_core_v3_RemoteDataSource, _envoy_config_core_v3_RemoteDataSource__Output>
           RequestMethod: EnumTypeDefinition
-          RetryPolicy: MessageTypeDefinition
+          RetryPolicy: MessageTypeDefinition<_envoy_config_core_v3_RetryPolicy, _envoy_config_core_v3_RetryPolicy__Output>
           RoutingPriority: EnumTypeDefinition
-          RuntimeDouble: MessageTypeDefinition
-          RuntimeFeatureFlag: MessageTypeDefinition
-          RuntimeFractionalPercent: MessageTypeDefinition
-          RuntimePercent: MessageTypeDefinition
-          RuntimeUInt32: MessageTypeDefinition
-          SchemeHeaderTransformation: MessageTypeDefinition
-          SelfConfigSource: MessageTypeDefinition
-          SocketAddress: MessageTypeDefinition
-          SocketOption: MessageTypeDefinition
-          SocketOptionsOverride: MessageTypeDefinition
-          TcpKeepalive: MessageTypeDefinition
-          TcpProtocolOptions: MessageTypeDefinition
+          RuntimeDouble: MessageTypeDefinition<_envoy_config_core_v3_RuntimeDouble, _envoy_config_core_v3_RuntimeDouble__Output>
+          RuntimeFeatureFlag: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFeatureFlag, _envoy_config_core_v3_RuntimeFeatureFlag__Output>
+          RuntimeFractionalPercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimeFractionalPercent, _envoy_config_core_v3_RuntimeFractionalPercent__Output>
+          RuntimePercent: MessageTypeDefinition<_envoy_config_core_v3_RuntimePercent, _envoy_config_core_v3_RuntimePercent__Output>
+          RuntimeUInt32: MessageTypeDefinition<_envoy_config_core_v3_RuntimeUInt32, _envoy_config_core_v3_RuntimeUInt32__Output>
+          SchemeHeaderTransformation: MessageTypeDefinition<_envoy_config_core_v3_SchemeHeaderTransformation, _envoy_config_core_v3_SchemeHeaderTransformation__Output>
+          SelfConfigSource: MessageTypeDefinition<_envoy_config_core_v3_SelfConfigSource, _envoy_config_core_v3_SelfConfigSource__Output>
+          SocketAddress: MessageTypeDefinition<_envoy_config_core_v3_SocketAddress, _envoy_config_core_v3_SocketAddress__Output>
+          SocketOption: MessageTypeDefinition<_envoy_config_core_v3_SocketOption, _envoy_config_core_v3_SocketOption__Output>
+          SocketOptionsOverride: MessageTypeDefinition<_envoy_config_core_v3_SocketOptionsOverride, _envoy_config_core_v3_SocketOptionsOverride__Output>
+          TcpKeepalive: MessageTypeDefinition<_envoy_config_core_v3_TcpKeepalive, _envoy_config_core_v3_TcpKeepalive__Output>
+          TcpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_TcpProtocolOptions, _envoy_config_core_v3_TcpProtocolOptions__Output>
           TrafficDirection: EnumTypeDefinition
-          TransportSocket: MessageTypeDefinition
-          TypedExtensionConfig: MessageTypeDefinition
-          UpstreamHttpProtocolOptions: MessageTypeDefinition
-          WatchedDirectory: MessageTypeDefinition
+          TransportSocket: MessageTypeDefinition<_envoy_config_core_v3_TransportSocket, _envoy_config_core_v3_TransportSocket__Output>
+          TypedExtensionConfig: MessageTypeDefinition<_envoy_config_core_v3_TypedExtensionConfig, _envoy_config_core_v3_TypedExtensionConfig__Output>
+          UpstreamHttpProtocolOptions: MessageTypeDefinition<_envoy_config_core_v3_UpstreamHttpProtocolOptions, _envoy_config_core_v3_UpstreamHttpProtocolOptions__Output>
+          WatchedDirectory: MessageTypeDefinition<_envoy_config_core_v3_WatchedDirectory, _envoy_config_core_v3_WatchedDirectory__Output>
         }
       }
       endpoint: {
         v3: {
-          ClusterLoadAssignment: MessageTypeDefinition
-          Endpoint: MessageTypeDefinition
-          LbEndpoint: MessageTypeDefinition
-          LedsClusterLocalityConfig: MessageTypeDefinition
-          LocalityLbEndpoints: MessageTypeDefinition
+          ClusterLoadAssignment: MessageTypeDefinition<_envoy_config_endpoint_v3_ClusterLoadAssignment, _envoy_config_endpoint_v3_ClusterLoadAssignment__Output>
+          Endpoint: MessageTypeDefinition<_envoy_config_endpoint_v3_Endpoint, _envoy_config_endpoint_v3_Endpoint__Output>
+          LbEndpoint: MessageTypeDefinition<_envoy_config_endpoint_v3_LbEndpoint, _envoy_config_endpoint_v3_LbEndpoint__Output>
+          LedsClusterLocalityConfig: MessageTypeDefinition<_envoy_config_endpoint_v3_LedsClusterLocalityConfig, _envoy_config_endpoint_v3_LedsClusterLocalityConfig__Output>
+          LocalityLbEndpoints: MessageTypeDefinition<_envoy_config_endpoint_v3_LocalityLbEndpoints, _envoy_config_endpoint_v3_LocalityLbEndpoints__Output>
         }
       }
     }
@@ -110,7 +277,7 @@ export interface ProtoGrpcType {
       load_balancing_policies: {
         wrr_locality: {
           v3: {
-            WrrLocality: MessageTypeDefinition
+            WrrLocality: MessageTypeDefinition<_envoy_extensions_load_balancing_policies_wrr_locality_v3_WrrLocality, _envoy_extensions_load_balancing_policies_wrr_locality_v3_WrrLocality__Output>
           }
         }
       }
@@ -118,129 +285,129 @@ export interface ProtoGrpcType {
     type: {
       matcher: {
         v3: {
-          ListStringMatcher: MessageTypeDefinition
-          RegexMatchAndSubstitute: MessageTypeDefinition
-          RegexMatcher: MessageTypeDefinition
-          StringMatcher: MessageTypeDefinition
+          ListStringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_ListStringMatcher, _envoy_type_matcher_v3_ListStringMatcher__Output>
+          RegexMatchAndSubstitute: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatchAndSubstitute, _envoy_type_matcher_v3_RegexMatchAndSubstitute__Output>
+          RegexMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_RegexMatcher, _envoy_type_matcher_v3_RegexMatcher__Output>
+          StringMatcher: MessageTypeDefinition<_envoy_type_matcher_v3_StringMatcher, _envoy_type_matcher_v3_StringMatcher__Output>
         }
       }
       metadata: {
         v3: {
-          MetadataKey: MessageTypeDefinition
-          MetadataKind: MessageTypeDefinition
+          MetadataKey: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKey, _envoy_type_metadata_v3_MetadataKey__Output>
+          MetadataKind: MessageTypeDefinition<_envoy_type_metadata_v3_MetadataKind, _envoy_type_metadata_v3_MetadataKind__Output>
         }
       }
       v3: {
         CodecClientType: EnumTypeDefinition
-        DoubleRange: MessageTypeDefinition
-        FractionalPercent: MessageTypeDefinition
-        Int32Range: MessageTypeDefinition
-        Int64Range: MessageTypeDefinition
-        Percent: MessageTypeDefinition
-        SemanticVersion: MessageTypeDefinition
+        DoubleRange: MessageTypeDefinition<_envoy_type_v3_DoubleRange, _envoy_type_v3_DoubleRange__Output>
+        FractionalPercent: MessageTypeDefinition<_envoy_type_v3_FractionalPercent, _envoy_type_v3_FractionalPercent__Output>
+        Int32Range: MessageTypeDefinition<_envoy_type_v3_Int32Range, _envoy_type_v3_Int32Range__Output>
+        Int64Range: MessageTypeDefinition<_envoy_type_v3_Int64Range, _envoy_type_v3_Int64Range__Output>
+        Percent: MessageTypeDefinition<_envoy_type_v3_Percent, _envoy_type_v3_Percent__Output>
+        SemanticVersion: MessageTypeDefinition<_envoy_type_v3_SemanticVersion, _envoy_type_v3_SemanticVersion__Output>
       }
     }
   }
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DescriptorProto: MessageTypeDefinition<_google_protobuf_DescriptorProto, _google_protobuf_DescriptorProto__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
       Edition: EnumTypeDefinition
-      Empty: MessageTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      ListValue: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
+      Empty: MessageTypeDefinition<_google_protobuf_Empty, _google_protobuf_Empty__Output>
+      EnumDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumDescriptorProto, _google_protobuf_EnumDescriptorProto__Output>
+      EnumOptions: MessageTypeDefinition<_google_protobuf_EnumOptions, _google_protobuf_EnumOptions__Output>
+      EnumValueDescriptorProto: MessageTypeDefinition<_google_protobuf_EnumValueDescriptorProto, _google_protobuf_EnumValueDescriptorProto__Output>
+      EnumValueOptions: MessageTypeDefinition<_google_protobuf_EnumValueOptions, _google_protobuf_EnumValueOptions__Output>
+      ExtensionRangeOptions: MessageTypeDefinition<_google_protobuf_ExtensionRangeOptions, _google_protobuf_ExtensionRangeOptions__Output>
+      FeatureSet: MessageTypeDefinition<_google_protobuf_FeatureSet, _google_protobuf_FeatureSet__Output>
+      FeatureSetDefaults: MessageTypeDefinition<_google_protobuf_FeatureSetDefaults, _google_protobuf_FeatureSetDefaults__Output>
+      FieldDescriptorProto: MessageTypeDefinition<_google_protobuf_FieldDescriptorProto, _google_protobuf_FieldDescriptorProto__Output>
+      FieldOptions: MessageTypeDefinition<_google_protobuf_FieldOptions, _google_protobuf_FieldOptions__Output>
+      FileDescriptorProto: MessageTypeDefinition<_google_protobuf_FileDescriptorProto, _google_protobuf_FileDescriptorProto__Output>
+      FileDescriptorSet: MessageTypeDefinition<_google_protobuf_FileDescriptorSet, _google_protobuf_FileDescriptorSet__Output>
+      FileOptions: MessageTypeDefinition<_google_protobuf_FileOptions, _google_protobuf_FileOptions__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      GeneratedCodeInfo: MessageTypeDefinition<_google_protobuf_GeneratedCodeInfo, _google_protobuf_GeneratedCodeInfo__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      ListValue: MessageTypeDefinition<_google_protobuf_ListValue, _google_protobuf_ListValue__Output>
+      MessageOptions: MessageTypeDefinition<_google_protobuf_MessageOptions, _google_protobuf_MessageOptions__Output>
+      MethodDescriptorProto: MessageTypeDefinition<_google_protobuf_MethodDescriptorProto, _google_protobuf_MethodDescriptorProto__Output>
+      MethodOptions: MessageTypeDefinition<_google_protobuf_MethodOptions, _google_protobuf_MethodOptions__Output>
       NullValue: EnumTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Struct: MessageTypeDefinition
+      OneofDescriptorProto: MessageTypeDefinition<_google_protobuf_OneofDescriptorProto, _google_protobuf_OneofDescriptorProto__Output>
+      OneofOptions: MessageTypeDefinition<_google_protobuf_OneofOptions, _google_protobuf_OneofOptions__Output>
+      ServiceDescriptorProto: MessageTypeDefinition<_google_protobuf_ServiceDescriptorProto, _google_protobuf_ServiceDescriptorProto__Output>
+      ServiceOptions: MessageTypeDefinition<_google_protobuf_ServiceOptions, _google_protobuf_ServiceOptions__Output>
+      SourceCodeInfo: MessageTypeDefinition<_google_protobuf_SourceCodeInfo, _google_protobuf_SourceCodeInfo__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Struct: MessageTypeDefinition<_google_protobuf_Struct, _google_protobuf_Struct__Output>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
-      Value: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
+      UninterpretedOption: MessageTypeDefinition<_google_protobuf_UninterpretedOption, _google_protobuf_UninterpretedOption__Output>
+      Value: MessageTypeDefinition<_google_protobuf_Value, _google_protobuf_Value__Output>
     }
   }
   udpa: {
     annotations: {
-      FieldMigrateAnnotation: MessageTypeDefinition
-      FieldSecurityAnnotation: MessageTypeDefinition
-      FileMigrateAnnotation: MessageTypeDefinition
-      MigrateAnnotation: MessageTypeDefinition
+      FieldMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FieldMigrateAnnotation, _udpa_annotations_FieldMigrateAnnotation__Output>
+      FieldSecurityAnnotation: MessageTypeDefinition<_udpa_annotations_FieldSecurityAnnotation, _udpa_annotations_FieldSecurityAnnotation__Output>
+      FileMigrateAnnotation: MessageTypeDefinition<_udpa_annotations_FileMigrateAnnotation, _udpa_annotations_FileMigrateAnnotation__Output>
+      MigrateAnnotation: MessageTypeDefinition<_udpa_annotations_MigrateAnnotation, _udpa_annotations_MigrateAnnotation__Output>
       PackageVersionStatus: EnumTypeDefinition
-      StatusAnnotation: MessageTypeDefinition
-      VersioningAnnotation: MessageTypeDefinition
+      StatusAnnotation: MessageTypeDefinition<_udpa_annotations_StatusAnnotation, _udpa_annotations_StatusAnnotation__Output>
+      VersioningAnnotation: MessageTypeDefinition<_udpa_annotations_VersioningAnnotation, _udpa_annotations_VersioningAnnotation__Output>
     }
   }
   validate: {
-    AnyRules: MessageTypeDefinition
-    BoolRules: MessageTypeDefinition
-    BytesRules: MessageTypeDefinition
-    DoubleRules: MessageTypeDefinition
-    DurationRules: MessageTypeDefinition
-    EnumRules: MessageTypeDefinition
-    FieldRules: MessageTypeDefinition
-    Fixed32Rules: MessageTypeDefinition
-    Fixed64Rules: MessageTypeDefinition
-    FloatRules: MessageTypeDefinition
-    Int32Rules: MessageTypeDefinition
-    Int64Rules: MessageTypeDefinition
+    AnyRules: MessageTypeDefinition<_validate_AnyRules, _validate_AnyRules__Output>
+    BoolRules: MessageTypeDefinition<_validate_BoolRules, _validate_BoolRules__Output>
+    BytesRules: MessageTypeDefinition<_validate_BytesRules, _validate_BytesRules__Output>
+    DoubleRules: MessageTypeDefinition<_validate_DoubleRules, _validate_DoubleRules__Output>
+    DurationRules: MessageTypeDefinition<_validate_DurationRules, _validate_DurationRules__Output>
+    EnumRules: MessageTypeDefinition<_validate_EnumRules, _validate_EnumRules__Output>
+    FieldRules: MessageTypeDefinition<_validate_FieldRules, _validate_FieldRules__Output>
+    Fixed32Rules: MessageTypeDefinition<_validate_Fixed32Rules, _validate_Fixed32Rules__Output>
+    Fixed64Rules: MessageTypeDefinition<_validate_Fixed64Rules, _validate_Fixed64Rules__Output>
+    FloatRules: MessageTypeDefinition<_validate_FloatRules, _validate_FloatRules__Output>
+    Int32Rules: MessageTypeDefinition<_validate_Int32Rules, _validate_Int32Rules__Output>
+    Int64Rules: MessageTypeDefinition<_validate_Int64Rules, _validate_Int64Rules__Output>
     KnownRegex: EnumTypeDefinition
-    MapRules: MessageTypeDefinition
-    MessageRules: MessageTypeDefinition
-    RepeatedRules: MessageTypeDefinition
-    SFixed32Rules: MessageTypeDefinition
-    SFixed64Rules: MessageTypeDefinition
-    SInt32Rules: MessageTypeDefinition
-    SInt64Rules: MessageTypeDefinition
-    StringRules: MessageTypeDefinition
-    TimestampRules: MessageTypeDefinition
-    UInt32Rules: MessageTypeDefinition
-    UInt64Rules: MessageTypeDefinition
+    MapRules: MessageTypeDefinition<_validate_MapRules, _validate_MapRules__Output>
+    MessageRules: MessageTypeDefinition<_validate_MessageRules, _validate_MessageRules__Output>
+    RepeatedRules: MessageTypeDefinition<_validate_RepeatedRules, _validate_RepeatedRules__Output>
+    SFixed32Rules: MessageTypeDefinition<_validate_SFixed32Rules, _validate_SFixed32Rules__Output>
+    SFixed64Rules: MessageTypeDefinition<_validate_SFixed64Rules, _validate_SFixed64Rules__Output>
+    SInt32Rules: MessageTypeDefinition<_validate_SInt32Rules, _validate_SInt32Rules__Output>
+    SInt64Rules: MessageTypeDefinition<_validate_SInt64Rules, _validate_SInt64Rules__Output>
+    StringRules: MessageTypeDefinition<_validate_StringRules, _validate_StringRules__Output>
+    TimestampRules: MessageTypeDefinition<_validate_TimestampRules, _validate_TimestampRules__Output>
+    UInt32Rules: MessageTypeDefinition<_validate_UInt32Rules, _validate_UInt32Rules__Output>
+    UInt64Rules: MessageTypeDefinition<_validate_UInt64Rules, _validate_UInt64Rules__Output>
   }
   xds: {
     annotations: {
       v3: {
-        FieldStatusAnnotation: MessageTypeDefinition
-        FileStatusAnnotation: MessageTypeDefinition
-        MessageStatusAnnotation: MessageTypeDefinition
+        FieldStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FieldStatusAnnotation, _xds_annotations_v3_FieldStatusAnnotation__Output>
+        FileStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_FileStatusAnnotation, _xds_annotations_v3_FileStatusAnnotation__Output>
+        MessageStatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_MessageStatusAnnotation, _xds_annotations_v3_MessageStatusAnnotation__Output>
         PackageVersionStatus: EnumTypeDefinition
-        StatusAnnotation: MessageTypeDefinition
+        StatusAnnotation: MessageTypeDefinition<_xds_annotations_v3_StatusAnnotation, _xds_annotations_v3_StatusAnnotation__Output>
       }
     }
     core: {
       v3: {
-        Authority: MessageTypeDefinition
-        CollectionEntry: MessageTypeDefinition
-        ContextParams: MessageTypeDefinition
-        ResourceLocator: MessageTypeDefinition
-        TypedExtensionConfig: MessageTypeDefinition
+        Authority: MessageTypeDefinition<_xds_core_v3_Authority, _xds_core_v3_Authority__Output>
+        CollectionEntry: MessageTypeDefinition<_xds_core_v3_CollectionEntry, _xds_core_v3_CollectionEntry__Output>
+        ContextParams: MessageTypeDefinition<_xds_core_v3_ContextParams, _xds_core_v3_ContextParams__Output>
+        ResourceLocator: MessageTypeDefinition<_xds_core_v3_ResourceLocator, _xds_core_v3_ResourceLocator__Output>
+        TypedExtensionConfig: MessageTypeDefinition<_xds_core_v3_TypedExtensionConfig, _xds_core_v3_TypedExtensionConfig__Output>
       }
     }
   }

--- a/packages/grpc-js-xds/test/generated/echo.ts
+++ b/packages/grpc-js-xds/test/generated/echo.ts
@@ -1,11 +1,21 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { DebugInfo as _grpc_testing_DebugInfo, DebugInfo__Output as _grpc_testing_DebugInfo__Output } from './grpc/testing/DebugInfo';
+import type { EchoRequest as _grpc_testing_EchoRequest, EchoRequest__Output as _grpc_testing_EchoRequest__Output } from './grpc/testing/EchoRequest';
+import type { EchoResponse as _grpc_testing_EchoResponse, EchoResponse__Output as _grpc_testing_EchoResponse__Output } from './grpc/testing/EchoResponse';
 import type { EchoTest1ServiceClient as _grpc_testing_EchoTest1ServiceClient, EchoTest1ServiceDefinition as _grpc_testing_EchoTest1ServiceDefinition } from './grpc/testing/EchoTest1Service';
 import type { EchoTest2ServiceClient as _grpc_testing_EchoTest2ServiceClient, EchoTest2ServiceDefinition as _grpc_testing_EchoTest2ServiceDefinition } from './grpc/testing/EchoTest2Service';
 import type { EchoTestServiceClient as _grpc_testing_EchoTestServiceClient, EchoTestServiceDefinition as _grpc_testing_EchoTestServiceDefinition } from './grpc/testing/EchoTestService';
+import type { ErrorStatus as _grpc_testing_ErrorStatus, ErrorStatus__Output as _grpc_testing_ErrorStatus__Output } from './grpc/testing/ErrorStatus';
 import type { NoRpcServiceClient as _grpc_testing_NoRpcServiceClient, NoRpcServiceDefinition as _grpc_testing_NoRpcServiceDefinition } from './grpc/testing/NoRpcService';
+import type { RequestParams as _grpc_testing_RequestParams, RequestParams__Output as _grpc_testing_RequestParams__Output } from './grpc/testing/RequestParams';
+import type { ResponseParams as _grpc_testing_ResponseParams, ResponseParams__Output as _grpc_testing_ResponseParams__Output } from './grpc/testing/ResponseParams';
+import type { SimpleRequest as _grpc_testing_SimpleRequest, SimpleRequest__Output as _grpc_testing_SimpleRequest__Output } from './grpc/testing/SimpleRequest';
+import type { SimpleResponse as _grpc_testing_SimpleResponse, SimpleResponse__Output as _grpc_testing_SimpleResponse__Output } from './grpc/testing/SimpleResponse';
+import type { StringValue as _grpc_testing_StringValue, StringValue__Output as _grpc_testing_StringValue__Output } from './grpc/testing/StringValue';
 import type { UnimplementedEchoServiceClient as _grpc_testing_UnimplementedEchoServiceClient, UnimplementedEchoServiceDefinition as _grpc_testing_UnimplementedEchoServiceDefinition } from './grpc/testing/UnimplementedEchoService';
+import type { OrcaLoadReport as _xds_data_orca_v3_OrcaLoadReport, OrcaLoadReport__Output as _xds_data_orca_v3_OrcaLoadReport__Output } from './xds/data/orca/v3/OrcaLoadReport';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -14,22 +24,22 @@ type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> 
 export interface ProtoGrpcType {
   grpc: {
     testing: {
-      DebugInfo: MessageTypeDefinition
-      EchoRequest: MessageTypeDefinition
-      EchoResponse: MessageTypeDefinition
+      DebugInfo: MessageTypeDefinition<_grpc_testing_DebugInfo, _grpc_testing_DebugInfo__Output>
+      EchoRequest: MessageTypeDefinition<_grpc_testing_EchoRequest, _grpc_testing_EchoRequest__Output>
+      EchoResponse: MessageTypeDefinition<_grpc_testing_EchoResponse, _grpc_testing_EchoResponse__Output>
       EchoTest1Service: SubtypeConstructor<typeof grpc.Client, _grpc_testing_EchoTest1ServiceClient> & { service: _grpc_testing_EchoTest1ServiceDefinition }
       EchoTest2Service: SubtypeConstructor<typeof grpc.Client, _grpc_testing_EchoTest2ServiceClient> & { service: _grpc_testing_EchoTest2ServiceDefinition }
       EchoTestService: SubtypeConstructor<typeof grpc.Client, _grpc_testing_EchoTestServiceClient> & { service: _grpc_testing_EchoTestServiceDefinition }
-      ErrorStatus: MessageTypeDefinition
+      ErrorStatus: MessageTypeDefinition<_grpc_testing_ErrorStatus, _grpc_testing_ErrorStatus__Output>
       /**
        * A service without any rpc defined to test coverage.
        */
       NoRpcService: SubtypeConstructor<typeof grpc.Client, _grpc_testing_NoRpcServiceClient> & { service: _grpc_testing_NoRpcServiceDefinition }
-      RequestParams: MessageTypeDefinition
-      ResponseParams: MessageTypeDefinition
-      SimpleRequest: MessageTypeDefinition
-      SimpleResponse: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
+      RequestParams: MessageTypeDefinition<_grpc_testing_RequestParams, _grpc_testing_RequestParams__Output>
+      ResponseParams: MessageTypeDefinition<_grpc_testing_ResponseParams, _grpc_testing_ResponseParams__Output>
+      SimpleRequest: MessageTypeDefinition<_grpc_testing_SimpleRequest, _grpc_testing_SimpleRequest__Output>
+      SimpleResponse: MessageTypeDefinition<_grpc_testing_SimpleResponse, _grpc_testing_SimpleResponse__Output>
+      StringValue: MessageTypeDefinition<_grpc_testing_StringValue, _grpc_testing_StringValue__Output>
       UnimplementedEchoService: SubtypeConstructor<typeof grpc.Client, _grpc_testing_UnimplementedEchoServiceClient> & { service: _grpc_testing_UnimplementedEchoServiceDefinition }
     }
   }
@@ -37,7 +47,7 @@ export interface ProtoGrpcType {
     data: {
       orca: {
         v3: {
-          OrcaLoadReport: MessageTypeDefinition
+          OrcaLoadReport: MessageTypeDefinition<_xds_data_orca_v3_OrcaLoadReport, _xds_data_orca_v3_OrcaLoadReport__Output>
         }
       }
     }

--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -57,7 +57,7 @@
     "compile": "tsc -p .",
     "format": "clang-format -i -style=\"{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}\" src/*.ts test/*.ts",
     "lint": "eslint src/*.ts test/*.ts",
-    "prepare": "npm run generate-types && npm run compile",
+    "prepare": "npm run generate-types && npm run generate-test-types && npm run compile",
     "test": "gulp test",
     "check": "npm run lint",
     "fix": "eslint --fix src/*.ts test/*.ts",

--- a/packages/grpc-js/src/generated/channelz.ts
+++ b/packages/grpc-js/src/generated/channelz.ts
@@ -1,7 +1,53 @@
 import type * as grpc from '../index';
 import type { MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { Any as _google_protobuf_Any, Any__Output as _google_protobuf_Any__Output } from './google/protobuf/Any';
+import type { BoolValue as _google_protobuf_BoolValue, BoolValue__Output as _google_protobuf_BoolValue__Output } from './google/protobuf/BoolValue';
+import type { BytesValue as _google_protobuf_BytesValue, BytesValue__Output as _google_protobuf_BytesValue__Output } from './google/protobuf/BytesValue';
+import type { DoubleValue as _google_protobuf_DoubleValue, DoubleValue__Output as _google_protobuf_DoubleValue__Output } from './google/protobuf/DoubleValue';
+import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from './google/protobuf/Duration';
+import type { FloatValue as _google_protobuf_FloatValue, FloatValue__Output as _google_protobuf_FloatValue__Output } from './google/protobuf/FloatValue';
+import type { Int32Value as _google_protobuf_Int32Value, Int32Value__Output as _google_protobuf_Int32Value__Output } from './google/protobuf/Int32Value';
+import type { Int64Value as _google_protobuf_Int64Value, Int64Value__Output as _google_protobuf_Int64Value__Output } from './google/protobuf/Int64Value';
+import type { StringValue as _google_protobuf_StringValue, StringValue__Output as _google_protobuf_StringValue__Output } from './google/protobuf/StringValue';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from './google/protobuf/Timestamp';
+import type { UInt32Value as _google_protobuf_UInt32Value, UInt32Value__Output as _google_protobuf_UInt32Value__Output } from './google/protobuf/UInt32Value';
+import type { UInt64Value as _google_protobuf_UInt64Value, UInt64Value__Output as _google_protobuf_UInt64Value__Output } from './google/protobuf/UInt64Value';
+import type { Address as _grpc_channelz_v1_Address, Address__Output as _grpc_channelz_v1_Address__Output } from './grpc/channelz/v1/Address';
+import type { Channel as _grpc_channelz_v1_Channel, Channel__Output as _grpc_channelz_v1_Channel__Output } from './grpc/channelz/v1/Channel';
+import type { ChannelConnectivityState as _grpc_channelz_v1_ChannelConnectivityState, ChannelConnectivityState__Output as _grpc_channelz_v1_ChannelConnectivityState__Output } from './grpc/channelz/v1/ChannelConnectivityState';
+import type { ChannelData as _grpc_channelz_v1_ChannelData, ChannelData__Output as _grpc_channelz_v1_ChannelData__Output } from './grpc/channelz/v1/ChannelData';
+import type { ChannelRef as _grpc_channelz_v1_ChannelRef, ChannelRef__Output as _grpc_channelz_v1_ChannelRef__Output } from './grpc/channelz/v1/ChannelRef';
+import type { ChannelTrace as _grpc_channelz_v1_ChannelTrace, ChannelTrace__Output as _grpc_channelz_v1_ChannelTrace__Output } from './grpc/channelz/v1/ChannelTrace';
+import type { ChannelTraceEvent as _grpc_channelz_v1_ChannelTraceEvent, ChannelTraceEvent__Output as _grpc_channelz_v1_ChannelTraceEvent__Output } from './grpc/channelz/v1/ChannelTraceEvent';
 import type { ChannelzClient as _grpc_channelz_v1_ChannelzClient, ChannelzDefinition as _grpc_channelz_v1_ChannelzDefinition } from './grpc/channelz/v1/Channelz';
+import type { GetChannelRequest as _grpc_channelz_v1_GetChannelRequest, GetChannelRequest__Output as _grpc_channelz_v1_GetChannelRequest__Output } from './grpc/channelz/v1/GetChannelRequest';
+import type { GetChannelResponse as _grpc_channelz_v1_GetChannelResponse, GetChannelResponse__Output as _grpc_channelz_v1_GetChannelResponse__Output } from './grpc/channelz/v1/GetChannelResponse';
+import type { GetServerRequest as _grpc_channelz_v1_GetServerRequest, GetServerRequest__Output as _grpc_channelz_v1_GetServerRequest__Output } from './grpc/channelz/v1/GetServerRequest';
+import type { GetServerResponse as _grpc_channelz_v1_GetServerResponse, GetServerResponse__Output as _grpc_channelz_v1_GetServerResponse__Output } from './grpc/channelz/v1/GetServerResponse';
+import type { GetServerSocketsRequest as _grpc_channelz_v1_GetServerSocketsRequest, GetServerSocketsRequest__Output as _grpc_channelz_v1_GetServerSocketsRequest__Output } from './grpc/channelz/v1/GetServerSocketsRequest';
+import type { GetServerSocketsResponse as _grpc_channelz_v1_GetServerSocketsResponse, GetServerSocketsResponse__Output as _grpc_channelz_v1_GetServerSocketsResponse__Output } from './grpc/channelz/v1/GetServerSocketsResponse';
+import type { GetServersRequest as _grpc_channelz_v1_GetServersRequest, GetServersRequest__Output as _grpc_channelz_v1_GetServersRequest__Output } from './grpc/channelz/v1/GetServersRequest';
+import type { GetServersResponse as _grpc_channelz_v1_GetServersResponse, GetServersResponse__Output as _grpc_channelz_v1_GetServersResponse__Output } from './grpc/channelz/v1/GetServersResponse';
+import type { GetSocketRequest as _grpc_channelz_v1_GetSocketRequest, GetSocketRequest__Output as _grpc_channelz_v1_GetSocketRequest__Output } from './grpc/channelz/v1/GetSocketRequest';
+import type { GetSocketResponse as _grpc_channelz_v1_GetSocketResponse, GetSocketResponse__Output as _grpc_channelz_v1_GetSocketResponse__Output } from './grpc/channelz/v1/GetSocketResponse';
+import type { GetSubchannelRequest as _grpc_channelz_v1_GetSubchannelRequest, GetSubchannelRequest__Output as _grpc_channelz_v1_GetSubchannelRequest__Output } from './grpc/channelz/v1/GetSubchannelRequest';
+import type { GetSubchannelResponse as _grpc_channelz_v1_GetSubchannelResponse, GetSubchannelResponse__Output as _grpc_channelz_v1_GetSubchannelResponse__Output } from './grpc/channelz/v1/GetSubchannelResponse';
+import type { GetTopChannelsRequest as _grpc_channelz_v1_GetTopChannelsRequest, GetTopChannelsRequest__Output as _grpc_channelz_v1_GetTopChannelsRequest__Output } from './grpc/channelz/v1/GetTopChannelsRequest';
+import type { GetTopChannelsResponse as _grpc_channelz_v1_GetTopChannelsResponse, GetTopChannelsResponse__Output as _grpc_channelz_v1_GetTopChannelsResponse__Output } from './grpc/channelz/v1/GetTopChannelsResponse';
+import type { Security as _grpc_channelz_v1_Security, Security__Output as _grpc_channelz_v1_Security__Output } from './grpc/channelz/v1/Security';
+import type { Server as _grpc_channelz_v1_Server, Server__Output as _grpc_channelz_v1_Server__Output } from './grpc/channelz/v1/Server';
+import type { ServerData as _grpc_channelz_v1_ServerData, ServerData__Output as _grpc_channelz_v1_ServerData__Output } from './grpc/channelz/v1/ServerData';
+import type { ServerRef as _grpc_channelz_v1_ServerRef, ServerRef__Output as _grpc_channelz_v1_ServerRef__Output } from './grpc/channelz/v1/ServerRef';
+import type { Socket as _grpc_channelz_v1_Socket, Socket__Output as _grpc_channelz_v1_Socket__Output } from './grpc/channelz/v1/Socket';
+import type { SocketData as _grpc_channelz_v1_SocketData, SocketData__Output as _grpc_channelz_v1_SocketData__Output } from './grpc/channelz/v1/SocketData';
+import type { SocketOption as _grpc_channelz_v1_SocketOption, SocketOption__Output as _grpc_channelz_v1_SocketOption__Output } from './grpc/channelz/v1/SocketOption';
+import type { SocketOptionLinger as _grpc_channelz_v1_SocketOptionLinger, SocketOptionLinger__Output as _grpc_channelz_v1_SocketOptionLinger__Output } from './grpc/channelz/v1/SocketOptionLinger';
+import type { SocketOptionTcpInfo as _grpc_channelz_v1_SocketOptionTcpInfo, SocketOptionTcpInfo__Output as _grpc_channelz_v1_SocketOptionTcpInfo__Output } from './grpc/channelz/v1/SocketOptionTcpInfo';
+import type { SocketOptionTimeout as _grpc_channelz_v1_SocketOptionTimeout, SocketOptionTimeout__Output as _grpc_channelz_v1_SocketOptionTimeout__Output } from './grpc/channelz/v1/SocketOptionTimeout';
+import type { SocketRef as _grpc_channelz_v1_SocketRef, SocketRef__Output as _grpc_channelz_v1_SocketRef__Output } from './grpc/channelz/v1/SocketRef';
+import type { Subchannel as _grpc_channelz_v1_Subchannel, Subchannel__Output as _grpc_channelz_v1_Subchannel__Output } from './grpc/channelz/v1/Subchannel';
+import type { SubchannelRef as _grpc_channelz_v1_SubchannelRef, SubchannelRef__Output as _grpc_channelz_v1_SubchannelRef__Output } from './grpc/channelz/v1/SubchannelRef';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -10,62 +56,62 @@ type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> 
 export interface ProtoGrpcType {
   google: {
     protobuf: {
-      Any: MessageTypeDefinition
-      BoolValue: MessageTypeDefinition
-      BytesValue: MessageTypeDefinition
-      DoubleValue: MessageTypeDefinition
-      Duration: MessageTypeDefinition
-      FloatValue: MessageTypeDefinition
-      Int32Value: MessageTypeDefinition
-      Int64Value: MessageTypeDefinition
-      StringValue: MessageTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UInt32Value: MessageTypeDefinition
-      UInt64Value: MessageTypeDefinition
+      Any: MessageTypeDefinition<_google_protobuf_Any, _google_protobuf_Any__Output>
+      BoolValue: MessageTypeDefinition<_google_protobuf_BoolValue, _google_protobuf_BoolValue__Output>
+      BytesValue: MessageTypeDefinition<_google_protobuf_BytesValue, _google_protobuf_BytesValue__Output>
+      DoubleValue: MessageTypeDefinition<_google_protobuf_DoubleValue, _google_protobuf_DoubleValue__Output>
+      Duration: MessageTypeDefinition<_google_protobuf_Duration, _google_protobuf_Duration__Output>
+      FloatValue: MessageTypeDefinition<_google_protobuf_FloatValue, _google_protobuf_FloatValue__Output>
+      Int32Value: MessageTypeDefinition<_google_protobuf_Int32Value, _google_protobuf_Int32Value__Output>
+      Int64Value: MessageTypeDefinition<_google_protobuf_Int64Value, _google_protobuf_Int64Value__Output>
+      StringValue: MessageTypeDefinition<_google_protobuf_StringValue, _google_protobuf_StringValue__Output>
+      Timestamp: MessageTypeDefinition<_google_protobuf_Timestamp, _google_protobuf_Timestamp__Output>
+      UInt32Value: MessageTypeDefinition<_google_protobuf_UInt32Value, _google_protobuf_UInt32Value__Output>
+      UInt64Value: MessageTypeDefinition<_google_protobuf_UInt64Value, _google_protobuf_UInt64Value__Output>
     }
   }
   grpc: {
     channelz: {
       v1: {
-        Address: MessageTypeDefinition
-        Channel: MessageTypeDefinition
-        ChannelConnectivityState: MessageTypeDefinition
-        ChannelData: MessageTypeDefinition
-        ChannelRef: MessageTypeDefinition
-        ChannelTrace: MessageTypeDefinition
-        ChannelTraceEvent: MessageTypeDefinition
+        Address: MessageTypeDefinition<_grpc_channelz_v1_Address, _grpc_channelz_v1_Address__Output>
+        Channel: MessageTypeDefinition<_grpc_channelz_v1_Channel, _grpc_channelz_v1_Channel__Output>
+        ChannelConnectivityState: MessageTypeDefinition<_grpc_channelz_v1_ChannelConnectivityState, _grpc_channelz_v1_ChannelConnectivityState__Output>
+        ChannelData: MessageTypeDefinition<_grpc_channelz_v1_ChannelData, _grpc_channelz_v1_ChannelData__Output>
+        ChannelRef: MessageTypeDefinition<_grpc_channelz_v1_ChannelRef, _grpc_channelz_v1_ChannelRef__Output>
+        ChannelTrace: MessageTypeDefinition<_grpc_channelz_v1_ChannelTrace, _grpc_channelz_v1_ChannelTrace__Output>
+        ChannelTraceEvent: MessageTypeDefinition<_grpc_channelz_v1_ChannelTraceEvent, _grpc_channelz_v1_ChannelTraceEvent__Output>
         /**
          * Channelz is a service exposed by gRPC servers that provides detailed debug
          * information.
          */
         Channelz: SubtypeConstructor<typeof grpc.Client, _grpc_channelz_v1_ChannelzClient> & { service: _grpc_channelz_v1_ChannelzDefinition }
-        GetChannelRequest: MessageTypeDefinition
-        GetChannelResponse: MessageTypeDefinition
-        GetServerRequest: MessageTypeDefinition
-        GetServerResponse: MessageTypeDefinition
-        GetServerSocketsRequest: MessageTypeDefinition
-        GetServerSocketsResponse: MessageTypeDefinition
-        GetServersRequest: MessageTypeDefinition
-        GetServersResponse: MessageTypeDefinition
-        GetSocketRequest: MessageTypeDefinition
-        GetSocketResponse: MessageTypeDefinition
-        GetSubchannelRequest: MessageTypeDefinition
-        GetSubchannelResponse: MessageTypeDefinition
-        GetTopChannelsRequest: MessageTypeDefinition
-        GetTopChannelsResponse: MessageTypeDefinition
-        Security: MessageTypeDefinition
-        Server: MessageTypeDefinition
-        ServerData: MessageTypeDefinition
-        ServerRef: MessageTypeDefinition
-        Socket: MessageTypeDefinition
-        SocketData: MessageTypeDefinition
-        SocketOption: MessageTypeDefinition
-        SocketOptionLinger: MessageTypeDefinition
-        SocketOptionTcpInfo: MessageTypeDefinition
-        SocketOptionTimeout: MessageTypeDefinition
-        SocketRef: MessageTypeDefinition
-        Subchannel: MessageTypeDefinition
-        SubchannelRef: MessageTypeDefinition
+        GetChannelRequest: MessageTypeDefinition<_grpc_channelz_v1_GetChannelRequest, _grpc_channelz_v1_GetChannelRequest__Output>
+        GetChannelResponse: MessageTypeDefinition<_grpc_channelz_v1_GetChannelResponse, _grpc_channelz_v1_GetChannelResponse__Output>
+        GetServerRequest: MessageTypeDefinition<_grpc_channelz_v1_GetServerRequest, _grpc_channelz_v1_GetServerRequest__Output>
+        GetServerResponse: MessageTypeDefinition<_grpc_channelz_v1_GetServerResponse, _grpc_channelz_v1_GetServerResponse__Output>
+        GetServerSocketsRequest: MessageTypeDefinition<_grpc_channelz_v1_GetServerSocketsRequest, _grpc_channelz_v1_GetServerSocketsRequest__Output>
+        GetServerSocketsResponse: MessageTypeDefinition<_grpc_channelz_v1_GetServerSocketsResponse, _grpc_channelz_v1_GetServerSocketsResponse__Output>
+        GetServersRequest: MessageTypeDefinition<_grpc_channelz_v1_GetServersRequest, _grpc_channelz_v1_GetServersRequest__Output>
+        GetServersResponse: MessageTypeDefinition<_grpc_channelz_v1_GetServersResponse, _grpc_channelz_v1_GetServersResponse__Output>
+        GetSocketRequest: MessageTypeDefinition<_grpc_channelz_v1_GetSocketRequest, _grpc_channelz_v1_GetSocketRequest__Output>
+        GetSocketResponse: MessageTypeDefinition<_grpc_channelz_v1_GetSocketResponse, _grpc_channelz_v1_GetSocketResponse__Output>
+        GetSubchannelRequest: MessageTypeDefinition<_grpc_channelz_v1_GetSubchannelRequest, _grpc_channelz_v1_GetSubchannelRequest__Output>
+        GetSubchannelResponse: MessageTypeDefinition<_grpc_channelz_v1_GetSubchannelResponse, _grpc_channelz_v1_GetSubchannelResponse__Output>
+        GetTopChannelsRequest: MessageTypeDefinition<_grpc_channelz_v1_GetTopChannelsRequest, _grpc_channelz_v1_GetTopChannelsRequest__Output>
+        GetTopChannelsResponse: MessageTypeDefinition<_grpc_channelz_v1_GetTopChannelsResponse, _grpc_channelz_v1_GetTopChannelsResponse__Output>
+        Security: MessageTypeDefinition<_grpc_channelz_v1_Security, _grpc_channelz_v1_Security__Output>
+        Server: MessageTypeDefinition<_grpc_channelz_v1_Server, _grpc_channelz_v1_Server__Output>
+        ServerData: MessageTypeDefinition<_grpc_channelz_v1_ServerData, _grpc_channelz_v1_ServerData__Output>
+        ServerRef: MessageTypeDefinition<_grpc_channelz_v1_ServerRef, _grpc_channelz_v1_ServerRef__Output>
+        Socket: MessageTypeDefinition<_grpc_channelz_v1_Socket, _grpc_channelz_v1_Socket__Output>
+        SocketData: MessageTypeDefinition<_grpc_channelz_v1_SocketData, _grpc_channelz_v1_SocketData__Output>
+        SocketOption: MessageTypeDefinition<_grpc_channelz_v1_SocketOption, _grpc_channelz_v1_SocketOption__Output>
+        SocketOptionLinger: MessageTypeDefinition<_grpc_channelz_v1_SocketOptionLinger, _grpc_channelz_v1_SocketOptionLinger__Output>
+        SocketOptionTcpInfo: MessageTypeDefinition<_grpc_channelz_v1_SocketOptionTcpInfo, _grpc_channelz_v1_SocketOptionTcpInfo__Output>
+        SocketOptionTimeout: MessageTypeDefinition<_grpc_channelz_v1_SocketOptionTimeout, _grpc_channelz_v1_SocketOptionTimeout__Output>
+        SocketRef: MessageTypeDefinition<_grpc_channelz_v1_SocketRef, _grpc_channelz_v1_SocketRef__Output>
+        Subchannel: MessageTypeDefinition<_grpc_channelz_v1_Subchannel, _grpc_channelz_v1_Subchannel__Output>
+        SubchannelRef: MessageTypeDefinition<_grpc_channelz_v1_SubchannelRef, _grpc_channelz_v1_SubchannelRef__Output>
       }
     }
   }

--- a/packages/grpc-js/test/generated/Request.ts
+++ b/packages/grpc-js/test/generated/Request.ts
@@ -5,10 +5,14 @@ export interface Request {
   'error'?: (boolean);
   'message'?: (string);
   'errorAfter'?: (number);
+  'responseLength'?: (number);
+  'code'?: (number);
 }
 
 export interface Request__Output {
   'error': (boolean);
   'message': (string);
   'errorAfter': (number);
+  'responseLength': (number);
+  'code': (number);
 }

--- a/packages/grpc-js/test/generated/test_service.ts
+++ b/packages/grpc-js/test/generated/test_service.ts
@@ -1,6 +1,8 @@
 import type * as grpc from '../../src/index';
 import type { MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { Request as _Request, Request__Output as _Request__Output } from './Request';
+import type { Response as _Response, Response__Output as _Response__Output } from './Response';
 import type { TestServiceClient as _TestServiceClient, TestServiceDefinition as _TestServiceDefinition } from './TestService';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
@@ -8,8 +10,8 @@ type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> 
 };
 
 export interface ProtoGrpcType {
-  Request: MessageTypeDefinition
-  Response: MessageTypeDefinition
+  Request: MessageTypeDefinition<_Request, _Request__Output>
+  Response: MessageTypeDefinition<_Response, _Response__Output>
   TestService: SubtypeConstructor<typeof grpc.Client, _TestServiceClient> & { service: _TestServiceDefinition }
 }
 

--- a/packages/proto-loader/golden-generated/echo.ts
+++ b/packages/proto-loader/golden-generated/echo.ts
@@ -1,8 +1,57 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';
 
+import type { ICustomHttpPattern as I_google_api_CustomHttpPattern, OCustomHttpPattern as O_google_api_CustomHttpPattern } from './google/api/CustomHttpPattern';
+import type { IHttp as I_google_api_Http, OHttp as O_google_api_Http } from './google/api/Http';
+import type { IHttpRule as I_google_api_HttpRule, OHttpRule as O_google_api_HttpRule } from './google/api/HttpRule';
+import type { ICancelOperationRequest as I_google_longrunning_CancelOperationRequest, OCancelOperationRequest as O_google_longrunning_CancelOperationRequest } from './google/longrunning/CancelOperationRequest';
+import type { IDeleteOperationRequest as I_google_longrunning_DeleteOperationRequest, ODeleteOperationRequest as O_google_longrunning_DeleteOperationRequest } from './google/longrunning/DeleteOperationRequest';
+import type { IGetOperationRequest as I_google_longrunning_GetOperationRequest, OGetOperationRequest as O_google_longrunning_GetOperationRequest } from './google/longrunning/GetOperationRequest';
+import type { IListOperationsRequest as I_google_longrunning_ListOperationsRequest, OListOperationsRequest as O_google_longrunning_ListOperationsRequest } from './google/longrunning/ListOperationsRequest';
+import type { IListOperationsResponse as I_google_longrunning_ListOperationsResponse, OListOperationsResponse as O_google_longrunning_ListOperationsResponse } from './google/longrunning/ListOperationsResponse';
+import type { IOperation as I_google_longrunning_Operation, OOperation as O_google_longrunning_Operation } from './google/longrunning/Operation';
+import type { IOperationInfo as I_google_longrunning_OperationInfo, OOperationInfo as O_google_longrunning_OperationInfo } from './google/longrunning/OperationInfo';
 import type { OperationsClient as _google_longrunning_OperationsClient, OperationsDefinition as _google_longrunning_OperationsDefinition } from './google/longrunning/Operations';
+import type { IWaitOperationRequest as I_google_longrunning_WaitOperationRequest, OWaitOperationRequest as O_google_longrunning_WaitOperationRequest } from './google/longrunning/WaitOperationRequest';
+import type { IAny as I_google_protobuf_Any, OAny as O_google_protobuf_Any } from './google/protobuf/Any';
+import type { IDescriptorProto as I_google_protobuf_DescriptorProto, ODescriptorProto as O_google_protobuf_DescriptorProto } from './google/protobuf/DescriptorProto';
+import type { IDuration as I_google_protobuf_Duration, ODuration as O_google_protobuf_Duration } from './google/protobuf/Duration';
+import type { IEmpty as I_google_protobuf_Empty, OEmpty as O_google_protobuf_Empty } from './google/protobuf/Empty';
+import type { IEnumDescriptorProto as I_google_protobuf_EnumDescriptorProto, OEnumDescriptorProto as O_google_protobuf_EnumDescriptorProto } from './google/protobuf/EnumDescriptorProto';
+import type { IEnumOptions as I_google_protobuf_EnumOptions, OEnumOptions as O_google_protobuf_EnumOptions } from './google/protobuf/EnumOptions';
+import type { IEnumValueDescriptorProto as I_google_protobuf_EnumValueDescriptorProto, OEnumValueDescriptorProto as O_google_protobuf_EnumValueDescriptorProto } from './google/protobuf/EnumValueDescriptorProto';
+import type { IEnumValueOptions as I_google_protobuf_EnumValueOptions, OEnumValueOptions as O_google_protobuf_EnumValueOptions } from './google/protobuf/EnumValueOptions';
+import type { IExtensionRangeOptions as I_google_protobuf_ExtensionRangeOptions, OExtensionRangeOptions as O_google_protobuf_ExtensionRangeOptions } from './google/protobuf/ExtensionRangeOptions';
+import type { IFeatureSet as I_google_protobuf_FeatureSet, OFeatureSet as O_google_protobuf_FeatureSet } from './google/protobuf/FeatureSet';
+import type { IFeatureSetDefaults as I_google_protobuf_FeatureSetDefaults, OFeatureSetDefaults as O_google_protobuf_FeatureSetDefaults } from './google/protobuf/FeatureSetDefaults';
+import type { IFieldDescriptorProto as I_google_protobuf_FieldDescriptorProto, OFieldDescriptorProto as O_google_protobuf_FieldDescriptorProto } from './google/protobuf/FieldDescriptorProto';
+import type { IFieldOptions as I_google_protobuf_FieldOptions, OFieldOptions as O_google_protobuf_FieldOptions } from './google/protobuf/FieldOptions';
+import type { IFileDescriptorProto as I_google_protobuf_FileDescriptorProto, OFileDescriptorProto as O_google_protobuf_FileDescriptorProto } from './google/protobuf/FileDescriptorProto';
+import type { IFileDescriptorSet as I_google_protobuf_FileDescriptorSet, OFileDescriptorSet as O_google_protobuf_FileDescriptorSet } from './google/protobuf/FileDescriptorSet';
+import type { IFileOptions as I_google_protobuf_FileOptions, OFileOptions as O_google_protobuf_FileOptions } from './google/protobuf/FileOptions';
+import type { IGeneratedCodeInfo as I_google_protobuf_GeneratedCodeInfo, OGeneratedCodeInfo as O_google_protobuf_GeneratedCodeInfo } from './google/protobuf/GeneratedCodeInfo';
+import type { IMessageOptions as I_google_protobuf_MessageOptions, OMessageOptions as O_google_protobuf_MessageOptions } from './google/protobuf/MessageOptions';
+import type { IMethodDescriptorProto as I_google_protobuf_MethodDescriptorProto, OMethodDescriptorProto as O_google_protobuf_MethodDescriptorProto } from './google/protobuf/MethodDescriptorProto';
+import type { IMethodOptions as I_google_protobuf_MethodOptions, OMethodOptions as O_google_protobuf_MethodOptions } from './google/protobuf/MethodOptions';
+import type { IOneofDescriptorProto as I_google_protobuf_OneofDescriptorProto, OOneofDescriptorProto as O_google_protobuf_OneofDescriptorProto } from './google/protobuf/OneofDescriptorProto';
+import type { IOneofOptions as I_google_protobuf_OneofOptions, OOneofOptions as O_google_protobuf_OneofOptions } from './google/protobuf/OneofOptions';
+import type { IServiceDescriptorProto as I_google_protobuf_ServiceDescriptorProto, OServiceDescriptorProto as O_google_protobuf_ServiceDescriptorProto } from './google/protobuf/ServiceDescriptorProto';
+import type { IServiceOptions as I_google_protobuf_ServiceOptions, OServiceOptions as O_google_protobuf_ServiceOptions } from './google/protobuf/ServiceOptions';
+import type { ISourceCodeInfo as I_google_protobuf_SourceCodeInfo, OSourceCodeInfo as O_google_protobuf_SourceCodeInfo } from './google/protobuf/SourceCodeInfo';
+import type { ITimestamp as I_google_protobuf_Timestamp, OTimestamp as O_google_protobuf_Timestamp } from './google/protobuf/Timestamp';
+import type { IUninterpretedOption as I_google_protobuf_UninterpretedOption, OUninterpretedOption as O_google_protobuf_UninterpretedOption } from './google/protobuf/UninterpretedOption';
+import type { IStatus as I_google_rpc_Status, OStatus as O_google_rpc_Status } from './google/rpc/Status';
+import type { IBlockRequest as I_google_showcase_v1beta1_BlockRequest, OBlockRequest as O_google_showcase_v1beta1_BlockRequest } from './google/showcase/v1beta1/BlockRequest';
+import type { IBlockResponse as I_google_showcase_v1beta1_BlockResponse, OBlockResponse as O_google_showcase_v1beta1_BlockResponse } from './google/showcase/v1beta1/BlockResponse';
 import type { EchoClient as _google_showcase_v1beta1_EchoClient, EchoDefinition as _google_showcase_v1beta1_EchoDefinition } from './google/showcase/v1beta1/Echo';
+import type { IEchoRequest as I_google_showcase_v1beta1_EchoRequest, OEchoRequest as O_google_showcase_v1beta1_EchoRequest } from './google/showcase/v1beta1/EchoRequest';
+import type { IEchoResponse as I_google_showcase_v1beta1_EchoResponse, OEchoResponse as O_google_showcase_v1beta1_EchoResponse } from './google/showcase/v1beta1/EchoResponse';
+import type { IExpandRequest as I_google_showcase_v1beta1_ExpandRequest, OExpandRequest as O_google_showcase_v1beta1_ExpandRequest } from './google/showcase/v1beta1/ExpandRequest';
+import type { IPagedExpandRequest as I_google_showcase_v1beta1_PagedExpandRequest, OPagedExpandRequest as O_google_showcase_v1beta1_PagedExpandRequest } from './google/showcase/v1beta1/PagedExpandRequest';
+import type { IPagedExpandResponse as I_google_showcase_v1beta1_PagedExpandResponse, OPagedExpandResponse as O_google_showcase_v1beta1_PagedExpandResponse } from './google/showcase/v1beta1/PagedExpandResponse';
+import type { IWaitMetadata as I_google_showcase_v1beta1_WaitMetadata, OWaitMetadata as O_google_showcase_v1beta1_WaitMetadata } from './google/showcase/v1beta1/WaitMetadata';
+import type { IWaitRequest as I_google_showcase_v1beta1_WaitRequest, OWaitRequest as O_google_showcase_v1beta1_WaitRequest } from './google/showcase/v1beta1/WaitRequest';
+import type { IWaitResponse as I_google_showcase_v1beta1_WaitResponse, OWaitResponse as O_google_showcase_v1beta1_WaitResponse } from './google/showcase/v1beta1/WaitResponse';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
   new(...args: ConstructorParameters<Constructor>): Subtype;
@@ -11,22 +60,22 @@ type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> 
 export interface ProtoGrpcType {
   google: {
     api: {
-      CustomHttpPattern: MessageTypeDefinition
+      CustomHttpPattern: MessageTypeDefinition<I_google_api_CustomHttpPattern, O_google_api_CustomHttpPattern>
       FieldBehavior: EnumTypeDefinition
-      Http: MessageTypeDefinition
-      HttpRule: MessageTypeDefinition
+      Http: MessageTypeDefinition<I_google_api_Http, O_google_api_Http>
+      HttpRule: MessageTypeDefinition<I_google_api_HttpRule, O_google_api_HttpRule>
     }
     longrunning: {
-      CancelOperationRequest: MessageTypeDefinition
-      DeleteOperationRequest: MessageTypeDefinition
-      GetOperationRequest: MessageTypeDefinition
-      ListOperationsRequest: MessageTypeDefinition
-      ListOperationsResponse: MessageTypeDefinition
-      Operation: MessageTypeDefinition
-      OperationInfo: MessageTypeDefinition
+      CancelOperationRequest: MessageTypeDefinition<I_google_longrunning_CancelOperationRequest, O_google_longrunning_CancelOperationRequest>
+      DeleteOperationRequest: MessageTypeDefinition<I_google_longrunning_DeleteOperationRequest, O_google_longrunning_DeleteOperationRequest>
+      GetOperationRequest: MessageTypeDefinition<I_google_longrunning_GetOperationRequest, O_google_longrunning_GetOperationRequest>
+      ListOperationsRequest: MessageTypeDefinition<I_google_longrunning_ListOperationsRequest, O_google_longrunning_ListOperationsRequest>
+      ListOperationsResponse: MessageTypeDefinition<I_google_longrunning_ListOperationsResponse, O_google_longrunning_ListOperationsResponse>
+      Operation: MessageTypeDefinition<I_google_longrunning_Operation, O_google_longrunning_Operation>
+      OperationInfo: MessageTypeDefinition<I_google_longrunning_OperationInfo, O_google_longrunning_OperationInfo>
       /**
        * Manages long-running operations with an API service.
-       * 
+       *
        * When an API method normally takes long time to complete, it can be designed
        * to return [Operation][google.longrunning.Operation] to the client, and the client can use this
        * interface to receive the real response asynchronously by polling the
@@ -36,46 +85,46 @@ export interface ProtoGrpcType {
        * so developers can have a consistent client experience.
        */
       Operations: SubtypeConstructor<typeof grpc.Client, _google_longrunning_OperationsClient> & { service: _google_longrunning_OperationsDefinition }
-      WaitOperationRequest: MessageTypeDefinition
+      WaitOperationRequest: MessageTypeDefinition<I_google_longrunning_WaitOperationRequest, O_google_longrunning_WaitOperationRequest>
     }
     protobuf: {
-      Any: MessageTypeDefinition
-      DescriptorProto: MessageTypeDefinition
-      Duration: MessageTypeDefinition
+      Any: MessageTypeDefinition<I_google_protobuf_Any, O_google_protobuf_Any>
+      DescriptorProto: MessageTypeDefinition<I_google_protobuf_DescriptorProto, O_google_protobuf_DescriptorProto>
+      Duration: MessageTypeDefinition<I_google_protobuf_Duration, O_google_protobuf_Duration>
       Edition: EnumTypeDefinition
-      Empty: MessageTypeDefinition
-      EnumDescriptorProto: MessageTypeDefinition
-      EnumOptions: MessageTypeDefinition
-      EnumValueDescriptorProto: MessageTypeDefinition
-      EnumValueOptions: MessageTypeDefinition
-      ExtensionRangeOptions: MessageTypeDefinition
-      FeatureSet: MessageTypeDefinition
-      FeatureSetDefaults: MessageTypeDefinition
-      FieldDescriptorProto: MessageTypeDefinition
-      FieldOptions: MessageTypeDefinition
-      FileDescriptorProto: MessageTypeDefinition
-      FileDescriptorSet: MessageTypeDefinition
-      FileOptions: MessageTypeDefinition
-      GeneratedCodeInfo: MessageTypeDefinition
-      MessageOptions: MessageTypeDefinition
-      MethodDescriptorProto: MessageTypeDefinition
-      MethodOptions: MessageTypeDefinition
-      OneofDescriptorProto: MessageTypeDefinition
-      OneofOptions: MessageTypeDefinition
-      ServiceDescriptorProto: MessageTypeDefinition
-      ServiceOptions: MessageTypeDefinition
-      SourceCodeInfo: MessageTypeDefinition
+      Empty: MessageTypeDefinition<I_google_protobuf_Empty, O_google_protobuf_Empty>
+      EnumDescriptorProto: MessageTypeDefinition<I_google_protobuf_EnumDescriptorProto, O_google_protobuf_EnumDescriptorProto>
+      EnumOptions: MessageTypeDefinition<I_google_protobuf_EnumOptions, O_google_protobuf_EnumOptions>
+      EnumValueDescriptorProto: MessageTypeDefinition<I_google_protobuf_EnumValueDescriptorProto, O_google_protobuf_EnumValueDescriptorProto>
+      EnumValueOptions: MessageTypeDefinition<I_google_protobuf_EnumValueOptions, O_google_protobuf_EnumValueOptions>
+      ExtensionRangeOptions: MessageTypeDefinition<I_google_protobuf_ExtensionRangeOptions, O_google_protobuf_ExtensionRangeOptions>
+      FeatureSet: MessageTypeDefinition<I_google_protobuf_FeatureSet, O_google_protobuf_FeatureSet>
+      FeatureSetDefaults: MessageTypeDefinition<I_google_protobuf_FeatureSetDefaults, O_google_protobuf_FeatureSetDefaults>
+      FieldDescriptorProto: MessageTypeDefinition<I_google_protobuf_FieldDescriptorProto, O_google_protobuf_FieldDescriptorProto>
+      FieldOptions: MessageTypeDefinition<I_google_protobuf_FieldOptions, O_google_protobuf_FieldOptions>
+      FileDescriptorProto: MessageTypeDefinition<I_google_protobuf_FileDescriptorProto, O_google_protobuf_FileDescriptorProto>
+      FileDescriptorSet: MessageTypeDefinition<I_google_protobuf_FileDescriptorSet, O_google_protobuf_FileDescriptorSet>
+      FileOptions: MessageTypeDefinition<I_google_protobuf_FileOptions, O_google_protobuf_FileOptions>
+      GeneratedCodeInfo: MessageTypeDefinition<I_google_protobuf_GeneratedCodeInfo, O_google_protobuf_GeneratedCodeInfo>
+      MessageOptions: MessageTypeDefinition<I_google_protobuf_MessageOptions, O_google_protobuf_MessageOptions>
+      MethodDescriptorProto: MessageTypeDefinition<I_google_protobuf_MethodDescriptorProto, O_google_protobuf_MethodDescriptorProto>
+      MethodOptions: MessageTypeDefinition<I_google_protobuf_MethodOptions, O_google_protobuf_MethodOptions>
+      OneofDescriptorProto: MessageTypeDefinition<I_google_protobuf_OneofDescriptorProto, O_google_protobuf_OneofDescriptorProto>
+      OneofOptions: MessageTypeDefinition<I_google_protobuf_OneofOptions, O_google_protobuf_OneofOptions>
+      ServiceDescriptorProto: MessageTypeDefinition<I_google_protobuf_ServiceDescriptorProto, O_google_protobuf_ServiceDescriptorProto>
+      ServiceOptions: MessageTypeDefinition<I_google_protobuf_ServiceOptions, O_google_protobuf_ServiceOptions>
+      SourceCodeInfo: MessageTypeDefinition<I_google_protobuf_SourceCodeInfo, O_google_protobuf_SourceCodeInfo>
       SymbolVisibility: EnumTypeDefinition
-      Timestamp: MessageTypeDefinition
-      UninterpretedOption: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition<I_google_protobuf_Timestamp, O_google_protobuf_Timestamp>
+      UninterpretedOption: MessageTypeDefinition<I_google_protobuf_UninterpretedOption, O_google_protobuf_UninterpretedOption>
     }
     rpc: {
-      Status: MessageTypeDefinition
+      Status: MessageTypeDefinition<I_google_rpc_Status, O_google_rpc_Status>
     }
     showcase: {
       v1beta1: {
-        BlockRequest: MessageTypeDefinition
-        BlockResponse: MessageTypeDefinition
+        BlockRequest: MessageTypeDefinition<I_google_showcase_v1beta1_BlockRequest, O_google_showcase_v1beta1_BlockRequest>
+        BlockResponse: MessageTypeDefinition<I_google_showcase_v1beta1_BlockResponse, O_google_showcase_v1beta1_BlockResponse>
         /**
          * This service is used showcase the four main types of rpcs - unary, server
          * side streaming, client side streaming, and bidirectional streaming. This
@@ -84,17 +133,16 @@ export interface ProtoGrpcType {
          * to have the values echoed in the response trailers.
          */
         Echo: SubtypeConstructor<typeof grpc.Client, _google_showcase_v1beta1_EchoClient> & { service: _google_showcase_v1beta1_EchoDefinition }
-        EchoRequest: MessageTypeDefinition
-        EchoResponse: MessageTypeDefinition
-        ExpandRequest: MessageTypeDefinition
-        PagedExpandRequest: MessageTypeDefinition
-        PagedExpandResponse: MessageTypeDefinition
+        EchoRequest: MessageTypeDefinition<I_google_showcase_v1beta1_EchoRequest, O_google_showcase_v1beta1_EchoRequest>
+        EchoResponse: MessageTypeDefinition<I_google_showcase_v1beta1_EchoResponse, O_google_showcase_v1beta1_EchoResponse>
+        ExpandRequest: MessageTypeDefinition<I_google_showcase_v1beta1_ExpandRequest, O_google_showcase_v1beta1_ExpandRequest>
+        PagedExpandRequest: MessageTypeDefinition<I_google_showcase_v1beta1_PagedExpandRequest, O_google_showcase_v1beta1_PagedExpandRequest>
+        PagedExpandResponse: MessageTypeDefinition<I_google_showcase_v1beta1_PagedExpandResponse, O_google_showcase_v1beta1_PagedExpandResponse>
         Severity: EnumTypeDefinition
-        WaitMetadata: MessageTypeDefinition
-        WaitRequest: MessageTypeDefinition
-        WaitResponse: MessageTypeDefinition
+        WaitMetadata: MessageTypeDefinition<I_google_showcase_v1beta1_WaitMetadata, O_google_showcase_v1beta1_WaitMetadata>
+        WaitRequest: MessageTypeDefinition<I_google_showcase_v1beta1_WaitRequest, O_google_showcase_v1beta1_WaitRequest>
+        WaitResponse: MessageTypeDefinition<I_google_showcase_v1beta1_WaitResponse, O_google_showcase_v1beta1_WaitResponse>
       }
     }
   }
 }
-

--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.7.15",
+  "version": "0.8.0",
   "author": "Google Inc.",
   "contributors": [
     {
@@ -47,7 +47,7 @@
   "dependencies": {
     "lodash.camelcase": "^4.3.0",
     "long": "^5.0.0",
-    "protobufjs": "^7.2.5",
+    "protobufjs": "^7.5.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/packages/proto-loader/test/descriptor_type_test.ts
+++ b/packages/proto-loader/test/descriptor_type_test.ts
@@ -27,7 +27,7 @@ const TEST_PROTO_DIR = `${__dirname}/../../test_protos/`;
 
 type TypeDefinition =
   | proto_loader.EnumTypeDefinition
-  | proto_loader.MessageTypeDefinition;
+  | proto_loader.MessageTypeDefinition<object, object>;
 
 function isTypeObject(obj: proto_loader.AnyDefinition): obj is TypeDefinition {
   return 'format' in obj;


### PR DESCRIPTION
This implements the change described in https://github.com/grpc/proposal/pull/503 for both the runtime generator and the TypeScript generator. This doesn't add any types to the API, it just makes the serialize and deserialize functions more generally usable. It breaks the API by changing the `MessageTypeDefinition` type signature, so I bumped the version.