### PR TITLE
grpc-js-xds: Remove .only from a test, switch port finding library

### DIFF
--- a/packages/grpc-js-xds/package.json
+++ b/packages/grpc-js-xds/package.json
@@ -34,16 +34,16 @@
   "devDependencies": {
     "@grpc/grpc-js": "file:../grpc-js",
     "@grpc/proto-loader": "file:../proto-loader",
+    "@grpc/reflection": "file:../grpc-reflection",
     "@types/gulp": "^4.0.6",
     "@types/gulp-mocha": "0.0.32",
     "@types/mocha": "^5.2.6",
     "@types/node": ">=20.11.20",
-    "@grpc/reflection": "file:../grpc-reflection",
     "@types/yargs": "^15.0.5",
-    "find-free-ports": "^3.1.1",
     "grpc-health-check": "file:../grpc-health-check",
     "gts": "^5.0.1",
     "ncp": "^2.0.0",
+    "portfinder": "^1.0.37",
     "typescript": "^5.1.3",
     "yargs": "^15.4.1"
   },

--- a/packages/grpc-js-xds/test/backend.ts
+++ b/packages/grpc-js-xds/test/backend.ts
@@ -21,11 +21,9 @@ import { ProtoGrpcType } from "./generated/echo";
 import { EchoRequest__Output } from "./generated/grpc/testing/EchoRequest";
 import { EchoResponse } from "./generated/grpc/testing/EchoResponse";
 
-import * as net from 'net';
 import { XdsServer } from "../src";
 import { ControlPlaneServer } from "./xds-server";
-import { findFreePorts } from 'find-free-ports';
-import { XdsServerCredentials } from "../src/xds-credentials";
+import { getPortsPromise } from 'portfinder';
 
 const loadedProtos = loadPackageDefinition(loadSync(
   [
@@ -148,6 +146,6 @@ export class Backend {
 }
 
 export async function createBackends(count: number, useXdsServer?: boolean, creds?: ServerCredentials | undefined, serverOptions?: ServerOptions): Promise<Backend[]> {
-  const ports = await findFreePorts(count);
+  const ports = await getPortsPromise(count);
   return ports.map(port => new Backend(port, useXdsServer ?? true, creds, serverOptions));
 }

--- a/packages/grpc-js-xds/test/test-rbac-filter.ts
+++ b/packages/grpc-js-xds/test/test-rbac-filter.ts
@@ -24,7 +24,7 @@ import { AnyExtension } from '@grpc/proto-loader';
 import { RBAC } from '../src/generated/envoy/extensions/filters/http/rbac/v3/RBAC';
 import { status } from '@grpc/grpc-js';
 
-describe.only('RBAC HTTP filter', () => {
+describe('RBAC HTTP filter', () => {
   let xdsServer: ControlPlaneServer;
   let client: XdsTestClient;
   beforeEach(done => {


### PR DESCRIPTION
That `.only` was causing other tests to be skipped. And `find-free-ports` was sometimes failing to detect that ports were in use, causing strings of failures where servers would repeatedly try to bind the same used port.