### PR TITLE
grpc-js-xds: Enable federation by default

### DIFF
--- a/packages/grpc-js-xds/gulpfile.ts
+++ b/packages/grpc-js-xds/gulpfile.ts
@@ -69,7 +69,6 @@ const copyTestFixtures = checkTask(() =>
 );
 
 const runTests = checkTask(() => {
-  process.env.GRPC_EXPERIMENTAL_XDS_FEDERATION = 'true';
   process.env.GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG = 'true';
   process.env.GRPC_XDS_EXPERIMENTAL_RBAC = 'true';
   process.env.GRPC_EXPERIMENTAL_XDS_WRR_LB = 'true';

--- a/packages/grpc-js-xds/src/environment.ts
+++ b/packages/grpc-js-xds/src/environment.ts
@@ -21,7 +21,7 @@
 export const EXPERIMENTAL_FAULT_INJECTION = (process.env.GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION ?? 'true') === 'true';
 export const EXPERIMENTAL_OUTLIER_DETECTION = (process.env.GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION ?? 'true') === 'true';
 export const EXPERIMENTAL_RETRY = (process.env.GRPC_XDS_EXPERIMENTAL_ENABLE_RETRY ?? 'true') === 'true';
-export const EXPERIMENTAL_FEDERATION = (process.env.GRPC_EXPERIMENTAL_XDS_FEDERATION ?? 'false') === 'true';
+export const EXPERIMENTAL_FEDERATION = (process.env.GRPC_EXPERIMENTAL_XDS_FEDERATION ?? 'true') === 'true';
 export const EXPERIMENTAL_CUSTOM_LB_CONFIG = (process.env.GRPC_EXPERIMENTAL_XDS_CUSTOM_LB_CONFIG ?? 'true') === 'true';
 export const EXPERIMENTAL_RING_HASH = (process.env.GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH ?? 'true') === 'true';
 export const EXPERIMENTAL_PICK_FIRST = (process.env.GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG ?? 'false') === 'true';


### PR DESCRIPTION
The open source interop test for this was added in https://github.com/grpc/psm-interop/pull/185, and it has been passing consistently for over a week.