### PR TITLE
grpc-js: Implement ORCA client-side OOB metrics

### DIFF
--- a/packages/grpc-js/src/index.ts
+++ b/packages/grpc-js/src/index.ts
@@ -285,6 +285,8 @@ export {
   ServerInterceptor,
 } from './server-interceptors';
 
+export { ServerMetricRecorder } from './orca';
+
 import * as experimental from './experimental';
 export { experimental };
 

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -34,7 +34,7 @@ import {
 } from './picker';
 import { Endpoint, SubchannelAddress, subchannelAddressToString } from './subchannel-address';
 import * as logging from './logging';
-import { LogVerbosity } from './constants';
+import { LogVerbosity, Status } from './constants';
 import {
   SubchannelInterface,
   ConnectivityStateListener,
@@ -44,6 +44,12 @@ import { isTcpSubchannelAddress } from './subchannel-address';
 import { isIPv6 } from 'net';
 import { ChannelOptions } from './channel-options';
 import { StatusOr, statusOrFromValue } from './call-interface';
+import { OrcaLoadReport__Output } from './generated/xds/data/orca/v3/OrcaLoadReport';
+import { OpenRcaServiceClient } from './generated/xds/service/orca/v3/OpenRcaService';
+import { ClientReadableStream, ServiceError } from './call';
+import { createOrcaClient } from './orca';
+import { msToDuration } from './duration';
+import { BackoffTimeout } from './backoff-timeout';
 
 const TRACER_NAME = 'pick_first';
 
@@ -58,6 +64,8 @@ const TYPE_NAME = 'pick_first';
  * connection on the next subchannel in the list, for Happy Eyeballs algorithm.
  */
 const CONNECTION_DELAY_INTERVAL_MS = 250;
+
+export type MetricsListener = (loadReport: OrcaLoadReport__Output) => void;
 
 export class PickFirstLoadBalancingConfig implements TypedLoadBalancingConfig {
   constructor(private readonly shuffleAddressList: boolean) {}
@@ -239,6 +247,13 @@ export class PickFirstLoadBalancer implements LoadBalancer {
 
   private latestResolutionNote: string = '';
 
+  private metricsListeners: Map<MetricsListener, number> = new Map();
+  private orcaClient: OpenRcaServiceClient | null = null;
+  private metricsCall: ClientReadableStream<OrcaLoadReport__Output> | null = null;
+  private currentMetricsIntervalMs: number = Infinity;
+  private orcaUnsupported = false;
+  private metricsBackoffTimer = new BackoffTimeout(() => this.updateMetricsSubscription());
+
   /**
    * Load balancer that attempts to connect to each backend in the address list
    * in order, and picks the first one that connects, using it for every
@@ -336,6 +351,12 @@ export class PickFirstLoadBalancer implements LoadBalancer {
       this.currentPick.removeHealthStateWatcher(
         this.pickedSubchannelHealthListener
       );
+      this.orcaClient?.close();
+      this.orcaClient = null;
+      this.metricsCall?.cancel();
+      this.metricsCall = null;
+      this.metricsBackoffTimer.stop();
+      this.metricsBackoffTimer.reset();
       // Unref last, to avoid triggering listeners
       this.currentPick.unref();
       this.currentPick = null;
@@ -439,6 +460,7 @@ export class PickFirstLoadBalancer implements LoadBalancer {
     this.currentPick = subchannel;
     clearTimeout(this.connectionDelayTimeout);
     this.calculateAndReportNewState();
+    this.updateMetricsSubscription();
   }
 
   private updateState(newState: ConnectivityState, picker: Picker, errorMessage: string | null) {
@@ -573,6 +595,67 @@ export class PickFirstLoadBalancer implements LoadBalancer {
   getTypeName(): string {
     return TYPE_NAME;
   }
+
+  private getOrCreateOrcaClient(): OpenRcaServiceClient | null {
+    if (this.orcaClient) {
+      return this.orcaClient;
+    }
+    if (this.currentPick) {
+      const channel = this.currentPick.getChannel();
+      this.orcaClient = createOrcaClient(channel);
+      return this.orcaClient;
+    }
+    return null;
+  }
+
+  private updateMetricsSubscription() {
+    if (this.orcaUnsupported) {
+      return;
+    }
+    if (this.metricsListeners.size > 0) {
+      const newInterval = Math.min(...Array.from(this.metricsListeners.values()));
+      if (!this.metricsCall || newInterval !== this.currentMetricsIntervalMs) {
+        const orcaClient = this.getOrCreateOrcaClient();
+        if (!orcaClient) {
+          return;
+        }
+        this.metricsCall?.cancel();
+        this.currentMetricsIntervalMs = newInterval;
+        const metricsCall = orcaClient.streamCoreMetrics({report_interval: msToDuration(newInterval)});
+        this.metricsCall = metricsCall;
+        metricsCall.on('data', (report: OrcaLoadReport__Output) => {
+          this.metricsListeners.forEach((interval, listener) => {
+            listener(report);
+          });
+        });
+        metricsCall.on('error', (error: ServiceError) => {
+          this.metricsCall = null;
+          if (error.code === Status.UNIMPLEMENTED) {
+            this.orcaUnsupported = true;
+            return;
+          }
+          if (error.code === Status.CANCELLED) {
+            return;
+          }
+          this.metricsBackoffTimer.runOnce();
+        });
+      }
+    } else {
+      this.metricsCall?.cancel();
+      this.metricsCall = null;
+      this.currentMetricsIntervalMs = Infinity;
+    }
+  }
+
+  addMetricsSubscription(listener: MetricsListener, intervalMs: number): void {
+    this.metricsListeners.set(listener, intervalMs);
+    this.updateMetricsSubscription();
+  }
+
+  removeMetricsSubscription(listener: MetricsListener): void {
+    this.metricsListeners.delete(listener);
+    this.updateMetricsSubscription();
+  }
 }
 
 const LEAF_CONFIG = new PickFirstLoadBalancingConfig(false);
@@ -649,6 +732,14 @@ export class LeafLoadBalancer {
 
   destroy() {
     this.pickFirstBalancer.destroy();
+  }
+
+  addMetricsSubscription(listener: MetricsListener, intervalMs: number): void {
+    this.pickFirstBalancer.addMetricsSubscription(listener, intervalMs);
+  }
+
+  removeMetricsSubscription(listener: MetricsListener): void {
+    this.pickFirstBalancer.removeMetricsSubscription(listener);
   }
 }
 

--- a/packages/grpc-js/src/orca.ts
+++ b/packages/grpc-js/src/orca.ts
@@ -20,9 +20,11 @@ import { OrcaLoadReport } from "./generated/xds/data/orca/v3/OrcaLoadReport";
 import type { loadSync } from '@grpc/proto-loader';
 import { ProtoGrpcType as OrcaProtoGrpcType } from "./generated/orca";
 import { loadPackageDefinition } from "./make-client";
-import { OpenRcaServiceHandlers } from "./generated/xds/service/orca/v3/OpenRcaService";
+import { OpenRcaServiceClient, OpenRcaServiceHandlers } from "./generated/xds/service/orca/v3/OpenRcaService";
 import { durationMessageToDuration, durationToMs } from "./duration";
 import { Server } from "./server";
+import { ChannelCredentials } from "./channel-credentials";
+import { Channel } from "./channel";
 
 const loadedOrcaProto: OrcaProtoGrpcType | null = null;
 function loadOrcaProto(): OrcaProtoGrpcType {
@@ -205,4 +207,9 @@ export class ServerMetricRecorder {
     const serviceDefinition = loadOrcaProto().xds.service.orca.v3.OpenRcaService.service;
     server.addService(serviceDefinition, this.serviceImplementation);
   }
+}
+
+export function createOrcaClient(channel: Channel): OpenRcaServiceClient {
+  const ClientClass = loadOrcaProto().xds.service.orca.v3.OpenRcaService;
+  return new ClientClass('unused', ChannelCredentials.createInsecure(), {channelOverride: channel});
 }

--- a/packages/grpc-js/src/subchannel-interface.ts
+++ b/packages/grpc-js/src/subchannel-interface.ts
@@ -16,6 +16,7 @@
  */
 
 import { CallCredentials } from './call-credentials';
+import { Channel } from './channel';
 import type { SubchannelRef } from './channelz';
 import { ConnectivityState } from './connectivity-state';
 import { Subchannel } from './subchannel';
@@ -67,6 +68,10 @@ export interface SubchannelInterface {
    * subchannel.
    */
   getCallCredentials(): CallCredentials;
+  /**
+   * Get a channel that can be used to make requests with just this
+   */
+  getChannel(): Channel;
 }
 
 export abstract class BaseSubchannelWrapper implements SubchannelInterface {
@@ -142,5 +147,8 @@ export abstract class BaseSubchannelWrapper implements SubchannelInterface {
   }
   getCallCredentials(): CallCredentials {
     return this.child.getCallCredentials();
+  }
+  getChannel(): Channel {
+      return this.child.getChannel();
   }
 }

--- a/packages/grpc-js/src/subchannel.ts
+++ b/packages/grpc-js/src/subchannel.ts
@@ -47,6 +47,8 @@ import { SubchannelCallInterceptingListener } from './subchannel-call';
 import { SubchannelCall } from './subchannel-call';
 import { CallEventTracker, SubchannelConnector, Transport } from './transport';
 import { CallCredentials } from './call-credentials';
+import { SingleSubchannelChannel } from './single-subchannel-channel';
+import { Channel } from './channel';
 
 const TRACER_NAME = 'subchannel';
 
@@ -518,5 +520,9 @@ export class Subchannel implements SubchannelInterface {
   }
   getCallCredentials(): CallCredentials {
     return this.secureConnector.getCallCredentials();
+  }
+
+  getChannel(): Channel {
+    return new SingleSubchannelChannel(this, this.channelTarget, this.options);
   }
 }

--- a/packages/grpc-js/test/common.ts
+++ b/packages/grpc-js/test/common.ts
@@ -261,6 +261,9 @@ export class MockSubchannel implements SubchannelInterface {
   getCallCredentials(): grpc.CallCredentials {
     return grpc.CallCredentials.createEmpty();
   }
+  getChannel(): grpc.Channel {
+    throw new Error('Method not implemented');
+  }
 }
 
 export { assert2 };


### PR DESCRIPTION
This implements the client-side out of band metrics part of [gRFC A51](https://github.com/grpc/proposal/blob/master/A51-custom-backend-metrics.md). This change adds `addMetricsSubscription` and `removeMetricsSubscription` methods to `PickFirstLoadBalancer` and `LeafLoadBalancer`. Petiole load balancing policies can subscribe to out of band metrics updates using those methods.