### PR TITLE
grpc-tools: Fix Mac build by allowing lower CMake versions

### DIFF
--- a/packages/grpc-tools/build_binaries.sh
+++ b/packages/grpc-tools/build_binaries.sh
@@ -36,7 +36,8 @@ build() {
   rm -f "$protobuf_base/CMakeCache.txt"
   rm -rf "$protobuf_base/CMakeFiles"
 
-  cmake -DCMAKE_TOOLCHAIN_FILE=linux.toolchain.cmake $cmake_flag . && cmake --build . --target clean && cmake --build . -- -j 12
+  # CMAKE_POLICY_VERSION_MINIMUM option is needed until the protobuf dependency is updated
+  cmake -DCMAKE_TOOLCHAIN_FILE=linux.toolchain.cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 $cmake_flag . && cmake --build . --target clean && cmake --build . -- -j 12
 
   mkdir -p "$base/build/bin"
 


### PR DESCRIPTION
This is an attempt to fix #3012.