### PR TITLE
fix: bump protobufjs to ^7.5.5 to address GHSA-xq3m-2v4x-88gg

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "lodash.camelcase": "^4.3.0",
     "long": "^5.0.0",
-    "protobufjs": "^7.5.3",
+    "protobufjs": "^7.5.5",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
**Summary**

Bumps protobufjs from ^7.5.3 to ^7.5.5 to address the arbitrary code execution vulnerability in protobufjs < 7.5.5.
Security advisory: GHSA-xq3m-2v4x-88gg

**Details**

Attackers can inject arbitrary code into the type fields of protobuf definitions, which executes during object decoding. Fixed in protobufjs 7.5.5.

**Testing**

8/8 unit tests pass