### PR TITLE
Skip tests on Windows that behave differently

### DIFF
--- a/packages/grpc-js/test/test-client.ts
+++ b/packages/grpc-js/test/test-client.ts
@@ -124,6 +124,12 @@ describe('Client with a nonexistent target domain', () => {
     client.close();
   });
   it('should fail multiple calls', function (done) {
+    if (process.platform === 'win32') {
+      // DNS has some weird behavior on Windows
+      this.skip();
+      // @ts-ignore: Unreachable code error
+      return;
+    }
     this.timeout(5000);
     // Regression test for https://github.com/grpc/grpc-node/issues/1411
     client.makeUnaryRequest(

--- a/packages/grpc-js/test/test-idle-timer.ts
+++ b/packages/grpc-js/test/test-idle-timer.ts
@@ -150,7 +150,15 @@ describe('Channel idle timer with UDS', () => {
       client = null;
     }
   });
-  after(() => {
+  after(function () {
+    if (process.platform === 'win32') {
+      /* The Node API that creates a UDS on Linux actually creates a named
+       * pipe on Windows, and those have a different naming scheme than UDS
+       * so the test setup doesn't work on Windows. */
+      this.skip();
+      // @ts-ignore: Unreachable code error
+      return;
+    }
     server.shutdown();
   });
   it('Should be able to make a request after going idle', function (done) {

--- a/packages/grpc-js/test/test-idle-timer.ts
+++ b/packages/grpc-js/test/test-idle-timer.ts
@@ -132,7 +132,15 @@ describe('Channel idle timer', () => {
 describe('Channel idle timer with UDS', () => {
   let server: TestServer;
   let client: TestClient | null = null;
-  before(() => {
+  before(function() {
+    if (process.platform === 'win32') {
+      /* The Node API that creates a UDS on Linux actually creates a named
+       * pipe on Windows, and those have a different naming scheme than UDS
+       * so the test setup doesn't work on Windows. */
+      this.skip();
+      // @ts-ignore: Unreachable code error
+      return;
+    }
     server = new TestServer(false);
     return server.startUds();
   });


### PR DESCRIPTION
These tests consistently fail on Windows because the underlying behavior is different (in DNS and UDS, respectively). So we skip them only on Windows, so that we can still test the behavior on other systems.