### PR TITLE
fix: remediate mocha CVEs by upgrading to mocha 10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/execa": "^0.8.0",
     "@types/gulp": "^4.0.5",
-    "@types/gulp-mocha": "0.0.31",
+    "@types/gulp-mocha": "0.0.37",
     "@types/ncp": "^2.0.1",
     "@types/node": "^8.0.32",
     "@types/pify": "^3.0.0",
@@ -21,7 +21,7 @@
     "execa": "^0.8.0",
     "gulp": "^4.0.1",
     "gulp-jshint": "^2.0.4",
-    "gulp-mocha": "^4.3.1",
+    "gulp-mocha": "9.0.0",
     "gulp-sourcemaps": "^2.6.1",
     "gulp-tslint": "^8.1.1",
     "gulp-typescript": "^3.2.2",
@@ -30,8 +30,8 @@
     "jshint": "^2.9.5",
     "make-dir": "^1.1.0",
     "merge2": "^1.1.0",
-    "mocha": "^3.5.3",
-    "mocha-jenkins-reporter": "^0.3.9",
+    "mocha": "^10.8.2",
+    "mocha-jenkins-reporter": "^0.4.8",
     "ncp": "^2.0.0",
     "nyc": "^11.7.2",
     "pify": "^3.0.0",
@@ -58,6 +58,14 @@
     ],
     "cache": true,
     "all": true
+  },
+  "overrides": {
+    "mocha": {
+      "serialize-javascript": "^7.0.5"
+    },
+    "mocha-jenkins-reporter": {
+      "diff": "^4.0.4"
+    }
   },
   "scripts": {
     "test": "nyc gulp test",

--- a/test/client-libraries-integration/package.json
+++ b/test/client-libraries-integration/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "dot-prop": "^5.2.0",
     "google-proto-files": "^0.15.1",
-    "mocha": "^5.0.4",
+    "mocha": "^10.8.2",
     "shimmer": "^1.2.0"
   }
 }


### PR DESCRIPTION
## Summary
  
  Upgrades the mocha test toolchain to clear 7 dev-dependency CVEs. No production dependencies affected.

 - `gulp-mocha` 4.3.1 → 9.0.0
  - `mocha` ^3.5.3 → ^10.8.2
  - `mocha-jenkins-reporter` ^0.3.9 → ^0.4.8
  - `@types/gulp-mocha` 0.0.31 → 0.0.37
  - Added `overrides` for `serialize-javascript` (^7.0.5) and `diff` (^4.0.4)
  
  ### Advisories resolved
  | Advisory | Severity | Package |
  |---|---|---|
  | GHSA-qh2h-chj9-jffq | Critical | growl (removed) |
  | GHSA-xvch-5gv4-984h | Critical | minimist (removed) |
  | GHSA-vh95-rmgr-6w4m | Moderate | minimist (removed) |
  | GHSA-5c6j-r48x-rmvq | High     | serialize-javascript |
  | GHSA-qj8w-gfj5-8c6v | Moderate | serialize-javascript |
  | GHSA-9vvw-cc9w-f27h | High     | debug |
  | GHSA-gxpj-cx7g-858c | Low      | debug |
  | GHSA-73rr-hh4g-fpgx | Low      | diff (mocha-jenkins-reporter) |


