### PR TITLE
grpc-js: fix Buffer-only .copy() crash on Uint8Array messages in CompressionFilter

### DIFF
--- a/packages/grpc-js/src/compression-filter.ts
+++ b/packages/grpc-js/src/compression-filter.ts
@@ -56,7 +56,7 @@ abstract class CompressionHandler {
     const output = Buffer.allocUnsafe(messageBuffer.length + 5);
     output.writeUInt8(compress ? 1 : 0, 0);
     output.writeUInt32BE(messageBuffer.length, 1);
-    messageBuffer.copy(output, 5);
+    output.set(messageBuffer, 5);
     return output;
   }
   /**
@@ -84,7 +84,7 @@ class IdentityHandler extends CompressionHandler {
      * uncompressed */
     output.writeUInt8(0, 0);
     output.writeUInt32BE(message.length, 1);
-    message.copy(output, 5);
+    output.set(message, 5);
     return output;
   }
 

--- a/packages/grpc-js/test/test-compression-filter.ts
+++ b/packages/grpc-js/test/test-compression-filter.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import * as assert from 'assert';
+import { WriteFlags, WriteObject } from '../src/call-interface';
+import { CompressionAlgorithms } from '../src/compression-algorithms';
+import { CompressionFilter } from '../src/compression-filter';
+
+describe('CompressionFilter', () => {
+  describe('sendMessage', () => {
+    /* Request serializers are caller-supplied and only nominally typed as
+     * returning a Buffer. Libraries such as protobufjs can fall back to
+     * returning a plain Uint8Array at runtime (e.g. when its optional
+     * Buffer utility is unavailable), so the filter needs to handle that
+     * without crashing. */
+    it('frames a Uint8Array message under identity compression', async () => {
+      const filter = new CompressionFilter({}, {});
+      const payload = new Uint8Array([1, 2, 3, 4, 5]);
+      assert.strictEqual(payload instanceof Buffer, false);
+      const writeObject: WriteObject = {
+        message: payload as unknown as Buffer,
+      };
+      const result = await filter.sendMessage(Promise.resolve(writeObject));
+      assert.strictEqual(result.message.readUInt8(0), 0);
+      assert.strictEqual(result.message.readUInt32BE(1), payload.length);
+      assert.deepStrictEqual(
+        Array.from(result.message.subarray(5)),
+        Array.from(payload)
+      );
+    });
+
+    it('frames a Uint8Array message when compression is skipped via NoCompress', async () => {
+      const filter = new CompressionFilter(
+        { 'grpc.default_compression_algorithm': CompressionAlgorithms.gzip },
+        {}
+      );
+      const payload = new Uint8Array([9, 8, 7, 6]);
+      assert.strictEqual(payload instanceof Buffer, false);
+      const writeObject: WriteObject = {
+        message: payload as unknown as Buffer,
+        flags: WriteFlags.NoCompress,
+      };
+      const result = await filter.sendMessage(Promise.resolve(writeObject));
+      assert.strictEqual(result.message.readUInt8(0), 0);
+      assert.strictEqual(result.message.readUInt32BE(1), payload.length);
+      assert.deepStrictEqual(
+        Array.from(result.message.subarray(5)),
+        Array.from(payload)
+      );
+    });
+  });
+});


### PR DESCRIPTION
CompressionFilter's writeMessage (both the shared base implementation and IdentityHandler's override) calls `message.copy(output, 5)` to frame the outgoing message. `.copy()` only exists on `Buffer`, but the message here comes straight from the caller's `serialize` function, which is only nominally typed as returning a `Buffer` — nothing enforces that at runtime. protobufjs in particular falls back to a plain `Uint8Array` from `Writer.finish()` when its optional Buffer util isn't available (some bundlers strip it out), so this can throw `TypeError: message.copy is not a function` deep inside grpc-js with basically no context for whoever hits it.

`Buffer.prototype.set` (inherited from `Uint8Array`) does the same job and works for both types, so this just swaps `.copy()` for `.set()` in both spots. Added a test that sends a `Uint8Array` payload through both the identity path and a non-identity handler with the `NoCompress` flag, since both call sites had the same bug.

Ref #3050.