### PR TITLE
grpc-js: Remove calls from the pick queue immediately when they end

### DIFF
--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -342,7 +342,7 @@ export class InternalChannel {
       },
       updateState: (connectivityState: ConnectivityState, picker: Picker) => {
         this.currentPicker = picker;
-        const queueCopy = {...this.pickQueue};
+        const queueCopy = this.pickQueue;
         this.pickQueue = new Set();
         if (queueCopy.size > 0) {
           this.callRefTimerUnref();

--- a/packages/grpc-js/src/internal-channel.ts
+++ b/packages/grpc-js/src/internal-channel.ts
@@ -193,7 +193,7 @@ export class InternalChannel {
    * first time the resolver returns a result, which includes the ConfigSelector.
    */
   private configSelectionQueue: ResolvingCall[] = [];
-  private pickQueue: LoadBalancingCall[] = [];
+  private pickQueue: Set<LoadBalancingCall> = new Set();
   private connectivityStateWatchers: ConnectivityStateWatcher[] = [];
   private readonly defaultAuthority: string;
   private readonly filterStackFactory: FilterStackFactory;
@@ -342,9 +342,9 @@ export class InternalChannel {
       },
       updateState: (connectivityState: ConnectivityState, picker: Picker) => {
         this.currentPicker = picker;
-        const queueCopy = this.pickQueue.slice();
-        this.pickQueue = [];
-        if (queueCopy.length > 0) {
+        const queueCopy = {...this.pickQueue};
+        this.pickQueue = new Set();
+        if (queueCopy.size > 0) {
           this.callRefTimerUnref();
         }
         for (const call of queueCopy) {
@@ -479,8 +479,8 @@ export class InternalChannel {
       this.trace(
         'callRefTimer.ref | configSelectionQueue.length=' +
           this.configSelectionQueue.length +
-          ' pickQueue.length=' +
-          this.pickQueue.length
+          ' pickQueue.size=' +
+          this.pickQueue.size
       );
       this.callRefTimer.ref?.();
     }
@@ -492,8 +492,8 @@ export class InternalChannel {
       this.trace(
         'callRefTimer.unref | configSelectionQueue.length=' +
           this.configSelectionQueue.length +
-          ' pickQueue.length=' +
-          this.pickQueue.length
+          ' pickQueue.size=' +
+          this.pickQueue.size
       );
       this.callRefTimer?.unref?.();
     }
@@ -571,8 +571,15 @@ export class InternalChannel {
   }
 
   queueCallForPick(call: LoadBalancingCall) {
-    this.pickQueue.push(call);
+    this.pickQueue.add(call);
     this.callRefTimerRef();
+  }
+
+  removeCallFromPickQueue(call: LoadBalancingCall) {
+    this.pickQueue.delete(call);
+    if (this.pickQueue.size === 0) {
+      this.callRefTimerUnref();
+    }
   }
 
   getConfig(method: string, metadata: Metadata): GetConfigResult {
@@ -771,7 +778,7 @@ export class InternalChannel {
     for (const call of this.pickQueue) {
       call.cancelWithStatus(Status.UNAVAILABLE, 'Channel closed before call started');
     }
-    this.pickQueue = [];
+    this.pickQueue.clear();
     if (this.callRefTimer) {
       clearInterval(this.callRefTimer);
     }

--- a/packages/grpc-js/src/load-balancing-call.ts
+++ b/packages/grpc-js/src/load-balancing-call.ts
@@ -128,6 +128,7 @@ export class LoadBalancingCall implements Call, DeadlineInfoProvider {
       const finalStatus = { ...status, progress };
       this.listener?.onReceiveStatus(finalStatus);
       this.onCallEnded?.(finalStatus.code, finalStatus.details, finalStatus.metadata);
+      this.channel.removeCallFromPickQueue(this);
     }
   }
 


### PR DESCRIPTION
This is a defense-in-depth fix for the bug reported in https://github.com/grpc/grpc-node/issues/2785#issuecomment-5607201959. If, due to another bug, a channel gets stuck in a non-READY state for a long period of time, call references can accumulate in the pick queue, and they aren't removed immediately if they end locally due to cancellation or a deadline. With this change, calls are always immediately removed from the queue when they end.

Also, as suggested in that comment, I made the pick queue a set to make that removal efficient.