### PR TITLE
grpc-js: Implement ORCA client-side per-call metrics

### DIFF
--- a/packages/grpc-js/src/load-balancer-outlier-detection.ts
+++ b/packages/grpc-js/src/load-balancer-outlier-detection.ts
@@ -428,13 +428,13 @@ class OutlierDetectionPicker implements Picker {
       if (mapEntry) {
         let onCallEnded = wrappedPick.onCallEnded;
         if (this.countCalls) {
-          onCallEnded = statusCode => {
+          onCallEnded = (statusCode, details, metadata) => {
             if (statusCode === Status.OK) {
               mapEntry.counter.addSuccess();
             } else {
               mapEntry.counter.addFailure();
             }
-            wrappedPick.onCallEnded?.(statusCode);
+            wrappedPick.onCallEnded?.(statusCode, details, metadata);
           };
         }
         return {

--- a/packages/grpc-js/src/load-balancer-pick-first.ts
+++ b/packages/grpc-js/src/load-balancer-pick-first.ts
@@ -47,7 +47,7 @@ import { StatusOr, statusOrFromValue } from './call-interface';
 import { OrcaLoadReport__Output } from './generated/xds/data/orca/v3/OrcaLoadReport';
 import { OpenRcaServiceClient } from './generated/xds/service/orca/v3/OpenRcaService';
 import { ClientReadableStream, ServiceError } from './call';
-import { createOrcaClient } from './orca';
+import { createOrcaClient, MetricsListener } from './orca';
 import { msToDuration } from './duration';
 import { BackoffTimeout } from './backoff-timeout';
 
@@ -64,8 +64,6 @@ const TYPE_NAME = 'pick_first';
  * connection on the next subchannel in the list, for Happy Eyeballs algorithm.
  */
 const CONNECTION_DELAY_INTERVAL_MS = 250;
-
-export type MetricsListener = (loadReport: OrcaLoadReport__Output) => void;
 
 export class PickFirstLoadBalancingConfig implements TypedLoadBalancingConfig {
   constructor(private readonly shuffleAddressList: boolean) {}

--- a/packages/grpc-js/src/load-balancing-call.ts
+++ b/packages/grpc-js/src/load-balancing-call.ts
@@ -29,7 +29,7 @@ import { LogVerbosity, Status } from './constants';
 import { Deadline, formatDateDifference, getDeadlineTimeoutString } from './deadline';
 import { InternalChannel } from './internal-channel';
 import { Metadata } from './metadata';
-import { PickResultType } from './picker';
+import { OnCallEnded, PickResultType } from './picker';
 import { CallConfig } from './resolver';
 import { splitHostPort } from './uri-parser';
 import * as logging from './logging';
@@ -60,7 +60,7 @@ export class LoadBalancingCall implements Call, DeadlineInfoProvider {
   private serviceUrl: string;
   private metadata: Metadata | null = null;
   private listener: InterceptingListener | null = null;
-  private onCallEnded: ((statusCode: Status) => void) | null = null;
+  private onCallEnded: OnCallEnded | null = null;
   private startTime: Date;
   private childStartTime: Date | null = null;
   constructor(
@@ -127,7 +127,7 @@ export class LoadBalancingCall implements Call, DeadlineInfoProvider {
       );
       const finalStatus = { ...status, progress };
       this.listener?.onReceiveStatus(finalStatus);
-      this.onCallEnded?.(finalStatus.code);
+      this.onCallEnded?.(finalStatus.code, finalStatus.details, finalStatus.metadata);
     }
   }
 

--- a/packages/grpc-js/src/metadata.ts
+++ b/packages/grpc-js/src/metadata.ts
@@ -89,6 +89,7 @@ export interface MetadataOptions {
 export class Metadata {
   protected internalRepr: MetadataObject = new Map<string, MetadataValue[]>();
   private options: MetadataOptions;
+  private opaqueData: Map<string, unknown> = new Map();
 
   constructor(options: MetadataOptions = {}) {
     this.options = options;
@@ -243,6 +244,27 @@ export class Metadata {
       result[key] = values;
     }
     return result;
+  }
+
+  /**
+   * Attach additional data of any type to the metadata object, which will not
+   * be included when sending headers. The data can later be retrieved with
+   * `getOpaque`. Keys with the prefix `grpc` are reserved for use by this
+   * library.
+   * @param key
+   * @param value
+   */
+  setOpaque(key: string, value: unknown) {
+    this.opaqueData.set(key, value);
+  }
+
+  /**
+   * Retrieve data previously added with `setOpaque`.
+   * @param key
+   * @returns
+   */
+  getOpaque(key: string) {
+    return this.opaqueData.get(key);
   }
 
   /**

--- a/packages/grpc-js/src/picker.ts
+++ b/packages/grpc-js/src/picker.ts
@@ -28,6 +28,8 @@ export enum PickResultType {
   DROP,
 }
 
+export type OnCallEnded = (statusCode: Status, details: string, metadata: Metadata) => void;
+
 export interface PickResult {
   pickResultType: PickResultType;
   /**
@@ -42,7 +44,7 @@ export interface PickResult {
    */
   status: StatusObject | null;
   onCallStarted: (() => void) | null;
-  onCallEnded: ((statusCode: Status) => void) | null;
+  onCallEnded: OnCallEnded | null;
 }
 
 export interface CompletePickResult extends PickResult {
@@ -50,7 +52,7 @@ export interface CompletePickResult extends PickResult {
   subchannel: SubchannelInterface | null;
   status: null;
   onCallStarted: (() => void) | null;
-  onCallEnded: ((statusCode: Status) => void) | null;
+  onCallEnded: OnCallEnded | null;
 }
 
 export interface QueuePickResult extends PickResult {

--- a/packages/grpc-js/src/server-interceptors.ts
+++ b/packages/grpc-js/src/server-interceptors.ts
@@ -35,7 +35,7 @@ import { CallEventTracker } from './transport';
 import * as logging from './logging';
 import { AuthContext } from './auth-context';
 import { TLSSocket } from 'tls';
-import { PerRequestMetricRecorder } from './orca';
+import { GRPC_METRICS_HEADER, PerRequestMetricRecorder } from './orca';
 
 const TRACER_NAME = 'server_call';
 
@@ -491,7 +491,6 @@ const GRPC_ENCODING_HEADER = 'grpc-encoding';
 const GRPC_MESSAGE_HEADER = 'grpc-message';
 const GRPC_STATUS_HEADER = 'grpc-status';
 const GRPC_TIMEOUT_HEADER = 'grpc-timeout';
-const GRPC_METRICS_HEADER = 'endpoint-load-metrics-bin';
 const DEADLINE_REGEX = /(\d{1,8})\s*([HMSmun])/;
 const deadlineUnitsToMs: DeadlineUnitIndexSignature = {
   H: 3600000,


### PR DESCRIPTION
This adds a function `createMetricsReader`, which can be used to create a callback that can be used in a picker to watch for per-call metrics in the status.

I also added methods `setOpaque` and `getOpaque` methods to the `Metadata` class, which can be used to preserve opaque data for the lifetime of the metadata object.