### PR TITLE
removed the .start() method as it is deprecated

### DIFF
--- a/examples/routeguide/dynamic_codegen/route_guide_server.js
+++ b/examples/routeguide/dynamic_codegen/route_guide_server.js
@@ -237,7 +237,6 @@ if (require.main === module) {
     fs.readFile(path.resolve(argv.db_path), function(err, data) {
       if (err) throw err;
       feature_list = JSON.parse(data);
-      routeServer.start();
     });
   });
 }


### PR DESCRIPTION
.start() method is directly integrated in the bindAsync function