### PR TITLE
proto-loader: Update protobufjs dependency to 8.x

### DIFF
--- a/packages/proto-loader/package.json
+++ b/packages/proto-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/proto-loader",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "author": "Google Inc.",
   "contributors": [
     {
@@ -47,7 +47,7 @@
   "dependencies": {
     "lodash.camelcase": "^4.3.0",
     "long": "^5.0.0",
-    "protobufjs": "^7.5.5",
+    "protobufjs": "^8.7.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -366,6 +366,7 @@ function createPackageDefinitionFromDescriptorSet(
 
   const root = Protobuf.Root.fromDescriptor(
     decodedDescriptorSet,
+    {keepCase: options.keepCase}
   );
   root.resolveAll();
   return createPackageDefinition(root, options);

--- a/packages/proto-loader/src/index.ts
+++ b/packages/proto-loader/src/index.ts
@@ -59,40 +59,6 @@ export function isAnyExtension(obj: object): obj is AnyExtension {
   return ('@type' in obj) && (typeof (obj as AnyExtension)['@type'] === 'string');
 }
 
-declare module 'protobufjs' {
-  interface Type {
-    toDescriptor(
-      protoVersion: string
-    ): Protobuf.Message<descriptor.IDescriptorProto> &
-      descriptor.IDescriptorProto;
-  }
-
-  interface RootConstructor {
-    new (options?: Options): Root;
-    fromDescriptor(
-      descriptorSet:
-        | descriptor.IFileDescriptorSet
-        | Protobuf.Reader
-        | Uint8Array
-    ): Root;
-    fromJSON(json: Protobuf.INamespace, root?: Root): Root;
-  }
-
-  interface Root {
-    toDescriptor(
-      protoVersion: string
-    ): Protobuf.Message<descriptor.IFileDescriptorSet> &
-      descriptor.IFileDescriptorSet;
-  }
-
-  interface Enum {
-    toDescriptor(
-      protoVersion: string
-    ): Protobuf.Message<descriptor.IEnumDescriptorProto> &
-      descriptor.IEnumDescriptorProto;
-  }
-}
-
 export interface Serialize<T> {
   (value: T): Buffer;
 }
@@ -342,7 +308,7 @@ function createEnumDefinition(
 ): EnumTypeDefinition {
   const enumDescriptor: protobuf.Message<
     descriptor.IEnumDescriptorProto
-  > = enumType.toDescriptor('proto3');
+  > = enumType.toDescriptor();
   return {
     format: 'Protocol Buffer 3 EnumDescriptorProto',
     type: enumDescriptor.$type.toObject(enumDescriptor, descriptorOptions),
@@ -398,8 +364,8 @@ function createPackageDefinitionFromDescriptorSet(
 ) {
   options = options || {};
 
-  const root = (Protobuf.Root as Protobuf.RootConstructor).fromDescriptor(
-    decodedDescriptorSet
+  const root = Protobuf.Root.fromDescriptor(
+    decodedDescriptorSet,
   );
   root.resolveAll();
   return createPackageDefinition(root, options);


### PR DESCRIPTION
The only [breaking change](https://github.com/protobufjs/protobuf.js/blob/eaefa1f9cb7bb888b16f53de22215de1c35643aa/CHANGELOG.md#800-2025-12-16) in the 8.x train is the Edition 2024 support

I took the liberty to bump the version number by a minor the same way 7b4704cc921cddf7c6084c69704ac940c4450b98 did.

Fixes #3062