### PR TITLE
grpc-js-xds: Fix weighted cluster total calculation

### DIFF
--- a/packages/grpc-js-xds/src/resolver-xds.ts
+++ b/packages/grpc-js-xds/src/resolver-xds.ts
@@ -332,7 +332,16 @@ class XdsResolver implements Resolver {
             }
             weightedClusters.push({name: clusterWeight.name, weight: clusterWeight.weight?.value ?? 0, dynamicFilterFactories: extraFilterFactories});
           }
-          routeAction = new WeightedClusterRouteAction(weightedClusters, route.route!.weighted_clusters!.total_weight?.value ?? 100, {name: [], timeout: timeout, retryPolicy: retryPolicy}, hashPolicies);
+          const totalWeight = weightedClusters.reduce(
+            (sum, cluster) => sum + cluster.weight,
+            0
+          );
+          routeAction = new WeightedClusterRouteAction(
+            weightedClusters,
+            totalWeight,
+            {name: [], timeout: timeout, retryPolicy: retryPolicy},
+            hashPolicies
+          );
           break;
         }
         default:
@@ -356,7 +365,15 @@ class XdsResolver implements Resolver {
         for (const {matcher, action} of matchList) {
           if (matcher.apply(methodName, metadata)) {
             const clusterResult = action.getCluster();
-            const clusterRef = this.clusterRefs.get(clusterResult.name)!;
+            const clusterRef = this.clusterRefs.get(clusterResult.name);
+            if (!clusterRef) {
+              return {
+                methodConfig: clusterResult.methodConfig,
+                pickInformation: {cluster: '', hash: ''},
+                status: status.UNAVAILABLE,
+                dynamicFilterFactories: clusterResult.dynamicFilterFactories,
+              };
+            }
             clusterRef.ref();
             const onCommitted = () => {
               clusterRef.unref();

--- a/packages/grpc-js-xds/test/test-core.ts
+++ b/packages/grpc-js-xds/test/test-core.ts
@@ -62,6 +62,49 @@ describe('core xDS functionality', () => {
     await routeGroup.waitForAllBackendsToReceiveTraffic();
     client.stopCalls();
   });
+  it('should use the cluster weight sum when total_weight is omitted', async () => {
+    const [backend] = await createBackends(1);
+    const serverRoute = new FakeServerRoute(backend.getPort(), 'serverRoute');
+    xdsServer.setRdsResource(serverRoute.getRouteConfiguration());
+    xdsServer.setLdsResource(serverRoute.getListener());
+    xdsServer.addResponseListener((typeUrl, responseState) => {
+      if (responseState.state === 'NACKED') {
+        assert.fail(
+          `Client NACKED ${typeUrl} resource with message ${responseState.errorMessage}`
+        );
+      }
+    });
+    const cluster = new FakeEdsCluster('cluster1', 'endpoint1', [
+      {backends: [backend], locality: {region: 'region1'}},
+    ]);
+    const routeGroup = new FakeRouteGroup('listener1', 'route1', [
+      {
+        weightedClusters: [{cluster: cluster, weight: 1}],
+      },
+    ]);
+    await routeGroup.startAllBackends(xdsServer);
+    xdsServer.setEdsResource(cluster.getEndpointConfig());
+    xdsServer.setCdsResource(cluster.getClusterConfig());
+    xdsServer.setRdsResource(routeGroup.getRouteConfiguration());
+    xdsServer.setLdsResource(routeGroup.getListener());
+    client = XdsTestClient.createFromServer('listener1', xdsServer);
+    const originalRandom = Math.random;
+    // With the old denominator of 100, this value selected no cluster.
+    Math.random = () => 0.5;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        client.sendOneCall(error => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
   it('should be able to enter and exit idle', function(done) {
     this.timeout(5000);
     createBackends(1).then(([backend]) => {


### PR DESCRIPTION
Fixes #3069.

The xDS resolver previously defaulted to a total weight of `100` if the `total_weight` field is empty (which is [deprecated](https://github.com/envoyproxy/envoy/blob/742a3b297d7cbc31bd9266ef6adcce186b271df2/api/envoy/config/route/v3/route_components.proto#L483)).

Instead, sum the cluster weights to get the total before using it in calculations.

Without this, resolution of a cluster with total weights of "1" would fail with:

```
TypeError: Cannot read properties of undefined (reading 'ref')
    at Object.invoke (.../node_modules/@grpc/grpc-js-xds/build/src/resolver-xds.js:343:36)
```

Testing:

- added regression test