### PR TITLE
Increase timeout for lb tests (v1.10.x)

### DIFF
--- a/test/kokoro/xds_k8s_lb.cfg
+++ b/test/kokoro/xds_k8s_lb.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-node/packages/grpc-js-xds/scripts/psm-interop-test-node.sh"
-timeout_mins: 180
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"


### PR DESCRIPTION
Increase timeout for lb tests for v1.10.x because of continuous streaks of timeout errors on this branch http://shortn/_5MeUHfsJfl.