### PR TITLE
ci: pin windows_build to windows-2022

### DIFF
--- a/.github/workflows/grpc-tools-build.yml
+++ b/.github/workflows/grpc-tools-build.yml
@@ -42,7 +42,7 @@ jobs:
           path: artifacts/
   windows_build:
     name: Windows grpc-tools Build
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         arch: [ia32, x64]


### PR DESCRIPTION
This is a cherry-pick of a commit made for #3067. Maybe this can land independently. It already impacted other PRs such as #3074. 

---
`windows-latest` defaults to `windows-2025` since September 2025[^1] and ships CMake v4. This project still has requirements for specific v3 CMake.

[^1]:https://github.blog/changelog/2025-07-31-github-actions-new-apis-and-windows-latest-migration-notice/