### PR TITLE
grpc-js: Ensure message send errors have proper status information

### DIFF
--- a/packages/grpc-js/src/resolving-call.ts
+++ b/packages/grpc-js/src/resolving-call.ts
@@ -189,7 +189,7 @@ export class ResolvingCall implements Call {
         }
       },
       (status: StatusObject) => {
-        this.cancelWithStatus(status.code, status.details);
+        this.cancelWithStatus(status.code ?? Status.INTERNAL, status.details ?? 'Failed to write message');
       }
     );
   }


### PR DESCRIPTION
This fixes #3051. If the status is not actually a status object as expected, fill in generic error information so that the error that bubbles up to the surface has the expected fields.