### PR TITLE
grpc-js: Declare buffer type to avoid build error (1.13.x)

### DIFF
--- a/packages/grpc-js/src/compression-filter.ts
+++ b/packages/grpc-js/src/compression-filter.ts
@@ -65,7 +65,7 @@ abstract class CompressionHandler {
    */
   async readMessage(data: Buffer): Promise<Buffer> {
     const compressed = data.readUInt8(0) === 1;
-    let messageBuffer = data.slice(5);
+    let messageBuffer: Buffer<ArrayBufferLike> = data.slice(5);
     if (compressed) {
       messageBuffer = await this.decompressMessage(messageBuffer);
     }


### PR DESCRIPTION
Backport #2987 to 1.13.x