### PR TITLE
grpc-js: support grpc-node.flow_control_window on the server

### DIFF
--- a/packages/grpc-js/src/server.ts
+++ b/packages/grpc-js/src/server.ts
@@ -105,6 +105,11 @@ function serverCallTrace(text: string) {
 
 type AnyHttp2Server = http2.Http2Server | http2.Http2SecureServer;
 
+/* incrementWindowSize exists at runtime but is absent from the http2 typings. */
+interface IncrementWindowSize {
+  incrementWindowSize(delta: number): void;
+}
+
 interface BindResult {
   port: number;
   count: number;
@@ -365,7 +370,14 @@ export class Server {
     }
     if ('grpc.max_concurrent_streams' in this.options) {
       this.commonServerOptions.settings = {
+        ...this.commonServerOptions.settings,
         maxConcurrentStreams: this.options['grpc.max_concurrent_streams'],
+      };
+    }
+    if ('grpc-node.flow_control_window' in this.options) {
+      this.commonServerOptions.settings = {
+        ...this.commonServerOptions.settings,
+        initialWindowSize: this.options['grpc-node.flow_control_window'],
       };
     }
     this.interceptors = this.options.interceptors ?? [];
@@ -1516,6 +1528,31 @@ export class Server {
   ) {
     return (session: http2.ServerHttp2Session) => {
       this.http2Servers.get(http2Server)?.sessions.add(session);
+
+      const flowControlWindow = this.options['grpc-node.flow_control_window'];
+      if (flowControlWindow !== undefined) {
+        const defaultWindow =
+          http2.getDefaultSettings?.()?.initialWindowSize ?? 65535;
+        if (flowControlWindow > defaultWindow) {
+          /* The settings.initialWindowSize above sets the per-stream window.
+           * Also raise the connection-level window so a large multi-stream
+           * transfer is not throttled by the default 64 KB connection window. */
+          try {
+            session.setLocalWindowSize(flowControlWindow);
+          } catch {
+            /* Fallback for older Node, where setLocalWindowSize is unavailable:
+             * bump the window by the delta. incrementWindowSize is not in the
+             * http2 typings, so it is referenced through a narrow interface. */
+            const delta =
+              flowControlWindow - (session.state.localWindowSize ?? defaultWindow);
+            if (delta > 0) {
+              (session as unknown as IncrementWindowSize).incrementWindowSize(
+                delta
+              );
+            }
+          }
+        }
+      }
 
       let connectionAgeTimer: NodeJS.Timeout | null = null;
       let connectionAgeGraceTimer: NodeJS.Timeout | null = null;

--- a/packages/grpc-js/test/test-server.ts
+++ b/packages/grpc-js/test/test-server.ts
@@ -331,6 +331,58 @@ describe('Server', () => {
     });
   });
 
+  describe('flow control window', () => {
+    let server: Server;
+    let client: ServiceClient;
+    const protoFile = path.join(__dirname, 'fixtures', 'echo_service.proto');
+    const echoService = loadProtoFile(protoFile)
+      .EchoService as ServiceClientConstructor;
+
+    const serviceImplementation = {
+      echo(call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) {
+        callback(null, call.request);
+      },
+    };
+
+    afterEach(done => {
+      client.close();
+      server.tryShutdown(done);
+    });
+
+    it('Should accept grpc-node.flow_control_window and round-trip a large message', done => {
+      const flowControlWindow = 4 * 1024 * 1024;
+      server = new Server({
+        'grpc-node.flow_control_window': flowControlWindow,
+        'grpc.max_receive_message_length': -1,
+        'grpc.max_send_message_length': -1,
+      });
+      server.addService(echoService.service, serviceImplementation);
+      server.bindAsync(
+        'localhost:0',
+        ServerCredentials.createInsecure(),
+        (err, port) => {
+          assert.ifError(err);
+          client = new echoService(
+            `localhost:${port}`,
+            grpc.credentials.createInsecure(),
+            {
+              'grpc.max_receive_message_length': -1,
+              'grpc.max_send_message_length': -1,
+            }
+          );
+          // Larger than the default 64 KB window, so the transfer exercises
+          // the raised connection window rather than stalling on it.
+          const value = 'a'.repeat(2 * 1024 * 1024);
+          client.echo({ value }, (error: ServiceError, response: any) => {
+            assert.ifError(error);
+            assert.strictEqual(response.value, value);
+            done();
+          });
+        }
+      );
+    });
+  });
+
   describe('start', () => {
     let server: Server;
 


### PR DESCRIPTION
## Problem

`grpc-node.flow_control_window` was added for the client transport in #2864, but the **server** never reads it. As a result a server's HTTP/2 receive window is always pinned to Node's default of 64 KB, with no channel option to raise it.

On high-RTT links this throttles large uploads. With a 64 KB window, every 64 KB of data requires a full round-trip for a `WINDOW_UPDATE` before more can be sent, so throughput is bounded by `window / RTT`. A ~19 MB unary upload to a server one or two hops away can take tens of seconds, and the data arrives as a long sequence of 16 KB frames with periodic multi-second stalls. The same option already fixes this on the client side; the server side had no equivalent.

`grpc.max_send_message_length` / `grpc.max_receive_message_length` do not help here, since they cap message size, not the flow-control window.

## Change

Make the server honor `grpc-node.flow_control_window`, mirroring the existing client implementation in `transport.ts`:

1. On server construction, set `settings.initialWindowSize` from the option. This advertises a larger per-stream window in the SETTINGS frame for new sessions.
2. Per session, raise the connection-level window via `session.setLocalWindowSize(...)`, with an `incrementWindowSize` fallback for older Node versions. This is guarded by `flowControlWindow > defaultWindow` so it is a no-op when the option is unset or not larger than the default.

## Testing

Added a test in `test/test-server.ts` that sets `grpc-node.flow_control_window` on the server and round-trips a message larger than the default window. The full `test-server` suite passes.

I reproduced the original problem and verified the fix out of cluster using `tc netem` to inject RTT on loopback: a 19 MB unary call at ~20 ms RTT took ~15 s with the default window and ~3.4 s with a 4 MB window, with the remaining time being application work. The effect was identical across grpc-js 1.10, 1.12, and 1.14, confirming this is the default-window behavior rather than a regression.

## Note for reviewers

`setLocalWindowSize` is present in current `@types/node`, but `incrementWindowSize` is not, so the fallback references it through a small local interface rather than `any`. The client code in `transport.ts` uses `as any` for the same call; happy to match that style if preferred.
