### PR TITLE
grpc-js-xds: interop: Fix order of submodule update and npm install

### DIFF
--- a/packages/grpc-js-xds/scripts/xds.sh
+++ b/packages/grpc-js-xds/scripts/xds.sh
@@ -34,6 +34,9 @@ echo "source $NVM_DIR/nvm.sh" > ~/.profile
 echo "source $NVM_DIR/nvm.sh" > ~/.shrc
 export ENV=~/.shrc
 
+cd $base
+git submodule update --init --recursive
+
 cd $base/../proto-loader
 npm install
 
@@ -47,8 +50,6 @@ cd $base/../grpc-reflection
 npm install
 
 # grpc-js-xds has a dev dependency on "../grpc-js", so it should pull that in automatically
-cd $base
-git submodule update --init --recursive
 npm install
 
 cd ../../..


### PR DESCRIPTION
With #2978, the grpc-js install script now needs access to the contents of a submodule. So, this script now runs `git submodule update` before any `npm install`.