### PR TITLE
grpc-js: Re-add a couple of accidentally removed HTTP/2 session settings

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -720,7 +720,13 @@ export class Http2SubchannelConnector implements SubchannelConnector {
           initialWindowSize:
             options['grpc-node.flow_control_window'] ??
             http2.getDefaultSettings?.()?.initialWindowSize ?? 65535,
-        }
+        },
+        maxSendHeaderBlockLength: Number.MAX_SAFE_INTEGER,
+        /* By default, set a very large max session memory limit, to effectively
+         * disable enforcement of the limit. Some testing indicates that Node's
+         * behavior degrades badly when this limit is reached, so we solve that
+         * by disabling the check entirely. */
+        maxSessionMemory: options['grpc-node.max_session_memory'] ?? Number.MAX_SAFE_INTEGER
       };
       const session = http2.connect(`${scheme}://${targetPath}`, sessionOptions);
       // Prepare window size configuration for remoteSettings handler


### PR DESCRIPTION
These settings were accidentally removed when refactoring the transport in #2855, as noted in https://github.com/grpc/grpc-node/pull/2855#discussion_r2457813594. This may have caused a regression that increased the frequency of RESOURCE_EXHAUSTED errors.