### PR TITLE
Fix server keep alive timeout not properly destroying connections

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -1609,7 +1609,7 @@ export class Server {
               if (err) {
                 this.keepaliveTrace('Ping failed with error: ' + err.message);
                 sessionClosedByServer = true;
-                session.close();
+                session.destroy();
               } else {
                 this.keepaliveTrace('Received ping response');
                 maybeStartKeepalivePingTimer();
@@ -1631,7 +1631,7 @@ export class Server {
             'Connection dropped due to ping send error: ' + pingSendError
           );
           sessionClosedByServer = true;
-          session.close();
+          session.destroy();
           return;
         }
 
@@ -1640,7 +1640,7 @@ export class Server {
           this.keepaliveTrace('Ping timeout passed without response');
           this.trace('Connection dropped by keepalive timeout');
           sessionClosedByServer = true;
-          session.close();
+          session.destroy();
         }, this.keepaliveTimeoutMs);
         keepaliveTimer.unref?.();
       };
@@ -1803,7 +1803,7 @@ export class Server {
                     duration
                 );
                 sessionClosedByServer = true;
-                session.close();
+                session.destroy();
               } else {
                 this.keepaliveTrace('Received ping response');
                 maybeStartKeepalivePingTimer();
@@ -1826,7 +1826,7 @@ export class Server {
             'Connection dropped due to ping send error: ' + pingSendError
           );
           sessionClosedByServer = true;
-          session.close();
+          session.destroy();
           return;
         }
 
@@ -1840,7 +1840,7 @@ export class Server {
             'Connection dropped by keepalive timeout from ' + clientAddress
           );
           sessionClosedByServer = true;
-          session.close();
+          session.destroy();
         }, this.keepaliveTimeoutMs);
         keepaliveTimeout.unref?.();
       };


### PR DESCRIPTION
## Issue
**GitHub Issue:** #2953  
**Reporter:** @zabranskiy  
**Package:** @grpc/grpc-js  
**Severity:** Bug - Server connections hang indefinitely when clients don't respond to keepalive pings

## Root Cause
The server-side keepalive ping timeout handler uses `session.close()` to terminate connections when clients fail to respond to keepalive pings. However, `session.close()` performs a graceful shutdown that does not forcibly terminate the underlying connection, causing it to hang indefinitely.

## Fix Summary
Changed keepalive error handlers to use `session.destroy()` instead of `session.close()` to forcibly close connections when:
- Keepalive ping timeout expires without response
- Ping callback receives an error
- Sending the ping fails

## Files Modified
- `packages/grpc-js/src/server.ts` (6 occurrences changed)
  - 3 changes in `_sessionHandler` method (lines ~1609, ~1635, ~1643)
  - 3 changes in `_channelzSessionHandler` method (lines ~1807, ~1830, ~1843)

## Testing Recommendations
To verify the fix:
1. Start a gRPC server with these options:
   ```javascript
   {
     'grpc.keepalive_time_ms': 10000,
     'grpc.keepalive_timeout_ms': 5000,
     'grpc.keepalive_permit_without_calls': 1
   }
   ```
2. Connect a client and send a request
3. Stop the client process (SIGSTOP) after receiving the first ping response
4. Observe server logs - after the timeout, the connection should be destroyed (not hanging)

## Consistency
This change aligns server-side keepalive handling with the client-side transport implementation (`packages/grpc-js/src/transport.ts`), which already uses `session.destroy()` via `handleDisconnect()` for keepalive timeouts.

## Backward Compatibility
This is a bug fix that should not affect normal operation:
- Proper keepalive implementations will continue to work normally
- Only affects scenarios where clients fail to respond to keepalive pings
- Changes do not affect the public API or configuration options